### PR TITLE
fix: AllowAnonymous on AuthCallback [v0.2.4]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.2.3</Version>
+    <Version>0.2.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/AuthCallback.razor
+++ b/src/OvcinaHra.Client/Pages/AuthCallback.razor
@@ -1,4 +1,5 @@
 @page "/auth-callback"
+@attribute [AllowAnonymous]
 @inject IJSRuntime JS
 @inject HttpClient Http
 @inject JwtAuthStateProvider AuthProvider


### PR DESCRIPTION
## Summary
- Add `[AllowAnonymous]` to AuthCallback.razor — `AuthorizeRouteView` was blocking the page for unauthenticated users, preventing OIDC code exchange

## Root cause
The OIDC redirect comes back to `/auth-callback` with a code, but the user isn't authenticated yet. `AuthorizeRouteView` in `App.razor` showed the Login page instead of AuthCallback, so the code exchange never executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)