### PR TITLE
feat: SecretStash catalog refactor + item Effect column

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/TreasureConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/TreasureConfiguration.cs
@@ -10,12 +10,19 @@ public class SecretStashConfiguration : IEntityTypeConfiguration<SecretStash>
     {
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Name).IsRequired().HasMaxLength(200);
-        builder.HasIndex(e => new { e.GameId, e.Name }).IsUnique();
-        builder.HasOne(e => e.Location).WithMany(l => l.SecretStashes).HasForeignKey(e => e.LocationId);
-        builder.HasOne(e => e.Game).WithMany(g => g.SecretStashes).HasForeignKey(e => e.GameId);
+        builder.HasIndex(e => e.Name).IsUnique();
+    }
+}
 
-        // Max 3 secret stashes per location per game — enforced at API level
-        // (CHECK constraints on count require triggers in PostgreSQL)
+public class GameSecretStashConfiguration : IEntityTypeConfiguration<GameSecretStash>
+{
+    public void Configure(EntityTypeBuilder<GameSecretStash> builder)
+    {
+        builder.HasKey(e => new { e.GameId, e.SecretStashId });
+        builder.HasOne(e => e.Game).WithMany(g => g.GameSecretStashes).HasForeignKey(e => e.GameId);
+        builder.HasOne(e => e.SecretStash).WithMany(s => s.GameSecretStashes).HasForeignKey(e => e.SecretStashId);
+        builder.HasOne(e => e.Location).WithMany(l => l.GameSecretStashes).HasForeignKey(e => e.LocationId);
+        builder.HasIndex(e => e.GameId);
     }
 }
 

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -26,6 +26,7 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<QuestEncounter> QuestEncounters => Set<QuestEncounter>();
     public DbSet<QuestReward> QuestRewards => Set<QuestReward>();
     public DbSet<SecretStash> SecretStashes => Set<SecretStash>();
+    public DbSet<GameSecretStash> GameSecretStashes => Set<GameSecretStash>();
     public DbSet<TreasureQuest> TreasureQuests => Set<TreasureQuest>();
     public DbSet<TreasureItem> TreasureItems => Set<TreasureItem>();
     public DbSet<GameTimeSlot> GameTimeSlots => Set<GameTimeSlot>();

--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -38,7 +38,7 @@ public static class ItemEndpoints
     {
         var items = await db.Items
             .OrderBy(i => i.Name)
-            .Select(i => new ItemListDto(i.Id, i.Name, i.ItemType, i.IsCraftable, i.IsUnique, i.IsLimited))
+            .Select(i => new ItemListDto(i.Id, i.Name, i.ItemType, i.Effect, i.IsCraftable, i.IsUnique, i.IsLimited))
             .ToListAsync();
         return TypedResults.Ok(items);
     }
@@ -176,7 +176,7 @@ public static class ItemEndpoints
             var required = cr.GetRequirement(playerClass);
             return required > 0 && level >= required;
         })
-        .Select(i => new ItemListDto(i.Id, i.Name, i.ItemType, i.IsCraftable, i.IsUnique, i.IsLimited))
+        .Select(i => new ItemListDto(i.Id, i.Name, i.ItemType, i.Effect, i.IsCraftable, i.IsUnique, i.IsLimited))
         .OrderBy(i => i.Name)
         .ToList();
 

--- a/src/OvcinaHra.Api/Endpoints/SecretStashEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SecretStashEndpoints.cs
@@ -12,22 +12,29 @@ public static class SecretStashEndpoints
     {
         var group = routes.MapGroup("/api/secret-stashes").WithTags("SecretStashes");
 
-        group.MapGet("/by-game/{gameId:int}", GetByGame);
+        // Catalog CRUD
+        group.MapGet("/", GetAll);
         group.MapGet("/{id:int}", GetById);
         group.MapPost("/", Create);
         group.MapPut("/{id:int}", Update);
         group.MapDelete("/{id:int}", Delete);
 
+        // Per-game assignment
+        group.MapGet("/by-game/{gameId:int}", GetByGame);
+        group.MapPost("/game-stash", CreateGameStash);
+        group.MapPut("/game-stash/{gameId:int}/{stashId:int}", UpdateGameStash);
+        group.MapDelete("/game-stash/{gameId:int}/{stashId:int}", DeleteGameStash);
+
         return group;
     }
 
-    private static async Task<Ok<List<SecretStashListDto>>> GetByGame(int gameId, WorldDbContext db)
+    // --- Catalog ---
+
+    private static async Task<Ok<List<SecretStashListDto>>> GetAll(WorldDbContext db)
     {
         var stashes = await db.SecretStashes
-            .Where(s => s.GameId == gameId)
-            .Include(s => s.Location)
             .OrderBy(s => s.Name)
-            .Select(s => new SecretStashListDto(s.Id, s.Name, s.LocationId, s.Location.Name, s.GameId))
+            .Select(s => new SecretStashListDto(s.Id, s.Name, s.Description))
             .ToListAsync();
         return TypedResults.Ok(stashes);
     }
@@ -36,40 +43,22 @@ public static class SecretStashEndpoints
     {
         var s = await db.SecretStashes.FindAsync(id);
         if (s is null) return TypedResults.NotFound();
-        return TypedResults.Ok(new SecretStashDetailDto(s.Id, s.Name, s.Description, s.ImagePath, s.LocationId, s.GameId));
+        return TypedResults.Ok(new SecretStashDetailDto(s.Id, s.Name, s.Description, s.ImagePath));
     }
 
-    private static async Task<Results<Created<SecretStashDetailDto>, ValidationProblem>> Create(CreateSecretStashDto dto, WorldDbContext db)
+    private static async Task<Created<SecretStashDetailDto>> Create(CreateSecretStashDto dto, WorldDbContext db)
     {
-        // Max 3 per location per game
-        var count = await db.SecretStashes.CountAsync(s => s.GameId == dto.GameId && s.LocationId == dto.LocationId);
-        if (count >= 3)
-        {
-            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
-            {
-                ["LocationId"] = ["Maximálně 3 tajné skrýše na lokaci za hru."]
-            });
-        }
-
-        var stash = new SecretStash
-        {
-            Name = dto.Name,
-            LocationId = dto.LocationId,
-            GameId = dto.GameId,
-            Description = dto.Description
-        };
+        var stash = new SecretStash { Name = dto.Name, Description = dto.Description };
         db.SecretStashes.Add(stash);
         await db.SaveChangesAsync();
-
         return TypedResults.Created($"/api/secret-stashes/{stash.Id}",
-            new SecretStashDetailDto(stash.Id, stash.Name, stash.Description, stash.ImagePath, stash.LocationId, stash.GameId));
+            new SecretStashDetailDto(stash.Id, stash.Name, stash.Description, stash.ImagePath));
     }
 
     private static async Task<Results<NoContent, NotFound>> Update(int id, UpdateSecretStashDto dto, WorldDbContext db)
     {
         var s = await db.SecretStashes.FindAsync(id);
         if (s is null) return TypedResults.NotFound();
-
         s.Name = dto.Name;
         s.Description = dto.Description;
         await db.SaveChangesAsync();
@@ -81,6 +70,69 @@ public static class SecretStashEndpoints
         var s = await db.SecretStashes.FindAsync(id);
         if (s is null) return TypedResults.NotFound();
         db.SecretStashes.Remove(s);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    // --- Per-game assignment ---
+
+    private static async Task<Ok<List<GameSecretStashDto>>> GetByGame(int gameId, WorldDbContext db)
+    {
+        var stashes = await db.GameSecretStashes
+            .Where(gs => gs.GameId == gameId)
+            .Include(gs => gs.SecretStash)
+            .Include(gs => gs.Location)
+            .OrderBy(gs => gs.SecretStash.Name)
+            .Select(gs => new GameSecretStashDto(gs.GameId, gs.SecretStashId, gs.SecretStash.Name, gs.LocationId, gs.Location.Name))
+            .ToListAsync();
+        return TypedResults.Ok(stashes);
+    }
+
+    private static async Task<Results<Created<GameSecretStashDto>, Conflict, ValidationProblem>> CreateGameStash(
+        CreateGameSecretStashDto dto, WorldDbContext db)
+    {
+        if (await db.GameSecretStashes.AnyAsync(gs => gs.GameId == dto.GameId && gs.SecretStashId == dto.SecretStashId))
+            return TypedResults.Conflict();
+
+        // Max 3 per location per game
+        var count = await db.GameSecretStashes.CountAsync(gs => gs.GameId == dto.GameId && gs.LocationId == dto.LocationId);
+        if (count >= 3)
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["LocationId"] = ["Maximálně 3 tajné skrýše na lokaci za hru."]
+            });
+        }
+
+        db.GameSecretStashes.Add(new GameSecretStash
+        {
+            GameId = dto.GameId,
+            SecretStashId = dto.SecretStashId,
+            LocationId = dto.LocationId
+        });
+        await db.SaveChangesAsync();
+
+        var stashName = (await db.SecretStashes.FindAsync(dto.SecretStashId))?.Name ?? "";
+        var locName = (await db.Locations.FindAsync(dto.LocationId))?.Name ?? "";
+        return TypedResults.Created($"/api/secret-stashes/game-stash/{dto.GameId}/{dto.SecretStashId}",
+            new GameSecretStashDto(dto.GameId, dto.SecretStashId, stashName, dto.LocationId, locName));
+    }
+
+    private static async Task<Results<NoContent, NotFound>> UpdateGameStash(
+        int gameId, int stashId, UpdateGameSecretStashDto dto, WorldDbContext db)
+    {
+        var gs = await db.GameSecretStashes.FindAsync(gameId, stashId);
+        if (gs is null) return TypedResults.NotFound();
+        gs.LocationId = dto.LocationId;
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound>> DeleteGameStash(int gameId, int stashId, WorldDbContext db)
+    {
+        var gs = await db.GameSecretStashes.FindAsync(gameId, stashId);
+        if (gs is null) return TypedResults.NotFound();
+        db.GameSecretStashes.Remove(gs);
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -151,7 +151,8 @@ public static class TreasurePlanningEndpoints
 
         var locations = await db.Locations
             .Where(l => gameLocationIds.Contains(l.Id))
-            .Include(l => l.SecretStashes.Where(s => s.GameId == gameId))
+            .Include(l => l.GameSecretStashes.Where(gs => gs.GameId == gameId))
+            .ThenInclude(gs => gs.SecretStash)
             .OrderBy(l => l.Name)
             .ToListAsync();
 
@@ -164,17 +165,17 @@ public static class TreasurePlanningEndpoints
         var result = locations.Select(loc =>
         {
             var locationQuests = quests.Where(q => q.LocationId == loc.Id).ToList();
-            var stashIds = loc.SecretStashes.Select(s => s.Id).ToHashSet();
+            var stashIds = loc.GameSecretStashes.Select(gs => gs.SecretStashId).ToHashSet();
             var stashQuests = quests.Where(q => q.SecretStashId.HasValue && stashIds.Contains(q.SecretStashId.Value)).ToList();
             var allQuests = locationQuests.Concat(stashQuests).ToList();
 
             int CountByDifficulty(TreasureQuestDifficulty d) =>
                 allQuests.Where(q => q.Difficulty == d).SelectMany(q => q.TreasureItems).Sum(ti => ti.Count);
 
-            var stashSummaries = loc.SecretStashes.Select(s =>
+            var stashSummaries = loc.GameSecretStashes.Select(gs =>
             {
-                var sQuests = quests.Where(q => q.SecretStashId == s.Id).ToList();
-                return new StashSummaryDto(s.Id, s.Name, sQuests.SelectMany(q => q.TreasureItems).Sum(ti => ti.Count));
+                var sQuests = quests.Where(q => q.SecretStashId == gs.SecretStashId).ToList();
+                return new StashSummaryDto(gs.SecretStashId, gs.SecretStash.Name, sQuests.SelectMany(q => q.TreasureItems).Sum(ti => ti.Count));
             }).ToList();
 
             return new TreasurePlanningLocationDto(
@@ -184,7 +185,7 @@ public static class TreasurePlanningEndpoints
                 CountByDifficulty(TreasureQuestDifficulty.Midgame),
                 CountByDifficulty(TreasureQuestDifficulty.Lategame),
                 allQuests.SelectMany(q => q.TreasureItems).Sum(ti => ti.Count),
-                loc.SecretStashes.Count, 3,
+                loc.GameSecretStashes.Count, 3,
                 stashSummaries);
         }).ToList();
 

--- a/src/OvcinaHra.Api/Migrations/20260412171216_RefactorSecretStashCatalog.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260412171216_RefactorSecretStashCatalog.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260412171216_RefactorSecretStashCatalog")]
+    partial class RefactorSecretStashCatalog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260412171216_RefactorSecretStashCatalog.cs
+++ b/src/OvcinaHra.Api/Migrations/20260412171216_RefactorSecretStashCatalog.cs
@@ -1,0 +1,142 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class RefactorSecretStashCatalog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_SecretStashes_Games_GameId",
+                table: "SecretStashes");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SecretStashes_Locations_LocationId",
+                table: "SecretStashes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SecretStashes_GameId_Name",
+                table: "SecretStashes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SecretStashes_LocationId",
+                table: "SecretStashes");
+
+            migrationBuilder.DropColumn(
+                name: "GameId",
+                table: "SecretStashes");
+
+            migrationBuilder.DropColumn(
+                name: "LocationId",
+                table: "SecretStashes");
+
+            migrationBuilder.CreateTable(
+                name: "GameSecretStashes",
+                columns: table => new
+                {
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    SecretStashId = table.Column<int>(type: "integer", nullable: false),
+                    LocationId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameSecretStashes", x => new { x.GameId, x.SecretStashId });
+                    table.ForeignKey(
+                        name: "FK_GameSecretStashes_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GameSecretStashes_Locations_LocationId",
+                        column: x => x.LocationId,
+                        principalTable: "Locations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GameSecretStashes_SecretStashes_SecretStashId",
+                        column: x => x.SecretStashId,
+                        principalTable: "SecretStashes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SecretStashes_Name",
+                table: "SecretStashes",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameSecretStashes_GameId",
+                table: "GameSecretStashes",
+                column: "GameId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameSecretStashes_LocationId",
+                table: "GameSecretStashes",
+                column: "LocationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameSecretStashes_SecretStashId",
+                table: "GameSecretStashes",
+                column: "SecretStashId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GameSecretStashes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SecretStashes_Name",
+                table: "SecretStashes");
+
+            migrationBuilder.AddColumn<int>(
+                name: "GameId",
+                table: "SecretStashes",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "LocationId",
+                table: "SecretStashes",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SecretStashes_GameId_Name",
+                table: "SecretStashes",
+                columns: new[] { "GameId", "Name" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SecretStashes_LocationId",
+                table: "SecretStashes",
+                column: "LocationId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SecretStashes_Games_GameId",
+                table: "SecretStashes",
+                column: "GameId",
+                principalTable: "Games",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SecretStashes_Locations_LocationId",
+                table: "SecretStashes",
+                column: "LocationId",
+                principalTable: "Locations",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -35,6 +35,7 @@ else
                 RowClick="@(e => OpenModal((ItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
+            <DxGridDataColumn FieldName="Effect" Caption="Efekt" />
             <DxGridDataColumn FieldName="ItemType" Caption="Typ" Width="150px">
                 <CellDisplayTemplate>@(((ItemType)context.Value).GetDisplayName())</CellDisplayTemplate>
             </DxGridDataColumn>

--- a/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
+++ b/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
@@ -6,41 +6,71 @@
 @implements IDisposable
 
 <div class="d-flex justify-content-between align-items-center mb-3">
-    <h1 class="mb-0">Tajné skrýše</h1>
-    <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová skrýš</button>
+    <h1 class="mb-0">@(Catalog ? "Katalog tajných skrýší" : "Tajné skrýše")</h1>
+    <div class="d-flex gap-2">
+        <div class="d-flex gap-2">
+            <button class="btn btn-sm @(Catalog ? "btn-outline-primary" : "btn-primary")"
+                    @onclick='() => Nav.NavigateTo("/secret-stashes")'>Jen tato hra</button>
+            <button class="btn btn-sm @(Catalog ? "btn-primary" : "btn-outline-primary")"
+                    @onclick='() => Nav.NavigateTo("/secret-stashes?catalog=true")'>Katalog</button>
+        </div>
+        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová skrýš</button>
+    </div>
 </div>
 
 @if (loading) { <p>Načítám...</p> }
-else if (stashes.Count == 0)
+else if (!Catalog && gameStashes.Count == 0)
 {
     <div class="text-center text-muted py-5">
         <i class="bi bi-lock fs-1 d-block mb-2"></i>
-        <p>Žádné tajné skrýše pro tuto hru.</p>
-        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová skrýš</button>
+        <p>Žádné tajné skrýše přiřazeny k této hře.</p>
+        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/secret-stashes?catalog=true")'>Otevřít katalog</button>
     </div>
 }
-else
+else if (Catalog)
 {
-    <OvcinaGrid Data="@stashes" KeyFieldName="Id" LayoutKey="grid-layout-secret-stashes"
+    <OvcinaGrid Data="@catalogStashes" KeyFieldName="Id" LayoutKey="grid-layout-stashes-catalog"
                 RowClick="@(e => OpenModal((SecretStashListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
+            <DxGridDataColumn FieldName="Description" Caption="Popis" />
+            <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{
+                        var stashId = (int)context.Value;
+                        if (assignedStashIds.Contains(stashId))
+                        {
+                            <button class="btn btn-sm btn-outline-danger" @onclick:stopPropagation="true"
+                                    @onclick="() => UnassignStashAsync(stashId)">Odebrat</button>
+                        }
+                        else
+                        {
+                            <button class="btn btn-sm btn-outline-success" @onclick:stopPropagation="true"
+                                    @onclick="() => OpenAssignPopup(stashId)">Přidat</button>
+                        }
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+        </Columns>
+    </OvcinaGrid>
+}
+else
+{
+    <OvcinaGrid Data="@gameStashes" KeyFieldName="SecretStashId" LayoutKey="grid-layout-stashes-game"
+                RowClick="@(e => OpenGameStashDetail((GameSecretStashDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+        <Columns>
+            <DxGridDataColumn FieldName="StashName" Caption="Název" />
             <DxGridDataColumn FieldName="LocationName" Caption="Lokace" Width="200px" />
-            <DxGridDataColumn FieldName="GameId" Caption="Hra ID" Width="80px" Visible="false" />
         </Columns>
     </OvcinaGrid>
 }
 
+@* Edit popup (catalog) *@
 <DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="550px">
     <BodyContentTemplate Context="popupContext">
         <DxFormLayout>
             <DxFormLayoutItem Caption="Název" ColSpanMd="12">
                 <DxTextBox @bind-Text="@name" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
-                <DxComboBox Data="@gameLocations" @bind-Value="@locationId"
-                            TextFieldName="Name" ValueFieldName="Id"
-                            NullText="Vyberte lokaci..." />
             </DxFormLayoutItem>
             <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
                 <DxMemo @bind-Text="@description" Rows="3" />
@@ -56,6 +86,7 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+@* Delete confirmation *@
 <DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
     <BodyContentTemplate Context="popupContext">
         <p>Smazat skrýš <strong>@name</strong>?</p>
@@ -66,49 +97,115 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+@* Assign to game popup (pick location) *@
+<DxPopup @bind-Visible="@isAssignVisible" HeaderText="Přiřadit skrýš k hře" Width="450px">
+    <BodyContentTemplate Context="popupContext">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
+                <DxComboBox Data="@gameLocations" @bind-Value="@assignLocationId"
+                            TextFieldName="Name" ValueFieldName="Id"
+                            NullText="Vyberte lokaci..." SearchMode="ListSearchMode.AutoSearch" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        @if (assignError is not null) { <div class="alert alert-danger mt-2">@assignError</div> }
+        <div class="d-flex gap-2 mt-3 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isAssignVisible = false">Zrušit</button>
+            <button class="btn btn-primary" @onclick="ConfirmAssignAsync" disabled="@(assignLocationId is null)">Přidat do hry</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @code {
-    private List<SecretStashListDto> stashes = [];
-    private List<LocationListDto> gameLocations = [];
+    [SupplyParameterFromQuery]
+    public bool Catalog { get; set; }
+
+    // Catalog state
+    private List<SecretStashListDto> catalogStashes = [];
     private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
     private string modalTitle = "", name = "";
     private string? error, description;
-    private int? editingId, locationId;
+    private int? editingId;
+
+    // Game state
+    private List<GameSecretStashDto> gameStashes = [];
+    private HashSet<int> assignedStashIds = [];
+
+    // Assign popup state
+    private bool isAssignVisible;
+    private int? assignStashId, assignLocationId;
+    private string? assignError;
+    private List<LocationListDto> gameLocations = [];
+
     private int gameId => GameContext.SelectedGameId ?? 1;
 
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
         GameContext.OnGameChanged += OnGameChanged;
+        await LoadLocationsAsync();
         await LoadAsync();
+    }
+
+    private async Task LoadLocationsAsync()
+    {
+        if (GameContext.SelectedGameId is int gid)
+            gameLocations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gid}");
     }
 
     private async Task LoadAsync()
     {
         loading = true;
-        stashes = await Api.GetListAsync<SecretStashListDto>($"/api/secret-stashes/by-game/{gameId}");
+
+        if (Catalog)
+        {
+            catalogStashes = await Api.GetListAsync<SecretStashListDto>("/api/secret-stashes");
+            if (GameContext.SelectedGameId is int gid)
+            {
+                var gs = await Api.GetListAsync<GameSecretStashDto>($"/api/secret-stashes/by-game/{gid}");
+                assignedStashIds = gs.Select(g => g.SecretStashId).ToHashSet();
+            }
+        }
+        else
+        {
+            if (GameContext.SelectedGameId is int gid)
+                gameStashes = await Api.GetListAsync<GameSecretStashDto>($"/api/secret-stashes/by-game/{gid}");
+            else
+                gameStashes = [];
+        }
+
         loading = false;
     }
 
-    private async void OnGameChanged() { await LoadAsync(); StateHasChanged(); }
+    private async void OnGameChanged() { await LoadLocationsAsync(); await LoadAsync(); StateHasChanged(); }
     public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
 
-    private async void OpenModal(SecretStashListDto? s)
+    private void OpenModal(SecretStashListDto? s)
     {
         error = null;
-        gameLocations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gameId}");
         if (s is null)
         {
-            editingId = null; name = ""; description = null; locationId = null;
+            editingId = null; name = ""; description = null;
             modalTitle = "Nová tajná skrýš";
         }
         else
         {
-            editingId = s.Id; name = s.Name; locationId = s.LocationId;
+            editingId = s.Id; name = s.Name; description = s.Description;
             modalTitle = $"Upravit: {s.Name}";
-            var detail = await Api.GetAsync<SecretStashDetailDto>($"/api/secret-stashes/{s.Id}");
-            if (detail is not null) { description = detail.Description; }
         }
         isModalVisible = true;
+    }
+
+    private void OpenGameStashDetail(GameSecretStashDto gs)
+    {
+        // Open catalog edit for the underlying stash
+        OpenModal(new SecretStashListDto(gs.SecretStashId, gs.StashName, null));
+        _ = LoadStashDetailAsync(gs.SecretStashId);
+    }
+
+    private async Task LoadStashDetailAsync(int id)
+    {
+        var d = await Api.GetAsync<SecretStashDetailDto>($"/api/secret-stashes/{id}");
+        if (d is not null) { description = d.Description; }
         StateHasChanged();
     }
 
@@ -117,13 +214,13 @@ else
         error = null; isSaving = true;
         try
         {
-            if (locationId is null) { error = "Lokace je povinná."; return; }
             if (editingId.HasValue)
                 await Api.PutAsync($"/api/secret-stashes/{editingId}", new UpdateSecretStashDto(name, description));
             else
                 await Api.PostAsync<CreateSecretStashDto, SecretStashDetailDto>("/api/secret-stashes",
-                    new CreateSecretStashDto(name, locationId.Value, gameId, description));
-            isModalVisible = false; await LoadAsync();
+                    new CreateSecretStashDto(name, description));
+            isModalVisible = false;
+            await LoadAsync();
             StateHasChanged();
         }
         catch (Exception ex) { error = ex.Message; }
@@ -139,5 +236,41 @@ else
             await LoadAsync(); StateHasChanged();
         }
         catch (Exception ex) { error = ex.Message; }
+    }
+
+    // --- Assign / Unassign ---
+
+    private void OpenAssignPopup(int stashId)
+    {
+        assignStashId = stashId;
+        assignLocationId = null;
+        assignError = null;
+        isAssignVisible = true;
+    }
+
+    private async Task ConfirmAssignAsync()
+    {
+        if (assignStashId is null || assignLocationId is null) return;
+        assignError = null;
+        try
+        {
+            await Api.PostAsync<CreateGameSecretStashDto, GameSecretStashDto>("/api/secret-stashes/game-stash",
+                new CreateGameSecretStashDto(gameId, assignStashId.Value, assignLocationId.Value));
+            assignedStashIds.Add(assignStashId.Value);
+            isAssignVisible = false;
+            StateHasChanged();
+        }
+        catch (Exception ex) { assignError = ex.Message; }
+    }
+
+    private async Task UnassignStashAsync(int stashId)
+    {
+        try
+        {
+            await Api.DeleteAsync($"/api/secret-stashes/game-stash/{gameId}/{stashId}");
+            assignedStashIds.Remove(stashId);
+            StateHasChanged();
+        }
+        catch (Exception ex) { error = ex.Message; StateHasChanged(); }
     }
 }

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -267,7 +267,7 @@ else
             {
                 <DxFormLayoutItem Caption="Skrýš" ColSpanMd="12">
                     <DxComboBox Data="@editStashesFiltered" @bind-Value="@editStashId"
-                                TextFieldName="Name" ValueFieldName="Id"
+                                TextFieldName="StashName" ValueFieldName="SecretStashId"
                                 NullText="Vyberte skrýš..." ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
                 </DxFormLayoutItem>
             }
@@ -367,8 +367,8 @@ else
     private bool editToStash;
     private List<TreasureItemDto> editQuestItems = [];
     private List<LocationListDto> editLocations = [];
-    private List<SecretStashListDto> editStashes = [];
-    private List<SecretStashListDto> editStashesFiltered =>
+    private List<GameSecretStashDto> editStashes = [];
+    private List<GameSecretStashDto> editStashesFiltered =>
         editLocationId.HasValue
             ? editStashes.Where(s => s.LocationId == editLocationId.Value).ToList()
             : editStashes;
@@ -529,7 +529,7 @@ else
     private async Task LoadEditDetailAsync(int id)
     {
         editLocations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gameId}");
-        editStashes = await Api.GetListAsync<SecretStashListDto>($"/api/secret-stashes/by-game/{gameId}");
+        editStashes = await Api.GetListAsync<GameSecretStashDto>($"/api/secret-stashes/by-game/{gameId}");
         var d = await Api.GetAsync<TreasureQuestDetailDto>($"/api/treasure-quests/{id}");
         if (d is not null)
         {

--- a/src/OvcinaHra.Shared/Domain/Entities/Game.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Game.cs
@@ -20,7 +20,7 @@ public class Game
 
     public ICollection<GameLocation> GameLocations { get; set; } = [];
     public ICollection<GameItem> GameItems { get; set; } = [];
-    public ICollection<SecretStash> SecretStashes { get; set; } = [];
+    public ICollection<GameSecretStash> GameSecretStashes { get; set; } = [];
     public ICollection<GameBuilding> GameBuildings { get; set; } = [];
     public ICollection<CraftingRecipe> CraftingRecipes { get; set; } = [];
     public ICollection<GameMonster> GameMonsters { get; set; } = [];

--- a/src/OvcinaHra.Shared/Domain/Entities/GameSecretStash.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameSecretStash.cs
@@ -1,0 +1,12 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class GameSecretStash
+{
+    public int GameId { get; set; }
+    public int SecretStashId { get; set; }
+    public int LocationId { get; set; }
+
+    public Game Game { get; set; } = null!;
+    public SecretStash SecretStash { get; set; } = null!;
+    public Location Location { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/Location.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Location.cs
@@ -29,7 +29,7 @@ public class Location
     public ICollection<Location> Variants { get; set; } = [];
 
     public ICollection<GameLocation> GameLocations { get; set; } = [];
-    public ICollection<SecretStash> SecretStashes { get; set; } = [];
+    public ICollection<GameSecretStash> GameSecretStashes { get; set; } = [];
     public ICollection<Building> Buildings { get; set; } = [];
     public ICollection<QuestLocationLink> QuestLocations { get; set; } = [];
     public ICollection<TreasureQuest> TreasureQuests { get; set; } = [];

--- a/src/OvcinaHra.Shared/Domain/Entities/SecretStash.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/SecretStash.cs
@@ -6,10 +6,7 @@ public class SecretStash
     public required string Name { get; set; }
     public string? Description { get; set; }
     public string? ImagePath { get; set; }
-    public int LocationId { get; set; }
-    public int GameId { get; set; }
 
-    public Location Location { get; set; } = null!;
-    public Game Game { get; set; } = null!;
+    public ICollection<GameSecretStash> GameSecretStashes { get; set; } = [];
     public ICollection<TreasureQuest> TreasureQuests { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
@@ -2,7 +2,7 @@ using OvcinaHra.Shared.Domain.Enums;
 
 namespace OvcinaHra.Shared.Dtos;
 
-public record ItemListDto(int Id, string Name, ItemType ItemType, bool IsCraftable, bool IsUnique, bool IsLimited);
+public record ItemListDto(int Id, string Name, ItemType ItemType, string? Effect, bool IsCraftable, bool IsUnique, bool IsLimited);
 
 public record ItemDetailDto(
     int Id,

--- a/src/OvcinaHra.Shared/Dtos/SecretStashDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/SecretStashDtos.cs
@@ -1,21 +1,17 @@
 namespace OvcinaHra.Shared.Dtos;
 
-public record SecretStashListDto(int Id, string Name, int LocationId, string LocationName, int GameId);
+// Catalog (master list)
+public record SecretStashListDto(int Id, string Name, string? Description);
 
-public record SecretStashDetailDto(
-    int Id,
-    string Name,
-    string? Description,
-    string? ImagePath,
-    int LocationId,
-    int GameId);
+public record SecretStashDetailDto(int Id, string Name, string? Description, string? ImagePath);
 
-public record CreateSecretStashDto(
-    string Name,
-    int LocationId,
-    int GameId,
-    string? Description = null);
+public record CreateSecretStashDto(string Name, string? Description = null);
 
-public record UpdateSecretStashDto(
-    string Name,
-    string? Description);
+public record UpdateSecretStashDto(string Name, string? Description);
+
+// Per-game assignment
+public record GameSecretStashDto(int GameId, int SecretStashId, string StashName, int LocationId, string LocationName);
+
+public record CreateGameSecretStashDto(int GameId, int SecretStashId, int LocationId);
+
+public record UpdateGameSecretStashDto(int LocationId);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/SecretStashEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/SecretStashEndpointTests.cs
@@ -8,15 +8,12 @@ namespace OvcinaHra.Api.Tests.Endpoints;
 
 public class SecretStashEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
 {
+    // --- Catalog CRUD ---
+
     [Fact]
-    public async Task GetByGame_Empty_ReturnsEmptyList()
+    public async Task GetAll_Empty_ReturnsEmptyList()
     {
-        var gameResponse = await Client.PostAsJsonAsync("/api/games",
-            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
-        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
-
-        var stashes = await Client.GetFromJsonAsync<List<SecretStashListDto>>($"/api/secret-stashes/by-game/{game!.Id}");
-
+        var stashes = await Client.GetFromJsonAsync<List<SecretStashListDto>>("/api/secret-stashes");
         Assert.NotNull(stashes);
         Assert.Empty(stashes);
     }
@@ -24,39 +21,21 @@ public class SecretStashEndpointTests(PostgresFixture postgres) : IntegrationTes
     [Fact]
     public async Task Create_ValidStash_ReturnsCreated()
     {
-        var gameResponse = await Client.PostAsJsonAsync("/api/games",
-            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
-        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
-
-        var locationResponse = await Client.PostAsJsonAsync("/api/locations",
-            new CreateLocationDto("Hora", LocationKind.Wilderness, 49.5m, 17.1m));
-        var location = await locationResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
-
-        var dto = new CreateSecretStashDto("Tajná skrýš u dubu", location!.Id, game!.Id);
-
-        var response = await Client.PostAsJsonAsync("/api/secret-stashes", dto);
+        var response = await Client.PostAsJsonAsync("/api/secret-stashes",
+            new CreateSecretStashDto("Tajná skrýš u dubu", "Pod kořenem"));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         var created = await response.Content.ReadFromJsonAsync<SecretStashDetailDto>();
         Assert.NotNull(created);
         Assert.Equal("Tajná skrýš u dubu", created.Name);
-        Assert.Equal(location.Id, created.LocationId);
-        Assert.Equal(game.Id, created.GameId);
+        Assert.Equal("Pod kořenem", created.Description);
     }
 
     [Fact]
     public async Task GetById_ExistingStash_ReturnsStash()
     {
-        var gameResponse = await Client.PostAsJsonAsync("/api/games",
-            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
-        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
-
-        var locationResponse = await Client.PostAsJsonAsync("/api/locations",
-            new CreateLocationDto("Hora", LocationKind.Wilderness, 49.5m, 17.1m));
-        var location = await locationResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
-
         var createResponse = await Client.PostAsJsonAsync("/api/secret-stashes",
-            new CreateSecretStashDto("Tajná skrýš u dubu", location!.Id, game!.Id));
+            new CreateSecretStashDto("Tajná skrýš u dubu"));
         var created = await createResponse.Content.ReadFromJsonAsync<SecretStashDetailDto>();
 
         var response = await Client.GetAsync($"/api/secret-stashes/{created!.Id}");
@@ -72,28 +51,18 @@ public class SecretStashEndpointTests(PostgresFixture postgres) : IntegrationTes
     public async Task GetById_NonExistent_ReturnsNotFound()
     {
         var response = await Client.GetAsync("/api/secret-stashes/999999");
-
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
     public async Task Update_ExistingStash_ReturnsNoContent()
     {
-        var gameResponse = await Client.PostAsJsonAsync("/api/games",
-            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
-        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
-
-        var locationResponse = await Client.PostAsJsonAsync("/api/locations",
-            new CreateLocationDto("Hora", LocationKind.Wilderness, 49.5m, 17.1m));
-        var location = await locationResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
-
         var createResponse = await Client.PostAsJsonAsync("/api/secret-stashes",
-            new CreateSecretStashDto("Tajná skrýš u dubu", location!.Id, game!.Id));
+            new CreateSecretStashDto("Tajná skrýš u dubu"));
         var created = await createResponse.Content.ReadFromJsonAsync<SecretStashDetailDto>();
 
-        var updateDto = new UpdateSecretStashDto("Přejmenovaná skrýš", "Nový popis");
-
-        var response = await Client.PutAsJsonAsync($"/api/secret-stashes/{created!.Id}", updateDto);
+        var response = await Client.PutAsJsonAsync($"/api/secret-stashes/{created!.Id}",
+            new UpdateSecretStashDto("Přejmenovaná skrýš", "Nový popis"));
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
     }
@@ -101,16 +70,8 @@ public class SecretStashEndpointTests(PostgresFixture postgres) : IntegrationTes
     [Fact]
     public async Task Delete_ExistingStash_ReturnsNoContent()
     {
-        var gameResponse = await Client.PostAsJsonAsync("/api/games",
-            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
-        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
-
-        var locationResponse = await Client.PostAsJsonAsync("/api/locations",
-            new CreateLocationDto("Hora", LocationKind.Wilderness, 49.5m, 17.1m));
-        var location = await locationResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
-
         var createResponse = await Client.PostAsJsonAsync("/api/secret-stashes",
-            new CreateSecretStashDto("Tajná skrýš u dubu", location!.Id, game!.Id));
+            new CreateSecretStashDto("Tajná skrýš u dubu"));
         var created = await createResponse.Content.ReadFromJsonAsync<SecretStashDetailDto>();
 
         var response = await Client.DeleteAsync($"/api/secret-stashes/{created!.Id}");
@@ -118,47 +79,126 @@ public class SecretStashEndpointTests(PostgresFixture postgres) : IntegrationTes
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
     }
 
+    // --- Per-game assignment ---
+
     [Fact]
-    public async Task Create_ThreeStashesAtSameLocation_AllSucceed()
+    public async Task GetByGame_Empty_ReturnsEmptyList()
     {
         var gameResponse = await Client.PostAsJsonAsync("/api/games",
             new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
         var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
 
-        var locationResponse = await Client.PostAsJsonAsync("/api/locations",
-            new CreateLocationDto("Hora", LocationKind.Wilderness, 49.5m, 17.1m));
-        var location = await locationResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+        var stashes = await Client.GetFromJsonAsync<List<GameSecretStashDto>>($"/api/secret-stashes/by-game/{game!.Id}");
 
-        var r1 = await Client.PostAsJsonAsync("/api/secret-stashes",
-            new CreateSecretStashDto("Skrýš 1", location!.Id, game!.Id));
-        var r2 = await Client.PostAsJsonAsync("/api/secret-stashes",
-            new CreateSecretStashDto("Skrýš 2", location.Id, game.Id));
-        var r3 = await Client.PostAsJsonAsync("/api/secret-stashes",
-            new CreateSecretStashDto("Skrýš 3", location.Id, game.Id));
-
-        Assert.Equal(HttpStatusCode.Created, r1.StatusCode);
-        Assert.Equal(HttpStatusCode.Created, r2.StatusCode);
-        Assert.Equal(HttpStatusCode.Created, r3.StatusCode);
+        Assert.NotNull(stashes);
+        Assert.Empty(stashes);
     }
 
     [Fact]
-    public async Task Create_FourthAtSameLocation_Returns422()
+    public async Task AssignToGame_ValidStash_ReturnsCreated()
+    {
+        var (game, location, stash) = await CreateGameLocationStash();
+
+        var response = await Client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+            new CreateGameSecretStashDto(game.Id, stash.Id, location.Id));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var assigned = await response.Content.ReadFromJsonAsync<GameSecretStashDto>();
+        Assert.NotNull(assigned);
+        Assert.Equal(stash.Id, assigned.SecretStashId);
+        Assert.Equal(location.Id, assigned.LocationId);
+    }
+
+    [Fact]
+    public async Task AssignToGame_Duplicate_ReturnsConflict()
+    {
+        var (game, location, stash) = await CreateGameLocationStash();
+
+        await Client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+            new CreateGameSecretStashDto(game.Id, stash.Id, location.Id));
+        var response = await Client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+            new CreateGameSecretStashDto(game.Id, stash.Id, location.Id));
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AssignThreeToSameLocation_AllSucceed()
     {
         var gameResponse = await Client.PostAsJsonAsync("/api/games",
             new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
-        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+        var game = (await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>())!;
 
-        var locationResponse = await Client.PostAsJsonAsync("/api/locations",
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
             new CreateLocationDto("Hora", LocationKind.Wilderness, 49.5m, 17.1m));
-        var location = await locationResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+        var location = (await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>())!;
 
-        await Client.PostAsJsonAsync("/api/secret-stashes", new CreateSecretStashDto("Skrýš 1", location!.Id, game!.Id));
-        await Client.PostAsJsonAsync("/api/secret-stashes", new CreateSecretStashDto("Skrýš 2", location.Id, game.Id));
-        await Client.PostAsJsonAsync("/api/secret-stashes", new CreateSecretStashDto("Skrýš 3", location.Id, game.Id));
+        for (int i = 1; i <= 3; i++)
+        {
+            var s = await Client.PostAsJsonAsync("/api/secret-stashes", new CreateSecretStashDto($"Skrýš {i}"));
+            var stash = (await s.Content.ReadFromJsonAsync<SecretStashDetailDto>())!;
+            var r = await Client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+                new CreateGameSecretStashDto(game.Id, stash.Id, location.Id));
+            Assert.Equal(HttpStatusCode.Created, r.StatusCode);
+        }
+    }
 
-        var response = await Client.PostAsJsonAsync("/api/secret-stashes",
-            new CreateSecretStashDto("Skrýš 4", location.Id, game.Id));
+    [Fact]
+    public async Task AssignFourthToSameLocation_Returns422()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = (await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>())!;
+
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Hora", LocationKind.Wilderness, 49.5m, 17.1m));
+        var location = (await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>())!;
+
+        for (int i = 1; i <= 3; i++)
+        {
+            var s = await Client.PostAsJsonAsync("/api/secret-stashes", new CreateSecretStashDto($"Skrýš {i}"));
+            var stash = (await s.Content.ReadFromJsonAsync<SecretStashDetailDto>())!;
+            await Client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+                new CreateGameSecretStashDto(game.Id, stash.Id, location.Id));
+        }
+
+        var s4 = await Client.PostAsJsonAsync("/api/secret-stashes", new CreateSecretStashDto("Skrýš 4"));
+        var stash4 = (await s4.Content.ReadFromJsonAsync<SecretStashDetailDto>())!;
+        var response = await Client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+            new CreateGameSecretStashDto(game.Id, stash4.Id, location.Id));
 
         Assert.False(response.IsSuccessStatusCode, "Fourth stash at same location should be rejected");
+    }
+
+    [Fact]
+    public async Task UnassignFromGame_ReturnsNoContent()
+    {
+        var (game, location, stash) = await CreateGameLocationStash();
+
+        await Client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+            new CreateGameSecretStashDto(game.Id, stash.Id, location.Id));
+
+        var response = await Client.DeleteAsync($"/api/secret-stashes/game-stash/{game.Id}/{stash.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    // --- Helper ---
+
+    private async Task<(GameDetailDto Game, LocationDetailDto Location, SecretStashDetailDto Stash)> CreateGameLocationStash()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = (await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>())!;
+
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Hora", LocationKind.Wilderness, 49.5m, 17.1m));
+        var location = (await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>())!;
+
+        var stashResponse = await Client.PostAsJsonAsync("/api/secret-stashes",
+            new CreateSecretStashDto("Tajná skrýš u dubu"));
+        var stash = (await stashResponse.Content.ReadFromJsonAsync<SecretStashDetailDto>())!;
+
+        return (game, location, stash);
     }
 }

--- a/tests/OvcinaHra.E2E/LocationManagementTests.cs
+++ b/tests/OvcinaHra.E2E/LocationManagementTests.cs
@@ -114,17 +114,24 @@ public class LocationManagementTests
             new CreateLocationDto("Stash Loc", LocationKind.Dungeon, 49.5m, 17.1m));
         var loc = await locResp.Content.ReadFromJsonAsync<LocationDetailDto>();
 
-        // Create 3 — should succeed
+        // Create 3 catalog stashes and assign — should succeed
         for (int i = 1; i <= 3; i++)
         {
-            var resp = await client.PostAsJsonAsync("/api/secret-stashes",
-                new CreateSecretStashDto($"Skrýš {i}", loc!.Id, game!.Id));
-            resp.EnsureSuccessStatusCode();
+            var stashResp = await client.PostAsJsonAsync("/api/secret-stashes",
+                new CreateSecretStashDto($"Skrýš {i}"));
+            stashResp.EnsureSuccessStatusCode();
+            var stash = await stashResp.Content.ReadFromJsonAsync<SecretStashDetailDto>();
+            var assignResp = await client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+                new CreateGameSecretStashDto(game!.Id, stash!.Id, loc!.Id));
+            assignResp.EnsureSuccessStatusCode();
         }
 
         // 4th — should fail with validation error
-        var fourthResp = await client.PostAsJsonAsync("/api/secret-stashes",
-            new CreateSecretStashDto("Skrýš 4", loc!.Id, game!.Id));
-        Assert.Equal(System.Net.HttpStatusCode.BadRequest, fourthResp.StatusCode);
+        var s4Resp = await client.PostAsJsonAsync("/api/secret-stashes",
+            new CreateSecretStashDto("Skrýš 4"));
+        var s4 = await s4Resp.Content.ReadFromJsonAsync<SecretStashDetailDto>();
+        var fourthResp = await client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+            new CreateGameSecretStashDto(game!.Id, s4!.Id, loc!.Id));
+        Assert.False(fourthResp.IsSuccessStatusCode);
     }
 }


### PR DESCRIPTION
## Summary
- SecretStash split into reusable catalog entity + `GameSecretStash` join table (per-game location assignment)
- Stash page gets catalog/game toggle with location picker popup on assign
- TreasurePlanning updated to use `GameSecretStash` for stash summaries
- Items grid shows Effect column
- Max 3 stashes per location per game constraint preserved on the join table

## Test plan
- [x] Build: 0 warnings, 0 errors
- [x] 137 integration tests pass (4 new stash tests)
- [ ] Manual: create stash in catalog, assign to game with location
- [ ] Manual: verify treasure planning still shows stash summaries
- [ ] Manual: verify items grid shows Effect column

🤖 Generated with [Claude Code](https://claude.com/claude-code)