### PR TITLE
feat: stash edit UI polish + catalog reload fix [v0.3.2]

### DIFF
--- a/src/OvcinaHra.Client/Components/ImagePicker.razor
+++ b/src/OvcinaHra.Client/Components/ImagePicker.razor
@@ -1,13 +1,39 @@
-<div class="image-picker">
-    @if (currentUrl is not null)
+<div class="image-picker @(CardMode ? "image-picker-card" : "")">
+    @if (CardMode)
     {
-        <div class="position-relative d-inline-block mb-2">
-            <img src="@currentUrl" alt="@Alt" style="max-width: 100%; max-height: 200px; border-radius: 4px;" />
-            <button class="btn btn-sm btn-danger position-absolute top-0 end-0 m-1"
-                    @onclick="DeleteImage" disabled="@isWorking">&#10005;</button>
-        </div>
+        <label class="image-card-label">
+            @if (currentUrl is not null)
+            {
+                <img src="@currentUrl" alt="@Alt" class="image-card-img" />
+                <button class="btn btn-sm btn-danger image-card-delete"
+                        @onclick="DeleteImage" @onclick:stopPropagation="true" disabled="@isWorking">
+                    &#10005;
+                </button>
+            }
+            else
+            {
+                <div class="image-card-placeholder">
+                    <i class="bi bi-image fs-1"></i>
+                    <div>Žádný obrázek</div>
+                    <small class="text-muted">Klikněte pro nahrání</small>
+                </div>
+            }
+            <InputFile OnChange="HandleFileSelected" accept=".jpg,.jpeg,.png,.webp"
+                       disabled="@isWorking" class="d-none" />
+        </label>
     }
-    <InputFile OnChange="HandleFileSelected" accept=".jpg,.jpeg,.png,.webp" disabled="@isWorking" />
+    else
+    {
+        @if (currentUrl is not null)
+        {
+            <div class="position-relative d-inline-block mb-2">
+                <img src="@currentUrl" alt="@Alt" style="max-width: 100%; max-height: 200px; border-radius: 4px;" />
+                <button class="btn btn-sm btn-danger position-absolute top-0 end-0 m-1"
+                        @onclick="DeleteImage" disabled="@isWorking">&#10005;</button>
+            </div>
+        }
+        <InputFile OnChange="HandleFileSelected" accept=".jpg,.jpeg,.png,.webp" disabled="@isWorking" />
+    }
     @if (errorMessage is not null)
     {
         <div class="text-danger small mt-1">@errorMessage</div>
@@ -21,6 +47,7 @@
     [Parameter, EditorRequired] public int EntityId { get; set; }
     [Parameter] public string? Field { get; set; }
     [Parameter] public string Alt { get; set; } = "Obrázek";
+    [Parameter] public bool CardMode { get; set; } = false;
 
     private string? currentUrl;
     private string? errorMessage;

--- a/src/OvcinaHra.Client/Components/ImagePicker.razor.css
+++ b/src/OvcinaHra.Client/Components/ImagePicker.razor.css
@@ -1,0 +1,41 @@
+.image-picker-card .image-card-label {
+    display: block;
+    cursor: pointer;
+    width: 100%;
+    position: relative;
+}
+
+.image-picker-card .image-card-img {
+    width: 100%;
+    height: auto;
+    max-height: 500px;
+    object-fit: contain;
+    border-radius: 8px;
+    display: block;
+}
+
+.image-picker-card .image-card-placeholder {
+    width: 100%;
+    aspect-ratio: 3 / 4;
+    background: #f5f5f5;
+    border: 2px dashed #ccc;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: #999;
+    gap: 0.5rem;
+    transition: border-color 0.15s, background 0.15s;
+}
+
+.image-picker-card .image-card-label:hover .image-card-placeholder {
+    border-color: #888;
+    background: #ececec;
+}
+
+.image-picker-card .image-card-delete {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+}

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.3.1</Version>
+    <Version>0.3.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
@@ -108,11 +108,23 @@ else
     private HashSet<int> assignedBuildingIds = [];
     private int gameId => GameContext.SelectedGameId ?? 1;
 
+    private bool _previousCatalog;
+
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
         GameContext.OnGameChanged += OnGameChanged;
+        _previousCatalog = Catalog;
         await LoadAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Catalog != _previousCatalog)
+        {
+            _previousCatalog = Catalog;
+            await LoadAsync();
+        }
     }
     private async Task LoadAsync()
     {

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -291,13 +291,25 @@ else
     // Catalog assign state
     private HashSet<int> assignedItemIds = [];
 
+    private bool _previousCatalog;
+
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
+        _previousCatalog = Catalog;
         await LoadAsync();
         allItems = await Api.GetListAsync<ItemListDto>("/api/items");
         if (GameContext.SelectedGameId is int gid)
             allBuildings = await Api.GetListAsync<BuildingListDto>($"/api/buildings/by-game/{gid}");
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Catalog != _previousCatalog)
+        {
+            _previousCatalog = Catalog;
+            await LoadAsync();
+        }
     }
 
     private async Task LoadAsync()

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
@@ -205,11 +205,23 @@ else
     // Catalog assign state
     private HashSet<int> assignedMonsterIds = [];
 
+    private bool _previousCatalog;
+
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
+        _previousCatalog = Catalog;
         await LoadAsync();
         allItems = await Api.GetListAsync<ItemListDto>("/api/items");
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Catalog != _previousCatalog)
+        {
+            _previousCatalog = Catalog;
+            await LoadAsync();
+        }
     }
 
     private async Task LoadAsync()

--- a/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
+++ b/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
@@ -65,25 +65,34 @@ else
     </OvcinaGrid>
 }
 
-@* Edit popup (catalog) *@
-<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="850px">
+@* Edit popup *@
+<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="900px">
     <BodyContentTemplate Context="popupContext">
-        <div class="row">
+        <div class="row g-2">
             @if (editingId.HasValue)
             {
                 <div class="col-md-5">
                     <div class="stash-card-image">
-                        <ImagePicker EntityType="secretstashes" EntityId="editingId.Value" Alt="Obrázek skrýše" />
+                        <ImagePicker EntityType="secretstashes" EntityId="editingId.Value"
+                                     Alt="Obrázek skrýše" CardMode="true" />
                     </div>
                 </div>
             }
-            <div class="@(editingId.HasValue ? "col-md-7" : "col-12")">
+            <div class="@(editingId.HasValue ? "col-md-7" : "col-12") ps-md-2">
                 <DxFormLayout>
                     <DxFormLayoutItem Caption="Název" ColSpanMd="12">
                         <DxTextBox @bind-Text="@name" />
                     </DxFormLayoutItem>
+                    @if (currentStashLocation is not null)
+                    {
+                        <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
+                            <div class="form-control-plaintext">
+                                <i class="bi bi-geo-alt me-1"></i>@currentStashLocation
+                            </div>
+                        </DxFormLayoutItem>
+                    }
                     <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
-                        <DxMemo @bind-Text="@description" Rows="5" />
+                        <DxMemo @bind-Text="@description" Rows="6" />
                     </DxFormLayoutItem>
                 </DxFormLayout>
             </div>
@@ -138,6 +147,10 @@ else
     private string? error, description;
     private int? editingId;
 
+    // Location context (set when opening from game grid)
+    private string? currentStashLocation;
+    private int? currentStashLocationId;
+
     // Game state
     private List<GameSecretStashDto> gameStashes = [];
     private HashSet<int> assignedStashIds = [];
@@ -150,12 +163,25 @@ else
 
     private int gameId => GameContext.SelectedGameId ?? 1;
 
+    private bool _previousCatalog;
+
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
         GameContext.OnGameChanged += OnGameChanged;
         await LoadLocationsAsync();
+        _previousCatalog = Catalog;
         await LoadAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        // Reload when the Catalog query parameter flips (same component, different URL)
+        if (Catalog != _previousCatalog)
+        {
+            _previousCatalog = Catalog;
+            await LoadAsync();
+        }
     }
 
     private async Task LoadLocationsAsync()
@@ -194,6 +220,8 @@ else
     private void OpenModal(SecretStashListDto? s)
     {
         error = null;
+        currentStashLocation = null;
+        currentStashLocationId = null;
         if (s is null)
         {
             editingId = null; name = ""; description = null;
@@ -209,8 +237,9 @@ else
 
     private void OpenGameStashDetail(GameSecretStashDto gs)
     {
-        // Open catalog edit for the underlying stash
         OpenModal(new SecretStashListDto(gs.SecretStashId, gs.StashName, null));
+        currentStashLocationId = gs.LocationId;
+        currentStashLocation = gs.LocationName;
         _ = LoadStashDetailAsync(gs.SecretStashId);
     }
 

--- a/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor.css
+++ b/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor.css
@@ -1,6 +1,1 @@
-::deep .stash-card-image .image-picker img {
-    max-height: 400px;
-    width: 100%;
-    object-fit: contain;
-    border-radius: 8px;
-}
+/* Image sizing is now handled by ImagePicker card-mode styles */


### PR DESCRIPTION
## Summary
- **ImagePicker CardMode**: click anywhere on the image (or placeholder) to upload, no visible Choose File button
- **Stash edit popup**: bigger image area (up to 500px), empty placeholder when no image, text column closer
- **Show location** in stash detail when editing from the game grid (not in catalog view)
- **Fix catalog reload**: Items, Buildings, Monsters, SecretStashes didn't reload when the URL flipped from game mode to catalog — OnParametersSetAsync added

## Test plan
- [x] Build clean
- [ ] Manual: stash edit shows big image or placeholder, click uploads
- [ ] Manual: flip between "Jen tato hra" and "Katalog" — data reloads on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)