### PR TITLE
feat: NPC polish — years, role filter, adult player picker [v0.4.4]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Dtos;
 
@@ -24,7 +25,26 @@ public static class NpcEndpoints
         group.MapPut("/game-npc/{gameId:int}/{npcId:int}", UpdateGameNpc);
         group.MapDelete("/game-npc/{gameId:int}/{npcId:int}", DeleteGameNpc);
 
+        // Eligible players (adults from registrace) for the NPC picker.
+        group.MapGet("/available-players/{gameId:int}", GetAvailablePlayers);
+
         return group;
+    }
+
+    private static async Task<Results<Ok<List<RegistraceAdultDto>>, ProblemHttpResult>> GetAvailablePlayers(
+        int gameId, RegistraceImportService registrace)
+    {
+        try
+        {
+            var adults = await registrace.FetchAdultsAsync(gameId);
+            return TypedResults.Ok(adults);
+        }
+        catch (HttpRequestException ex)
+        {
+            return TypedResults.Problem(
+                detail: $"Registrace unreachable: {ex.Message}",
+                statusCode: StatusCodes.Status502BadGateway);
+        }
     }
 
     private static async Task<Ok<List<NpcListDto>>> GetAll(WorldDbContext db)
@@ -32,7 +52,7 @@ public static class NpcEndpoints
         var npcs = await db.Npcs
             .Where(n => !n.IsDeleted)
             .OrderBy(n => n.Name)
-            .Select(n => new NpcListDto(n.Id, n.Name, n.Role, n.Description))
+            .Select(n => new NpcListDto(n.Id, n.Name, n.Role, n.Description, n.BirthYear, n.DeathYear))
             .ToListAsync();
         return TypedResults.Ok(npcs);
     }
@@ -43,7 +63,7 @@ public static class NpcEndpoints
         if (n is null) return TypedResults.NotFound();
 
         return TypedResults.Ok(new NpcDetailDto(
-            n.Id, n.Name, n.Role, n.Description, n.Notes, n.ImagePath));
+            n.Id, n.Name, n.Role, n.Description, n.Notes, n.ImagePath, n.BirthYear, n.DeathYear));
     }
 
     private static async Task<Created<NpcDetailDto>> Create(CreateNpcDto dto, WorldDbContext db)
@@ -53,13 +73,15 @@ public static class NpcEndpoints
             Name = dto.Name,
             Role = dto.Role,
             Description = dto.Description,
-            Notes = dto.Notes
+            Notes = dto.Notes,
+            BirthYear = dto.BirthYear,
+            DeathYear = dto.DeathYear
         };
         db.Npcs.Add(n);
         await db.SaveChangesAsync();
 
         return TypedResults.Created($"/api/npcs/{n.Id}",
-            new NpcDetailDto(n.Id, n.Name, n.Role, n.Description, n.Notes, n.ImagePath));
+            new NpcDetailDto(n.Id, n.Name, n.Role, n.Description, n.Notes, n.ImagePath, n.BirthYear, n.DeathYear));
     }
 
     private static async Task<Results<NoContent, NotFound>> Update(int id, UpdateNpcDto dto, WorldDbContext db)
@@ -71,6 +93,8 @@ public static class NpcEndpoints
         n.Role = dto.Role;
         n.Description = dto.Description;
         n.Notes = dto.Notes;
+        n.BirthYear = dto.BirthYear;
+        n.DeathYear = dto.DeathYear;
         n.UpdatedAtUtc = DateTime.UtcNow;
 
         await db.SaveChangesAsync();

--- a/src/OvcinaHra.Api/Migrations/20260414120039_AddNpcBirthDeathYear.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260414120039_AddNpcBirthDeathYear.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414120039_AddNpcBirthDeathYear")]
+    partial class AddNpcBirthDeathYear
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260414120039_AddNpcBirthDeathYear.cs
+++ b/src/OvcinaHra.Api/Migrations/20260414120039_AddNpcBirthDeathYear.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNpcBirthDeathYear : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BirthYear",
+                table: "Npcs",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "DeathYear",
+                table: "Npcs",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BirthYear",
+                table: "Npcs");
+
+            migrationBuilder.DropColumn(
+                name: "DeathYear",
+                table: "Npcs");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Services/RegistraceImportService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceImportService.cs
@@ -137,6 +137,22 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
     }
 
+    public async Task<List<RegistraceAdultDto>> FetchAdultsAsync(int gameId)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get,
+            $"{_baseUrl.TrimEnd('/')}/api/v1/games/{gameId}/adults");
+
+        if (!string.IsNullOrWhiteSpace(_apiKey))
+            request.Headers.Add("X-Api-Key", _apiKey);
+
+        var response = await httpClient.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<List<RegistraceAdultDto>>(json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+    }
+
     private sealed record RegistraceCharacterRecord(
         [property: JsonPropertyName("characterId")] int CharacterId,
         [property: JsonPropertyName("personId")] int PersonId,

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.4.3</Version>
+    <Version>0.4.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Npcs/NpcList.razor
+++ b/src/OvcinaHra.Client/Pages/Npcs/NpcList.razor
@@ -56,8 +56,7 @@ else if (Catalog)
             <DxGridDataColumn FieldName="DeathYear" Caption="Stav" Width="130px">
                 <CellDisplayTemplate>
                     @{
-                        var deathYear = context.Value as int?;
-                        if (deathYear is int y)
+                        if (context.Value is int y)
                         {
                             <span class="text-danger">† @y</span>
                         }
@@ -380,6 +379,8 @@ else
         if (GameContext.SelectedGameId is not int gid)
         {
             availableAdults = [];
+            adultsLoadError = "Není vybrána žádná hra. Vyberte hru v horní liště.";
+            StateHasChanged();
             return;
         }
 
@@ -412,7 +413,7 @@ else
     private static string BuildAdultDisplay(RegistraceAdultDto a)
     {
         var name = $"{a.FirstName} {a.LastName}".Trim();
-        return a.Roles.Count > 0 ? $"{name} — {string.Join(", ", a.Roles)}" : name;
+        return a.Roles is { Count: > 0 } ? $"{name} — {string.Join(", ", a.Roles)}" : name;
     }
 
     private async Task ConfirmAssignAsync()

--- a/src/OvcinaHra.Client/Pages/Npcs/NpcList.razor
+++ b/src/OvcinaHra.Client/Pages/Npcs/NpcList.razor
@@ -38,7 +38,13 @@ else if (Catalog && npcs.Count == 0)
 }
 else if (Catalog)
 {
-    <OvcinaGrid Data="@npcs" KeyFieldName="Id" LayoutKey="grid-layout-npcs-catalog"
+    <div class="mb-2" style="max-width: 260px;">
+        <DxComboBox Data="@roleFilterValues" @bind-Value="@roleFilter"
+                    TextFieldName="Display" ValueFieldName="Value"
+                    NullText="Všechny role"
+                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+    </div>
+    <OvcinaGrid Data="@filteredCatalog" KeyFieldName="Id" LayoutKey="grid-layout-npcs-catalog"
                 RowClick="@(e => OpenModal((NpcListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
@@ -46,6 +52,22 @@ else if (Catalog)
                 <CellDisplayTemplate>@(((NpcRole)context.Value).GetDisplayName())</CellDisplayTemplate>
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="Description" Caption="Popis" />
+            <DxGridDataColumn FieldName="BirthYear" Caption="Narozen" Width="100px" Visible="false" />
+            <DxGridDataColumn FieldName="DeathYear" Caption="Stav" Width="130px">
+                <CellDisplayTemplate>
+                    @{
+                        var deathYear = context.Value as int?;
+                        if (deathYear is int y)
+                        {
+                            <span class="text-danger">† @y</span>
+                        }
+                        else
+                        {
+                            <span class="text-success">aktivní</span>
+                        }
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
             <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>
                     @{
@@ -98,6 +120,12 @@ else
                             <DxComboBox Data="@roleValues" @bind-Value="@role"
                                         TextFieldName="Display" ValueFieldName="Value" />
                         </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Rok narození" ColSpanMd="6">
+                            <DxSpinEdit @bind-Value="@birthYear" NullText="—" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Rok úmrtí" ColSpanMd="6">
+                            <DxSpinEdit @bind-Value="@deathYear" NullText="(žije)" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                        </DxFormLayoutItem>
                         <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
                             <DxMemo @bind-Text="@description" Rows="3" />
                         </DxFormLayoutItem>
@@ -117,6 +145,12 @@ else
                         <DxFormLayoutItem Caption="Role" ColSpanMd="12">
                             <DxComboBox Data="@roleValues" @bind-Value="@role"
                                         TextFieldName="Display" ValueFieldName="Value" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Rok narození" ColSpanMd="6">
+                            <DxSpinEdit @bind-Value="@birthYear" NullText="—" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Rok úmrtí" ColSpanMd="6">
+                            <DxSpinEdit @bind-Value="@deathYear" NullText="(žije)" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
                         </DxFormLayoutItem>
                         <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
                             <DxMemo @bind-Text="@description" Rows="3" />
@@ -150,29 +184,40 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
-<DxPopup @bind-Visible="@isAssignVisible" HeaderText="Přiřadit NPC ke hře" Width="500px">
+<DxPopup @bind-Visible="@isAssignVisible" HeaderText="Přiřadit NPC ke hře" Width="550px">
     <BodyContentTemplate Context="popupContext">
-        <DxFormLayout>
-            <DxFormLayoutItem Caption="Jméno hráče" ColSpanMd="12">
-                <DxTextBox @bind-Text="@assignPlayerName" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Email hráče" ColSpanMd="12">
-                <DxTextBox @bind-Text="@assignPlayerEmail" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="ID osoby" ColSpanMd="12">
-                <DxSpinEdit @bind-Value="@assignPersonId" MinValue="1" />
-                <small class="text-muted">Volitelné — z registrace</small>
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
-                <DxMemo @bind-Text="@assignNotes" Rows="2" />
-            </DxFormLayoutItem>
-        </DxFormLayout>
+        @if (isLoadingAdults)
+        {
+            <p class="text-muted">Načítám hráče z registrace…</p>
+        }
+        else if (availableAdults.Count == 0 && adultsLoadError is null)
+        {
+            <div class="alert alert-warning">
+                Pro tuto hru nejsou v registraci žádní dospělí hráči.
+            </div>
+        }
+        else
+        {
+            <DxFormLayout>
+                <DxFormLayoutItem Caption="Hráč" ColSpanMd="12">
+                    <DxComboBox Data="@availableAdults" @bind-Value="@selectedAdultPersonId"
+                                TextFieldName="Display" ValueFieldName="PersonId"
+                                NullText="(vyberte dospělého hráče)"
+                                SearchMode="ListSearchMode.AutoSearch" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
+                    <DxMemo @bind-Text="@assignNotes" Rows="2" />
+                </DxFormLayoutItem>
+            </DxFormLayout>
+        }
 
+        @if (adultsLoadError is not null) { <div class="alert alert-danger mt-2">@adultsLoadError</div> }
         @if (assignError is not null) { <div class="alert alert-danger mt-2">@assignError</div> }
 
         <div class="d-flex gap-2 mt-3 justify-content-end">
             <button class="btn btn-secondary" @onclick="() => isAssignVisible = false">Zrušit</button>
-            <button class="btn btn-primary" @onclick="ConfirmAssignAsync">Přiřadit</button>
+            <button class="btn btn-primary" @onclick="ConfirmAssignAsync"
+                    disabled="@(selectedAdultPersonId is null || isLoadingAdults)">Přiřadit</button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
@@ -187,10 +232,20 @@ else
     private string modalTitle = "", name = "";
     private string? error, description, notes;
     private int? editingId;
+    private int? birthYear, deathYear;
     private NpcRole role = NpcRole.Other;
 
     private static readonly List<EnumItem<NpcRole>> roleValues = Enum.GetValues<NpcRole>()
         .Select(v => new EnumItem<NpcRole>(v, v.GetDisplayName())).ToList();
+
+    // Role filter for the catalog grid — nullable so "Všechny role" is selectable.
+    private static readonly List<EnumItem<NpcRole?>> roleFilterValues = Enum.GetValues<NpcRole>()
+        .Select(v => new EnumItem<NpcRole?>(v, v.GetDisplayName())).ToList();
+    private NpcRole? roleFilter;
+    private List<NpcListDto> filteredCatalog => roleFilter is null
+        ? npcs
+        : npcs.Where(n => n.Role == roleFilter).ToList();
+
     record EnumItem<T>(T Value, string Display);
 
     // Catalog assign state
@@ -199,9 +254,16 @@ else
     // Assign popup state
     private bool isAssignVisible;
     private int? assignNpcId;
-    private string? assignPlayerName, assignPlayerEmail, assignNotes;
-    private int? assignPersonId;
+    private string? assignNotes;
     private string? assignError;
+
+    // Adult picker state — loaded from /api/npcs/available-players/{gameId}.
+    private bool isLoadingAdults;
+    private string? adultsLoadError;
+    private List<AdultPickerItem> availableAdults = [];
+    private int? selectedAdultPersonId;
+
+    private record AdultPickerItem(int PersonId, string FirstName, string LastName, string? Email, string Display);
 
     private bool _previousCatalog;
 
@@ -252,12 +314,14 @@ else
         {
             editingId = null; name = ""; role = NpcRole.Other;
             description = null; notes = null;
+            birthYear = null; deathYear = null;
             modalTitle = "Nová NPC";
         }
         else
         {
             editingId = n.Id; name = n.Name; role = n.Role;
             description = n.Description;
+            birthYear = n.BirthYear; deathYear = n.DeathYear;
             modalTitle = $"Upravit: {n.Name}";
             _ = LoadDetailAsync(n.Id);
         }
@@ -277,9 +341,9 @@ else
         try
         {
             if (editingId.HasValue)
-                await Api.PutAsync($"/api/npcs/{editingId}", new UpdateNpcDto(name, role, description, notes));
+                await Api.PutAsync($"/api/npcs/{editingId}", new UpdateNpcDto(name, role, description, notes, birthYear, deathYear));
             else
-                await Api.PostAsync<CreateNpcDto, NpcDetailDto>("/api/npcs", new CreateNpcDto(name, role, description, notes));
+                await Api.PostAsync<CreateNpcDto, NpcDetailDto>("/api/npcs", new CreateNpcDto(name, role, description, notes, birthYear, deathYear));
             isModalVisible = false;
             await LoadAsync();
         }
@@ -303,21 +367,74 @@ else
     private void OpenAssignPopup(int npcId)
     {
         assignNpcId = npcId;
-        assignPlayerName = null; assignPlayerEmail = null; assignNotes = null; assignPersonId = null;
+        assignNotes = null;
+        selectedAdultPersonId = null;
         assignError = null;
+        adultsLoadError = null;
         isAssignVisible = true;
+        _ = LoadAvailableAdultsAsync();
+    }
+
+    private async Task LoadAvailableAdultsAsync()
+    {
+        if (GameContext.SelectedGameId is not int gid)
+        {
+            availableAdults = [];
+            return;
+        }
+
+        isLoadingAdults = true;
+        adultsLoadError = null;
+        StateHasChanged();
+
+        try
+        {
+            var adults = await Api.GetListAsync<RegistraceAdultDto>($"/api/npcs/available-players/{gid}");
+            availableAdults = adults
+                .OrderBy(a => a.LastName).ThenBy(a => a.FirstName)
+                .Select(a => new AdultPickerItem(
+                    a.PersonId, a.FirstName, a.LastName, a.Email,
+                    BuildAdultDisplay(a)))
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            availableAdults = [];
+            adultsLoadError = $"Nepodařilo se načíst hráče z registrace: {ex.Message}";
+        }
+        finally
+        {
+            isLoadingAdults = false;
+            StateHasChanged();
+        }
+    }
+
+    private static string BuildAdultDisplay(RegistraceAdultDto a)
+    {
+        var name = $"{a.FirstName} {a.LastName}".Trim();
+        return a.Roles.Count > 0 ? $"{name} — {string.Join(", ", a.Roles)}" : name;
     }
 
     private async Task ConfirmAssignAsync()
     {
-        if (assignNpcId is null || GameContext.SelectedGameId is null) return;
+        if (assignNpcId is null || GameContext.SelectedGameId is null || selectedAdultPersonId is null) return;
         assignError = null;
+
+        var adult = availableAdults.FirstOrDefault(a => a.PersonId == selectedAdultPersonId.Value);
+        if (adult is null)
+        {
+            assignError = "Vybraný hráč nebyl nalezen.";
+            return;
+        }
+
         try
         {
+            var playerName = $"{adult.FirstName} {adult.LastName}".Trim();
             await Api.PostAsync<CreateGameNpcDto, GameNpcDto>("/api/npcs/game-npc",
                 new CreateGameNpcDto(GameContext.SelectedGameId.Value, assignNpcId.Value,
-                    assignPersonId, assignPlayerName, assignPlayerEmail, assignNotes));
+                    adult.PersonId, playerName, adult.Email, assignNotes));
             assignedNpcIds.Add(assignNpcId.Value);
+            await LoadAsync();
             isAssignVisible = false;
             StateHasChanged();
         }

--- a/src/OvcinaHra.Shared/Domain/Entities/Npc.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Npc.cs
@@ -10,6 +10,8 @@ public class Npc
     public string? Description { get; set; }
     public string? Notes { get; set; }
     public string? ImagePath { get; set; }
+    public int? BirthYear { get; set; }
+    public int? DeathYear { get; set; }
     public bool IsDeleted { get; set; }
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;

--- a/src/OvcinaHra.Shared/Dtos/NpcDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/NpcDtos.cs
@@ -37,10 +37,11 @@ public record UpdateGameNpcDto(
     int? PlayedByPersonId, string? PlayedByName, string? PlayedByEmail, string? Notes);
 
 // Adults from registrace — eligible to play NPCs.
+// Roles is nullable because the upstream service may omit or null it.
 public record RegistraceAdultDto(
     int PersonId,
     string FirstName,
     string LastName,
     int? BirthYear,
     string? Email,
-    List<string> Roles);
+    List<string>? Roles);

--- a/src/OvcinaHra.Shared/Dtos/NpcDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/NpcDtos.cs
@@ -3,15 +3,24 @@ using OvcinaHra.Shared.Domain.Enums;
 namespace OvcinaHra.Shared.Dtos;
 
 // Catalog
-public record NpcListDto(int Id, string Name, NpcRole Role, string? Description);
+public record NpcListDto(
+    int Id, string Name, NpcRole Role, string? Description,
+    int? BirthYear, int? DeathYear);
 
 public record NpcDetailDto(
     int Id, string Name, NpcRole Role,
-    string? Description, string? Notes, string? ImagePath);
+    string? Description, string? Notes, string? ImagePath,
+    int? BirthYear, int? DeathYear);
 
-public record CreateNpcDto(string Name, NpcRole Role, string? Description = null, string? Notes = null);
+public record CreateNpcDto(
+    string Name, NpcRole Role,
+    string? Description = null, string? Notes = null,
+    int? BirthYear = null, int? DeathYear = null);
 
-public record UpdateNpcDto(string Name, NpcRole Role, string? Description, string? Notes);
+public record UpdateNpcDto(
+    string Name, NpcRole Role,
+    string? Description, string? Notes,
+    int? BirthYear = null, int? DeathYear = null);
 
 // Per-game assignment
 public record GameNpcDto(
@@ -26,3 +35,12 @@ public record CreateGameNpcDto(
 
 public record UpdateGameNpcDto(
     int? PlayedByPersonId, string? PlayedByName, string? PlayedByEmail, string? Notes);
+
+// Adults from registrace — eligible to play NPCs.
+public record RegistraceAdultDto(
+    int PersonId,
+    string FirstName,
+    string LastName,
+    int? BirthYear,
+    string? Email,
+    List<string> Roles);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/NpcEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/NpcEndpointTests.cs
@@ -69,6 +69,44 @@ public class NpcEndpointTests(PostgresFixture postgres) : IntegrationTestBase(po
     }
 
     [Fact]
+    public async Task Create_WithBirthAndDeathYears_PersistsYears()
+    {
+        var response = await Client.PostAsJsonAsync("/api/npcs",
+            new CreateNpcDto("Boromir", NpcRole.Story, "Syn Denethora",
+                BirthYear: 2978, DeathYear: 3019));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var created = await response.Content.ReadFromJsonAsync<NpcDetailDto>();
+        Assert.NotNull(created);
+        Assert.Equal(2978, created.BirthYear);
+        Assert.Equal(3019, created.DeathYear);
+
+        var fetched = await Client.GetFromJsonAsync<NpcDetailDto>($"/api/npcs/{created.Id}");
+        Assert.NotNull(fetched);
+        Assert.Equal(2978, fetched.BirthYear);
+        Assert.Equal(3019, fetched.DeathYear);
+    }
+
+    [Fact]
+    public async Task Update_ChangesDeathYear_PersistsChange()
+    {
+        var createResponse = await Client.PostAsJsonAsync("/api/npcs",
+            new CreateNpcDto("Théoden", NpcRole.King, "Král Rohanu", BirthYear: 2948));
+        var created = (await createResponse.Content.ReadFromJsonAsync<NpcDetailDto>())!;
+        Assert.Null(created.DeathYear);
+
+        var updateResponse = await Client.PutAsJsonAsync($"/api/npcs/{created.Id}",
+            new UpdateNpcDto("Théoden", NpcRole.King, "Král Rohanu", null,
+                BirthYear: 2948, DeathYear: 3019));
+        Assert.Equal(HttpStatusCode.NoContent, updateResponse.StatusCode);
+
+        var fetched = await Client.GetFromJsonAsync<NpcDetailDto>($"/api/npcs/{created.Id}");
+        Assert.NotNull(fetched);
+        Assert.Equal(2948, fetched.BirthYear);
+        Assert.Equal(3019, fetched.DeathYear);
+    }
+
+    [Fact]
     public async Task Delete_SoftDeletes_ReturnsNoContent()
     {
         var createResponse = await Client.PostAsJsonAsync("/api/npcs",


### PR DESCRIPTION
## Summary

Three organizer-facing improvements to the NPC catalog and assignment flow, bundled into one branch.

### 1. BirthYear / DeathYear on Npc

Third-age lore years. Simple flag semantics — if `DeathYear` is set, the NPC shows as dead, regardless of which game year you're in.

- Nullable `int?` fields on the `Npc` entity, DTOs, endpoints, and a new EF migration (`20260414120039_AddNpcBirthDeathYear`).
- Edit modal gains `Rok narození` / `Rok úmrtí` spin edits.
- Catalog grid gains a `Stav` column: `aktivní` in green, or `† {year}` in red when `DeathYear` is set.
- Two new integration tests: create-with-years and update-death-year.

### 2. Role filter on catalog grid

A `DxComboBox` above the catalog grid bound to a nullable `NpcRole`. Null = all roles. Grid data becomes a computed `filteredCatalog`.

### 3. Player picker driven by registrace adults endpoint

This piece required a companion change in `registrace-ovcina-cz` v0.9.5, which shipped the new `GET /api/v1/games/{gameId}/adults` endpoint (thanks Devana 👋).

- `RegistraceImportService.FetchAdultsAsync` calls the new endpoint with the existing `X-Api-Key` and deserializes into `RegistraceAdultDto`.
- New OvcinaHra endpoint `GET /api/npcs/available-players/{gameId}` proxies the call and maps network failures to `ProblemHttpResult 502`.
- Assign popup replaces three manual inputs (jméno, email, ID osoby) with one searchable `DxComboBox` of adults, labeled `First Last — role1, role2` for context. `ConfirmAssignAsync` pulls name / email / personId from the picked `AdultPickerItem`. Loading state while adults fetch; warning when empty; error banner when registrace is unreachable.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test tests/OvcinaHra.Api.Tests` — 176/176 pass
- [ ] Manual: open `/npcs?catalog=true`, confirm role filter, create an NPC with BirthYear, set DeathYear, confirm `Stav` column flips
- [ ] Manual: click `Přidat` on a catalog NPC in game 30, confirm adults list loads, pick one, confirm NPC appears in `/npcs` with correct PlayedByName/PlayedByEmail
- [ ] Manual: simulate registrace unreachable (turn off wifi briefly), confirm popup shows error banner without crashing

## Migration notes

EF migration adds two nullable columns to `Npcs` — safe rolling deploy, no data loss on rollback (both columns stay nullable in reverse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)