### PR TITLE
fix: persist auth across reloads + refresh token rotation [v0.4.2]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/AuthEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/AuthEndpoints.cs
@@ -154,7 +154,11 @@ public static class AuthEndpoints
                 if (tokenData?.AccessToken is null)
                     return Results.Unauthorized();
 
-                return Results.Ok(new TokenResponse(tokenData.AccessToken, DateTime.UtcNow.AddSeconds(tokenData.ExpiresIn), tokenData.ExpiresIn));
+                return Results.Ok(new OidcExchangeResponse(
+                    tokenData.AccessToken,
+                    DateTime.UtcNow.AddSeconds(tokenData.ExpiresIn),
+                    tokenData.ExpiresIn,
+                    tokenData.RefreshToken));
             }).AllowAnonymous();
         }
 

--- a/src/OvcinaHra.Client/Auth/JwtAuthStateProvider.cs
+++ b/src/OvcinaHra.Client/Auth/JwtAuthStateProvider.cs
@@ -1,20 +1,25 @@
 using System.Net.Http.Json;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 
 namespace OvcinaHra.Client.Auth;
 
 public class JwtAuthStateProvider : AuthenticationStateProvider
 {
-    private const string TokenKey = "auth_token";
+    private const string TokenKey = TokenRefreshService.AccessTokenKey;
+    private const string RefreshTokenKey = TokenRefreshService.RefreshTokenKey;
+
     private readonly IJSRuntime _js;
     private readonly HttpClient _http;
+    private readonly IServiceProvider _services;
 
-    public JwtAuthStateProvider(IJSRuntime js, HttpClient http)
+    public JwtAuthStateProvider(IJSRuntime js, HttpClient http, IServiceProvider services)
     {
         _js = js;
         _http = http;
+        _services = services;
     }
 
     public override async Task<AuthenticationState> GetAuthenticationStateAsync()
@@ -26,11 +31,10 @@ public class JwtAuthStateProvider : AuthenticationStateProvider
             return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
         }
 
-        // Set the Bearer header so /auth/me works
         _http.DefaultRequestHeaders.Authorization =
             new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
 
-        // Validate by calling the API — works with both dev JWTs and OIDC encrypted tokens
+        // Validate by calling the API — works with both dev JWTs and OIDC encrypted tokens.
         try
         {
             var response = await _http.GetAsync("/api/auth/me");
@@ -48,6 +52,10 @@ public class JwtAuthStateProvider : AuthenticationStateProvider
                     foreach (var role in me.Roles)
                         claims.Add(new(ClaimTypes.Role, role));
 
+                    // Token is valid — make sure the refresh timer is running.
+                    // Fire-and-forget; TryBootAsync is idempotent.
+                    _ = _services.GetRequiredService<TokenRefreshService>().TryBootAsync();
+
                     return new AuthenticationState(
                         new ClaimsPrincipal(new ClaimsIdentity(claims, "oidc")));
                 }
@@ -55,10 +63,10 @@ public class JwtAuthStateProvider : AuthenticationStateProvider
         }
         catch
         {
-            // API unreachable — treat as unauthenticated
+            // API unreachable — treat as unauthenticated.
         }
 
-        // Token invalid or API down — clear stale token from localStorage
+        // Token invalid or API down — clear stale tokens from localStorage.
         await ClearTokenAsync();
         return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
     }
@@ -86,7 +94,9 @@ public class JwtAuthStateProvider : AuthenticationStateProvider
     public async Task ClearTokenAsync()
     {
         await _js.InvokeVoidAsync("localStorage.removeItem", TokenKey);
+        await _js.InvokeVoidAsync("localStorage.removeItem", RefreshTokenKey);
         _http.DefaultRequestHeaders.Authorization = null;
+        _services.GetRequiredService<TokenRefreshService>().Stop();
         NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
     }
 

--- a/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
+++ b/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Timers;
@@ -106,9 +107,16 @@ public class TokenRefreshService : IDisposable
                     }
                 }
 
-                // Refresh token rejected — clear it so we don't keep retrying.
-                await ClearStoredRefreshTokenAsync();
-                await _authProvider.ClearTokenAsync();
+                if (IsExplicitAuthFailure(response.StatusCode))
+                {
+                    // Refresh token definitively rejected — clear it so we don't keep retrying.
+                    await ClearStoredRefreshTokenAsync();
+                    await _authProvider.ClearTokenAsync();
+                    return;
+                }
+
+                // Transient (5xx, 408, 429, or null body on 2xx) — keep the tokens, retry shortly.
+                ScheduleRetryAfterError();
                 return;
             }
 
@@ -126,13 +134,23 @@ public class TokenRefreshService : IDisposable
         }
         catch
         {
-            // Network error — retry in 30 seconds.
-            _timer?.Dispose();
-            _timer = new Timer(30_000);
-            _timer.Elapsed += async (_, _) => await RefreshAsync();
-            _timer.AutoReset = false;
-            _timer.Start();
+            // Network error — retry shortly.
+            ScheduleRetryAfterError();
         }
+    }
+
+    private static bool IsExplicitAuthFailure(HttpStatusCode status) =>
+        status == HttpStatusCode.BadRequest
+        || status == HttpStatusCode.Unauthorized
+        || status == HttpStatusCode.Forbidden;
+
+    private void ScheduleRetryAfterError()
+    {
+        _timer?.Dispose();
+        _timer = new Timer(30_000);
+        _timer.Elapsed += async (_, _) => await RefreshAsync();
+        _timer.AutoReset = false;
+        _timer.Start();
     }
 
     public void Stop()

--- a/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
+++ b/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
@@ -1,34 +1,79 @@
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Timers;
+using Microsoft.JSInterop;
 using Timer = System.Timers.Timer;
 
 namespace OvcinaHra.Client.Auth;
 
 public record TokenResponse(string Token, DateTime ExpiresUtc, int ExpiresInSeconds);
 
+public record OidcExchangeResponse(string Token, DateTime ExpiresUtc, int ExpiresInSeconds, string? RefreshToken);
+
+internal record OidcRefreshRequestDto(string RefreshToken);
+
 /// <summary>
-/// Automatically refreshes the JWT token before it expires.
-/// Runs a timer that fires at 80% of token lifetime.
+/// Refreshes the access token before it expires, and re-arms itself after every reload.
+/// Uses /api/auth/oidc-refresh when a refresh_token is stored (production OIDC path),
+/// otherwise /api/auth/refresh (dev self-issued path).
 /// </summary>
 public class TokenRefreshService : IDisposable
 {
+    internal const string AccessTokenKey = "auth_token";
+    internal const string RefreshTokenKey = "refresh_token";
+
     private readonly HttpClient _http;
     private readonly JwtAuthStateProvider _authProvider;
+    private readonly IJSRuntime _js;
     private Timer? _timer;
+    private bool _booted;
 
-    public TokenRefreshService(HttpClient http, JwtAuthStateProvider authProvider)
+    public TokenRefreshService(HttpClient http, JwtAuthStateProvider authProvider, IJSRuntime js)
     {
         _http = http;
         _authProvider = authProvider;
+        _js = js;
+    }
+
+    /// <summary>
+    /// Reads the stored access token, parses its <c>exp</c> claim, and schedules
+    /// a refresh for 80% of the remaining lifetime. If the token is already
+    /// expired or within 30 seconds of expiring, refreshes immediately.
+    /// Idempotent — safe to call multiple times per app boot.
+    /// </summary>
+    public async Task TryBootAsync()
+    {
+        if (_booted) return;
+        _booted = true;
+
+        var token = await GetStoredAccessTokenAsync();
+        if (string.IsNullOrEmpty(token)) return;
+
+        var expiry = GetJwtExpiry(token);
+        if (expiry is null)
+        {
+            // Unparseable token — try a refresh to see if we can recover.
+            await RefreshAsync();
+            return;
+        }
+
+        var remaining = expiry.Value - DateTimeOffset.UtcNow;
+        if (remaining.TotalSeconds < 30)
+        {
+            await RefreshAsync();
+            return;
+        }
+
+        ScheduleRefresh((int)remaining.TotalSeconds);
     }
 
     public void ScheduleRefresh(int expiresInSeconds)
     {
         _timer?.Dispose();
 
-        // Refresh at 80% of token lifetime
+        // Refresh at 80% of remaining lifetime, minimum 10 seconds.
         var refreshMs = expiresInSeconds * 800;
-        if (refreshMs < 10_000) refreshMs = 10_000; // At least 10 seconds
+        if (refreshMs < 10_000) refreshMs = 10_000;
 
         _timer = new Timer(refreshMs);
         _timer.Elapsed += async (_, _) => await RefreshAsync();
@@ -40,10 +85,38 @@ public class TokenRefreshService : IDisposable
     {
         try
         {
-            var response = await _http.PostAsync("/api/auth/refresh", null);
-            if (response.IsSuccessStatusCode)
+            var refreshToken = await GetStoredRefreshTokenAsync();
+
+            if (!string.IsNullOrEmpty(refreshToken))
             {
-                var token = await response.Content.ReadFromJsonAsync<TokenResponse>();
+                // Production OIDC path — stored refresh_token from registrace-ovcina.
+                var response = await _http.PostAsJsonAsync("/api/auth/oidc-refresh",
+                    new OidcRefreshRequestDto(refreshToken));
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var token = await response.Content.ReadFromJsonAsync<OidcExchangeResponse>();
+                    if (token is not null)
+                    {
+                        await _authProvider.SetTokenAsync(token.Token);
+                        if (!string.IsNullOrEmpty(token.RefreshToken))
+                            await SetStoredRefreshTokenAsync(token.RefreshToken);
+                        ScheduleRefresh(token.ExpiresInSeconds);
+                        return;
+                    }
+                }
+
+                // Refresh token rejected — clear it so we don't keep retrying.
+                await ClearStoredRefreshTokenAsync();
+                await _authProvider.ClearTokenAsync();
+                return;
+            }
+
+            // Dev path — self-issued token, no refresh_token involved.
+            var devResponse = await _http.PostAsync("/api/auth/refresh", null);
+            if (devResponse.IsSuccessStatusCode)
+            {
+                var token = await devResponse.Content.ReadFromJsonAsync<TokenResponse>();
                 if (token is not null)
                 {
                     await _authProvider.SetTokenAsync(token.Token);
@@ -53,13 +126,75 @@ public class TokenRefreshService : IDisposable
         }
         catch
         {
-            // Network error — retry in 30 seconds
+            // Network error — retry in 30 seconds.
             _timer?.Dispose();
             _timer = new Timer(30_000);
             _timer.Elapsed += async (_, _) => await RefreshAsync();
             _timer.AutoReset = false;
             _timer.Start();
         }
+    }
+
+    public void Stop()
+    {
+        _timer?.Dispose();
+        _timer = null;
+        _booted = false;
+    }
+
+    // --- localStorage helpers ---
+
+    private async Task<string?> GetStoredAccessTokenAsync()
+    {
+        try { return await _js.InvokeAsync<string?>("localStorage.getItem", AccessTokenKey); }
+        catch { return null; }
+    }
+
+    private async Task<string?> GetStoredRefreshTokenAsync()
+    {
+        try { return await _js.InvokeAsync<string?>("localStorage.getItem", RefreshTokenKey); }
+        catch { return null; }
+    }
+
+    private async Task SetStoredRefreshTokenAsync(string value)
+    {
+        try { await _js.InvokeVoidAsync("localStorage.setItem", RefreshTokenKey, value); }
+        catch { }
+    }
+
+    private async Task ClearStoredRefreshTokenAsync()
+    {
+        try { await _js.InvokeVoidAsync("localStorage.removeItem", RefreshTokenKey); }
+        catch { }
+    }
+
+    // --- JWT exp parsing (payload only, no signature check — client just needs the timestamp) ---
+
+    private static DateTimeOffset? GetJwtExpiry(string jwt)
+    {
+        try
+        {
+            var parts = jwt.Split('.');
+            if (parts.Length < 2) return null;
+
+            var payload = Base64UrlDecode(parts[1]);
+            using var doc = JsonDocument.Parse(payload);
+            if (doc.RootElement.TryGetProperty("exp", out var exp) && exp.TryGetInt64(out var unix))
+                return DateTimeOffset.FromUnixTimeSeconds(unix);
+        }
+        catch { }
+        return null;
+    }
+
+    private static byte[] Base64UrlDecode(string input)
+    {
+        var s = input.Replace('-', '+').Replace('_', '/');
+        switch (s.Length % 4)
+        {
+            case 2: s += "=="; break;
+            case 3: s += "="; break;
+        }
+        return Convert.FromBase64String(s);
     }
 
     public void Dispose()

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.4.1</Version>
+    <Version>0.4.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/AuthCallback.razor
+++ b/src/OvcinaHra.Client/Pages/AuthCallback.razor
@@ -82,7 +82,8 @@
                 if (token?.Token is not null)
                 {
                     if (!string.IsNullOrEmpty(token.RefreshToken))
-                        await JS.InvokeVoidAsync("localStorage.setItem", "refresh_token", token.RefreshToken);
+                        await JS.InvokeVoidAsync("localStorage.setItem",
+                            OvcinaHra.Client.Auth.TokenRefreshService.RefreshTokenKey, token.RefreshToken);
 
                     await AuthProvider.SetTokenAsync(token.Token);
                     RefreshService.ScheduleRefresh(token.ExpiresInSeconds);

--- a/src/OvcinaHra.Client/Pages/AuthCallback.razor
+++ b/src/OvcinaHra.Client/Pages/AuthCallback.razor
@@ -77,10 +77,13 @@
 
             if (response.IsSuccessStatusCode)
             {
-                var token = await response.Content.ReadFromJsonAsync<OvcinaHra.Client.Auth.TokenResponse>();
+                var token = await response.Content.ReadFromJsonAsync<OvcinaHra.Client.Auth.OidcExchangeResponse>();
 
                 if (token?.Token is not null)
                 {
+                    if (!string.IsNullOrEmpty(token.RefreshToken))
+                        await JS.InvokeVoidAsync("localStorage.setItem", "refresh_token", token.RefreshToken);
+
                     await AuthProvider.SetTokenAsync(token.Token);
                     RefreshService.ScheduleRefresh(token.ExpiresInSeconds);
                     Nav.NavigateTo("/");


### PR DESCRIPTION
## Summary

Three compounding bugs caused users to land on the login screen on every page reload. This fixes all three.

- **Bug A — refresh token thrown away.** `AuthCallback` parsed the OIDC code-exchange response as `TokenResponse` (no refresh_token field), so the refresh_token from registrace-ovcina was silently discarded.
- **Bug B — refresh timer didn't survive reload.** `TokenRefreshService.ScheduleRefresh()` was only ever called from `AuthCallback`, which runs once per OAuth round-trip. After any page reload the WASM app rebooted and the timer was gone; the stored access token sat untouched until it expired.
- **Bug C — refresh endpoint wired wrong in prod.** `TokenRefreshService.RefreshAsync()` POSTed to `/api/auth/refresh`, which is mounted only when `isDevelopment`. In production with OIDC the only valid refresh path is `/api/auth/oidc-refresh`, which needs a refresh_token the client never had (Bug A).

## Changes

- `AuthEndpoints.cs` — `/api/auth/oidc-refresh` returns `OidcExchangeResponse` so rotated refresh_tokens are captured (OpenIddict rotates by default).
- `AuthCallback.razor` — parses `OidcExchangeResponse`, stores `refresh_token` in localStorage alongside `auth_token`.
- `TokenRefreshService.cs` — rewritten to read both tokens from localStorage, pick `/oidc-refresh` when refresh_token is present and `/refresh` otherwise, persist rotated refresh_tokens on success, and parse the JWT `exp` claim to bootstrap the timer on app boot via a new idempotent `TryBootAsync()`. Adds `Stop()` for logout.
- `JwtAuthStateProvider.cs` — lazy-resolves `TokenRefreshService` through `IServiceProvider` (avoids circular DI) and fires `TryBootAsync` after every successful `/auth/me`. `ClearTokenAsync` now also wipes the refresh_token and stops the timer.
- Version bump 0.4.1 → 0.4.2.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test tests/OvcinaHra.Api.Tests` — 172/172 pass
- [ ] Manual: log in via prod OIDC, hard-refresh (Ctrl+Shift+R), confirm still authenticated
- [ ] Manual: log in, close tab, reopen after >1h, confirm still authenticated
- [ ] Manual: logout clears both `auth_token` and `refresh_token` in DevTools → Application → Local Storage

## Migration notes

Existing logged-in users will need one more login after this deploys to populate `refresh_token` in their localStorage. Subsequent reloads will then survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)