### PR TITLE
feat: Quest catalog entries with nullable GameId [v0.3.3]

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/QuestConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/QuestConfiguration.cs
@@ -12,7 +12,7 @@ public class QuestConfiguration : IEntityTypeConfiguration<Quest>
         builder.Property(e => e.Name).IsRequired().HasMaxLength(300);
         builder.Property(e => e.QuestType).HasConversion<string>().HasMaxLength(30);
         builder.HasOne(e => e.ParentQuest).WithMany(q => q.ChildQuests).HasForeignKey(e => e.ParentQuestId);
-        builder.HasOne(e => e.Game).WithMany(g => g.Quests).HasForeignKey(e => e.GameId);
+        builder.HasOne(e => e.Game).WithMany(g => g.Quests).HasForeignKey(e => e.GameId).IsRequired(false);
 
         builder.Property<NpgsqlTypes.NpgsqlTsVector>("SearchVector")
             .HasColumnType("tsvector")

--- a/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
@@ -42,9 +42,9 @@ public static class QuestEndpoints
     private static async Task<Ok<List<QuestCatalogDto>>> GetAll(WorldDbContext db)
     {
         var quests = await db.Quests
-            .Include(q => q.Game)
-            .OrderBy(q => q.Game.Edition).ThenBy(q => q.Name)
-            .Select(q => new QuestCatalogDto(q.Id, q.Name, q.QuestType, q.GameId, q.Game.Name, q.Game.Edition))
+            .Where(q => q.GameId == null)
+            .OrderBy(q => q.Name)
+            .Select(q => new QuestCatalogDto(q.Id, q.Name, q.QuestType, null, null, null))
             .ToListAsync();
         return TypedResults.Ok(quests);
     }

--- a/src/OvcinaHra.Api/Migrations/20260413041510_QuestCatalogEntries.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260413041510_QuestCatalogEntries.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413041510_QuestCatalogEntries")]
+    partial class QuestCatalogEntries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260413041510_QuestCatalogEntries.cs
+++ b/src/OvcinaHra.Api/Migrations/20260413041510_QuestCatalogEntries.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class QuestCatalogEntries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Quests_Games_GameId",
+                table: "Quests");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "GameId",
+                table: "Quests",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Quests_Games_GameId",
+                table: "Quests",
+                column: "GameId",
+                principalTable: "Games",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Quests_Games_GameId",
+                table: "Quests");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "GameId",
+                table: "Quests",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Quests_Games_GameId",
+                table: "Quests",
+                column: "GameId",
+                principalTable: "Games",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.3.2</Version>
+    <Version>0.3.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
@@ -12,10 +12,7 @@
             <button class="btn @(Catalog ? "btn-outline-secondary" : "btn-secondary")" @onclick="() => SetCatalog(false)">Aktuální hra</button>
             <button class="btn @(Catalog ? "btn-secondary" : "btn-outline-secondary")" @onclick="() => SetCatalog(true)">Katalog</button>
         </div>
-        @if (!Catalog)
-        {
-            <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nový quest</button>
-        }
+        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nový quest</button>
     </div>
 </div>
 
@@ -23,14 +20,12 @@
 else if (Catalog)
 {
     <OvcinaGrid Data="@catalogQuests" KeyFieldName="Id" LayoutKey="grid-layout-quests-catalog"
-                RowClick="@(e => OpenCopyPopup((QuestCatalogDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+                RowClick="@(e => OpenModalFromCatalog((QuestCatalogDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
             <DxGridDataColumn FieldName="QuestType" Caption="Typ" Width="140px">
                 <CellDisplayTemplate>@(((QuestType)context.Value).GetDisplayName())</CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="GameName" Caption="Hra" Width="180px" />
-            <DxGridDataColumn FieldName="GameEdition" Caption="Edice" Width="80px" />
         </Columns>
     </OvcinaGrid>
 }
@@ -272,7 +267,10 @@ else
         @if (copySource is not null)
         {
             <p>Quest: <strong>@copySource.Name</strong></p>
-            <p class="text-muted">Zdrojová hra: @copySource.GameName (edice @copySource.GameEdition)</p>
+            @if (copySource.GameName is not null)
+            {
+                <p class="text-muted">Zdrojová hra: @copySource.GameName (edice @copySource.GameEdition)</p>
+            }
             @if (copyWarnings.Count > 0)
             {
                 <div class="alert alert-warning">
@@ -370,6 +368,11 @@ else
     {
         copySource = q; copyWarnings = []; copyError = null; copyDone = false;
         isCopyVisible = true;
+    }
+
+    private void OpenModalFromCatalog(QuestCatalogDto q)
+    {
+        OpenModal(new QuestListDto(q.Id, q.Name, q.QuestType, null, null, q.GameId));
     }
 
     private async Task ConfirmCopyAsync()
@@ -508,7 +511,10 @@ else
             if (editingId.HasValue)
                 await Api.PutAsync($"/api/quests/{editingId}", new UpdateQuestDto(name, questType, description, fullText, timeSlot, xp, money, rewardNotes, chain, parent));
             else
-                await Api.PostAsync<CreateQuestDto, QuestListDto>("/api/quests", new CreateQuestDto(name, questType, gameId, description, fullText, timeSlot, xp, money, rewardNotes, chain, parent));
+            {
+                var gameIdForCreate = Catalog ? (int?)null : gameId;
+                await Api.PostAsync<CreateQuestDto, QuestListDto>("/api/quests", new CreateQuestDto(name, questType, gameIdForCreate, description, fullText, timeSlot, xp, money, rewardNotes, chain, parent));
+            }
             isModalVisible = false; await LoadAsync();
         }
         catch (Exception ex) { error = ex.Message; } finally { isSaving = false; }

--- a/src/OvcinaHra.Shared/Domain/Entities/Quest.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Quest.cs
@@ -15,10 +15,10 @@ public class Quest
     public string? RewardNotes { get; set; }
     public int? ChainOrder { get; set; }
     public int? ParentQuestId { get; set; }
-    public int GameId { get; set; }
+    public int? GameId { get; set; }
 
     public Quest? ParentQuest { get; set; }
-    public Game Game { get; set; } = null!;
+    public Game? Game { get; set; }
     public ICollection<Quest> ChildQuests { get; set; } = [];
     public ICollection<QuestTagLink> QuestTags { get; set; } = [];
     public ICollection<QuestLocationLink> QuestLocations { get; set; } = [];

--- a/src/OvcinaHra.Shared/Dtos/QuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/QuestDtos.cs
@@ -2,7 +2,7 @@ using OvcinaHra.Shared.Domain.Enums;
 
 namespace OvcinaHra.Shared.Dtos;
 
-public record QuestListDto(int Id, string Name, QuestType QuestType, int? ChainOrder, int? ParentQuestId, int GameId);
+public record QuestListDto(int Id, string Name, QuestType QuestType, int? ChainOrder, int? ParentQuestId, int? GameId);
 
 public record QuestDetailDto(
     int Id,
@@ -16,7 +16,7 @@ public record QuestDetailDto(
     string? RewardNotes,
     int? ChainOrder,
     int? ParentQuestId,
-    int GameId,
+    int? GameId,
     List<TagDto> Tags,
     List<QuestLocationDto> Locations,
     List<QuestEncounterDto> Encounters,
@@ -25,7 +25,7 @@ public record QuestDetailDto(
 public record CreateQuestDto(
     string Name,
     QuestType QuestType,
-    int GameId,
+    int? GameId = null,
     string? Description = null,
     string? FullText = null,
     string? TimeSlot = null,
@@ -55,5 +55,5 @@ public record AddQuestLocationDto(int LocationId);
 public record AddQuestEncounterDto(int MonsterId, int Quantity = 1);
 public record AddQuestRewardDto(int ItemId, int Quantity = 1);
 
-public record QuestCatalogDto(int Id, string Name, QuestType QuestType, int GameId, string GameName, int GameEdition);
+public record QuestCatalogDto(int Id, string Name, QuestType QuestType, int? GameId, string? GameName, int? GameEdition);
 public record QuestCopyResultDto(QuestListDto Quest, List<string> Warnings);


### PR DESCRIPTION
## Summary
- Quest.GameId is now nullable — null = catalog entry (master template), value = game-specific quest
- Catalog view filters to GameId IS NULL for a clean library
- New quest button available in catalog mode
- Catalog row-click opens edit modal directly (no more copy-only flow)
- Copy-to-game still works for deploying templates into specific games

## Data migration
After deploy, I'll run an API cleanup to set GameId=null on all quests currently in game 30 — moves them to catalog.

## Test plan
- [x] Build clean
- [x] 150 tests pass
- [ ] Manual: create quest in catalog, verify GameId null
- [ ] Manual: copy catalog quest to game 30, verify new quest appears in game

🤖 Generated with [Claude Code](https://claude.com/claude-code)