### PR TITLE
feat: NPC + GameEvent system [v0.4.0]

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/GameEventConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/GameEventConfiguration.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class GameEventConfiguration : IEntityTypeConfiguration<GameEvent>
+{
+    public void Configure(EntityTypeBuilder<GameEvent> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Name).IsRequired().HasMaxLength(300);
+        builder.HasOne(e => e.Game).WithMany(g => g.GameEvents).HasForeignKey(e => e.GameId);
+        builder.HasIndex(e => e.GameId);
+        builder.HasQueryFilter(e => !e.IsDeleted);
+    }
+}
+
+public class GameEventTimeSlotConfiguration : IEntityTypeConfiguration<GameEventTimeSlot>
+{
+    public void Configure(EntityTypeBuilder<GameEventTimeSlot> builder)
+    {
+        builder.HasKey(e => new { e.GameEventId, e.GameTimeSlotId });
+        builder.HasOne(e => e.GameEvent).WithMany(ge => ge.EventTimeSlots).HasForeignKey(e => e.GameEventId);
+        builder.HasOne(e => e.TimeSlot).WithMany(ts => ts.EventTimeSlots).HasForeignKey(e => e.GameTimeSlotId);
+    }
+}
+
+public class GameEventLocationConfiguration : IEntityTypeConfiguration<GameEventLocation>
+{
+    public void Configure(EntityTypeBuilder<GameEventLocation> builder)
+    {
+        builder.HasKey(e => new { e.GameEventId, e.LocationId });
+        builder.HasOne(e => e.GameEvent).WithMany(ge => ge.EventLocations).HasForeignKey(e => e.GameEventId);
+        builder.HasOne(e => e.Location).WithMany(l => l.EventLocations).HasForeignKey(e => e.LocationId);
+    }
+}
+
+public class GameEventQuestConfiguration : IEntityTypeConfiguration<GameEventQuest>
+{
+    public void Configure(EntityTypeBuilder<GameEventQuest> builder)
+    {
+        builder.HasKey(e => new { e.GameEventId, e.QuestId });
+        builder.HasOne(e => e.GameEvent).WithMany(ge => ge.EventQuests).HasForeignKey(e => e.GameEventId);
+        builder.HasOne(e => e.Quest).WithMany(q => q.EventQuests).HasForeignKey(e => e.QuestId);
+    }
+}
+
+public class GameEventNpcConfiguration : IEntityTypeConfiguration<GameEventNpc>
+{
+    public void Configure(EntityTypeBuilder<GameEventNpc> builder)
+    {
+        builder.HasKey(e => new { e.GameEventId, e.NpcId });
+        builder.Property(e => e.RoleInEvent).HasMaxLength(100);
+        builder.HasOne(e => e.GameEvent).WithMany(ge => ge.EventNpcs).HasForeignKey(e => e.GameEventId);
+        builder.HasOne(e => e.Npc).WithMany(n => n.EventNpcs).HasForeignKey(e => e.NpcId);
+    }
+}

--- a/src/OvcinaHra.Api/Data/Configurations/NpcConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/NpcConfiguration.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class NpcConfiguration : IEntityTypeConfiguration<Npc>
+{
+    public void Configure(EntityTypeBuilder<Npc> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Name).IsRequired().HasMaxLength(200);
+        builder.Property(e => e.Role).HasConversion<string>().HasMaxLength(20);
+        builder.HasQueryFilter(e => !e.IsDeleted);
+    }
+}
+
+public class GameNpcConfiguration : IEntityTypeConfiguration<GameNpc>
+{
+    public void Configure(EntityTypeBuilder<GameNpc> builder)
+    {
+        builder.HasKey(e => new { e.GameId, e.NpcId });
+        builder.HasOne(e => e.Game).WithMany(g => g.GameNpcs).HasForeignKey(e => e.GameId);
+        builder.HasOne(e => e.Npc).WithMany(n => n.GameNpcs).HasForeignKey(e => e.NpcId);
+        builder.HasIndex(e => e.GameId);
+        builder.HasIndex(e => e.PlayedByPersonId);
+        builder.HasIndex(e => e.PlayedByEmail);
+        builder.Property(e => e.PlayedByName).HasMaxLength(200);
+        builder.Property(e => e.PlayedByEmail).HasMaxLength(200);
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -17,6 +17,8 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<CraftingIngredient> CraftingIngredients => Set<CraftingIngredient>();
     public DbSet<CraftingBuildingRequirement> CraftingBuildingRequirements => Set<CraftingBuildingRequirement>();
     public DbSet<Monster> Monsters => Set<Monster>();
+    public DbSet<Npc> Npcs => Set<Npc>();
+    public DbSet<GameNpc> GameNpcs => Set<GameNpc>();
     public DbSet<MonsterTagLink> MonsterTagLinks => Set<MonsterTagLink>();
     public DbSet<MonsterLoot> MonsterLoots => Set<MonsterLoot>();
     public DbSet<GameMonster> GameMonsters => Set<GameMonster>();

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -37,6 +37,11 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<Character> Characters => Set<Character>();
     public DbSet<CharacterAssignment> CharacterAssignments => Set<CharacterAssignment>();
     public DbSet<CharacterEvent> CharacterEvents => Set<CharacterEvent>();
+    public DbSet<GameEvent> GameEvents => Set<GameEvent>();
+    public DbSet<GameEventTimeSlot> GameEventTimeSlots => Set<GameEventTimeSlot>();
+    public DbSet<GameEventLocation> GameEventLocations => Set<GameEventLocation>();
+    public DbSet<GameEventQuest> GameEventQuests => Set<GameEventQuest>();
+    public DbSet<GameEventNpc> GameEventNpcs => Set<GameEventNpc>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/OvcinaHra.Api/Endpoints/GameEventEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEventEndpoints.cs
@@ -1,0 +1,317 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Endpoints;
+
+public static class GameEventEndpoints
+{
+    public static IEndpointRouteBuilder MapGameEventEndpoints(this IEndpointRouteBuilder routes)
+    {
+        // Game-scoped event routes
+        var gameGroup = routes.MapGroup("/api/games/{gameId:int}/events")
+            .WithTags("GameEvents")
+            .RequireAuthorization();
+        gameGroup.MapGet("/", ListByGame);
+        gameGroup.MapGet("/current", GetCurrentEvents);
+        gameGroup.MapGet("/next", GetNextEvents);
+        gameGroup.MapPost("/", CreateForGame);
+
+        // Event-by-id routes
+        var eventGroup = routes.MapGroup("/api/events")
+            .WithTags("GameEvents")
+            .RequireAuthorization();
+        eventGroup.MapGet("/{id:int}", GetById);
+        eventGroup.MapPut("/{id:int}", Update);
+        eventGroup.MapDelete("/{id:int}", Delete);
+
+        // User schedule query
+        routes.MapGet("/api/users/{personId:int}/schedule", GetUserSchedule)
+            .WithTags("GameEvents")
+            .RequireAuthorization();
+
+        return routes;
+    }
+
+    private static async Task<Ok<List<GameEventListDto>>> ListByGame(int gameId, WorldDbContext db)
+    {
+        var events = await db.GameEvents
+            .Where(e => e.GameId == gameId && !e.IsDeleted)
+            .Select(e => new GameEventListDto(
+                e.Id, e.GameId, e.Name, e.Description,
+                e.EventTimeSlots.Count, e.EventLocations.Count,
+                e.EventQuests.Count, e.EventNpcs.Count))
+            .ToListAsync();
+        return TypedResults.Ok(events);
+    }
+
+    private static async Task<Ok<List<GameEventDetailDto>>> GetCurrentEvents(int gameId, WorldDbContext db)
+    {
+        var now = DateTime.UtcNow;
+        var events = await db.GameEvents
+            .Where(e => e.GameId == gameId && !e.IsDeleted)
+            .Include(e => e.EventTimeSlots).ThenInclude(ets => ets.TimeSlot)
+            .Include(e => e.EventLocations).ThenInclude(el => el.Location)
+            .Include(e => e.EventQuests).ThenInclude(eq => eq.Quest)
+            .Include(e => e.EventNpcs).ThenInclude(en => en.Npc)
+            .ToListAsync();
+
+        var gameNpcs = await db.GameNpcs.Where(gn => gn.GameId == gameId).ToListAsync();
+
+        var current = events
+            .Where(e => e.EventTimeSlots.Any(ets =>
+                ets.TimeSlot.StartTime <= now &&
+                now < ets.TimeSlot.StartTime.Add(ets.TimeSlot.Duration)))
+            .Select(e => ToDetailDto(e, gameNpcs))
+            .ToList();
+
+        return TypedResults.Ok(current);
+    }
+
+    private static async Task<Ok<List<GameEventDetailDto>>> GetNextEvents(
+        int gameId, WorldDbContext db, int count = 5)
+    {
+        var now = DateTime.UtcNow;
+        count = Math.Clamp(count <= 0 ? 5 : count, 1, 50);
+
+        var events = await db.GameEvents
+            .Where(e => e.GameId == gameId && !e.IsDeleted &&
+                        e.EventTimeSlots.Any(ets => ets.TimeSlot.StartTime > now))
+            .Include(e => e.EventTimeSlots).ThenInclude(ets => ets.TimeSlot)
+            .Include(e => e.EventLocations).ThenInclude(el => el.Location)
+            .Include(e => e.EventQuests).ThenInclude(eq => eq.Quest)
+            .Include(e => e.EventNpcs).ThenInclude(en => en.Npc)
+            .ToListAsync();
+
+        var gameNpcs = await db.GameNpcs.Where(gn => gn.GameId == gameId).ToListAsync();
+
+        var upcoming = events
+            .OrderBy(e => e.EventTimeSlots.Min(ets => ets.TimeSlot.StartTime))
+            .Take(count)
+            .Select(e => ToDetailDto(e, gameNpcs))
+            .ToList();
+
+        return TypedResults.Ok(upcoming);
+    }
+
+    private static async Task<Results<Ok<GameEventDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
+    {
+        var e = await db.GameEvents
+            .Where(ev => ev.Id == id && !ev.IsDeleted)
+            .Include(ev => ev.EventTimeSlots).ThenInclude(ets => ets.TimeSlot)
+            .Include(ev => ev.EventLocations).ThenInclude(el => el.Location)
+            .Include(ev => ev.EventQuests).ThenInclude(eq => eq.Quest)
+            .Include(ev => ev.EventNpcs).ThenInclude(en => en.Npc)
+            .FirstOrDefaultAsync();
+
+        if (e is null) return TypedResults.NotFound();
+
+        var gameNpcs = await db.GameNpcs.Where(gn => gn.GameId == e.GameId).ToListAsync();
+        return TypedResults.Ok(ToDetailDto(e, gameNpcs));
+    }
+
+    private static async Task<Results<Created<GameEventDetailDto>, BadRequest<string>>> CreateForGame(
+        int gameId, CreateGameEventDto dto, WorldDbContext db)
+    {
+        if (dto.TimeSlotIds.Count == 0)
+            return TypedResults.BadRequest("Událost musí mít alespoň jeden časový slot.");
+
+        // Validate time slots belong to this game
+        var validSlots = await db.GameTimeSlots
+            .Where(ts => ts.GameId == gameId && dto.TimeSlotIds.Contains(ts.Id))
+            .Select(ts => ts.Id)
+            .ToListAsync();
+        if (validSlots.Count != dto.TimeSlotIds.Distinct().Count())
+            return TypedResults.BadRequest("Některé časové sloty nepatří k této hře.");
+
+        // Validate quests belong to this game (or are catalog quests with null GameId)
+        if (dto.QuestIds.Count > 0)
+        {
+            var validQuests = await db.Quests
+                .Where(q => dto.QuestIds.Contains(q.Id) && (q.GameId == gameId || q.GameId == null))
+                .Select(q => q.Id)
+                .ToListAsync();
+            if (validQuests.Count != dto.QuestIds.Distinct().Count())
+                return TypedResults.BadRequest("Některé questy nepatří k této hře ani do katalogu.");
+        }
+
+        var ev = new GameEvent
+        {
+            GameId = gameId,
+            Name = dto.Name,
+            Description = dto.Description
+        };
+
+        foreach (var slotId in dto.TimeSlotIds.Distinct())
+            ev.EventTimeSlots.Add(new GameEventTimeSlot { GameTimeSlotId = slotId });
+        foreach (var locId in dto.LocationIds.Distinct())
+            ev.EventLocations.Add(new GameEventLocation { LocationId = locId });
+        foreach (var questId in dto.QuestIds.Distinct())
+            ev.EventQuests.Add(new GameEventQuest { QuestId = questId });
+        foreach (var n in dto.Npcs.DistinctBy(x => x.NpcId))
+            ev.EventNpcs.Add(new GameEventNpc { NpcId = n.NpcId, RoleInEvent = n.RoleInEvent });
+
+        db.GameEvents.Add(ev);
+        await db.SaveChangesAsync();
+
+        // Re-fetch with includes for response
+        var saved = await db.GameEvents
+            .Include(e => e.EventTimeSlots).ThenInclude(ets => ets.TimeSlot)
+            .Include(e => e.EventLocations).ThenInclude(el => el.Location)
+            .Include(e => e.EventQuests).ThenInclude(eq => eq.Quest)
+            .Include(e => e.EventNpcs).ThenInclude(en => en.Npc)
+            .FirstAsync(e => e.Id == ev.Id);
+
+        var gameNpcs = await db.GameNpcs.Where(gn => gn.GameId == gameId).ToListAsync();
+        return TypedResults.Created($"/api/events/{ev.Id}", ToDetailDto(saved, gameNpcs));
+    }
+
+    private static async Task<Results<Ok<GameEventDetailDto>, NotFound, BadRequest<string>>> Update(
+        int id, UpdateGameEventDto dto, WorldDbContext db)
+    {
+        if (dto.TimeSlotIds.Count == 0)
+            return TypedResults.BadRequest("Událost musí mít alespoň jeden časový slot.");
+
+        var ev = await db.GameEvents
+            .Where(e => e.Id == id && !e.IsDeleted)
+            .Include(e => e.EventTimeSlots)
+            .Include(e => e.EventLocations)
+            .Include(e => e.EventQuests)
+            .Include(e => e.EventNpcs)
+            .FirstOrDefaultAsync();
+
+        if (ev is null) return TypedResults.NotFound();
+
+        // Validate time slots belong to this game
+        var validSlots = await db.GameTimeSlots
+            .Where(ts => ts.GameId == ev.GameId && dto.TimeSlotIds.Contains(ts.Id))
+            .Select(ts => ts.Id)
+            .ToListAsync();
+        if (validSlots.Count != dto.TimeSlotIds.Distinct().Count())
+            return TypedResults.BadRequest("Některé časové sloty nepatří k této hře.");
+
+        // Validate quests
+        if (dto.QuestIds.Count > 0)
+        {
+            var validQuests = await db.Quests
+                .Where(q => dto.QuestIds.Contains(q.Id) && (q.GameId == ev.GameId || q.GameId == null))
+                .Select(q => q.Id)
+                .ToListAsync();
+            if (validQuests.Count != dto.QuestIds.Distinct().Count())
+                return TypedResults.BadRequest("Některé questy nepatří k této hře ani do katalogu.");
+        }
+
+        ev.Name = dto.Name;
+        ev.Description = dto.Description;
+        ev.UpdatedAtUtc = DateTime.UtcNow;
+
+        // Replace all junctions
+        ev.EventTimeSlots.Clear();
+        ev.EventLocations.Clear();
+        ev.EventQuests.Clear();
+        ev.EventNpcs.Clear();
+
+        foreach (var slotId in dto.TimeSlotIds.Distinct())
+            ev.EventTimeSlots.Add(new GameEventTimeSlot { GameTimeSlotId = slotId });
+        foreach (var locId in dto.LocationIds.Distinct())
+            ev.EventLocations.Add(new GameEventLocation { LocationId = locId });
+        foreach (var questId in dto.QuestIds.Distinct())
+            ev.EventQuests.Add(new GameEventQuest { QuestId = questId });
+        foreach (var n in dto.Npcs.DistinctBy(x => x.NpcId))
+            ev.EventNpcs.Add(new GameEventNpc { NpcId = n.NpcId, RoleInEvent = n.RoleInEvent });
+
+        await db.SaveChangesAsync();
+
+        // Re-fetch with navigation props for response
+        var saved = await db.GameEvents
+            .Include(e => e.EventTimeSlots).ThenInclude(ets => ets.TimeSlot)
+            .Include(e => e.EventLocations).ThenInclude(el => el.Location)
+            .Include(e => e.EventQuests).ThenInclude(eq => eq.Quest)
+            .Include(e => e.EventNpcs).ThenInclude(en => en.Npc)
+            .FirstAsync(e => e.Id == id);
+
+        var gameNpcs = await db.GameNpcs.Where(gn => gn.GameId == ev.GameId).ToListAsync();
+        return TypedResults.Ok(ToDetailDto(saved, gameNpcs));
+    }
+
+    private static async Task<Results<NoContent, NotFound>> Delete(int id, WorldDbContext db)
+    {
+        var ev = await db.GameEvents.FirstOrDefaultAsync(e => e.Id == id && !e.IsDeleted);
+        if (ev is null) return TypedResults.NotFound();
+
+        ev.IsDeleted = true;
+        ev.UpdatedAtUtc = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Ok<UserScheduleDto>> GetUserSchedule(
+        int personId, int gameId, WorldDbContext db)
+    {
+        var myNpcIds = await db.GameNpcs
+            .Where(gn => gn.GameId == gameId && gn.PlayedByPersonId == personId)
+            .Select(gn => gn.NpcId)
+            .ToListAsync();
+
+        if (myNpcIds.Count == 0)
+            return TypedResults.Ok(new UserScheduleDto(personId, gameId, []));
+
+        var events = await db.GameEvents
+            .Where(e => e.GameId == gameId && !e.IsDeleted &&
+                        e.EventNpcs.Any(en => myNpcIds.Contains(en.NpcId)))
+            .Include(e => e.EventTimeSlots).ThenInclude(ets => ets.TimeSlot)
+            .Include(e => e.EventLocations).ThenInclude(el => el.Location)
+            .Include(e => e.EventQuests).ThenInclude(eq => eq.Quest)
+            .Include(e => e.EventNpcs).ThenInclude(en => en.Npc)
+            .ToListAsync();
+
+        var ordered = events
+            .OrderBy(e => e.EventTimeSlots.Count > 0
+                ? e.EventTimeSlots.Min(ets => ets.TimeSlot.StartTime)
+                : DateTime.MaxValue)
+            .ToList();
+
+        var result = new List<UserScheduleEventDto>();
+        foreach (var e in ordered)
+        {
+            foreach (var en in e.EventNpcs.Where(en => myNpcIds.Contains(en.NpcId)))
+            {
+                result.Add(new UserScheduleEventDto(
+                    e.Id, e.Name, e.Description,
+                    e.EventTimeSlots.Select(ets => new GameEventTimeSlotDto(
+                        ets.TimeSlot.Id, ets.TimeSlot.StartTime,
+                        (decimal)ets.TimeSlot.Duration.TotalHours,
+                        ets.TimeSlot.InGameYear)).ToList(),
+                    e.EventLocations.Select(el => el.Location.Name).ToList(),
+                    e.EventQuests.Select(eq => eq.Quest.Name).ToList(),
+                    en.Npc.Name, en.Npc.Role, en.RoleInEvent));
+            }
+        }
+
+        return TypedResults.Ok(new UserScheduleDto(personId, gameId, result));
+    }
+
+    private static GameEventDetailDto ToDetailDto(GameEvent e, List<GameNpc> gameNpcs)
+    {
+        return new GameEventDetailDto(
+            e.Id, e.GameId, e.Name, e.Description,
+            e.EventTimeSlots.Select(ets => new GameEventTimeSlotDto(
+                ets.TimeSlot.Id, ets.TimeSlot.StartTime,
+                (decimal)ets.TimeSlot.Duration.TotalHours,
+                ets.TimeSlot.InGameYear)).ToList(),
+            e.EventLocations.Select(el => new GameEventLocationRefDto(
+                el.Location.Id, el.Location.Name)).ToList(),
+            e.EventQuests.Select(eq => new GameEventQuestRefDto(
+                eq.Quest.Id, eq.Quest.Name)).ToList(),
+            e.EventNpcs.Select(en =>
+            {
+                var gn = gameNpcs.FirstOrDefault(g => g.NpcId == en.NpcId);
+                return new GameEventNpcRefDto(
+                    en.Npc.Id, en.Npc.Name, en.Npc.Role, en.RoleInEvent,
+                    gn?.PlayedByName, gn?.PlayedByEmail);
+            }).ToList(),
+            e.CreatedAtUtc, e.UpdatedAtUtc);
+    }
+}

--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -8,7 +8,7 @@ namespace OvcinaHra.Api.Endpoints;
 
 public static class ImageEndpoints
 {
-    private static readonly HashSet<string> ValidEntityTypes = ["locations", "items", "monsters", "secretstashes"];
+    private static readonly HashSet<string> ValidEntityTypes = ["locations", "items", "monsters", "secretstashes", "npcs"];
     private static readonly HashSet<string> AllowedContentTypes = ["image/jpeg", "image/png", "image/webp"];
     private const long MaxFileSize = 5 * 1024 * 1024; // 5 MB
 
@@ -125,6 +125,10 @@ public static class ImageEndpoints
                 var stash = await db.SecretStashes.FindAsync(entityId);
                 if (stash is not null) stash.ImagePath = blobKey;
                 break;
+            case "npcs":
+                var npc = await db.Npcs.FindAsync(entityId);
+                if (npc is not null) npc.ImagePath = blobKey;
+                break;
         }
 
         await db.SaveChangesAsync();
@@ -147,6 +151,9 @@ public static class ImageEndpoints
             "secretstashes" => await db.SecretStashes.Where(s => s.Id == entityId)
                 .Select(s => new ValueTuple<string?, string?>(s.ImagePath, null))
                 .FirstOrDefaultAsync(),
+            "npcs" => await db.Npcs.Where(n => n.Id == entityId)
+                .Select(n => new ValueTuple<string?, string?>(n.ImagePath, null))
+                .FirstOrDefaultAsync(),
             _ => (null, null)
         };
     }
@@ -159,6 +166,7 @@ public static class ImageEndpoints
             "items" => await db.Items.AnyAsync(i => i.Id == entityId),
             "monsters" => await db.Monsters.AnyAsync(m => m.Id == entityId),
             "secretstashes" => await db.SecretStashes.AnyAsync(s => s.Id == entityId),
+            "npcs" => await db.Npcs.AnyAsync(n => n.Id == entityId),
             _ => false
         };
     }

--- a/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
@@ -1,0 +1,149 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Endpoints;
+
+public static class NpcEndpoints
+{
+    public static RouteGroupBuilder MapNpcEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/npcs").WithTags("Npcs");
+
+        group.MapGet("/", GetAll);
+        group.MapGet("/{id:int}", GetById);
+        group.MapPost("/", Create);
+        group.MapPut("/{id:int}", Update);
+        group.MapDelete("/{id:int}", Delete);
+
+        // Per-game assignment
+        group.MapGet("/by-game/{gameId:int}", GetByGame);
+        group.MapPost("/game-npc", CreateGameNpc);
+        group.MapPut("/game-npc/{gameId:int}/{npcId:int}", UpdateGameNpc);
+        group.MapDelete("/game-npc/{gameId:int}/{npcId:int}", DeleteGameNpc);
+
+        return group;
+    }
+
+    private static async Task<Ok<List<NpcListDto>>> GetAll(WorldDbContext db)
+    {
+        var npcs = await db.Npcs
+            .Where(n => !n.IsDeleted)
+            .OrderBy(n => n.Name)
+            .Select(n => new NpcListDto(n.Id, n.Name, n.Role, n.Description))
+            .ToListAsync();
+        return TypedResults.Ok(npcs);
+    }
+
+    private static async Task<Results<Ok<NpcDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
+    {
+        var n = await db.Npcs.FirstOrDefaultAsync(n => n.Id == id && !n.IsDeleted);
+        if (n is null) return TypedResults.NotFound();
+
+        return TypedResults.Ok(new NpcDetailDto(
+            n.Id, n.Name, n.Role, n.Description, n.Notes, n.ImagePath));
+    }
+
+    private static async Task<Created<NpcDetailDto>> Create(CreateNpcDto dto, WorldDbContext db)
+    {
+        var n = new Npc
+        {
+            Name = dto.Name,
+            Role = dto.Role,
+            Description = dto.Description,
+            Notes = dto.Notes
+        };
+        db.Npcs.Add(n);
+        await db.SaveChangesAsync();
+
+        return TypedResults.Created($"/api/npcs/{n.Id}",
+            new NpcDetailDto(n.Id, n.Name, n.Role, n.Description, n.Notes, n.ImagePath));
+    }
+
+    private static async Task<Results<NoContent, NotFound>> Update(int id, UpdateNpcDto dto, WorldDbContext db)
+    {
+        var n = await db.Npcs.FirstOrDefaultAsync(n => n.Id == id && !n.IsDeleted);
+        if (n is null) return TypedResults.NotFound();
+
+        n.Name = dto.Name;
+        n.Role = dto.Role;
+        n.Description = dto.Description;
+        n.Notes = dto.Notes;
+        n.UpdatedAtUtc = DateTime.UtcNow;
+
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound>> Delete(int id, WorldDbContext db)
+    {
+        var n = await db.Npcs.FirstOrDefaultAsync(n => n.Id == id && !n.IsDeleted);
+        if (n is null) return TypedResults.NotFound();
+
+        n.IsDeleted = true;
+        n.UpdatedAtUtc = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Ok<List<GameNpcDto>>> GetByGame(int gameId, WorldDbContext db)
+    {
+        var npcs = await db.GameNpcs
+            .Where(gn => gn.GameId == gameId)
+            .Include(gn => gn.Npc)
+            .OrderBy(gn => gn.Npc.Name)
+            .Select(gn => new GameNpcDto(
+                gn.GameId, gn.NpcId, gn.Npc.Name, gn.Npc.Role,
+                gn.PlayedByPersonId, gn.PlayedByName, gn.PlayedByEmail,
+                gn.Notes))
+            .ToListAsync();
+        return TypedResults.Ok(npcs);
+    }
+
+    private static async Task<Results<Created<GameNpcDto>, Conflict>> CreateGameNpc(CreateGameNpcDto dto, WorldDbContext db)
+    {
+        if (await db.GameNpcs.AnyAsync(gn => gn.GameId == dto.GameId && gn.NpcId == dto.NpcId))
+            return TypedResults.Conflict();
+
+        db.GameNpcs.Add(new GameNpc
+        {
+            GameId = dto.GameId,
+            NpcId = dto.NpcId,
+            PlayedByPersonId = dto.PlayedByPersonId,
+            PlayedByName = dto.PlayedByName,
+            PlayedByEmail = dto.PlayedByEmail,
+            Notes = dto.Notes
+        });
+        await db.SaveChangesAsync();
+
+        var npc = await db.Npcs.FindAsync(dto.NpcId);
+        return TypedResults.Created($"/api/npcs/game-npc/{dto.GameId}/{dto.NpcId}",
+            new GameNpcDto(dto.GameId, dto.NpcId, npc?.Name ?? "", npc?.Role ?? default,
+                dto.PlayedByPersonId, dto.PlayedByName, dto.PlayedByEmail, dto.Notes));
+    }
+
+    private static async Task<Results<NoContent, NotFound>> UpdateGameNpc(int gameId, int npcId, UpdateGameNpcDto dto, WorldDbContext db)
+    {
+        var gn = await db.GameNpcs.FindAsync(gameId, npcId);
+        if (gn is null) return TypedResults.NotFound();
+
+        gn.PlayedByPersonId = dto.PlayedByPersonId;
+        gn.PlayedByName = dto.PlayedByName;
+        gn.PlayedByEmail = dto.PlayedByEmail;
+        gn.Notes = dto.Notes;
+
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound>> DeleteGameNpc(int gameId, int npcId, WorldDbContext db)
+    {
+        var gn = await db.GameNpcs.FindAsync(gameId, npcId);
+        if (gn is null) return TypedResults.NotFound();
+        db.GameNpcs.Remove(gn);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+}

--- a/src/OvcinaHra.Api/Migrations/20260413074751_AddNpcCatalog.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260413074751_AddNpcCatalog.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413074751_AddNpcCatalog")]
+    partial class AddNpcCatalog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260413074751_AddNpcCatalog.cs
+++ b/src/OvcinaHra.Api/Migrations/20260413074751_AddNpcCatalog.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNpcCatalog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Npcs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Role = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    Notes = table.Column<string>(type: "text", nullable: true),
+                    ImagePath = table.Column<string>(type: "text", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Npcs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "GameNpcs",
+                columns: table => new
+                {
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    NpcId = table.Column<int>(type: "integer", nullable: false),
+                    PlayedByPersonId = table.Column<int>(type: "integer", nullable: true),
+                    PlayedByName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    PlayedByEmail = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    Notes = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameNpcs", x => new { x.GameId, x.NpcId });
+                    table.ForeignKey(
+                        name: "FK_GameNpcs_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GameNpcs_Npcs_NpcId",
+                        column: x => x.NpcId,
+                        principalTable: "Npcs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameNpcs_GameId",
+                table: "GameNpcs",
+                column: "GameId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameNpcs_NpcId",
+                table: "GameNpcs",
+                column: "NpcId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameNpcs_PlayedByEmail",
+                table: "GameNpcs",
+                column: "PlayedByEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameNpcs_PlayedByPersonId",
+                table: "GameNpcs",
+                column: "PlayedByPersonId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GameNpcs");
+
+            migrationBuilder.DropTable(
+                name: "Npcs");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Migrations/20260413075950_AddGameEventSystem.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260413075950_AddGameEventSystem.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413075950_AddGameEventSystem")]
+    partial class AddGameEventSystem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260413075950_AddGameEventSystem.cs
+++ b/src/OvcinaHra.Api/Migrations/20260413075950_AddGameEventSystem.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameEventSystem : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GameEvents",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    Name = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameEvents", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_GameEvents_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "GameEventLocations",
+                columns: table => new
+                {
+                    GameEventId = table.Column<int>(type: "integer", nullable: false),
+                    LocationId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameEventLocations", x => new { x.GameEventId, x.LocationId });
+                    table.ForeignKey(
+                        name: "FK_GameEventLocations_GameEvents_GameEventId",
+                        column: x => x.GameEventId,
+                        principalTable: "GameEvents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GameEventLocations_Locations_LocationId",
+                        column: x => x.LocationId,
+                        principalTable: "Locations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "GameEventNpcs",
+                columns: table => new
+                {
+                    GameEventId = table.Column<int>(type: "integer", nullable: false),
+                    NpcId = table.Column<int>(type: "integer", nullable: false),
+                    RoleInEvent = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameEventNpcs", x => new { x.GameEventId, x.NpcId });
+                    table.ForeignKey(
+                        name: "FK_GameEventNpcs_GameEvents_GameEventId",
+                        column: x => x.GameEventId,
+                        principalTable: "GameEvents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GameEventNpcs_Npcs_NpcId",
+                        column: x => x.NpcId,
+                        principalTable: "Npcs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "GameEventQuests",
+                columns: table => new
+                {
+                    GameEventId = table.Column<int>(type: "integer", nullable: false),
+                    QuestId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameEventQuests", x => new { x.GameEventId, x.QuestId });
+                    table.ForeignKey(
+                        name: "FK_GameEventQuests_GameEvents_GameEventId",
+                        column: x => x.GameEventId,
+                        principalTable: "GameEvents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GameEventQuests_Quests_QuestId",
+                        column: x => x.QuestId,
+                        principalTable: "Quests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "GameEventTimeSlots",
+                columns: table => new
+                {
+                    GameEventId = table.Column<int>(type: "integer", nullable: false),
+                    GameTimeSlotId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameEventTimeSlots", x => new { x.GameEventId, x.GameTimeSlotId });
+                    table.ForeignKey(
+                        name: "FK_GameEventTimeSlots_GameEvents_GameEventId",
+                        column: x => x.GameEventId,
+                        principalTable: "GameEvents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GameEventTimeSlots_GameTimeSlots_GameTimeSlotId",
+                        column: x => x.GameTimeSlotId,
+                        principalTable: "GameTimeSlots",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameEventLocations_LocationId",
+                table: "GameEventLocations",
+                column: "LocationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameEventNpcs_NpcId",
+                table: "GameEventNpcs",
+                column: "NpcId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameEventQuests_QuestId",
+                table: "GameEventQuests",
+                column: "QuestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameEvents_GameId",
+                table: "GameEvents",
+                column: "GameId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameEventTimeSlots_GameTimeSlotId",
+                table: "GameEventTimeSlots",
+                column: "GameTimeSlotId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GameEventLocations");
+
+            migrationBuilder.DropTable(
+                name: "GameEventNpcs");
+
+            migrationBuilder.DropTable(
+                name: "GameEventQuests");
+
+            migrationBuilder.DropTable(
+                name: "GameEventTimeSlots");
+
+            migrationBuilder.DropTable(
+                name: "GameEvents");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -189,6 +189,7 @@ try
     app.MapSecretStashEndpoints().RequireAuthorization();
     app.MapCharacterEndpoints().RequireAuthorization();
     app.MapMonsterEndpoints().RequireAuthorization();
+    app.MapNpcEndpoints().RequireAuthorization();
     app.MapQuestEndpoints().RequireAuthorization();
     app.MapBuildingEndpoints().RequireAuthorization();
     app.MapCraftingEndpoints().RequireAuthorization();

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -196,6 +196,7 @@ try
     app.MapTreasureQuestEndpoints().RequireAuthorization();
     app.MapTreasurePlanningEndpoints().RequireAuthorization();
     app.MapTimelineEndpoints().RequireAuthorization();
+    app.MapGameEventEndpoints();
     app.MapSearchEndpoints().RequireAuthorization();
     app.MapImageEndpoints().RequireAuthorization();
     app.MapScanEndpoints();

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -70,6 +70,16 @@
                 <i class="bi bi-person-fill"></i><span class="nav-label">Postavy</span>
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="npcs">
+                <i class="bi bi-person-badge-fill"></i><span class="nav-label">NPC</span>
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="events">
+                <i class="bi bi-calendar-event-fill"></i><span class="nav-label">Události</span>
+            </NavLink>
+        </div>
 
         <div class="oh-nav-section-label">Katalog světa</div>
         <div class="nav-item px-3">
@@ -100,6 +110,11 @@
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="secret-stashes?catalog=true">
                 <i class="bi bi-lock"></i><span class="nav-label">Tajné skrýše</span>
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="npcs?catalog=true">
+                <i class="bi bi-person-badge"></i><span class="nav-label">NPC</span>
             </NavLink>
         </div>
 

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.3.3</Version>
+    <Version>0.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Events/GameEventList.razor
+++ b/src/OvcinaHra.Client/Pages/Events/GameEventList.razor
@@ -1,0 +1,285 @@
+@page "/events"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject GameContextService GameContext
+@inject NavigationManager Nav
+@implements IDisposable
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Události</h1>
+    <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová událost</button>
+</div>
+
+@if (loading) { <p>Načítám...</p> }
+else if (events.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-calendar-event fs-1 d-block mb-2"></i>
+        <p>Žádné události pro tuto hru.</p>
+        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová událost</button>
+    </div>
+}
+else
+{
+    <OvcinaGrid Data="@events" KeyFieldName="Id" LayoutKey="grid-layout-game-events"
+                RowClick="@(e => OpenModal((GameEventListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+        <Columns>
+            <DxGridDataColumn FieldName="Name" Caption="Název" />
+            <DxGridDataColumn FieldName="Description" Caption="Popis" />
+            <DxGridDataColumn FieldName="TimeSlotCount" Caption="Časů" Width="80px" />
+            <DxGridDataColumn FieldName="LocationCount" Caption="Lokací" Width="90px" />
+            <DxGridDataColumn FieldName="QuestCount" Caption="Questů" Width="90px" />
+            <DxGridDataColumn FieldName="NpcCount" Caption="NPC" Width="80px" />
+        </Columns>
+    </OvcinaGrid>
+}
+
+<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="1000px">
+    <BodyContentTemplate Context="popupContext">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                <DxTextBox @bind-Text="@name" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
+                <DxMemo @bind-Text="@description" Rows="3" />
+            </DxFormLayoutItem>
+
+            @* Time slots — multi-select tagbox *@
+            <DxFormLayoutItem Caption="Časové sloty" ColSpanMd="12">
+                <DxTagBox Data="@availableTimeSlots" Values="@selectedTimeSlotIds"
+                          ValuesChanged="@((IEnumerable<int> vals) => selectedTimeSlotIds = vals.ToList())"
+                          TextFieldName="DisplayText" ValueFieldName="Id"
+                          NullText="Vyberte časové sloty (povinné)..." />
+                <div class="form-text">Povinné — událost musí mít alespoň jeden časový slot.</div>
+            </DxFormLayoutItem>
+
+            @* Locations *@
+            <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
+                <DxTagBox Data="@availableLocations" Values="@selectedLocationIds"
+                          ValuesChanged="@((IEnumerable<int> vals) => selectedLocationIds = vals.ToList())"
+                          TextFieldName="Name" ValueFieldName="Id"
+                          NullText="Vyberte lokace..." SearchMode="ListSearchMode.AutoSearch" />
+            </DxFormLayoutItem>
+
+            @* Quests *@
+            <DxFormLayoutItem Caption="Questy" ColSpanMd="12">
+                <DxTagBox Data="@availableQuests" Values="@selectedQuestIds"
+                          ValuesChanged="@((IEnumerable<int> vals) => selectedQuestIds = vals.ToList())"
+                          TextFieldName="Name" ValueFieldName="Id"
+                          NullText="Vyberte questy..." SearchMode="ListSearchMode.AutoSearch" />
+            </DxFormLayoutItem>
+
+            @* NPCs — need RoleInEvent per NPC, so use a simple add/remove list *@
+            <DxFormLayoutItem Caption="NPC ve hře" ColSpanMd="12">
+                <div>
+                    @if (selectedNpcs.Count > 0)
+                    {
+                        <table class="table table-sm">
+                            <thead><tr><th>NPC</th><th>Role v události</th><th style="width:60px"></th></tr></thead>
+                            <tbody>
+                                @foreach (var n in selectedNpcs)
+                                {
+                                    <tr>
+                                        <td>@GetNpcName(n.NpcId)</td>
+                                        <td><DxTextBox @bind-Text="@n.RoleInEvent" NullText="(volitelně)" /></td>
+                                        <td><button type="button" class="btn btn-sm btn-link text-danger p-0" @onclick="() => RemoveNpc(n.NpcId)"><i class="bi bi-x-circle"></i></button></td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                    else { <p class="text-muted small mb-2">Žádné NPC.</p> }
+
+                    <div class="d-flex gap-2 align-items-end">
+                        <div style="flex:1">
+                            <DxComboBox Data="@availableNpcs" @bind-Value="@newNpcId"
+                                        TextFieldName="NpcName" ValueFieldName="NpcId"
+                                        NullText="(přidat NPC)" SearchMode="ListSearchMode.AutoSearch" />
+                        </div>
+                        <button type="button" class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newNpcId is null)" @onclick="AddNpc">
+                            <i class="bi bi-plus"></i>
+                        </button>
+                    </div>
+                </div>
+            </DxFormLayoutItem>
+        </DxFormLayout>
+
+        @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
+        <div class="d-flex gap-2 mt-3">
+            @if (editingId.HasValue) { <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true" disabled="@isSaving">Smazat</button> }
+            <div style="flex: 1"></div>
+            <button class="btn btn-secondary" @onclick="() => isModalVisible = false" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">Uložit</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete smazat událost <strong>@name</strong>?</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    private int gameId => GameContext.SelectedGameId ?? 1;
+
+    private List<GameEventListDto> events = [];
+    private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
+    private string modalTitle = "", name = "";
+    private string? error, description;
+    private int? editingId;
+
+    // Available options for pickers
+    private List<TimeSlotOption> availableTimeSlots = [];
+    private List<LocationListDto> availableLocations = [];
+    private List<QuestListDto> availableQuests = [];
+    private List<GameNpcDto> availableNpcs = [];
+
+    // Selected values
+    private List<int> selectedTimeSlotIds = [];
+    private List<int> selectedLocationIds = [];
+    private List<int> selectedQuestIds = [];
+    private List<EventNpcRow> selectedNpcs = [];
+    private int? newNpcId;
+
+    private record TimeSlotOption(int Id, string DisplayText);
+    private class EventNpcRow
+    {
+        public int NpcId { get; set; }
+        public string? RoleInEvent { get; set; }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        GameContext.OnGameChanged += OnGameChanged;
+        await LoadAllAsync();
+    }
+
+    private async Task LoadAllAsync()
+    {
+        loading = true;
+        if (GameContext.SelectedGameId is int gid)
+        {
+            events = await Api.GetListAsync<GameEventListDto>($"/api/games/{gid}/events");
+
+            var slots = await Api.GetListAsync<GameTimeSlotDto>($"/api/timeline/slots/by-game/{gid}");
+            availableTimeSlots = slots
+                .OrderBy(s => s.StartTime)
+                .Select(s => new TimeSlotOption(s.Id, $"{s.StartTime:d.M. HH:mm} ({s.DurationHours}h)"))
+                .ToList();
+
+            availableLocations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gid}");
+
+            var gameQuests = await Api.GetListAsync<QuestListDto>($"/api/quests/by-game/{gid}");
+            availableQuests = gameQuests;
+
+            availableNpcs = await Api.GetListAsync<GameNpcDto>($"/api/npcs/by-game/{gid}");
+        }
+        else { events = []; }
+        loading = false;
+    }
+
+    private async void OnGameChanged() { await LoadAllAsync(); StateHasChanged(); }
+    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
+
+    private async void OpenModal(GameEventListDto? e)
+    {
+        error = null;
+        selectedTimeSlotIds = [];
+        selectedLocationIds = [];
+        selectedQuestIds = [];
+        selectedNpcs = [];
+        newNpcId = null;
+
+        if (e is null)
+        {
+            editingId = null;
+            name = ""; description = null;
+            modalTitle = "Nová událost";
+        }
+        else
+        {
+            editingId = e.Id;
+            name = e.Name; description = e.Description;
+            modalTitle = $"Upravit: {e.Name}";
+            await LoadDetailAsync(e.Id);
+        }
+        isModalVisible = true;
+        StateHasChanged();
+    }
+
+    private async Task LoadDetailAsync(int id)
+    {
+        var detail = await Api.GetAsync<GameEventDetailDto>($"/api/events/{id}");
+        if (detail is not null)
+        {
+            selectedTimeSlotIds = detail.TimeSlots.Select(t => t.TimeSlotId).ToList();
+            selectedLocationIds = detail.Locations.Select(l => l.LocationId).ToList();
+            selectedQuestIds = detail.Quests.Select(q => q.QuestId).ToList();
+            selectedNpcs = detail.Npcs.Select(n => new EventNpcRow
+            {
+                NpcId = n.NpcId,
+                RoleInEvent = n.RoleInEvent
+            }).ToList();
+        }
+    }
+
+    private string GetNpcName(int npcId) => availableNpcs.FirstOrDefault(n => n.NpcId == npcId)?.NpcName ?? $"#{npcId}";
+
+    private void AddNpc()
+    {
+        if (newNpcId is null) return;
+        if (selectedNpcs.Any(n => n.NpcId == newNpcId.Value)) return;
+        selectedNpcs.Add(new EventNpcRow { NpcId = newNpcId.Value });
+        newNpcId = null;
+    }
+
+    private void RemoveNpc(int npcId)
+    {
+        selectedNpcs.RemoveAll(n => n.NpcId == npcId);
+    }
+
+    private async Task SaveAsync()
+    {
+        error = null;
+        if (selectedTimeSlotIds.Count == 0) { error = "Alespoň jeden časový slot je povinný."; return; }
+        isSaving = true;
+        try
+        {
+            var npcDtos = selectedNpcs.Select(n => new CreateGameEventNpcDto(n.NpcId, n.RoleInEvent)).ToList();
+
+            if (editingId.HasValue)
+            {
+                await Api.PutAsync($"/api/events/{editingId}",
+                    new UpdateGameEventDto(name, description,
+                        selectedTimeSlotIds, selectedLocationIds, selectedQuestIds, npcDtos));
+            }
+            else
+            {
+                await Api.PostAsync<CreateGameEventDto, GameEventDetailDto>($"/api/games/{gameId}/events",
+                    new CreateGameEventDto(name, description,
+                        selectedTimeSlotIds, selectedLocationIds, selectedQuestIds, npcDtos));
+            }
+            isModalVisible = false;
+            await LoadAllAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        try
+        {
+            await Api.DeleteAsync($"/api/events/{editingId}");
+            isDeleteVisible = false; isModalVisible = false;
+            await LoadAllAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Npcs/NpcList.razor
+++ b/src/OvcinaHra.Client/Pages/Npcs/NpcList.razor
@@ -1,0 +1,338 @@
+@page "/npcs"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject GameContextService GameContext
+@inject NavigationManager Nav
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">@(Catalog ? "Katalog NPC" : "NPC ve hře")</h1>
+    <div class="d-flex gap-2">
+        <div class="d-flex gap-2">
+            <button class="btn btn-sm @(Catalog ? "btn-outline-primary" : "btn-primary")"
+                    @onclick='() => Nav.NavigateTo("/npcs")'>Jen tato hra</button>
+            <button class="btn btn-sm @(Catalog ? "btn-primary" : "btn-outline-primary")"
+                    @onclick='() => Nav.NavigateTo("/npcs?catalog=true")'>Katalog</button>
+        </div>
+        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová NPC</button>
+    </div>
+</div>
+
+@if (loading)
+{
+    <p>Načítám...</p>
+}
+else if (!Catalog && gameNpcs.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-person-badge fs-1 d-block mb-2"></i>
+        <p>Žádné NPC přiřazené k této hře. Otevřete katalog a přidejte NPC.</p>
+        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/npcs?catalog=true")'>Otevřít katalog</button>
+    </div>
+}
+else if (Catalog && npcs.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-person-badge fs-1 d-block mb-2"></i>
+        <p>Žádné NPC v katalogu. Vytvořte první NPC.</p>
+    </div>
+}
+else if (Catalog)
+{
+    <OvcinaGrid Data="@npcs" KeyFieldName="Id" LayoutKey="grid-layout-npcs-catalog"
+                RowClick="@(e => OpenModal((NpcListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+        <Columns>
+            <DxGridDataColumn FieldName="Name" Caption="Název" />
+            <DxGridDataColumn FieldName="Role" Caption="Role" Width="150px">
+                <CellDisplayTemplate>@(((NpcRole)context.Value).GetDisplayName())</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Description" Caption="Popis" />
+            <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{
+                        var npcId = (int)context.Value;
+                        if (assignedNpcIds.Contains(npcId))
+                        {
+                            <button class="btn btn-sm btn-outline-danger" @onclick:stopPropagation="true"
+                                    @onclick="() => UnassignNpcAsync(npcId)">Odebrat</button>
+                        }
+                        else
+                        {
+                            <button class="btn btn-sm btn-outline-success" @onclick:stopPropagation="true"
+                                    @onclick="() => OpenAssignPopup(npcId)">Přidat</button>
+                        }
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+        </Columns>
+    </OvcinaGrid>
+}
+else
+{
+    <OvcinaGrid Data="@gameNpcs" KeyFieldName="NpcId" LayoutKey="grid-layout-npcs-game"
+                RowClick="@(e => { var gn = (GameNpcDto)e.Grid.GetDataItem(e.VisibleIndex); var n = npcs.FirstOrDefault(x => x.Id == gn.NpcId); if (n is not null) OpenModal(n); })">
+        <Columns>
+            <DxGridDataColumn FieldName="NpcName" Caption="Název" />
+            <DxGridDataColumn FieldName="Role" Caption="Role" Width="150px">
+                <CellDisplayTemplate>@(((NpcRole)context.Value).GetDisplayName())</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="PlayedByName" Caption="Hraje" Width="180px" />
+            <DxGridDataColumn FieldName="PlayedByEmail" Caption="Email" Width="200px" Visible="false" />
+        </Columns>
+    </OvcinaGrid>
+}
+
+<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="900px">
+    <BodyContentTemplate Context="popupContext">
+        <div class="row g-3">
+            @if (editingId.HasValue)
+            {
+                <div class="col-md-5">
+                    <ImagePicker EntityType="npcs" EntityId="editingId.Value" Alt="Obrázek NPC" CardMode="true" />
+                </div>
+                <div class="col-md-7">
+                    <DxFormLayout>
+                        <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                            <DxTextBox @bind-Text="@name" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Role" ColSpanMd="12">
+                            <DxComboBox Data="@roleValues" @bind-Value="@role"
+                                        TextFieldName="Display" ValueFieldName="Value" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
+                            <DxMemo @bind-Text="@description" Rows="3" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
+                            <DxMemo @bind-Text="@notes" Rows="3" />
+                        </DxFormLayoutItem>
+                    </DxFormLayout>
+                </div>
+            }
+            else
+            {
+                <div class="col-12">
+                    <DxFormLayout>
+                        <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                            <DxTextBox @bind-Text="@name" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Role" ColSpanMd="12">
+                            <DxComboBox Data="@roleValues" @bind-Value="@role"
+                                        TextFieldName="Display" ValueFieldName="Value" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
+                            <DxMemo @bind-Text="@description" Rows="3" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
+                            <DxMemo @bind-Text="@notes" Rows="3" />
+                        </DxFormLayoutItem>
+                    </DxFormLayout>
+                </div>
+            }
+        </div>
+
+        @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
+
+        <div class="d-flex gap-2 mt-3">
+            @if (editingId.HasValue) { <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true" disabled="@isSaving">Smazat</button> }
+            <div style="flex: 1"></div>
+            <button class="btn btn-secondary" @onclick="() => isModalVisible = false" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">Uložit</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete smazat NPC <strong>@name</strong>?</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<DxPopup @bind-Visible="@isAssignVisible" HeaderText="Přiřadit NPC ke hře" Width="500px">
+    <BodyContentTemplate Context="popupContext">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Jméno hráče" ColSpanMd="12">
+                <DxTextBox @bind-Text="@assignPlayerName" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Email hráče" ColSpanMd="12">
+                <DxTextBox @bind-Text="@assignPlayerEmail" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="ID osoby" ColSpanMd="12">
+                <DxSpinEdit @bind-Value="@assignPersonId" MinValue="1" />
+                <small class="text-muted">Volitelné — z registrace</small>
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
+                <DxMemo @bind-Text="@assignNotes" Rows="2" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+
+        @if (assignError is not null) { <div class="alert alert-danger mt-2">@assignError</div> }
+
+        <div class="d-flex gap-2 mt-3 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isAssignVisible = false">Zrušit</button>
+            <button class="btn btn-primary" @onclick="ConfirmAssignAsync">Přiřadit</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [SupplyParameterFromQuery]
+    public bool Catalog { get; set; }
+
+    private List<NpcListDto> npcs = [];
+    private List<GameNpcDto> gameNpcs = [];
+    private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
+    private string modalTitle = "", name = "";
+    private string? error, description, notes;
+    private int? editingId;
+    private NpcRole role = NpcRole.Other;
+
+    private static readonly List<EnumItem<NpcRole>> roleValues = Enum.GetValues<NpcRole>()
+        .Select(v => new EnumItem<NpcRole>(v, v.GetDisplayName())).ToList();
+    record EnumItem<T>(T Value, string Display);
+
+    // Catalog assign state
+    private HashSet<int> assignedNpcIds = [];
+
+    // Assign popup state
+    private bool isAssignVisible;
+    private int? assignNpcId;
+    private string? assignPlayerName, assignPlayerEmail, assignNotes;
+    private int? assignPersonId;
+    private string? assignError;
+
+    private bool _previousCatalog;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        _previousCatalog = Catalog;
+        await LoadAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Catalog != _previousCatalog)
+        {
+            _previousCatalog = Catalog;
+            await LoadAsync();
+        }
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+
+        if (Catalog)
+        {
+            npcs = await Api.GetListAsync<NpcListDto>("/api/npcs");
+            if (GameContext.SelectedGameId is int gid)
+            {
+                var gns = await Api.GetListAsync<GameNpcDto>($"/api/npcs/by-game/{gid}");
+                assignedNpcIds = gns.Select(g => g.NpcId).ToHashSet();
+            }
+        }
+        else
+        {
+            if (GameContext.SelectedGameId is int gid)
+                gameNpcs = await Api.GetListAsync<GameNpcDto>($"/api/npcs/by-game/{gid}");
+            else
+                gameNpcs = [];
+        }
+
+        loading = false;
+    }
+
+    private void OpenModal(NpcListDto? n)
+    {
+        error = null;
+        if (n is null)
+        {
+            editingId = null; name = ""; role = NpcRole.Other;
+            description = null; notes = null;
+            modalTitle = "Nová NPC";
+        }
+        else
+        {
+            editingId = n.Id; name = n.Name; role = n.Role;
+            description = n.Description;
+            modalTitle = $"Upravit: {n.Name}";
+            _ = LoadDetailAsync(n.Id);
+        }
+        isModalVisible = true;
+    }
+
+    private async Task LoadDetailAsync(int id)
+    {
+        var d = await Api.GetAsync<NpcDetailDto>($"/api/npcs/{id}");
+        if (d is not null) { notes = d.Notes; }
+        StateHasChanged();
+    }
+
+    private async Task SaveAsync()
+    {
+        error = null; isSaving = true;
+        try
+        {
+            if (editingId.HasValue)
+                await Api.PutAsync($"/api/npcs/{editingId}", new UpdateNpcDto(name, role, description, notes));
+            else
+                await Api.PostAsync<CreateNpcDto, NpcDetailDto>("/api/npcs", new CreateNpcDto(name, role, description, notes));
+            isModalVisible = false;
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        try
+        {
+            await Api.DeleteAsync($"/api/npcs/{editingId}");
+            isDeleteVisible = false; isModalVisible = false;
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    // --- Assign popup ---
+
+    private void OpenAssignPopup(int npcId)
+    {
+        assignNpcId = npcId;
+        assignPlayerName = null; assignPlayerEmail = null; assignNotes = null; assignPersonId = null;
+        assignError = null;
+        isAssignVisible = true;
+    }
+
+    private async Task ConfirmAssignAsync()
+    {
+        if (assignNpcId is null || GameContext.SelectedGameId is null) return;
+        assignError = null;
+        try
+        {
+            await Api.PostAsync<CreateGameNpcDto, GameNpcDto>("/api/npcs/game-npc",
+                new CreateGameNpcDto(GameContext.SelectedGameId.Value, assignNpcId.Value,
+                    assignPersonId, assignPlayerName, assignPlayerEmail, assignNotes));
+            assignedNpcIds.Add(assignNpcId.Value);
+            isAssignVisible = false;
+            StateHasChanged();
+        }
+        catch (Exception ex) { assignError = ex.Message; }
+    }
+
+    private async Task UnassignNpcAsync(int npcId)
+    {
+        if (GameContext.SelectedGameId is null) return;
+        try
+        {
+            await Api.DeleteAsync($"/api/npcs/game-npc/{GameContext.SelectedGameId}/{npcId}");
+            assignedNpcIds.Remove(npcId);
+            StateHasChanged();
+        }
+        catch (Exception ex) { error = ex.Message; StateHasChanged(); }
+    }
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/Game.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Game.cs
@@ -30,4 +30,5 @@ public class Game
     public ICollection<GameTimeSlot> TimeSlots { get; set; } = [];
     public ICollection<BattlefieldBonus> BattlefieldBonuses { get; set; } = [];
     public ICollection<GameNpc> GameNpcs { get; set; } = [];
+    public ICollection<GameEvent> GameEvents { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/Game.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Game.cs
@@ -29,4 +29,5 @@ public class Game
     public ICollection<TreasureQuest> TreasureQuests { get; set; } = [];
     public ICollection<GameTimeSlot> TimeSlots { get; set; } = [];
     public ICollection<BattlefieldBonus> BattlefieldBonuses { get; set; } = [];
+    public ICollection<GameNpc> GameNpcs { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/GameEvent.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameEvent.cs
@@ -1,19 +1,18 @@
-using OvcinaHra.Shared.Domain.Enums;
-
 namespace OvcinaHra.Shared.Domain.Entities;
 
-public class Npc
+public class GameEvent
 {
     public int Id { get; set; }
+    public int GameId { get; set; }
     public required string Name { get; set; }
-    public NpcRole Role { get; set; }
     public string? Description { get; set; }
-    public string? Notes { get; set; }
-    public string? ImagePath { get; set; }
     public bool IsDeleted { get; set; }
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
 
-    public ICollection<GameNpc> GameNpcs { get; set; } = [];
+    public Game Game { get; set; } = null!;
+    public ICollection<GameEventTimeSlot> EventTimeSlots { get; set; } = [];
+    public ICollection<GameEventLocation> EventLocations { get; set; } = [];
+    public ICollection<GameEventQuest> EventQuests { get; set; } = [];
     public ICollection<GameEventNpc> EventNpcs { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/GameEventLocation.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameEventLocation.cs
@@ -1,0 +1,10 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class GameEventLocation
+{
+    public int GameEventId { get; set; }
+    public int LocationId { get; set; }
+
+    public GameEvent GameEvent { get; set; } = null!;
+    public Location Location { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/GameEventNpc.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameEventNpc.cs
@@ -1,0 +1,11 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class GameEventNpc
+{
+    public int GameEventId { get; set; }
+    public int NpcId { get; set; }
+    public string? RoleInEvent { get; set; }  // optional: "attacker", "narrator", etc.
+
+    public GameEvent GameEvent { get; set; } = null!;
+    public Npc Npc { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/GameEventQuest.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameEventQuest.cs
@@ -1,0 +1,10 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class GameEventQuest
+{
+    public int GameEventId { get; set; }
+    public int QuestId { get; set; }
+
+    public GameEvent GameEvent { get; set; } = null!;
+    public Quest Quest { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/GameEventTimeSlot.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameEventTimeSlot.cs
@@ -1,0 +1,10 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class GameEventTimeSlot
+{
+    public int GameEventId { get; set; }
+    public int GameTimeSlotId { get; set; }
+
+    public GameEvent GameEvent { get; set; } = null!;
+    public GameTimeSlot TimeSlot { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/GameNpc.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameNpc.cs
@@ -1,0 +1,18 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class GameNpc
+{
+    public int GameId { get; set; }
+    public int NpcId { get; set; }
+
+    // Player assignment — nullable for manual entry
+    // PersonId is canonical (from registrace), email/name are display helpers
+    public int? PlayedByPersonId { get; set; }
+    public string? PlayedByName { get; set; }
+    public string? PlayedByEmail { get; set; }
+
+    public string? Notes { get; set; }
+
+    public Game Game { get; set; } = null!;
+    public Npc Npc { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/GameTimeSlot.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameTimeSlot.cs
@@ -12,4 +12,5 @@ public class GameTimeSlot
 
     public BattlefieldBonus? BattlefieldBonus { get; set; }
     public Game Game { get; set; } = null!;
+    public ICollection<GameEventTimeSlot> EventTimeSlots { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/Location.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Location.cs
@@ -33,4 +33,5 @@ public class Location
     public ICollection<Building> Buildings { get; set; } = [];
     public ICollection<QuestLocationLink> QuestLocations { get; set; } = [];
     public ICollection<TreasureQuest> TreasureQuests { get; set; } = [];
+    public ICollection<GameEventLocation> EventLocations { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/Npc.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Npc.cs
@@ -1,0 +1,18 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class Npc
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public NpcRole Role { get; set; }
+    public string? Description { get; set; }
+    public string? Notes { get; set; }
+    public string? ImagePath { get; set; }
+    public bool IsDeleted { get; set; }
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public ICollection<GameNpc> GameNpcs { get; set; } = [];
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/Quest.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Quest.cs
@@ -24,4 +24,5 @@ public class Quest
     public ICollection<QuestLocationLink> QuestLocations { get; set; } = [];
     public ICollection<QuestEncounter> QuestEncounters { get; set; } = [];
     public ICollection<QuestReward> QuestRewards { get; set; } = [];
+    public ICollection<GameEventQuest> EventQuests { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Enums/NpcRole.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/NpcRole.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Domain.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum NpcRole
+{
+    [Display(Name = "Osudová")]
+    Fate,
+
+    [Display(Name = "Obchodník")]
+    Merchant,
+
+    [Display(Name = "Královská")]
+    King,
+
+    [Display(Name = "Nestvůra")]
+    Monster,
+
+    [Display(Name = "Příběhová")]
+    Story,
+
+    [Display(Name = "Ostatní")]
+    Other
+}

--- a/src/OvcinaHra.Shared/Dtos/GameEventDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/GameEventDtos.cs
@@ -1,0 +1,50 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Dtos;
+
+public record GameEventListDto(
+    int Id, int GameId, string Name, string? Description,
+    int TimeSlotCount, int LocationCount, int QuestCount, int NpcCount);
+
+public record GameEventDetailDto(
+    int Id, int GameId, string Name, string? Description,
+    List<GameEventTimeSlotDto> TimeSlots,
+    List<GameEventLocationRefDto> Locations,
+    List<GameEventQuestRefDto> Quests,
+    List<GameEventNpcRefDto> Npcs,
+    DateTime CreatedAtUtc, DateTime UpdatedAtUtc);
+
+public record GameEventTimeSlotDto(int TimeSlotId, DateTime StartTime, decimal DurationHours, int? InGameYear);
+public record GameEventLocationRefDto(int LocationId, string LocationName);
+public record GameEventQuestRefDto(int QuestId, string QuestName);
+public record GameEventNpcRefDto(
+    int NpcId, string NpcName, NpcRole Role, string? RoleInEvent,
+    string? PlayedByName, string? PlayedByEmail);
+
+public record CreateGameEventDto(
+    string Name, string? Description,
+    List<int> TimeSlotIds,
+    List<int> LocationIds,
+    List<int> QuestIds,
+    List<CreateGameEventNpcDto> Npcs);
+
+public record CreateGameEventNpcDto(int NpcId, string? RoleInEvent = null);
+
+public record UpdateGameEventDto(
+    string Name, string? Description,
+    List<int> TimeSlotIds,
+    List<int> LocationIds,
+    List<int> QuestIds,
+    List<CreateGameEventNpcDto> Npcs);
+
+// Bot schedule response
+public record UserScheduleDto(
+    int PersonId, int GameId,
+    List<UserScheduleEventDto> Events);
+
+public record UserScheduleEventDto(
+    int EventId, string EventName, string? Description,
+    List<GameEventTimeSlotDto> TimeSlots,
+    List<string> LocationNames,
+    List<string> QuestNames,
+    string NpcName, NpcRole NpcRole, string? NpcRoleInEvent);

--- a/src/OvcinaHra.Shared/Dtos/NpcDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/NpcDtos.cs
@@ -1,0 +1,28 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Dtos;
+
+// Catalog
+public record NpcListDto(int Id, string Name, NpcRole Role, string? Description);
+
+public record NpcDetailDto(
+    int Id, string Name, NpcRole Role,
+    string? Description, string? Notes, string? ImagePath);
+
+public record CreateNpcDto(string Name, NpcRole Role, string? Description = null, string? Notes = null);
+
+public record UpdateNpcDto(string Name, NpcRole Role, string? Description, string? Notes);
+
+// Per-game assignment
+public record GameNpcDto(
+    int GameId, int NpcId, string NpcName, NpcRole Role,
+    int? PlayedByPersonId, string? PlayedByName, string? PlayedByEmail,
+    string? Notes);
+
+public record CreateGameNpcDto(
+    int GameId, int NpcId,
+    int? PlayedByPersonId = null, string? PlayedByName = null, string? PlayedByEmail = null,
+    string? Notes = null);
+
+public record UpdateGameNpcDto(
+    int? PlayedByPersonId, string? PlayedByName, string? PlayedByEmail, string? Notes);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameEventEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameEventEndpointTests.cs
@@ -1,0 +1,226 @@
+using System.Net;
+using System.Net.Http.Json;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+public class GameEventEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<GameDetailDto> CreateGame()
+    {
+        var resp = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        return (await resp.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    private async Task<GameTimeSlotDto> CreateSlot(int gameId, DateTime startTime, decimal durationHours = 2m)
+    {
+        var resp = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(gameId, startTime, durationHours));
+        return (await resp.Content.ReadFromJsonAsync<GameTimeSlotDto>())!;
+    }
+
+    private async Task<NpcDetailDto> CreateNpc(string name = "Gandalf")
+    {
+        var resp = await Client.PostAsJsonAsync("/api/npcs",
+            new CreateNpcDto(name, NpcRole.Story, "Testový NPC"));
+        return (await resp.Content.ReadFromJsonAsync<NpcDetailDto>())!;
+    }
+
+    private async Task<GameEventDetailDto> CreateEvent(int gameId, int slotId, string name = "Bitva u brány")
+    {
+        var resp = await Client.PostAsJsonAsync($"/api/games/{gameId}/events",
+            new CreateGameEventDto(name, null, [slotId], [], [], []));
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<GameEventDetailDto>())!;
+    }
+
+    // ─── Tests ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListByGame_Empty_ReturnsEmpty()
+    {
+        var game = await CreateGame();
+
+        var list = await Client.GetFromJsonAsync<List<GameEventListDto>>($"/api/games/{game.Id}/events");
+
+        Assert.NotNull(list);
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public async Task Create_NoTimeSlots_Returns400()
+    {
+        var game = await CreateGame();
+
+        var resp = await Client.PostAsJsonAsync($"/api/games/{game.Id}/events",
+            new CreateGameEventDto("Událost bez slotu", null, [], [], [], []));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WithTimeSlot_Returns201()
+    {
+        var game = await CreateGame();
+        var slot = await CreateSlot(game.Id, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc));
+
+        var resp = await Client.PostAsJsonAsync($"/api/games/{game.Id}/events",
+            new CreateGameEventDto("Bitva u brány", "Velká bitva", [slot.Id], [], [], []));
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var created = await resp.Content.ReadFromJsonAsync<GameEventDetailDto>();
+        Assert.NotNull(created);
+        Assert.Equal("Bitva u brány", created.Name);
+        Assert.Equal("Velká bitva", created.Description);
+        Assert.Single(created.TimeSlots);
+        Assert.Equal(slot.Id, created.TimeSlots[0].TimeSlotId);
+    }
+
+    [Fact]
+    public async Task Create_TimeSlotFromWrongGame_Returns400()
+    {
+        var game1 = await CreateGame();
+        var game2 = await CreateGame();
+        var slot = await CreateSlot(game2.Id, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc));
+
+        var resp = await Client.PostAsJsonAsync($"/api/games/{game1.Id}/events",
+            new CreateGameEventDto("Událost", null, [slot.Id], [], [], []));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetById_ExistingEvent_ReturnsDetail()
+    {
+        var game = await CreateGame();
+        var slot = await CreateSlot(game.Id, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc));
+        var created = await CreateEvent(game.Id, slot.Id);
+
+        var resp = await Client.GetAsync($"/api/events/{created.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var detail = await resp.Content.ReadFromJsonAsync<GameEventDetailDto>();
+        Assert.NotNull(detail);
+        Assert.Equal(created.Id, detail.Id);
+        Assert.Equal("Bitva u brány", detail.Name);
+        Assert.Single(detail.TimeSlots);
+    }
+
+    [Fact]
+    public async Task Update_ReplacesJunctions_ReturnsOk()
+    {
+        var game = await CreateGame();
+        var slotA = await CreateSlot(game.Id, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc));
+        var slotB = await CreateSlot(game.Id, new DateTime(2026, 5, 1, 14, 0, 0, DateTimeKind.Utc));
+        var created = await CreateEvent(game.Id, slotA.Id);
+
+        var resp = await Client.PutAsJsonAsync($"/api/events/{created.Id}",
+            new UpdateGameEventDto("Přejmenovaná bitva", "Nový popis", [slotB.Id], [], [], []));
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var updated = await resp.Content.ReadFromJsonAsync<GameEventDetailDto>();
+        Assert.NotNull(updated);
+        Assert.Equal("Přejmenovaná bitva", updated.Name);
+        Assert.Single(updated.TimeSlots);
+        Assert.Equal(slotB.Id, updated.TimeSlots[0].TimeSlotId);
+    }
+
+    [Fact]
+    public async Task Delete_SoftDeletes_ReturnsNoContent()
+    {
+        var game = await CreateGame();
+        var slot = await CreateSlot(game.Id, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc));
+        var created = await CreateEvent(game.Id, slot.Id);
+
+        var deleteResp = await Client.DeleteAsync($"/api/events/{created.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResp.StatusCode);
+
+        var getResp = await Client.GetAsync($"/api/events/{created.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, getResp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetCurrent_NoEventsNow_ReturnsEmpty()
+    {
+        var game = await CreateGame();
+        // Slot far in the future
+        var slot = await CreateSlot(game.Id,
+            new DateTime(2099, 1, 1, 10, 0, 0, DateTimeKind.Utc));
+        await CreateEvent(game.Id, slot.Id);
+
+        var list = await Client.GetFromJsonAsync<List<GameEventDetailDto>>(
+            $"/api/games/{game.Id}/events/current");
+
+        Assert.NotNull(list);
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public async Task GetNext_OrdersByStartTime()
+    {
+        var game = await CreateGame();
+        var slotLater = await CreateSlot(game.Id,
+            new DateTime(2099, 6, 1, 10, 0, 0, DateTimeKind.Utc));
+        var slotEarlier = await CreateSlot(game.Id,
+            new DateTime(2099, 5, 1, 10, 0, 0, DateTimeKind.Utc));
+
+        await CreateEvent(game.Id, slotLater.Id, "Pozdější");
+        await CreateEvent(game.Id, slotEarlier.Id, "Dřívější");
+
+        var list = await Client.GetFromJsonAsync<List<GameEventDetailDto>>(
+            $"/api/games/{game.Id}/events/next?count=5");
+
+        Assert.NotNull(list);
+        Assert.Equal(2, list.Count);
+        Assert.Equal("Dřívější", list[0].Name);
+        Assert.Equal("Pozdější", list[1].Name);
+    }
+
+    [Fact]
+    public async Task GetUserSchedule_NoNpcs_ReturnsEmpty()
+    {
+        var game = await CreateGame();
+
+        var schedule = await Client.GetFromJsonAsync<UserScheduleDto>(
+            $"/api/users/999/schedule?gameId={game.Id}");
+
+        Assert.NotNull(schedule);
+        Assert.Empty(schedule.Events);
+    }
+
+    [Fact]
+    public async Task GetUserSchedule_WithNpcInEvent_ReturnsEvent()
+    {
+        var game = await CreateGame();
+        var slot = await CreateSlot(game.Id, new DateTime(2099, 5, 1, 10, 0, 0, DateTimeKind.Utc));
+        var npc = await CreateNpc("Merlin");
+
+        // Assign NPC to game with a personId
+        const int personId = 42;
+        var assignResp = await Client.PostAsJsonAsync("/api/npcs/game-npc",
+            new CreateGameNpcDto(game.Id, npc.Id, personId, "Hráč Merlin", "merlin@test.cz"));
+        assignResp.EnsureSuccessStatusCode();
+
+        // Create event with that NPC
+        var eventResp = await Client.PostAsJsonAsync($"/api/games/{game.Id}/events",
+            new CreateGameEventDto("Souboj", null, [slot.Id], [], [],
+                [new CreateGameEventNpcDto(npc.Id, "útočník")]));
+        eventResp.EnsureSuccessStatusCode();
+
+        var schedule = await Client.GetFromJsonAsync<UserScheduleDto>(
+            $"/api/users/{personId}/schedule?gameId={game.Id}");
+
+        Assert.NotNull(schedule);
+        Assert.Equal(personId, schedule.PersonId);
+        Assert.Single(schedule.Events);
+        var ev = schedule.Events[0];
+        Assert.Equal("Souboj", ev.EventName);
+        Assert.Equal("útočník", ev.NpcRoleInEvent);
+        Assert.Single(ev.TimeSlots);
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/NpcEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/NpcEndpointTests.cs
@@ -1,0 +1,169 @@
+using System.Net;
+using System.Net.Http.Json;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+public class NpcEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    // --- Catalog CRUD ---
+
+    [Fact]
+    public async Task GetAll_Empty_ReturnsEmptyList()
+    {
+        var npcs = await Client.GetFromJsonAsync<List<NpcListDto>>("/api/npcs");
+        Assert.NotNull(npcs);
+        Assert.Empty(npcs);
+    }
+
+    [Fact]
+    public async Task Create_ValidNpc_ReturnsCreated()
+    {
+        var response = await Client.PostAsJsonAsync("/api/npcs",
+            new CreateNpcDto("Gandalf", NpcRole.Story, "Šedý čaroděj"));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var created = await response.Content.ReadFromJsonAsync<NpcDetailDto>();
+        Assert.NotNull(created);
+        Assert.Equal("Gandalf", created.Name);
+        Assert.Equal(NpcRole.Story, created.Role);
+        Assert.Equal("Šedý čaroděj", created.Description);
+    }
+
+    [Fact]
+    public async Task GetById_ExistingNpc_ReturnsNpc()
+    {
+        var createResponse = await Client.PostAsJsonAsync("/api/npcs",
+            new CreateNpcDto("Gandalf", NpcRole.Story, "Šedý čaroděj"));
+        var created = await createResponse.Content.ReadFromJsonAsync<NpcDetailDto>();
+
+        var response = await Client.GetAsync($"/api/npcs/{created!.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var npc = await response.Content.ReadFromJsonAsync<NpcDetailDto>();
+        Assert.NotNull(npc);
+        Assert.Equal(created.Id, npc.Id);
+        Assert.Equal("Gandalf", npc.Name);
+    }
+
+    [Fact]
+    public async Task GetById_NonExistent_ReturnsNotFound()
+    {
+        var response = await Client.GetAsync("/api/npcs/999999");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_ExistingNpc_ReturnsNoContent()
+    {
+        var createResponse = await Client.PostAsJsonAsync("/api/npcs",
+            new CreateNpcDto("Gandalf", NpcRole.Story, "Šedý čaroděj"));
+        var created = await createResponse.Content.ReadFromJsonAsync<NpcDetailDto>();
+
+        var response = await Client.PutAsJsonAsync($"/api/npcs/{created!.Id}",
+            new UpdateNpcDto("Gandalf Bílý", NpcRole.Fate, "Bílý čaroděj", null));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_SoftDeletes_ReturnsNoContent()
+    {
+        var createResponse = await Client.PostAsJsonAsync("/api/npcs",
+            new CreateNpcDto("Gandalf", NpcRole.Story, "Šedý čaroděj"));
+        var created = await createResponse.Content.ReadFromJsonAsync<NpcDetailDto>();
+
+        var deleteResponse = await Client.DeleteAsync($"/api/npcs/{created!.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var getResponse = await Client.GetAsync($"/api/npcs/{created.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
+
+    // --- Per-game assignment ---
+
+    [Fact]
+    public async Task GetByGame_Empty_ReturnsEmptyList()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var npcs = await Client.GetFromJsonAsync<List<GameNpcDto>>($"/api/npcs/by-game/{game!.Id}");
+
+        Assert.NotNull(npcs);
+        Assert.Empty(npcs);
+    }
+
+    [Fact]
+    public async Task AssignToGame_ValidNpc_ReturnsCreated()
+    {
+        var (game, npc) = await CreateGameAndNpc();
+
+        var response = await Client.PostAsJsonAsync("/api/npcs/game-npc",
+            new CreateGameNpcDto(game.Id, npc.Id));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var assigned = await response.Content.ReadFromJsonAsync<GameNpcDto>();
+        Assert.NotNull(assigned);
+        Assert.Equal(npc.Id, assigned.NpcId);
+        Assert.Equal(game.Id, assigned.GameId);
+    }
+
+    [Fact]
+    public async Task AssignToGame_Duplicate_ReturnsConflict()
+    {
+        var (game, npc) = await CreateGameAndNpc();
+
+        await Client.PostAsJsonAsync("/api/npcs/game-npc",
+            new CreateGameNpcDto(game.Id, npc.Id));
+        var response = await Client.PostAsJsonAsync("/api/npcs/game-npc",
+            new CreateGameNpcDto(game.Id, npc.Id));
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateGameNpc_ChangesPlayer_ReturnsNoContent()
+    {
+        var (game, npc) = await CreateGameAndNpc();
+
+        await Client.PostAsJsonAsync("/api/npcs/game-npc",
+            new CreateGameNpcDto(game.Id, npc.Id));
+
+        var response = await Client.PutAsJsonAsync($"/api/npcs/game-npc/{game.Id}/{npc.Id}",
+            new UpdateGameNpcDto(42, "Hráč Jeden", "hrac@example.com", "Dobrý hráč"));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnassignFromGame_ReturnsNoContent()
+    {
+        var (game, npc) = await CreateGameAndNpc();
+
+        await Client.PostAsJsonAsync("/api/npcs/game-npc",
+            new CreateGameNpcDto(game.Id, npc.Id));
+
+        var response = await Client.DeleteAsync($"/api/npcs/game-npc/{game.Id}/{npc.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    // --- Helper ---
+
+    private async Task<(GameDetailDto Game, NpcDetailDto Npc)> CreateGameAndNpc()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = (await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>())!;
+
+        var npcResponse = await Client.PostAsJsonAsync("/api/npcs",
+            new CreateNpcDto("Gandalf", NpcRole.Story, "Šedý čaroděj"));
+        var npc = (await npcResponse.Content.ReadFromJsonAsync<NpcDetailDto>())!;
+
+        return (game, npc);
+    }
+}


### PR DESCRIPTION
## Summary

Major feature — NPC catalog + GameEvent system for scheduling what happens during a game.

### NPC catalog (Tasks 1-5)
- `Npc` entity — persistent template with `NpcRole` enum (6 Czech roles: Osudová, Obchodník, Královská, Nestvůra, Příběhová, Ostatní)
- `GameNpc` per-game assignment with `PlayedByPersonId` / `PlayedByName` / `PlayedByEmail`
- One adult can play many NPCs per game; one NPC has one player per game (composite PK)
- NpcList.razor with catalog/game toggle, ImagePicker (CardMode), assign-to-game popup

### GameEvent system (Tasks 6-9)
- `GameEvent` with 4 junction tables: TimeSlots (M2M, required ≥1), Locations (M2M), Quests (M2M), NPCs (M2M with per-event RoleInEvent)
- CRUD endpoints + `current`, `next`, and `user/{personId}/schedule` bot queries
- GameEventList.razor with DxTagBox multi-pickers
- Validation: at least one time slot required; time slots/quests must belong to the target game or catalog

### Bot query support
- `GET /api/games/{gameId}/events/current` — what's happening right now
- `GET /api/games/{gameId}/events/next?count=N` — upcoming
- `GET /api/users/{personId}/schedule?gameId=X` — what NPC am I playing when

## Test plan
- [x] Build: 0 warnings, 0 errors
- [x] 172 integration tests pass (150 existing + 11 NPC + 11 GameEvent)
- [ ] Manual: create NPC in catalog, assign to game with player info
- [ ] Manual: create time slot, create event linking slot + NPCs
- [ ] Manual: verify bot can query user schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)