### PR TITLE
feat: character per-game snapshot + registrace import [v0.3.1]

### DIFF
--- a/docs/plans/2026-04-12-character-system-implementation.md
+++ b/docs/plans/2026-04-12-character-system-implementation.md
@@ -1,0 +1,540 @@
+# Character System Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add character management + QR scan workflow so organizers can track player characters at LARP events.
+
+**Architecture:** Three new entities (Character, CharacterAssignment, CharacterEvent) with event-sourced progression. Catalog CRUD for characters, per-game assignments, event log per assignment. Scan page `/p/{personId}` is the QR target — mobile-first, quick actions for field use. Import from registrace seed API for initial character population.
+
+**Tech Stack:** EF Core (Npgsql), Minimal API, Blazor WASM, existing PlayerClass enum, existing JWT auth (ClaimTypes.NameIdentifier + ClaimTypes.Name for organizer identity).
+
+**Design doc:** `prompt-hra-character-system.md` (OneDrive secret KB)
+
+**Version:** Bump `src/OvcinaHra.Client/OvcinaHra.Client.csproj` → 0.3.0 (major feature)
+
+---
+
+## Phase 1: Entities + Migrations (Tasks 1-3)
+
+### Task 1: Create Character entity + EF config
+
+**Files:**
+- Create: `src/OvcinaHra.Shared/Domain/Entities/Character.cs`
+- Create: `src/OvcinaHra.Api/Data/Configurations/CharacterConfiguration.cs`
+- Modify: `src/OvcinaHra.Api/Data/WorldDbContext.cs`
+
+**Step 1: Create Character entity**
+
+```csharp
+// src/OvcinaHra.Shared/Domain/Entities/Character.cs
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class Character
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public string? Race { get; set; }
+    public PlayerClass? Class { get; set; }
+    public string? Kingdom { get; set; }
+    public int? BirthYear { get; set; }
+    public string? Notes { get; set; }
+    public bool IsPlayedCharacter { get; set; }
+    public int? ExternalPersonId { get; set; }
+    public int? ParentCharacterId { get; set; }
+    public bool IsDeleted { get; set; }
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public Character? ParentCharacter { get; set; }
+    public ICollection<Character> Children { get; set; } = [];
+    public ICollection<CharacterAssignment> Assignments { get; set; } = [];
+}
+```
+
+**Step 2: Create EF configuration**
+
+```csharp
+// src/OvcinaHra.Api/Data/Configurations/CharacterConfiguration.cs
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class CharacterConfiguration : IEntityTypeConfiguration<Character>
+{
+    public void Configure(EntityTypeBuilder<Character> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Name).IsRequired().HasMaxLength(200);
+        builder.Property(e => e.Class).HasConversion<string>().HasMaxLength(20);
+        builder.HasIndex(e => e.ExternalPersonId).IsUnique().HasFilter("\"ExternalPersonId\" IS NOT NULL");
+        builder.HasOne(e => e.ParentCharacter).WithMany(e => e.Children).HasForeignKey(e => e.ParentCharacterId);
+        builder.HasQueryFilter(e => !e.IsDeleted);
+    }
+}
+```
+
+**Step 3: Add DbSet to WorldDbContext**
+
+Add `public DbSet<Character> Characters => Set<Character>();`
+
+**Step 4: Build to verify compilation**
+
+Run: `dotnet build --nologo -v q`
+
+**Step 5: Commit**
+
+```
+feat: add Character entity with EF config [v0.3.0]
+```
+
+### Task 2: Create CharacterAssignment + CharacterEvent entities
+
+**Files:**
+- Create: `src/OvcinaHra.Shared/Domain/Entities/CharacterAssignment.cs`
+- Create: `src/OvcinaHra.Shared/Domain/Entities/CharacterEvent.cs`
+- Create: `src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs`
+- Modify: `src/OvcinaHra.Api/Data/Configurations/CharacterConfiguration.cs` (add configs)
+- Modify: `src/OvcinaHra.Api/Data/WorldDbContext.cs`
+
+**Step 1: Create CharacterEventType enum**
+
+```csharp
+// src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Domain.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum CharacterEventType
+{
+    [Display(Name = "Zvýšení úrovně")]
+    LevelUp,
+
+    [Display(Name = "Získání dovednosti")]
+    SkillGained,
+
+    [Display(Name = "Změna bodů")]
+    PointsChanged,
+
+    [Display(Name = "Poznámka")]
+    Note,
+
+    [Display(Name = "Volba povolání")]
+    ClassChosen
+}
+```
+
+**Step 2: Create CharacterAssignment entity**
+
+```csharp
+// src/OvcinaHra.Shared/Domain/Entities/CharacterAssignment.cs
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class CharacterAssignment
+{
+    public int Id { get; set; }
+    public int CharacterId { get; set; }
+    public int GameId { get; set; }
+    public int ExternalPersonId { get; set; }
+    public bool IsActive { get; set; } = true;
+    public DateTime StartedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime? EndedAtUtc { get; set; }
+
+    public Character Character { get; set; } = null!;
+    public ICollection<CharacterEvent> Events { get; set; } = [];
+}
+```
+
+Note: `GameId` is an external reference to registrace Game.Id — NOT a local FK to the Game table.
+
+**Step 3: Create CharacterEvent entity**
+
+```csharp
+// src/OvcinaHra.Shared/Domain/Entities/CharacterEvent.cs
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class CharacterEvent
+{
+    public int Id { get; set; }
+    public int CharacterAssignmentId { get; set; }
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    public required string OrganizerUserId { get; set; }
+    public required string OrganizerName { get; set; }
+    public CharacterEventType EventType { get; set; }
+    public required string Data { get; set; }
+    public string? Location { get; set; }
+
+    public CharacterAssignment Assignment { get; set; } = null!;
+}
+```
+
+**Step 4: Add EF configs for Assignment and Event**
+
+Append to `CharacterConfiguration.cs`:
+
+```csharp
+public class CharacterAssignmentConfiguration : IEntityTypeConfiguration<CharacterAssignment>
+{
+    public void Configure(EntityTypeBuilder<CharacterAssignment> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.HasOne(e => e.Character).WithMany(c => c.Assignments).HasForeignKey(e => e.CharacterId);
+        builder.HasIndex(e => e.GameId);
+        builder.HasIndex(e => e.ExternalPersonId);
+        builder.HasIndex(e => e.CharacterId);
+    }
+}
+
+public class CharacterEventConfiguration : IEntityTypeConfiguration<CharacterEvent>
+{
+    public void Configure(EntityTypeBuilder<CharacterEvent> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.EventType).HasConversion<string>().HasMaxLength(30);
+        builder.HasOne(e => e.Assignment).WithMany(a => a.Events).HasForeignKey(e => e.CharacterAssignmentId);
+        builder.HasIndex(e => e.CharacterAssignmentId);
+    }
+}
+```
+
+**Step 5: Add DbSets to WorldDbContext**
+
+```csharp
+public DbSet<CharacterAssignment> CharacterAssignments => Set<CharacterAssignment>();
+public DbSet<CharacterEvent> CharacterEvents => Set<CharacterEvent>();
+```
+
+**Step 6: Build**
+
+**Step 7: Commit**
+
+```
+feat: add CharacterAssignment + CharacterEvent entities [v0.3.0]
+```
+
+### Task 3: Create EF migration
+
+**Step 1: Generate migration**
+
+Run: `dotnet ef migrations add AddCharacterSystem --project src/OvcinaHra.Api --startup-project src/OvcinaHra.Api`
+
+**Step 2: Review migration file** — verify it creates Characters, CharacterAssignments, CharacterEvents tables with correct columns, indexes, and constraints.
+
+**Step 3: Run tests** to ensure migration applies cleanly on Testcontainers DB.
+
+**Step 4: Commit**
+
+```
+chore: add AddCharacterSystem migration [v0.3.0]
+```
+
+---
+
+## Phase 2: Character CRUD API + DTOs (Tasks 4-5)
+
+### Task 4: Create Character DTOs
+
+**Files:**
+- Create: `src/OvcinaHra.Shared/Dtos/CharacterDtos.cs`
+
+```csharp
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Dtos;
+
+public record CharacterListDto(
+    int Id, string Name, string? Race, PlayerClass? Class,
+    string? Kingdom, bool IsPlayedCharacter, int? ExternalPersonId);
+
+public record CharacterDetailDto(
+    int Id, string Name, string? Race, PlayerClass? Class,
+    string? Kingdom, int? BirthYear, string? Notes,
+    bool IsPlayedCharacter, int? ExternalPersonId,
+    int? ParentCharacterId, string? ParentCharacterName,
+    string? ImagePath, DateTime CreatedAtUtc, DateTime UpdatedAtUtc);
+
+public record CreateCharacterDto(
+    string Name,
+    string? Race = null,
+    PlayerClass? Class = null,
+    string? Kingdom = null,
+    int? BirthYear = null,
+    string? Notes = null,
+    bool IsPlayedCharacter = false,
+    int? ExternalPersonId = null,
+    int? ParentCharacterId = null);
+
+public record UpdateCharacterDto(
+    string Name,
+    string? Race,
+    PlayerClass? Class,
+    string? Kingdom,
+    int? BirthYear,
+    string? Notes,
+    bool IsPlayedCharacter,
+    int? ExternalPersonId,
+    int? ParentCharacterId);
+
+// Per-game assignment
+public record CharacterAssignmentDto(
+    int Id, int CharacterId, string CharacterName,
+    int GameId, int ExternalPersonId,
+    bool IsActive, DateTime StartedAtUtc, DateTime? EndedAtUtc);
+
+// Event log
+public record CharacterEventDto(
+    int Id, CharacterEventType EventType, string Data,
+    string? Location, string OrganizerName, DateTime Timestamp);
+
+public record CreateCharacterEventDto(
+    CharacterEventType EventType, string Data, string? Location = null);
+
+// Scan page composite response
+public record ScanCharacterDto(
+    int CharacterId, string Name, string? Race, PlayerClass? Class,
+    string? Kingdom, int CurrentLevel, int TotalXp,
+    List<string> Skills, List<CharacterEventDto> RecentEvents);
+
+// Import summary
+public record ImportResultDto(int Created, int Updated, int Skipped);
+```
+
+**Step 1: Create the file**
+
+**Step 2: Build**
+
+**Step 3: Commit**
+
+```
+feat: add Character DTOs [v0.3.0]
+```
+
+### Task 5: Create Character CRUD endpoints + tests
+
+**Files:**
+- Create: `src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs`
+- Modify: `src/OvcinaHra.Api/Program.cs` — register `MapCharacterEndpoints()`
+- Create: `tests/OvcinaHra.Api.Tests/Endpoints/CharacterEndpointTests.cs`
+
+**Step 1: Write integration tests** for GET /, GET /{id}, POST /, PUT /{id}, DELETE /{id}
+
+Test cases:
+- `GetAll_Empty_ReturnsEmptyList`
+- `Create_ValidCharacter_ReturnsCreated`
+- `GetById_ExistingCharacter_ReturnsCharacter`
+- `GetById_DeletedCharacter_ReturnsNotFound` (soft delete via query filter)
+- `Update_ExistingCharacter_ReturnsNoContent`
+- `Delete_ExistingCharacter_SoftDeletes`
+- `GetAll_WithSearchQuery_FiltersResults`
+
+**Step 2: Run tests to verify they fail**
+
+**Step 3: Implement CharacterEndpoints.cs** following the existing pattern (MapGroup, TypedResults, WorldDbContext).
+
+Endpoints:
+```
+GET    /api/characters?search=...  — list all (non-deleted), optional name search
+GET    /api/characters/{id}        — detail with parent name
+POST   /api/characters             — create
+PUT    /api/characters/{id}        — update (sets UpdatedAtUtc)
+DELETE /api/characters/{id}        — soft delete (IsDeleted = true)
+GET    /api/characters/{id}/assignments — game appearances
+```
+
+**Step 4: Register in Program.cs** — add `app.MapGroup(...).MapCharacterEndpoints()` next to existing endpoint registrations.
+
+**Step 5: Run tests to verify they pass**
+
+**Step 6: Commit**
+
+```
+feat: Character CRUD endpoints with tests [v0.3.0]
+```
+
+---
+
+## Phase 3: Import from Registrace (Task 6)
+
+### Task 6: Import endpoint + service
+
+**Files:**
+- Create: `src/OvcinaHra.Api/Services/CharacterImportService.cs`
+- Modify: `src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs`
+- Modify: `src/OvcinaHra.Api/Program.cs` — register HttpClient + config
+
+**Step 1: Add configuration**
+
+In `appsettings.json` / environment:
+```json
+"IntegrationApi": {
+    "BaseUrl": "https://registrace.ovcina.cz",
+    "ApiKey": "ab5380ce6b84a05b1085cd2550c162b0a38a15c645a0e092c00069b5976237d0"
+}
+```
+
+**Step 2: Create CharacterImportService**
+
+- Calls `GET {BaseUrl}/api/v1/games/{gameId}/characters` with `X-Api-Key` header
+- For each character seed:
+  - Match by ExternalPersonId → update if exists, create if not
+  - Create CharacterAssignment for the game
+- Return ImportResultDto(created, updated, skipped)
+
+**Step 3: Add endpoint**
+
+```
+POST /api/characters/import/{gameId}  — trigger import
+```
+
+**Step 4: Register IHttpClientFactory for the import service in Program.cs**
+
+**Step 5: Write test** — mock the external API call or test the endpoint with a stub. At minimum test the upsert logic with seeded DB data.
+
+**Step 6: Commit**
+
+```
+feat: character import from registrace [v0.3.0]
+```
+
+---
+
+## Phase 4: Scan Page + Event Log (Tasks 7-9)
+
+### Task 7: Scan API endpoints
+
+**Files:**
+- Create: `src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs`
+- Modify: `src/OvcinaHra.Api/Program.cs`
+- Create: `tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs`
+
+**Endpoints:**
+```
+GET  /api/scan/{personId}        — resolve → ScanCharacterDto
+POST /api/scan/{personId}/events — log event (auth required, reads organizer from claims)
+GET  /api/scan/{personId}/events — recent events (last 20)
+```
+
+**Scan resolution logic:**
+1. Find active CharacterAssignment where ExternalPersonId = personId and IsActive = true
+2. Load Character + all events for this assignment
+3. Compute: currentLevel = count of LevelUp events, totalXp = count of LevelUp events (1 XP per level), skills = SkillGained event Data values
+4. Return ScanCharacterDto
+
+**Event creation logic:**
+1. Read organizer identity from `ClaimTypes.NameIdentifier` (userId) and `ClaimTypes.Name` (display name)
+2. If EventType = ClassChosen: also update Character.Class from event Data (parse PlayerClass)
+3. If EventType = LevelUp: auto-set Data to `{"level": N}` where N = current level + 1
+4. Create CharacterEvent, save
+
+**Test cases:**
+- `Scan_ActiveCharacter_ReturnsProfile`
+- `Scan_NoActiveAssignment_ReturnsNotFound`
+- `PostEvent_LevelUp_IncrementsLevel`
+- `PostEvent_ClassChosen_SetsCharacterClass`
+- `PostEvent_PointsChanged_RecordsEvent`
+
+**Step 1: Write tests → Step 2: Implement → Step 3: Commit**
+
+```
+feat: scan API endpoints with event logging [v0.3.0]
+```
+
+### Task 8: Character list + edit pages (Blazor)
+
+**Files:**
+- Create: `src/OvcinaHra.Client/Pages/Characters/CharacterList.razor`
+
+**Pattern:** Same as MonsterList — OvcinaGrid + DxPopup edit modal. No catalog toggle needed (characters are global).
+
+Grid columns: Name, Race, Class (GetDisplayName), Kingdom, IsPlayedCharacter badge
+Edit form: All fields from CreateCharacterDto, ParentCharacter dropdown (ComboBox searching characters)
+
+Empty state: "Žádné postavy. Importujte z registrace nebo vytvořte novou."
+
+**Import button** on the page header — calls POST /api/characters/import/{gameId}, shows result toast.
+
+**Step 1: Create page → Step 2: Build → Step 3: Commit**
+
+```
+feat: character list + edit page [v0.3.0]
+```
+
+### Task 9: Scan page (QR target — mobile-first)
+
+**Files:**
+- Create: `src/OvcinaHra.Client/Pages/Scan/ScanPage.razor`
+
+**Route:** `/p/{PersonId:int}`
+
+**This is the most critical page — used on phones in the field.**
+
+**Layout:**
+1. **Header:** Character name (large), Kingdom badge, Race
+2. **Status bar:** Level badge, Class badge (or "Začátečník"), XP counter
+3. **Class picker:** Only shown when totalXp >= 5 AND class is null. Four big buttons (PlayerClass enum values with GetDisplayName). Tapping sets the class.
+4. **Quick action buttons** (large, mobile-friendly, stacked vertically):
+   - "Level Up" (green) — one tap, immediate
+   - "Přidat body" — opens modal: category picker (Dobré/Špatné/Neutrální) + amount + note
+   - "Přidat poznámku" — opens modal: text area
+   - "Přidat dovednost" — opens modal: skill name text
+5. **Optional location field** — text input above actions, prepopulated from last event
+6. **Recent events** — last 10, compact list (time, type icon, summary)
+
+**If person not found:** Show error state: "Postava nenalezena. Tento hráč nemá aktivní postavu v aktuální hře."
+
+**CSS priorities:** Large touch targets (min 48px), readable on small screens, minimal scrolling to reach actions.
+
+**Step 1: Create page → Step 2: Build → Step 3: Test on mobile viewport → Step 4: Commit**
+
+```
+feat: scan page with quick actions [v0.3.0]
+```
+
+---
+
+## Phase 5: Navigation + Polish (Task 10)
+
+### Task 10: Wire up navigation + version bump
+
+**Files:**
+- Modify: `src/OvcinaHra.Client/Shared/NavMenu.razor` (or equivalent) — add "Postavy" nav item
+- Modify: `src/OvcinaHra.Client/OvcinaHra.Client.csproj` — bump Version to 0.3.0
+
+**Step 1: Add nav item with person icon (bi-person) for Characters page**
+
+**Step 2: Verify scan page works without nav (it's a QR target, not a menu item)**
+
+**Step 3: Run all tests**
+
+**Step 4: Bump version**
+
+**Step 5: Final commit**
+
+```
+feat: character nav + version bump to v0.3.0
+```
+
+---
+
+## Key Implementation Notes
+
+- **PlayerClass enum** already exists at `src/OvcinaHra.Shared/Domain/Enums/PlayerClass.cs` with Display names: Válečník, Střelec, Zloděj, Mág
+- **Auth claims:** `ClaimTypes.NameIdentifier` = user ID, `ClaimTypes.Name` = display name (from AuthEndpoints.cs)
+- **Soft delete:** Character uses `HasQueryFilter(e => !e.IsDeleted)` — EF automatically excludes deleted records from queries
+- **GameId on CharacterAssignment** is an external reference to registrace, NOT a local FK to the Game table
+- **CharacterEvent.Data** is freeform JSON — each EventType has its own shape:
+  - LevelUp: `{"level": 3}`
+  - PointsChanged: `{"category": "Dobré", "amount": 2, "note": "pomoc vesničanům"}`
+  - SkillGained: `{"skill": "Léčení"}`
+  - Note: `{"text": "Zajímavý rozhovor s kupcem"}`
+  - ClassChosen: `{"class": "Warrior"}`
+- **No offline sync** — retry on failure is sufficient
+- **Test command:** `dotnet test tests/OvcinaHra.Api.Tests --nologo -v q`
+- **Build command:** `dotnet build --nologo -v q`

--- a/src/OvcinaHra.Api/Data/Configurations/CharacterConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/CharacterConfiguration.cs
@@ -10,7 +10,8 @@ public class CharacterConfiguration : IEntityTypeConfiguration<Character>
     {
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Name).IsRequired().HasMaxLength(200);
-        builder.Property(e => e.Class).HasConversion<string>().HasMaxLength(20);
+        builder.Property(e => e.PlayerFirstName).HasMaxLength(100);
+        builder.Property(e => e.PlayerLastName).HasMaxLength(100);
         builder.HasIndex(e => e.ExternalPersonId).IsUnique().HasFilter("\"ExternalPersonId\" IS NOT NULL");
         builder.HasOne(e => e.ParentCharacter).WithMany(e => e.Children).HasForeignKey(e => e.ParentCharacterId);
         builder.HasQueryFilter(e => !e.IsDeleted);
@@ -22,10 +23,12 @@ public class CharacterAssignmentConfiguration : IEntityTypeConfiguration<Charact
     public void Configure(EntityTypeBuilder<CharacterAssignment> builder)
     {
         builder.HasKey(e => e.Id);
+        builder.Property(e => e.Class).HasConversion<string>().HasMaxLength(20);
         builder.HasOne(e => e.Character).WithMany(c => c.Assignments).HasForeignKey(e => e.CharacterId);
         builder.HasIndex(e => e.GameId);
         builder.HasIndex(e => e.ExternalPersonId);
         builder.HasIndex(e => e.CharacterId);
+        builder.HasIndex(e => new { e.GameId, e.ExternalPersonId }).IsUnique();
     }
 }
 

--- a/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Dtos;
 
@@ -19,9 +20,16 @@ public static class CharacterEndpoints
         group.MapDelete("/{id:int}", Delete);
         group.MapGet("/{id:int}/assignments", GetAssignments);
         group.MapPost("/{id:int}/assignments", CreateAssignment);
+        group.MapPut("/assignments/{id:int}", UpdateAssignment);
+        group.MapPost("/import/{gameId:int}", ImportFromRegistrace);
 
         return group;
     }
+
+    private static string? FullName(Character c) =>
+        string.IsNullOrWhiteSpace(c.PlayerFirstName) && string.IsNullOrWhiteSpace(c.PlayerLastName)
+            ? null
+            : $"{c.PlayerFirstName} {c.PlayerLastName}".Trim();
 
     private static async Task<Ok<List<CharacterListDto>>> GetAll(WorldDbContext db, string? search = null)
     {
@@ -32,12 +40,12 @@ public static class CharacterEndpoints
 
         var characters = await query
             .OrderBy(c => c.Name)
-            .Select(c => new CharacterListDto(
-                c.Id, c.Name, c.Race, c.Class,
-                c.Kingdom, c.IsPlayedCharacter, c.ExternalPersonId))
             .ToListAsync();
 
-        return TypedResults.Ok(characters);
+        return TypedResults.Ok(characters
+            .Select(c => new CharacterListDto(
+                c.Id, c.Name, FullName(c), c.Race, c.IsPlayedCharacter, c.ExternalPersonId))
+            .ToList());
     }
 
     private static async Task<Results<Ok<CharacterDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
@@ -49,11 +57,11 @@ public static class CharacterEndpoints
         if (c is null) return TypedResults.NotFound();
 
         return TypedResults.Ok(new CharacterDetailDto(
-            c.Id, c.Name, c.Race, c.Class,
-            c.Kingdom, c.BirthYear, c.Notes,
+            c.Id, c.Name, c.PlayerFirstName, c.PlayerLastName,
+            c.Race, c.BirthYear, c.Notes,
             c.IsPlayedCharacter, c.ExternalPersonId,
             c.ParentCharacterId, c.ParentCharacter?.Name,
-            null, c.CreatedAtUtc, c.UpdatedAtUtc));
+            c.CreatedAtUtc, c.UpdatedAtUtc));
     }
 
     private static async Task<Created<CharacterDetailDto>> Create(CreateCharacterDto dto, WorldDbContext db)
@@ -62,9 +70,9 @@ public static class CharacterEndpoints
         var c = new Character
         {
             Name = dto.Name,
+            PlayerFirstName = dto.PlayerFirstName,
+            PlayerLastName = dto.PlayerLastName,
             Race = dto.Race,
-            Class = dto.Class,
-            Kingdom = dto.Kingdom,
             BirthYear = dto.BirthYear,
             Notes = dto.Notes,
             IsPlayedCharacter = dto.IsPlayedCharacter,
@@ -78,11 +86,11 @@ public static class CharacterEndpoints
 
         return TypedResults.Created($"/api/characters/{c.Id}",
             new CharacterDetailDto(
-                c.Id, c.Name, c.Race, c.Class,
-                c.Kingdom, c.BirthYear, c.Notes,
+                c.Id, c.Name, c.PlayerFirstName, c.PlayerLastName,
+                c.Race, c.BirthYear, c.Notes,
                 c.IsPlayedCharacter, c.ExternalPersonId,
                 c.ParentCharacterId, null,
-                null, c.CreatedAtUtc, c.UpdatedAtUtc));
+                c.CreatedAtUtc, c.UpdatedAtUtc));
     }
 
     private static async Task<Results<NoContent, NotFound>> Update(int id, UpdateCharacterDto dto, WorldDbContext db)
@@ -91,9 +99,9 @@ public static class CharacterEndpoints
         if (c is null) return TypedResults.NotFound();
 
         c.Name = dto.Name;
+        c.PlayerFirstName = dto.PlayerFirstName;
+        c.PlayerLastName = dto.PlayerLastName;
         c.Race = dto.Race;
-        c.Class = dto.Class;
-        c.Kingdom = dto.Kingdom;
         c.BirthYear = dto.BirthYear;
         c.Notes = dto.Notes;
         c.IsPlayedCharacter = dto.IsPlayedCharacter;
@@ -128,6 +136,9 @@ public static class CharacterEndpoints
             CharacterId = id,
             GameId = dto.GameId,
             ExternalPersonId = dto.ExternalPersonId,
+            RegistraceCharacterId = dto.RegistraceCharacterId,
+            Class = dto.Class,
+            Kingdom = dto.Kingdom,
             IsActive = true,
             StartedAtUtc = DateTime.UtcNow
         };
@@ -137,7 +148,8 @@ public static class CharacterEndpoints
         return TypedResults.Created($"/api/characters/{id}/assignments",
             new CharacterAssignmentDto(
                 assignment.Id, assignment.CharacterId, character.Name,
-                assignment.GameId, assignment.ExternalPersonId,
+                assignment.GameId, assignment.ExternalPersonId, assignment.RegistraceCharacterId,
+                assignment.Class, assignment.Kingdom,
                 assignment.IsActive, assignment.StartedAtUtc, assignment.EndedAtUtc));
     }
 
@@ -149,10 +161,34 @@ public static class CharacterEndpoints
             .OrderByDescending(a => a.StartedAtUtc)
             .Select(a => new CharacterAssignmentDto(
                 a.Id, a.CharacterId, a.Character.Name,
-                a.GameId, a.ExternalPersonId,
+                a.GameId, a.ExternalPersonId, a.RegistraceCharacterId,
+                a.Class, a.Kingdom,
                 a.IsActive, a.StartedAtUtc, a.EndedAtUtc))
             .ToListAsync();
 
         return TypedResults.Ok(assignments);
+    }
+
+    private static async Task<Results<NoContent, NotFound>> UpdateAssignment(
+        int id, UpdateCharacterAssignmentDto dto, WorldDbContext db)
+    {
+        var assignment = await db.CharacterAssignments.FindAsync(id);
+        if (assignment is null) return TypedResults.NotFound();
+
+        assignment.Class = dto.Class;
+        assignment.Kingdom = dto.Kingdom;
+        assignment.IsActive = dto.IsActive;
+        if (!dto.IsActive && assignment.EndedAtUtc is null)
+            assignment.EndedAtUtc = DateTime.UtcNow;
+
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Ok<ImportResultDto>> ImportFromRegistrace(
+        int gameId, RegistraceImportService importService)
+    {
+        var result = await importService.ImportAsync(gameId);
+        return TypedResults.Ok(result);
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -32,7 +32,6 @@ public static class ScanEndpoints
 
         if (assignment is null) return TypedResults.NotFound();
 
-        var character = assignment.Character;
         var events = assignment.Events.ToList();
 
         var currentLevel = events.Count(e => e.EventType == CharacterEventType.LevelUp);
@@ -63,9 +62,18 @@ public static class ScanEndpoints
             .Select(e => new CharacterEventDto(e.Id, e.EventType, e.Data, e.Location, e.OrganizerName, e.Timestamp))
             .ToList();
 
+        var ch = assignment.Character;
+        var playerFullName =
+            string.IsNullOrWhiteSpace(ch.PlayerFirstName) && string.IsNullOrWhiteSpace(ch.PlayerLastName)
+                ? null
+                : $"{ch.PlayerFirstName} {ch.PlayerLastName}".Trim();
+
         return TypedResults.Ok(new ScanCharacterDto(
-            character.Id, character.Name, character.Race, character.Class,
-            character.Kingdom, currentLevel, totalXp, skills, recentEvents));
+            ch.Id, assignment.Id, personId,
+            ch.Name, playerFullName,
+            ch.Race, assignment.Class,
+            assignment.Kingdom, ch.BirthYear,
+            currentLevel, totalXp, skills, recentEvents));
     }
 
     private static async Task<Results<Created<CharacterEventDto>, NotFound, BadRequest<string>>> PostEvent(
@@ -91,7 +99,7 @@ public static class ScanEndpoints
         }
         else if (dto.EventType == CharacterEventType.ClassChosen)
         {
-            if (assignment.Character.Class is not null)
+            if (assignment.Class is not null)
                 return TypedResults.BadRequest("Character already has a class assigned.");
 
             try
@@ -104,8 +112,7 @@ public static class ScanEndpoints
                 if (!Enum.TryParse<PlayerClass>(className, ignoreCase: true, out var playerClass))
                     return TypedResults.BadRequest($"Unknown class: '{className}'.");
 
-                assignment.Character.Class = playerClass;
-                assignment.Character.UpdatedAtUtc = DateTime.UtcNow;
+                assignment.Class = playerClass;
             }
             catch (JsonException)
             {

--- a/src/OvcinaHra.Api/Migrations/20260413033205_RefactorCharacterPlayerNames.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260413033205_RefactorCharacterPlayerNames.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413033205_RefactorCharacterPlayerNames")]
+    partial class RefactorCharacterPlayerNames
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260413033205_RefactorCharacterPlayerNames.cs
+++ b/src/OvcinaHra.Api/Migrations/20260413033205_RefactorCharacterPlayerNames.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class RefactorCharacterPlayerNames : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Class",
+                table: "Characters");
+
+            migrationBuilder.DropColumn(
+                name: "Kingdom",
+                table: "Characters");
+
+            migrationBuilder.AddColumn<string>(
+                name: "PlayerFirstName",
+                table: "Characters",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PlayerLastName",
+                table: "Characters",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Class",
+                table: "CharacterAssignments",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Kingdom",
+                table: "CharacterAssignments",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "RegistraceCharacterId",
+                table: "CharacterAssignments",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CharacterAssignments_GameId_ExternalPersonId",
+                table: "CharacterAssignments",
+                columns: new[] { "GameId", "ExternalPersonId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CharacterAssignments_GameId_ExternalPersonId",
+                table: "CharacterAssignments");
+
+            migrationBuilder.DropColumn(
+                name: "PlayerFirstName",
+                table: "Characters");
+
+            migrationBuilder.DropColumn(
+                name: "PlayerLastName",
+                table: "Characters");
+
+            migrationBuilder.DropColumn(
+                name: "Class",
+                table: "CharacterAssignments");
+
+            migrationBuilder.DropColumn(
+                name: "Kingdom",
+                table: "CharacterAssignments");
+
+            migrationBuilder.DropColumn(
+                name: "RegistraceCharacterId",
+                table: "CharacterAssignments");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Class",
+                table: "Characters",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Kingdom",
+                table: "Characters",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -46,6 +46,8 @@ try
     var oidcAuthority = builder.Configuration["Oidc:Authority"];
     var jwtKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!));
 
+    builder.Services.AddHttpClient<RegistraceImportService>();
+
     builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {

--- a/src/OvcinaHra.Api/Services/RegistraceImportService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceImportService.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Services;
+
+public class RegistraceImportService(HttpClient httpClient, IConfiguration configuration, WorldDbContext db)
+{
+    private readonly string _baseUrl = configuration["IntegrationApi:BaseUrl"] ?? "https://registrace.ovcina.cz";
+    private readonly string? _apiKey = configuration["IntegrationApi:ApiKey"];
+
+    public async Task<ImportResultDto> ImportAsync(int gameId)
+    {
+        var created = 0;
+        var updated = 0;
+        var skipped = 0;
+        var errors = new List<string>();
+
+        List<RegistraceCharacterRecord> records;
+        try
+        {
+            records = await FetchCharactersAsync(gameId);
+        }
+        catch (Exception ex)
+        {
+            return new ImportResultDto(0, 0, 0, [$"Failed to fetch from registrace: {ex.Message}"]);
+        }
+
+        foreach (var record in records)
+        {
+            try
+            {
+                // Look up Character by ExternalPersonId (including deleted)
+                var character = await db.Characters
+                    .IgnoreQueryFilters()
+                    .FirstOrDefaultAsync(c => c.ExternalPersonId == record.PersonId);
+
+                if (character is null)
+                {
+                    var name = !string.IsNullOrWhiteSpace(record.CharacterName)
+                        ? record.CharacterName
+                        : $"{record.PersonFirstName} {record.PersonLastName}".Trim();
+
+                    character = new Character
+                    {
+                        Name = name,
+                        PlayerFirstName = record.PersonFirstName,
+                        PlayerLastName = record.PersonLastName,
+                        Race = record.Race,
+                        BirthYear = record.PersonBirthYear,
+                        IsPlayedCharacter = true,
+                        ExternalPersonId = record.PersonId,
+                        CreatedAtUtc = DateTime.UtcNow,
+                        UpdatedAtUtc = DateTime.UtcNow
+                    };
+                    db.Characters.Add(character);
+                    await db.SaveChangesAsync();
+                }
+                else
+                {
+                    // Update persistent lore attributes from latest registrace data
+                    // Name is intentionally NOT updated — it's user-editable in our app
+                    character.PlayerFirstName = record.PersonFirstName;
+                    character.PlayerLastName = record.PersonLastName;
+                    character.Race = record.Race;
+                    character.BirthYear = record.PersonBirthYear;
+                    character.UpdatedAtUtc = DateTime.UtcNow;
+                }
+
+                // Look up assignment by GameId + ExternalPersonId
+                var assignment = await db.CharacterAssignments
+                    .FirstOrDefaultAsync(a => a.GameId == gameId && a.ExternalPersonId == record.PersonId);
+
+                PlayerClass? playerClass = null;
+                if (!string.IsNullOrWhiteSpace(record.ClassOrType))
+                    Enum.TryParse<PlayerClass>(record.ClassOrType, ignoreCase: true, out var pc)
+                        .WhenTrue(pc, ref playerClass);
+
+                if (assignment is null)
+                {
+                    assignment = new CharacterAssignment
+                    {
+                        CharacterId = character.Id,
+                        GameId = gameId,
+                        ExternalPersonId = record.PersonId,
+                        RegistraceCharacterId = record.CharacterId,
+                        Class = playerClass,
+                        Kingdom = record.KingdomName,
+                        IsActive = true,
+                        StartedAtUtc = DateTime.UtcNow
+                    };
+                    db.CharacterAssignments.Add(assignment);
+                    created++;
+                }
+                else
+                {
+                    assignment.RegistraceCharacterId = record.CharacterId;
+                    assignment.Class = playerClass;
+                    assignment.Kingdom = record.KingdomName;
+                    updated++;
+                }
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"PersonId {record.PersonId}: {ex.Message}");
+                skipped++;
+            }
+        }
+
+        return new ImportResultDto(created, updated, skipped, errors);
+    }
+
+    private async Task<List<RegistraceCharacterRecord>> FetchCharactersAsync(int gameId)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get,
+            $"{_baseUrl.TrimEnd('/')}/api/v1/games/{gameId}/characters");
+
+        if (!string.IsNullOrWhiteSpace(_apiKey))
+            request.Headers.Add("X-Api-Key", _apiKey);
+
+        var response = await httpClient.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<List<RegistraceCharacterRecord>>(json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+    }
+
+    private sealed record RegistraceCharacterRecord(
+        [property: JsonPropertyName("characterId")] int CharacterId,
+        [property: JsonPropertyName("personId")] int PersonId,
+        [property: JsonPropertyName("personFirstName")] string PersonFirstName,
+        [property: JsonPropertyName("personLastName")] string PersonLastName,
+        [property: JsonPropertyName("personBirthYear")] int? PersonBirthYear,
+        [property: JsonPropertyName("characterName")] string? CharacterName,
+        [property: JsonPropertyName("race")] string? Race,
+        [property: JsonPropertyName("classOrType")] string? ClassOrType,
+        [property: JsonPropertyName("kingdomName")] string? KingdomName,
+        [property: JsonPropertyName("kingdomId")] int? KingdomId,
+        [property: JsonPropertyName("levelReached")] int? LevelReached,
+        [property: JsonPropertyName("continuityStatus")] string? ContinuityStatus);
+}
+
+internal static class BoolExtensions
+{
+    internal static void WhenTrue(this bool result, PlayerClass value, ref PlayerClass? target)
+    {
+        if (result) target = value;
+    }
+}

--- a/src/OvcinaHra.Api/appsettings.json
+++ b/src/OvcinaHra.Api/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "IntegrationApi": {
+    "BaseUrl": "https://registrace.ovcina.cz",
+    "ApiKey": ""
+  }
 }

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
+++ b/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
@@ -8,9 +8,24 @@
     <div class="d-flex gap-2">
         <DxTextBox Text="@searchText" NullText="Hledat..." ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
                    TextChanged="@(async (string s) => { searchText = s; await LoadAsync(); })" />
+        <button class="btn btn-outline-secondary" @onclick="ImportAsync" disabled="@isImporting">
+            @(isImporting ? "Importuji..." : "Importovat z registrace")
+        </button>
         <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová postava</button>
     </div>
 </div>
+
+@if (importResult is not null)
+{
+    <div class="alert alert-info alert-dismissible mb-3">
+        @importResult.Created nových, @importResult.Updated aktualizováno.
+        @if (importResult.Errors.Count > 0)
+        {
+            <span class="text-danger"> @importResult.Errors.Count chyb.</span>
+        }
+        <button type="button" class="btn-close" @onclick="() => importResult = null"></button>
+    </div>
+}
 
 @if (loading)
 {
@@ -30,42 +45,36 @@ else
                 RowClick="@(e => OpenModal((CharacterListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
+            <DxGridDataColumn FieldName="PlayerFullName" Caption="Hráč" Width="180px" />
             <DxGridDataColumn FieldName="Race" Caption="Rasa" Width="120px" />
-            <DxGridDataColumn FieldName="Class" Caption="Povolání" Width="130px">
-                <CellDisplayTemplate>
-                    @(context.Value is PlayerClass pc ? pc.GetDisplayName() : "Začátečník")
-                </CellDisplayTemplate>
-            </DxGridDataColumn>
-            <DxGridDataColumn FieldName="Kingdom" Caption="Království" Width="140px" />
-            <DxGridDataColumn FieldName="IsPlayedCharacter" Caption="Hráč" Width="80px">
+            <DxGridDataColumn FieldName="IsPlayedCharacter" Caption="Hráčská" Width="80px">
                 <CellDisplayTemplate>@((bool)context.Value ? "Ano" : "Ne")</CellDisplayTemplate>
             </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ExternalPersonId" Caption="ID v registraci" Width="140px" />
         </Columns>
     </OvcinaGrid>
 }
 
-<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="700px">
+<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="600px">
     <BodyContentTemplate Context="popupContext">
         <DxFormLayout>
-            <DxFormLayoutItem Caption="Název" ColSpanMd="8">
+            <DxFormLayoutItem Caption="Název postavy" ColSpanMd="8">
                 <DxTextBox @bind-Text="@name" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Rasa" ColSpanMd="4">
-                <DxTextBox @bind-Text="@race" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Povolání" ColSpanMd="6">
-                <DxComboBox Data="@playerClassValues" @bind-Value="@playerClass"
-                            TextFieldName="Display" ValueFieldName="Value"
-                            NullText="Začátečník" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Království" ColSpanMd="6">
-                <DxTextBox @bind-Text="@kingdom" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Rok narození" ColSpanMd="4">
-                <DxSpinEdit @bind-Value="@birthYear" MinValue="1" />
             </DxFormLayoutItem>
             <DxFormLayoutItem Caption="Hráčská postava" ColSpanMd="4">
                 <DxCheckBox @bind-Checked="@isPlayedCharacter" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Jméno hráče" ColSpanMd="6">
+                <DxTextBox @bind-Text="@playerFirstName" NullText="(nezadáno)" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Příjmení hráče" ColSpanMd="6">
+                <DxTextBox @bind-Text="@playerLastName" NullText="(nezadáno)" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Rasa" ColSpanMd="6">
+                <DxTextBox @bind-Text="@race" NullText="(nezadáno)" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Rok narození" ColSpanMd="6">
+                <DxSpinEdit @bind-Value="@birthYear" />
             </DxFormLayoutItem>
             @if (isPlayedCharacter)
             {
@@ -82,6 +91,15 @@ else
                 <DxMemo @bind-Text="@notes" Rows="3" />
             </DxFormLayoutItem>
         </DxFormLayout>
+
+        @if (editingId.HasValue && externalPersonId.HasValue)
+        {
+            <div class="mt-2">
+                <a href="https://registrace.ovcina.cz/person/@externalPersonId" target="_blank" class="btn btn-sm btn-outline-secondary">
+                    <i class="bi bi-box-arrow-up-right me-1"></i> Registrace
+                </a>
+            </div>
+        }
 
         @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
 
@@ -107,20 +125,16 @@ else
 @code {
     private List<CharacterListDto> characters = [];
     private List<CharacterListDto> allCharacters = [];
-    private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
+    private bool loading = true, isModalVisible, isDeleteVisible, isSaving, isImporting;
     private string modalTitle = "", name = "";
-    private string? error, race, kingdom, notes;
+    private string? error, notes, race, playerFirstName, playerLastName;
     private int? editingId;
-    private PlayerClass? playerClass;
-    private int? birthYear;
     private int? externalPersonId;
     private int? parentCharacterId;
+    private int? birthYear;
     private bool isPlayedCharacter;
     private string searchText = "";
-
-    private static readonly List<EnumItem<PlayerClass>> playerClassValues = Enum.GetValues<PlayerClass>()
-        .Select(v => new EnumItem<PlayerClass>(v, v.GetDisplayName())).ToList();
-    record EnumItem<T>(T Value, string Display);
+    private ImportResultDto? importResult;
 
     protected override async Task OnInitializedAsync()
     {
@@ -144,15 +158,16 @@ else
         error = null;
         if (c is null)
         {
-            editingId = null; name = ""; race = null; playerClass = null; kingdom = null;
-            birthYear = null; isPlayedCharacter = false; externalPersonId = null;
-            parentCharacterId = null; notes = null;
+            editingId = null; name = ""; isPlayedCharacter = false; externalPersonId = null;
+            parentCharacterId = null; notes = null; race = null; birthYear = null;
+            playerFirstName = null; playerLastName = null;
             modalTitle = "Nová postava";
         }
         else
         {
-            editingId = c.Id; name = c.Name; race = c.Race; playerClass = c.Class;
-            kingdom = c.Kingdom; isPlayedCharacter = c.IsPlayedCharacter;
+            editingId = c.Id; name = c.Name;
+            race = c.Race;
+            isPlayedCharacter = c.IsPlayedCharacter;
             externalPersonId = c.ExternalPersonId;
             modalTitle = $"Upravit: {c.Name}";
             _ = LoadDetailAsync(c.Id);
@@ -165,9 +180,12 @@ else
         var d = await Api.GetAsync<CharacterDetailDto>($"/api/characters/{id}");
         if (d is not null)
         {
-            birthYear = d.BirthYear;
             notes = d.Notes;
+            race = d.Race;
+            birthYear = d.BirthYear;
             parentCharacterId = d.ParentCharacterId;
+            playerFirstName = d.PlayerFirstName;
+            playerLastName = d.PlayerLastName;
         }
         StateHasChanged();
     }
@@ -179,10 +197,10 @@ else
         {
             if (editingId.HasValue)
                 await Api.PutAsync($"/api/characters/{editingId}",
-                    new UpdateCharacterDto(name, race, playerClass, kingdom, birthYear, notes, isPlayedCharacter, externalPersonId, parentCharacterId));
+                    new UpdateCharacterDto(name, playerFirstName, playerLastName, race, birthYear, notes, isPlayedCharacter, externalPersonId, parentCharacterId));
             else
                 await Api.PostAsync<CreateCharacterDto, CharacterDetailDto>("/api/characters",
-                    new CreateCharacterDto(name, race, playerClass, kingdom, birthYear, notes, isPlayedCharacter, externalPersonId, parentCharacterId));
+                    new CreateCharacterDto(name, playerFirstName, playerLastName, race, birthYear, notes, isPlayedCharacter, externalPersonId, parentCharacterId));
             isModalVisible = false;
             await LoadAsync();
             allCharacters = await Api.GetListAsync<CharacterListDto>("/api/characters");
@@ -201,5 +219,20 @@ else
             allCharacters = await Api.GetListAsync<CharacterListDto>("/api/characters");
         }
         catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task ImportAsync()
+    {
+        if (!GameContext.SelectedGameId.HasValue) return;
+        isImporting = true; importResult = null;
+        try
+        {
+            importResult = await Api.PostAsync<object, ImportResultDto>(
+                $"/api/characters/import/{GameContext.SelectedGameId}", new { });
+            await LoadAsync();
+            allCharacters = await Api.GetListAsync<CharacterListDto>("/api/characters");
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isImporting = false; }
     }
 }

--- a/src/OvcinaHra.Client/Pages/Scan/ScanPage.razor
+++ b/src/OvcinaHra.Client/Pages/Scan/ScanPage.razor
@@ -30,6 +30,10 @@ else if (character is not null)
     <div class="card mb-3" style="background: var(--oh-primary-surface, #f0ebe3);">
         <div class="card-body text-center">
             <h2 class="mb-1">@character.Name</h2>
+            @if (character.PlayerFullName is not null)
+            {
+                <small class="text-muted d-block mb-1">@character.PlayerFullName</small>
+            }
             <div class="d-flex justify-content-center gap-2 flex-wrap">
                 @if (character.Kingdom is not null)
                 {
@@ -109,6 +113,12 @@ else if (character is not null)
     }
 
     @* Recent events *@
+    <div class="mb-2">
+        <a href="https://registrace.ovcina.cz/person/@PersonId" target="_blank" class="btn btn-sm btn-outline-secondary">
+            <i class="bi bi-box-arrow-up-right me-1"></i> Otevřít v registraci
+        </a>
+    </div>
+
     <h5>Poslední události</h5>
     @if (character.RecentEvents.Count == 0)
     {

--- a/src/OvcinaHra.Shared/Domain/Entities/Character.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Character.cs
@@ -1,14 +1,12 @@
-using OvcinaHra.Shared.Domain.Enums;
-
 namespace OvcinaHra.Shared.Domain.Entities;
 
 public class Character
 {
     public int Id { get; set; }
     public required string Name { get; set; }
+    public string? PlayerFirstName { get; set; }
+    public string? PlayerLastName { get; set; }
     public string? Race { get; set; }
-    public PlayerClass? Class { get; set; }
-    public string? Kingdom { get; set; }
     public int? BirthYear { get; set; }
     public string? Notes { get; set; }
     public bool IsPlayedCharacter { get; set; }

--- a/src/OvcinaHra.Shared/Domain/Entities/CharacterAssignment.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/CharacterAssignment.cs
@@ -1,3 +1,5 @@
+using OvcinaHra.Shared.Domain.Enums;
+
 namespace OvcinaHra.Shared.Domain.Entities;
 
 public class CharacterAssignment
@@ -6,6 +8,12 @@ public class CharacterAssignment
     public int CharacterId { get; set; }
     public int GameId { get; set; }
     public int ExternalPersonId { get; set; }
+    public int? RegistraceCharacterId { get; set; }
+
+    // Per-game snapshot
+    public PlayerClass? Class { get; set; }
+    public string? Kingdom { get; set; }
+
     public bool IsActive { get; set; } = true;
     public DateTime StartedAtUtc { get; set; } = DateTime.UtcNow;
     public DateTime? EndedAtUtc { get; set; }

--- a/src/OvcinaHra.Shared/Dtos/CharacterDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/CharacterDtos.cs
@@ -2,22 +2,23 @@ using OvcinaHra.Shared.Domain.Enums;
 
 namespace OvcinaHra.Shared.Dtos;
 
+// Character catalog (persistent identity)
 public record CharacterListDto(
-    int Id, string Name, string? Race, PlayerClass? Class,
-    string? Kingdom, bool IsPlayedCharacter, int? ExternalPersonId);
+    int Id, string Name, string? PlayerFullName, string? Race,
+    bool IsPlayedCharacter, int? ExternalPersonId);
 
 public record CharacterDetailDto(
-    int Id, string Name, string? Race, PlayerClass? Class,
-    string? Kingdom, int? BirthYear, string? Notes,
+    int Id, string Name, string? PlayerFirstName, string? PlayerLastName,
+    string? Race, int? BirthYear, string? Notes,
     bool IsPlayedCharacter, int? ExternalPersonId,
     int? ParentCharacterId, string? ParentCharacterName,
-    string? ImagePath, DateTime CreatedAtUtc, DateTime UpdatedAtUtc);
+    DateTime CreatedAtUtc, DateTime UpdatedAtUtc);
 
 public record CreateCharacterDto(
     string Name,
+    string? PlayerFirstName = null,
+    string? PlayerLastName = null,
     string? Race = null,
-    PlayerClass? Class = null,
-    string? Kingdom = null,
     int? BirthYear = null,
     string? Notes = null,
     bool IsPlayedCharacter = false,
@@ -26,20 +27,34 @@ public record CreateCharacterDto(
 
 public record UpdateCharacterDto(
     string Name,
+    string? PlayerFirstName,
+    string? PlayerLastName,
     string? Race,
-    PlayerClass? Class,
-    string? Kingdom,
     int? BirthYear,
     string? Notes,
     bool IsPlayedCharacter,
     int? ExternalPersonId,
     int? ParentCharacterId);
 
+// Per-game assignment (per-game snapshot)
 public record CharacterAssignmentDto(
     int Id, int CharacterId, string CharacterName,
-    int GameId, int ExternalPersonId,
+    int GameId, int ExternalPersonId, int? RegistraceCharacterId,
+    PlayerClass? Class, string? Kingdom,
     bool IsActive, DateTime StartedAtUtc, DateTime? EndedAtUtc);
 
+public record CreateCharacterAssignmentDto(
+    int GameId, int ExternalPersonId,
+    PlayerClass? Class = null,
+    string? Kingdom = null,
+    int? RegistraceCharacterId = null);
+
+public record UpdateCharacterAssignmentDto(
+    PlayerClass? Class,
+    string? Kingdom,
+    bool IsActive);
+
+// Event log
 public record CharacterEventDto(
     int Id, CharacterEventType EventType, string Data,
     string? Location, string OrganizerName, DateTime Timestamp);
@@ -47,11 +62,13 @@ public record CharacterEventDto(
 public record CreateCharacterEventDto(
     CharacterEventType EventType, string Data, string? Location = null);
 
+// Scan page composite response
 public record ScanCharacterDto(
-    int CharacterId, string Name, string? Race, PlayerClass? Class,
-    string? Kingdom, int CurrentLevel, int TotalXp,
+    int CharacterId, int AssignmentId, int ExternalPersonId,
+    string Name, string? PlayerFullName,
+    string? Race, PlayerClass? Class, string? Kingdom, int? BirthYear,
+    int CurrentLevel, int TotalXp,
     List<string> Skills, List<CharacterEventDto> RecentEvents);
 
-public record CreateCharacterAssignmentDto(int GameId, int ExternalPersonId);
-
-public record ImportResultDto(int Created, int Updated, int Skipped);
+// Import summary
+public record ImportResultDto(int Created, int Updated, int Skipped, List<string> Errors);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/CharacterEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/CharacterEndpointTests.cs
@@ -19,14 +19,15 @@ public class CharacterEndpointTests(PostgresFixture postgres) : IntegrationTestB
     public async Task Create_ValidCharacter_ReturnsCreated()
     {
         var response = await Client.PostAsJsonAsync("/api/characters",
-            new CreateCharacterDto("Gandalf", Race: "Wizard", Class: null, Kingdom: "Gondor"));
+            new CreateCharacterDto("Gandalf", PlayerFirstName: "Ian", PlayerLastName: "McKellen",
+                Race: null, BirthYear: null, Notes: null, IsPlayedCharacter: false));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         var created = await response.Content.ReadFromJsonAsync<CharacterDetailDto>();
         Assert.NotNull(created);
         Assert.Equal("Gandalf", created.Name);
-        Assert.Equal("Wizard", created.Race);
-        Assert.Equal("Gondor", created.Kingdom);
+        Assert.Equal("Ian", created.PlayerFirstName);
+        Assert.Equal("McKellen", created.PlayerLastName);
     }
 
     [Fact]
@@ -53,7 +54,7 @@ public class CharacterEndpointTests(PostgresFixture postgres) : IntegrationTestB
         var created = await createResponse.Content.ReadFromJsonAsync<CharacterDetailDto>();
 
         var response = await Client.PutAsJsonAsync($"/api/characters/{created!.Id}",
-            new UpdateCharacterDto("Frodo Baggins", null, null, "Shire", null, null, true, null, null));
+            new UpdateCharacterDto("Frodo Baggins", "Elijah", "Wood", null, null, null, true, null, null));
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
     }
@@ -83,6 +84,8 @@ public class CharacterEndpointTests(PostgresFixture postgres) : IntegrationTestB
         Assert.NotNull(results);
         Assert.Single(results);
         Assert.Equal("Bilbo Baggins", results[0].Name);
+        // PlayerFullName is null when no player name set
+        Assert.Null(results[0].PlayerFullName);
     }
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
@@ -9,17 +9,17 @@ namespace OvcinaHra.Api.Tests.Endpoints;
 public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
 {
     private async Task<(CharacterDetailDto character, CharacterAssignmentDto assignment)> SeedCharacterWithAssignment(
-        int externalPersonId = 100, int gameId = 1)
+        int externalPersonId = 100, int gameId = 1,
+        string? race = "Dwarf", string? kingdom = "Erebor")
     {
         var createResponse = await Client.PostAsJsonAsync("/api/characters",
-            new CreateCharacterDto("Thorin", Race: "Dwarf", Class: null, Kingdom: "Erebor",
-                IsPlayedCharacter: true, ExternalPersonId: externalPersonId));
+            new CreateCharacterDto("Thorin", Race: race, IsPlayedCharacter: true, ExternalPersonId: externalPersonId));
         createResponse.EnsureSuccessStatusCode();
         var character = await createResponse.Content.ReadFromJsonAsync<CharacterDetailDto>();
 
         var assignResponse = await Client.PostAsJsonAsync(
             $"/api/characters/{character!.Id}/assignments",
-            new CreateCharacterAssignmentDto(gameId, externalPersonId));
+            new CreateCharacterAssignmentDto(gameId, externalPersonId, null, kingdom));
         assignResponse.EnsureSuccessStatusCode();
         var assignment = await assignResponse.Content.ReadFromJsonAsync<CharacterAssignmentDto>();
 
@@ -37,6 +37,7 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
         var profile = await response.Content.ReadFromJsonAsync<ScanCharacterDto>();
         Assert.NotNull(profile);
         Assert.Equal("Thorin", profile.Name);
+        Assert.Null(profile.PlayerFullName); // no player name set in seed
         Assert.Equal("Dwarf", profile.Race);
         Assert.Equal("Erebor", profile.Kingdom);
         Assert.Equal(0, profile.CurrentLevel);
@@ -69,7 +70,7 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
     }
 
     [Fact]
-    public async Task PostEvent_ClassChosen_SetsCharacterClass()
+    public async Task PostEvent_ClassChosen_SetsAssignmentClass()
     {
         await SeedCharacterWithAssignment(externalPersonId: 102);
 


### PR DESCRIPTION
## Summary
- **Character model restructure**: Race, BirthYear, Player name (first/last) stay on Character (persistent). Class, Kingdom move to CharacterAssignment (per-game).
- **Name separation**: Character.Name = role name (persistent), Character.PlayerFirstName/LastName = real person name (persistent)
- **Scan page** shows character name prominently, player name as subtitle
- **Registrace import** (`POST /api/characters/import/{gameId}`) — upserts characters + assignments from registrace seed API. Preserves user-edited Name on re-import.
- **Link to registrace** on character edit + scan page

## Test plan
- [x] Build: 0 warnings, 0 errors
- [x] 150 integration tests pass
- [ ] Manual: import from registrace for game 30
- [ ] Manual: scan a real person QR, verify name + player name display
- [ ] Manual: re-import, verify no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)