### PR TITLE
feat: PlayerClass enum with Czech Display names

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -2,8 +2,10 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Domain.ValueObjects;
 using OvcinaHra.Shared.Dtos;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Api.Endpoints;
 
@@ -154,12 +156,11 @@ public static class ItemEndpoints
         return TypedResults.NoContent();
     }
 
-    // Class: warrior, archer, mage, thief. Level: 1+.
     // Returns all items usable by that class at that level.
-    // An item is usable if: its class requirement is 0 for ALL classes (unrestricted),
+    // An item is usable if: unrestricted (all requirements 0),
     // OR the specified class requirement is > 0 and <= the given level.
     private static async Task<Ok<List<ItemListDto>>> GetUsableItems(
-        string playerClass, int level, WorldDbContext db, int? gameId = null)
+        PlayerClass playerClass, int level, WorldDbContext db, int? gameId = null)
     {
         var query = db.Items.AsQueryable();
         if (gameId.HasValue)
@@ -170,17 +171,9 @@ public static class ItemEndpoints
         var usable = items.Where(i =>
         {
             var cr = i.ClassRequirements;
-            var allZero = cr.Warrior == 0 && cr.Archer == 0 && cr.Mage == 0 && cr.Thief == 0;
-            if (allZero) return true; // unrestricted
+            if (cr.IsUnrestricted) return true;
 
-            var required = playerClass.ToLowerInvariant() switch
-            {
-                "warrior" => cr.Warrior,
-                "archer" => cr.Archer,
-                "mage" => cr.Mage,
-                "thief" => cr.Thief,
-                _ => 0
-            };
+            var required = cr.GetRequirement(playerClass);
             return required > 0 && level >= required;
         })
         .Select(i => new ItemListDto(i.Id, i.Name, i.ItemType, i.IsCraftable, i.IsUnique, i.IsLimited))
@@ -192,19 +185,19 @@ public static class ItemEndpoints
 
     // Check if a specific item can be used by a given class at a given level.
     private static async Task<Results<Ok<ItemUsabilityDto>, NotFound>> CanUseItem(
-        int id, string playerClass, int level, WorldDbContext db)
+        int id, PlayerClass playerClass, int level, WorldDbContext db)
     {
         var item = await db.Items.FindAsync(id);
         if (item is null) return TypedResults.NotFound();
 
         var cr = item.ClassRequirements;
-        var allZero = cr.Warrior == 0 && cr.Archer == 0 && cr.Mage == 0 && cr.Thief == 0;
+        var className = playerClass.GetDisplayName();
 
         bool canUse;
         int requiredLevel;
         string reason;
 
-        if (allZero)
+        if (cr.IsUnrestricted)
         {
             canUse = true;
             requiredLevel = 0;
@@ -212,29 +205,22 @@ public static class ItemEndpoints
         }
         else
         {
-            requiredLevel = playerClass.ToLowerInvariant() switch
-            {
-                "warrior" => cr.Warrior,
-                "archer" => cr.Archer,
-                "mage" => cr.Mage,
-                "thief" => cr.Thief,
-                _ => 0
-            };
+            requiredLevel = cr.GetRequirement(playerClass);
 
             if (requiredLevel == 0)
             {
                 canUse = false;
-                reason = $"Třída {playerClass} nemůže tento předmět použít";
+                reason = $"{className} nemůže tento předmět použít";
             }
             else if (level >= requiredLevel)
             {
                 canUse = true;
-                reason = $"Ano — vyžaduje {playerClass} úroveň {requiredLevel}+";
+                reason = $"Ano — vyžaduje {className} úroveň {requiredLevel}+";
             }
             else
             {
                 canUse = false;
-                reason = $"Ne — vyžaduje {playerClass} úroveň {requiredLevel}, máš {level}";
+                reason = $"Ne — vyžaduje {className} úroveň {requiredLevel}, máš {level}";
             }
         }
 

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -81,16 +81,16 @@ else
                 <DxTextBox @bind-Text="@effect" NullText="(3/5), +2/+2, ..." />
             </DxFormLayoutItem>
             <DxFormLayoutGroup Caption="Požadavky na povolání" ColSpanMd="12">
-                <DxFormLayoutItem Caption="Válečník" ColSpanMd="3">
+                <DxFormLayoutItem Caption="@PlayerClass.Warrior.GetDisplayName()" ColSpanMd="3">
                     <DxSpinEdit @bind-Value="@reqWarrior" MinValue="0" />
                 </DxFormLayoutItem>
-                <DxFormLayoutItem Caption="Lučištník" ColSpanMd="3">
+                <DxFormLayoutItem Caption="@PlayerClass.Archer.GetDisplayName()" ColSpanMd="3">
                     <DxSpinEdit @bind-Value="@reqArcher" MinValue="0" />
                 </DxFormLayoutItem>
-                <DxFormLayoutItem Caption="Mág" ColSpanMd="3">
+                <DxFormLayoutItem Caption="@PlayerClass.Mage.GetDisplayName()" ColSpanMd="3">
                     <DxSpinEdit @bind-Value="@reqMage" MinValue="0" />
                 </DxFormLayoutItem>
-                <DxFormLayoutItem Caption="Zloděj" ColSpanMd="3">
+                <DxFormLayoutItem Caption="@PlayerClass.Thief.GetDisplayName()" ColSpanMd="3">
                     <DxSpinEdit @bind-Value="@reqThief" MinValue="0" />
                 </DxFormLayoutItem>
             </DxFormLayoutGroup>

--- a/src/OvcinaHra.Shared/Domain/Enums/PlayerClass.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/PlayerClass.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Domain.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum PlayerClass
+{
+    [Display(Name = "Válečník")]
+    Warrior,
+
+    [Display(Name = "Střelec")]
+    Archer,
+
+    [Display(Name = "Zloděj")]
+    Thief,
+
+    [Display(Name = "Mág")]
+    Mage
+}

--- a/src/OvcinaHra.Shared/Domain/ValueObjects/ClassRequirements.cs
+++ b/src/OvcinaHra.Shared/Domain/ValueObjects/ClassRequirements.cs
@@ -1,3 +1,17 @@
+using OvcinaHra.Shared.Domain.Enums;
+
 namespace OvcinaHra.Shared.Domain.ValueObjects;
 
-public record ClassRequirements(int Warrior, int Archer, int Mage, int Thief);
+public record ClassRequirements(int Warrior, int Archer, int Mage, int Thief)
+{
+    public int GetRequirement(PlayerClass playerClass) => playerClass switch
+    {
+        PlayerClass.Warrior => Warrior,
+        PlayerClass.Archer => Archer,
+        PlayerClass.Mage => Mage,
+        PlayerClass.Thief => Thief,
+        _ => 0
+    };
+
+    public bool IsUnrestricted => Warrior == 0 && Archer == 0 && Mage == 0 && Thief == 0;
+}


### PR DESCRIPTION
## Summary
- New `PlayerClass` enum (Warrior=Válečník, Archer=Střelec, Thief=Zloděj, Mage=Mág) with `[Display]` attributes and `JsonStringEnumConverter`
- `ClassRequirements` gains `GetRequirement(PlayerClass)` helper and `IsUnrestricted` property — eliminates duplicate switch statements
- Usability API (`/api/items/usable`, `/api/items/{id}/can-use`) now accepts `PlayerClass` enum instead of raw strings; Czech reason messages use Display names
- Item edit UI labels driven by enum Display names instead of hardcoded strings

## Test plan
- [x] Build: 0 warnings, 0 errors
- [x] 133 integration tests pass
- [ ] Manual: verify item edit form shows correct Czech class names
- [ ] Manual: test `/api/items/usable?playerClass=Warrior&level=3` returns correct items
- [ ] Manual: test `/api/items/1/can-use?playerClass=Mage&level=2` returns Czech reason text

🤖 Generated with [Claude Code](https://claude.com/claude-code)