### PR TITLE
fix: import un-deletes + quest game reassignment [v0.4.1]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
@@ -19,6 +19,8 @@ public static class QuestEndpoints
         group.MapPut("/{id:int}", Update);
         group.MapDelete("/{id:int}", Delete);
         group.MapPost("/{id:int}/copy-to-game/{gameId:int}", CopyToGame);
+        group.MapPut("/{id:int}/game", MoveToGame);
+        group.MapDelete("/{id:int}/game", UnassignFromGame);
 
         // Tags
         group.MapPost("/{id:int}/tags/{tagId:int}", AddTag);
@@ -166,6 +168,26 @@ public static class QuestEndpoints
         var q = await db.Quests.FindAsync(id);
         if (q is null) return TypedResults.NotFound();
         db.Quests.Remove(q);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    // Move a quest to a specific game (assigns or re-assigns)
+    private static async Task<Results<NoContent, NotFound>> MoveToGame(int id, MoveQuestToGameDto dto, WorldDbContext db)
+    {
+        var q = await db.Quests.FindAsync(id);
+        if (q is null) return TypedResults.NotFound();
+        q.GameId = dto.GameId;
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    // Unassign a quest from its game (moves to catalog; GameId = null)
+    private static async Task<Results<NoContent, NotFound>> UnassignFromGame(int id, WorldDbContext db)
+    {
+        var q = await db.Quests.FindAsync(id);
+        if (q is null) return TypedResults.NotFound();
+        q.GameId = null;
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Services/RegistraceImportService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceImportService.cs
@@ -69,6 +69,11 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
                     character.Race = record.Race;
                     character.BirthYear = record.PersonBirthYear;
                     character.UpdatedAtUtc = DateTime.UtcNow;
+
+                    // If the character was soft-deleted (e.g., from a previous import),
+                    // restore it — this person is registered for the current game.
+                    if (character.IsDeleted)
+                        character.IsDeleted = false;
                 }
 
                 // Look up assignment by GameId + ExternalPersonId

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Shared/Dtos/QuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/QuestDtos.cs
@@ -57,3 +57,4 @@ public record AddQuestRewardDto(int ItemId, int Quantity = 1);
 
 public record QuestCatalogDto(int Id, string Name, QuestType QuestType, int? GameId, string? GameName, int? GameEdition);
 public record QuestCopyResultDto(QuestListDto Quest, List<string> Warnings);
+public record MoveQuestToGameDto(int GameId);


### PR DESCRIPTION
## Summary
- **RegistraceImportService**: when the import service found a soft-deleted Character (via IgnoreQueryFilters) and updated its fields, it didn't reset IsDeleted, so those characters stayed hidden from all queries. Now on update, IsDeleted flips back to false if set.
- **Quest game reassignment**: new PUT `/api/quests/{id}/game` to move a quest to a specific game, and DELETE `/api/quests/{id}/game` to unassign (moves to catalog, GameId = null). Needed to clean up game 30 which currently has 71 quests by mistake.

## Test plan
- [x] Build clean
- [ ] Manual: hit POST /api/characters/import/30, verify characters become visible
- [ ] Manual: unassign all quests from game 30 via DELETE loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)