### PR TITLE
fix: JWT issuer trailing slash + audience [v0.2.9]

### DIFF
--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -52,11 +52,11 @@ try
         {
             // Production: validate against registrace OIDC discovery endpoint
             options.Authority = oidcAuthority;
-            options.Audience = builder.Configuration["Oidc:ClientId"] ?? "ovcinahra";
             options.TokenValidationParameters = new TokenValidationParameters
             {
                 ValidateIssuer = true,
-                ValidateAudience = true,
+                ValidIssuer = oidcAuthority.TrimEnd('/') + "/", // OpenIddict adds trailing slash
+                ValidateAudience = false, // OpenIddict doesn't set aud to client_id by default
                 ValidateLifetime = true,
                 NameClaimType = "name",
                 RoleClaimType = "role",

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.2.8</Version>
+    <Version>0.2.9</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
OpenIddict issuer=https://registrace.ovcina.cz/ (trailing slash). Disable audience validation.