### PR TITLE
feat: GameMonster + empty states on all domain pages

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/GameMonsterConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/GameMonsterConfiguration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class GameMonsterConfiguration : IEntityTypeConfiguration<GameMonster>
+{
+    public void Configure(EntityTypeBuilder<GameMonster> builder)
+    {
+        builder.HasKey(e => new { e.GameId, e.MonsterId });
+        builder.HasOne(e => e.Game).WithMany(g => g.GameMonsters).HasForeignKey(e => e.GameId);
+        builder.HasOne(e => e.Monster).WithMany(m => m.GameMonsters).HasForeignKey(e => e.MonsterId);
+        builder.HasIndex(e => e.GameId);
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -19,6 +19,7 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<Monster> Monsters => Set<Monster>();
     public DbSet<MonsterTagLink> MonsterTagLinks => Set<MonsterTagLink>();
     public DbSet<MonsterLoot> MonsterLoots => Set<MonsterLoot>();
+    public DbSet<GameMonster> GameMonsters => Set<GameMonster>();
     public DbSet<Quest> Quests => Set<Quest>();
     public DbSet<QuestTagLink> QuestTagLinks => Set<QuestTagLink>();
     public DbSet<QuestLocationLink> QuestLocationLinks => Set<QuestLocationLink>();

--- a/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
@@ -19,6 +19,11 @@ public static class MonsterEndpoints
         group.MapPut("/{id:int}", Update);
         group.MapDelete("/{id:int}", Delete);
 
+        // Per-game assignment
+        group.MapGet("/by-game/{gameId:int}", GetByGame);
+        group.MapPost("/game-monster", CreateGameMonster);
+        group.MapDelete("/game-monster/{gameId:int}/{monsterId:int}", DeleteGameMonster);
+
         // Tags
         group.MapPost("/{id:int}/tags/{tagId:int}", AddTag);
         group.MapDelete("/{id:int}/tags/{tagId:int}", RemoveTag);
@@ -103,6 +108,39 @@ public static class MonsterEndpoints
         var m = await db.Monsters.FindAsync(id);
         if (m is null) return TypedResults.NotFound();
         db.Monsters.Remove(m);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Ok<List<GameMonsterDto>>> GetByGame(int gameId, WorldDbContext db)
+    {
+        var monsters = await db.GameMonsters
+            .Where(gm => gm.GameId == gameId)
+            .Include(gm => gm.Monster)
+            .OrderBy(gm => gm.Monster.Name)
+            .Select(gm => new GameMonsterDto(gm.GameId, gm.MonsterId, gm.Monster.Name))
+            .ToListAsync();
+        return TypedResults.Ok(monsters);
+    }
+
+    private static async Task<Results<Created<GameMonsterDto>, Conflict>> CreateGameMonster(CreateGameMonsterDto dto, WorldDbContext db)
+    {
+        if (await db.GameMonsters.AnyAsync(gm => gm.GameId == dto.GameId && gm.MonsterId == dto.MonsterId))
+            return TypedResults.Conflict();
+
+        db.GameMonsters.Add(new GameMonster { GameId = dto.GameId, MonsterId = dto.MonsterId });
+        await db.SaveChangesAsync();
+
+        var name = (await db.Monsters.FindAsync(dto.MonsterId))?.Name ?? "";
+        return TypedResults.Created($"/api/monsters/game-monster/{dto.GameId}/{dto.MonsterId}",
+            new GameMonsterDto(dto.GameId, dto.MonsterId, name));
+    }
+
+    private static async Task<Results<NoContent, NotFound>> DeleteGameMonster(int gameId, int monsterId, WorldDbContext db)
+    {
+        var gm = await db.GameMonsters.FindAsync(gameId, monsterId);
+        if (gm is null) return TypedResults.NotFound();
+        db.GameMonsters.Remove(gm);
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Migrations/20260412161140_AddGameMonster.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260412161140_AddGameMonster.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260412161140_AddGameMonster")]
+    partial class AddGameMonster
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260412161140_AddGameMonster.cs
+++ b/src/OvcinaHra.Api/Migrations/20260412161140_AddGameMonster.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameMonster : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GameMonsters",
+                columns: table => new
+                {
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    MonsterId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameMonsters", x => new { x.GameId, x.MonsterId });
+                    table.ForeignKey(
+                        name: "FK_GameMonsters_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GameMonsters_Monsters_MonsterId",
+                        column: x => x.MonsterId,
+                        principalTable: "Monsters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameMonsters_GameId",
+                table: "GameMonsters",
+                column: "GameId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameMonsters_MonsterId",
+                table: "GameMonsters",
+                column: "MonsterId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GameMonsters");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
@@ -19,6 +19,14 @@
 </div>
 
 @if (loading) { <p>Načítám...</p> }
+else if (!Catalog && buildings.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-house fs-1 d-block mb-2"></i>
+        <p>Žádné budovy přiřazeny k této hře.</p>
+        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/buildings?catalog=true")'>Otevřít katalog</button>
+    </div>
+}
 else
 {
     <OvcinaGrid Data="@buildings" KeyFieldName="Id" LayoutKey="grid-layout-buildings"

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -21,6 +21,14 @@
 {
     <p>Načítám...</p>
 }
+else if (!Catalog && items.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-box-seam fs-1 d-block mb-2"></i>
+        <p>Žádné předměty přiřazeny k této hře.</p>
+        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/items?catalog=true")'>Otevřít katalog</button>
+    </div>
+}
 else
 {
     <OvcinaGrid Data="@items" KeyFieldName="Id" LayoutKey="grid-layout-items"

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -25,6 +25,14 @@
 {
     <p>Načítám...</p>
 }
+else if (!Catalog && locations.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-geo-alt fs-1 d-block mb-2"></i>
+        <p>Žádné lokace přiřazeny k této hře.</p>
+        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/locations?catalog=true")'>Otevřít katalog</button>
+    </div>
+}
 else
 {
     <OvcinaGrid Data="@locations" KeyFieldName="Id" LayoutKey="grid-layout-locations"

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
@@ -2,15 +2,32 @@
 @attribute [Authorize]
 @inject ApiClient Api
 @inject GameContextService GameContext
+@inject NavigationManager Nav
 
 <div class="d-flex justify-content-between align-items-center mb-3">
-    <h1 class="mb-0">Příšery</h1>
-    <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová příšera</button>
+    <h1 class="mb-0">@(Catalog ? "Katalog příšer" : "Příšery")</h1>
+    <div class="d-flex gap-2">
+        <div class="d-flex gap-2">
+            <button class="btn btn-sm @(Catalog ? "btn-outline-primary" : "btn-primary")"
+                    @onclick='() => Nav.NavigateTo("/monsters")'>Jen tato hra</button>
+            <button class="btn btn-sm @(Catalog ? "btn-primary" : "btn-outline-primary")"
+                    @onclick='() => Nav.NavigateTo("/monsters?catalog=true")'>Katalog</button>
+        </div>
+        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová příšera</button>
+    </div>
 </div>
 
 @if (loading)
 {
     <p>Načítám...</p>
+}
+else if (!Catalog && monsters.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-emoji-neutral fs-1 d-block mb-2"></i>
+        <p>Žádné příšery přiřazeny k této hře.</p>
+        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/monsters?catalog=true")'>Otevřít katalog</button>
+    </div>
 }
 else
 {
@@ -25,6 +42,26 @@ else
             <DxGridDataColumn FieldName="Attack" Caption="Útok" Width="80px" />
             <DxGridDataColumn FieldName="Defense" Caption="Obrana" Width="80px" />
             <DxGridDataColumn FieldName="Health" Caption="Životy" Width="80px" />
+            @if (Catalog)
+            {
+                <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false">
+                    <CellDisplayTemplate>
+                        @{
+                            var monsterId = (int)context.Value;
+                            if (assignedMonsterIds.Contains(monsterId))
+                            {
+                                <button class="btn btn-sm btn-outline-danger" @onclick:stopPropagation="true"
+                                        @onclick="() => UnassignMonsterAsync(monsterId)">Odebrat</button>
+                            }
+                            else
+                            {
+                                <button class="btn btn-sm btn-outline-success" @onclick:stopPropagation="true"
+                                        @onclick="() => AssignMonsterAsync(monsterId)">Přidat</button>
+                            }
+                        }
+                    </CellDisplayTemplate>
+                </DxGridDataColumn>
+            }
         </Columns>
     </OvcinaGrid>
 }
@@ -143,6 +180,9 @@ else
 </DxPopup>
 
 @code {
+    [SupplyParameterFromQuery]
+    public bool Catalog { get; set; }
+
     private List<MonsterListDto> monsters = [];
     private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
     private string modalTitle = "", name = "";
@@ -162,13 +202,64 @@ else
     private int? newLootItemId;
     private int newLootQuantity = 1;
 
+    // Catalog assign state
+    private HashSet<int> assignedMonsterIds = [];
+
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
         await LoadAsync();
         allItems = await Api.GetListAsync<ItemListDto>("/api/items");
     }
-    private async Task LoadAsync() { loading = true; monsters = await Api.GetListAsync<MonsterListDto>("/api/monsters"); loading = false; }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        var allMonsters = await Api.GetListAsync<MonsterListDto>("/api/monsters");
+
+        if (!Catalog && GameContext.SelectedGameId is int gid)
+        {
+            var gameMonsters = await Api.GetListAsync<GameMonsterDto>($"/api/monsters/by-game/{gid}");
+            assignedMonsterIds = gameMonsters.Select(gm => gm.MonsterId).ToHashSet();
+            monsters = allMonsters.Where(m => assignedMonsterIds.Contains(m.Id)).ToList();
+        }
+        else
+        {
+            monsters = allMonsters;
+            if (Catalog && GameContext.SelectedGameId is int catalogGid)
+            {
+                var gameMonsters = await Api.GetListAsync<GameMonsterDto>($"/api/monsters/by-game/{catalogGid}");
+                assignedMonsterIds = gameMonsters.Select(gm => gm.MonsterId).ToHashSet();
+            }
+        }
+
+        loading = false;
+    }
+
+    private async Task AssignMonsterAsync(int monsterId)
+    {
+        if (GameContext.SelectedGameId is null) return;
+        try
+        {
+            await Api.PostAsync<CreateGameMonsterDto, GameMonsterDto>("/api/monsters/game-monster",
+                new CreateGameMonsterDto(GameContext.SelectedGameId.Value, monsterId));
+            assignedMonsterIds.Add(monsterId);
+            StateHasChanged();
+        }
+        catch (Exception ex) { error = ex.Message; StateHasChanged(); }
+    }
+
+    private async Task UnassignMonsterAsync(int monsterId)
+    {
+        if (GameContext.SelectedGameId is null) return;
+        try
+        {
+            await Api.DeleteAsync($"/api/monsters/game-monster/{GameContext.SelectedGameId}/{monsterId}");
+            assignedMonsterIds.Remove(monsterId);
+            StateHasChanged();
+        }
+        catch (Exception ex) { error = ex.Message; StateHasChanged(); }
+    }
 
     private void OpenModal(MonsterListDto? m)
     {

--- a/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
@@ -34,6 +34,14 @@ else if (Catalog)
         </Columns>
     </OvcinaGrid>
 }
+else if (quests.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-journal-text fs-1 d-block mb-2"></i>
+        <p>Žádné questy přiřazeny k této hře.</p>
+        <button class="btn btn-outline-primary" @onclick="() => SetCatalog(true)">Otevřít katalog</button>
+    </div>
+}
 else
 {
     <OvcinaGrid Data="@quests" KeyFieldName="Id" LayoutKey="grid-layout-quests"

--- a/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
+++ b/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
@@ -11,6 +11,14 @@
 </div>
 
 @if (loading) { <p>Načítám...</p> }
+else if (stashes.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-lock fs-1 d-block mb-2"></i>
+        <p>Žádné tajné skrýše pro tuto hru.</p>
+        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová skrýš</button>
+    </div>
+}
 else
 {
     <OvcinaGrid Data="@stashes" KeyFieldName="Id" LayoutKey="grid-layout-secret-stashes"

--- a/src/OvcinaHra.Client/Pages/Timeline/TimelinePage.razor
+++ b/src/OvcinaHra.Client/Pages/Timeline/TimelinePage.razor
@@ -7,6 +7,14 @@
 <h1 class="mb-3">Časová osa</h1>
 
 @if (loading) { <p>Načítám...</p> }
+else if (slots.Count == 0 && bonuses.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-clock-history fs-1 d-block mb-2"></i>
+        <p>Žádné časové bloky pro tuto hru.</p>
+        <button class="btn btn-primary" @onclick="() => OpenSlotModal(null)">+ Nové období</button>
+    </div>
+}
 else
 {
     <div class="row">

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -23,6 +23,14 @@
 {
     <p>Načítám...</p>
 }
+else if (poolItems.Count == 0 && locationCards.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-gem fs-1 d-block mb-2"></i>
+        <p>Žádné poklady pro tuto hru.</p>
+        <button class="btn btn-primary" @onclick="OpenAddToPoolModal">+ Přidat do zásobníku</button>
+    </div>
+}
 else
 {
     <div class="row">

--- a/src/OvcinaHra.Shared/Domain/Entities/Game.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Game.cs
@@ -23,6 +23,7 @@ public class Game
     public ICollection<SecretStash> SecretStashes { get; set; } = [];
     public ICollection<GameBuilding> GameBuildings { get; set; } = [];
     public ICollection<CraftingRecipe> CraftingRecipes { get; set; } = [];
+    public ICollection<GameMonster> GameMonsters { get; set; } = [];
     public ICollection<MonsterLoot> MonsterLoots { get; set; } = [];
     public ICollection<Quest> Quests { get; set; } = [];
     public ICollection<TreasureQuest> TreasureQuests { get; set; } = [];

--- a/src/OvcinaHra.Shared/Domain/Entities/GameMonster.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameMonster.cs
@@ -1,0 +1,10 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class GameMonster
+{
+    public int GameId { get; set; }
+    public int MonsterId { get; set; }
+
+    public Game Game { get; set; } = null!;
+    public Monster Monster { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/Monster.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Monster.cs
@@ -19,5 +19,6 @@ public class Monster
 
     public ICollection<MonsterTagLink> MonsterTags { get; set; } = [];
     public ICollection<MonsterLoot> MonsterLoots { get; set; } = [];
+    public ICollection<GameMonster> GameMonsters { get; set; } = [];
     public ICollection<QuestEncounter> QuestEncounters { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
@@ -46,6 +46,11 @@ public record UpdateMonsterDto(
     int? RewardMoney,
     string? RewardNotes);
 
+// Per-game monster assignment
+public record GameMonsterDto(int GameId, int MonsterId, string MonsterName);
+
+public record CreateGameMonsterDto(int GameId, int MonsterId);
+
 // Loot
 public record MonsterLootDto(int MonsterId, int ItemId, string ItemName, int GameId, int Quantity);
 


### PR DESCRIPTION
## Summary
- New `GameMonster` join entity for per-game monster assignment (same pattern as GameItem/GameBuilding)
- Monster page gets catalog/game-mode toggle with Přidat/Odebrat buttons
- Empty state messages on all 8 domain pages — catalog pages link to catalog, per-game pages show create button

## Test plan
- [x] Build: 0 warnings, 0 errors
- [x] 133 integration tests pass
- [ ] Manual: verify monster catalog toggle works (assign/unassign)
- [ ] Manual: verify empty states appear on all pages when no items linked
- [ ] Manual: verify "Otevřít katalog" button navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)