### PR TITLE
fix: bypass AuthorizeRouteView for auth pages [v0.2.5]

### DIFF
--- a/src/OvcinaHra.Client/App.razor
+++ b/src/OvcinaHra.Client/App.razor
@@ -1,11 +1,23 @@
 <CascadingAuthenticationState>
     <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
         <Found Context="routeData">
-            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
-                <NotAuthorized>
-                    <OvcinaHra.Client.Pages.Login />
-                </NotAuthorized>
-            </AuthorizeRouteView>
+            @{
+                var pageType = routeData.PageType;
+                var allowAnon = pageType == typeof(Pages.Login)
+                    || pageType == typeof(Pages.AuthCallback);
+            }
+            @if (allowAnon)
+            {
+                <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+            }
+            else
+            {
+                <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                    <NotAuthorized>
+                        <OvcinaHra.Client.Pages.Login />
+                    </NotAuthorized>
+                </AuthorizeRouteView>
+            }
             <FocusOnNavigate RouteData="@routeData" Selector="h1" />
         </Found>
     </Router>

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.2.4</Version>
+    <Version>0.2.5</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
AuthorizeRouteView ignores AllowAnonymous in Blazor WASM. Route Login + AuthCallback through plain RouteView.