### PR TITLE
fix: self-healing auth + Czech enum filter [v0.4.5]

### DIFF
--- a/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
+++ b/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
@@ -26,6 +26,7 @@ public class TokenRefreshService : IDisposable
     private readonly HttpClient _http;
     private readonly JwtAuthStateProvider _authProvider;
     private readonly IJSRuntime _js;
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
     private Timer? _timer;
     private bool _booted;
 
@@ -84,8 +85,19 @@ public class TokenRefreshService : IDisposable
 
     public async Task RefreshAsync()
     {
+        await _refreshLock.WaitAsync();
         try
         {
+            // Coalesce concurrent callers: if another refresh already produced a
+            // fresh access token while we were queued, skip the round-trip.
+            var currentToken = await GetStoredAccessTokenAsync();
+            if (!string.IsNullOrEmpty(currentToken))
+            {
+                var expiry = GetJwtExpiry(currentToken);
+                if (expiry.HasValue && (expiry.Value - DateTimeOffset.UtcNow).TotalSeconds > 60)
+                    return;
+            }
+
             var refreshToken = await GetStoredRefreshTokenAsync();
 
             if (!string.IsNullOrEmpty(refreshToken))
@@ -136,6 +148,10 @@ public class TokenRefreshService : IDisposable
         {
             // Network error — retry shortly.
             ScheduleRetryAfterError();
+        }
+        finally
+        {
+            _refreshLock.Release();
         }
     }
 

--- a/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
+++ b/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
@@ -83,9 +83,9 @@ public class TokenRefreshService : IDisposable
         _timer.Start();
     }
 
-    public async Task RefreshAsync()
+    public async Task RefreshAsync(CancellationToken cancellationToken = default)
     {
-        await _refreshLock.WaitAsync();
+        await _refreshLock.WaitAsync(cancellationToken);
         try
         {
             // Coalesce concurrent callers: if another refresh already produced a
@@ -103,12 +103,12 @@ public class TokenRefreshService : IDisposable
             if (!string.IsNullOrEmpty(refreshToken))
             {
                 // Production OIDC path — stored refresh_token from registrace-ovcina.
-                var response = await _http.PostAsJsonAsync("/api/auth/oidc-refresh",
-                    new OidcRefreshRequestDto(refreshToken));
+                using var response = await _http.PostAsJsonAsync("/api/auth/oidc-refresh",
+                    new OidcRefreshRequestDto(refreshToken), cancellationToken);
 
                 if (response.IsSuccessStatusCode)
                 {
-                    var token = await response.Content.ReadFromJsonAsync<OidcExchangeResponse>();
+                    var token = await response.Content.ReadFromJsonAsync<OidcExchangeResponse>(cancellationToken);
                     if (token is not null)
                     {
                         await _authProvider.SetTokenAsync(token.Token);
@@ -133,16 +133,20 @@ public class TokenRefreshService : IDisposable
             }
 
             // Dev path — self-issued token, no refresh_token involved.
-            var devResponse = await _http.PostAsync("/api/auth/refresh", null);
+            using var devResponse = await _http.PostAsync("/api/auth/refresh", null, cancellationToken);
             if (devResponse.IsSuccessStatusCode)
             {
-                var token = await devResponse.Content.ReadFromJsonAsync<TokenResponse>();
+                var token = await devResponse.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken);
                 if (token is not null)
                 {
                     await _authProvider.SetTokenAsync(token.Token);
                     ScheduleRefresh(token.ExpiresInSeconds);
                 }
             }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch
         {
@@ -234,5 +238,6 @@ public class TokenRefreshService : IDisposable
     public void Dispose()
     {
         _timer?.Dispose();
+        _refreshLock.Dispose();
     }
 }

--- a/src/OvcinaHra.Client/Auth/UnauthorizedRedirectHandler.cs
+++ b/src/OvcinaHra.Client/Auth/UnauthorizedRedirectHandler.cs
@@ -11,6 +11,8 @@ namespace OvcinaHra.Client.Auth;
 /// </summary>
 public class UnauthorizedRedirectHandler : DelegatingHandler
 {
+    private const long MaxBufferedBodyBytes = 50L * 1024 * 1024;
+
     private readonly NavigationManager _nav;
     private readonly IServiceProvider _services;
 
@@ -29,8 +31,20 @@ public class UnauthorizedRedirectHandler : DelegatingHandler
                            || path.EndsWith("/dev-token", StringComparison.OrdinalIgnoreCase)
                            || path.EndsWith("/service-token", StringComparison.OrdinalIgnoreCase);
 
+        byte[]? bufferedBody = null;
+        List<KeyValuePair<string, IEnumerable<string>>>? bufferedHeaders = null;
+
         if (request.Content is not null && !isTokenEndpoint)
-            await request.Content.LoadIntoBufferAsync();
+        {
+            var contentLength = request.Content.Headers.ContentLength;
+            if (!contentLength.HasValue || contentLength.Value <= MaxBufferedBodyBytes)
+            {
+                bufferedBody = await request.Content.ReadAsByteArrayAsync(cancellationToken);
+                bufferedHeaders = request.Content.Headers
+                    .Select(h => new KeyValuePair<string, IEnumerable<string>>(h.Key, h.Value))
+                    .ToList();
+            }
+        }
 
         var response = await base.SendAsync(request, cancellationToken);
 
@@ -40,7 +54,7 @@ public class UnauthorizedRedirectHandler : DelegatingHandler
         response.Dispose();
 
         var refresh = _services.GetRequiredService<TokenRefreshService>();
-        await refresh.RefreshAsync();
+        await refresh.RefreshAsync(cancellationToken);
 
         var auth = _services.GetRequiredService<JwtAuthStateProvider>();
         var newToken = await auth.GetTokenAsync();
@@ -51,7 +65,7 @@ public class UnauthorizedRedirectHandler : DelegatingHandler
             return new HttpResponseMessage(HttpStatusCode.Unauthorized);
         }
 
-        var retry = await CloneRequestAsync(request);
+        using var retry = CloneRequest(request, bufferedBody, bufferedHeaders);
         retry.Headers.Authorization = new AuthenticationHeaderValue("Bearer", newToken);
 
         var retryResponse = await base.SendAsync(retry, cancellationToken);
@@ -61,21 +75,25 @@ public class UnauthorizedRedirectHandler : DelegatingHandler
         return retryResponse;
     }
 
-    private static async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage original)
+    private static HttpRequestMessage CloneRequest(
+        HttpRequestMessage original,
+        byte[]? bufferedBody,
+        List<KeyValuePair<string, IEnumerable<string>>>? bufferedHeaders)
     {
         var clone = new HttpRequestMessage(original.Method, original.RequestUri)
         {
             Version = original.Version
         };
 
-        if (original.Content is not null)
+        if (bufferedBody is not null)
         {
-            var ms = new MemoryStream();
-            await original.Content.CopyToAsync(ms);
-            ms.Position = 0;
-            clone.Content = new StreamContent(ms);
-            foreach (var h in original.Content.Headers)
-                clone.Content.Headers.TryAddWithoutValidation(h.Key, h.Value);
+            var content = new ByteArrayContent(bufferedBody);
+            if (bufferedHeaders is not null)
+            {
+                foreach (var h in bufferedHeaders)
+                    content.Headers.TryAddWithoutValidation(h.Key, h.Value);
+            }
+            clone.Content = content;
         }
 
         foreach (var h in original.Headers)

--- a/src/OvcinaHra.Client/Auth/UnauthorizedRedirectHandler.cs
+++ b/src/OvcinaHra.Client/Auth/UnauthorizedRedirectHandler.cs
@@ -1,28 +1,86 @@
 using System.Net;
+using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Components;
 
 namespace OvcinaHra.Client.Auth;
 
+/// <summary>
+/// On API 401, refreshes the access token once and retries the request before
+/// falling back to /login. Token-producing endpoints are bypassed to prevent
+/// recursion.
+/// </summary>
 public class UnauthorizedRedirectHandler : DelegatingHandler
 {
     private readonly NavigationManager _nav;
+    private readonly IServiceProvider _services;
 
-    public UnauthorizedRedirectHandler(NavigationManager nav)
+    public UnauthorizedRedirectHandler(NavigationManager nav, IServiceProvider services)
     {
         _nav = nav;
+        _services = services;
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        var path = request.RequestUri?.AbsolutePath ?? "";
+        var isTokenEndpoint = path.EndsWith("/oidc-refresh", StringComparison.OrdinalIgnoreCase)
+                           || path.EndsWith("/oidc-exchange", StringComparison.OrdinalIgnoreCase)
+                           || path.EndsWith("/auth/refresh", StringComparison.OrdinalIgnoreCase)
+                           || path.EndsWith("/dev-token", StringComparison.OrdinalIgnoreCase)
+                           || path.EndsWith("/service-token", StringComparison.OrdinalIgnoreCase);
+
+        if (request.Content is not null && !isTokenEndpoint)
+            await request.Content.LoadIntoBufferAsync();
+
         var response = await base.SendAsync(request, cancellationToken);
 
-        // Don't redirect for auth endpoints — let them handle 401 internally
-        var path = request.RequestUri?.AbsolutePath ?? "";
-        if (response.StatusCode == HttpStatusCode.Unauthorized && !path.Contains("/auth/"))
+        if (response.StatusCode != HttpStatusCode.Unauthorized || isTokenEndpoint)
+            return response;
+
+        response.Dispose();
+
+        var refresh = _services.GetRequiredService<TokenRefreshService>();
+        await refresh.RefreshAsync();
+
+        var auth = _services.GetRequiredService<JwtAuthStateProvider>();
+        var newToken = await auth.GetTokenAsync();
+
+        if (string.IsNullOrEmpty(newToken))
         {
             _nav.NavigateTo("/login", forceLoad: true);
+            return new HttpResponseMessage(HttpStatusCode.Unauthorized);
         }
 
-        return response;
+        var retry = await CloneRequestAsync(request);
+        retry.Headers.Authorization = new AuthenticationHeaderValue("Bearer", newToken);
+
+        var retryResponse = await base.SendAsync(retry, cancellationToken);
+        if (retryResponse.StatusCode == HttpStatusCode.Unauthorized)
+            _nav.NavigateTo("/login", forceLoad: true);
+
+        return retryResponse;
+    }
+
+    private static async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage original)
+    {
+        var clone = new HttpRequestMessage(original.Method, original.RequestUri)
+        {
+            Version = original.Version
+        };
+
+        if (original.Content is not null)
+        {
+            var ms = new MemoryStream();
+            await original.Content.CopyToAsync(ms);
+            ms.Position = 0;
+            clone.Content = new StreamContent(ms);
+            foreach (var h in original.Content.Headers)
+                clone.Content.Headers.TryAddWithoutValidation(h.Key, h.Value);
+        }
+
+        foreach (var h in original.Headers)
+            clone.Headers.TryAddWithoutValidation(h.Key, h.Value);
+
+        return clone;
     }
 }

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.4.4</Version>
+    <Version>0.4.5</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.4" PrivateAssets="all" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -36,9 +36,8 @@ else
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
             <DxGridDataColumn FieldName="Effect" Caption="Efekt" />
-            <DxGridDataColumn FieldName="ItemType" Caption="Typ" Width="150px">
-                <CellDisplayTemplate>@(((ItemType)context.Value).GetDisplayName())</CellDisplayTemplate>
-            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="150px" />
+
             <DxGridDataColumn FieldName="IsCraftable" Caption="Vyrobitelný" Width="120px">
                 <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
             </DxGridDataColumn>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -50,9 +50,7 @@ else
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="Id" Caption="#" Width="50px" />
             <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="LocationKind" Caption="Typ" Width="160px">
-                <CellDisplayTemplate>@(((LocationKind)context.Value).GetDisplayName())</CellDisplayTemplate>
-            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="LocationKindDisplay" Caption="Typ" Width="160px" />
             <DxGridDataColumn FieldName="Region" Caption="Oblast" Width="140px" />
             <DxGridDataColumn FieldName="ParentLocationId" Caption="Rodič / Varianty" Width="250px">
                 <CellDisplayTemplate>

--- a/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
@@ -1,8 +1,14 @@
+using System.Text.Json.Serialization;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Shared.Dtos;
 
-public record ItemListDto(int Id, string Name, ItemType ItemType, string? Effect, bool IsCraftable, bool IsUnique, bool IsLimited);
+public record ItemListDto(int Id, string Name, ItemType ItemType, string? Effect, bool IsCraftable, bool IsUnique, bool IsLimited)
+{
+    [JsonIgnore]
+    public string ItemTypeDisplay => ItemType.GetDisplayName();
+}
 
 public record ItemDetailDto(
     int Id,

--- a/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
@@ -1,4 +1,6 @@
+using System.Text.Json.Serialization;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Shared.Dtos;
 
@@ -9,7 +11,11 @@ public record LocationListDto(
     string? Region,
     decimal? Latitude,
     decimal? Longitude,
-    int? ParentLocationId);
+    int? ParentLocationId)
+{
+    [JsonIgnore]
+    public string LocationKindDisplay => LocationKind.GetDisplayName();
+}
 
 public record LocationDetailDto(
     int Id,


### PR DESCRIPTION
## Summary

- **Auth** — HTTP handler now refreshes the access token on 401 and retries the request once before bouncing to `/login`. Fixes mid-session logouts when timer drifts (idle/backgrounded tab, clock skew, etc.).
- **Refresh race** — `TokenRefreshService.RefreshAsync` is now semaphore-guarded so concurrent 401s don't burn the rotating refresh_token.
- **Items filter** — filter popup on the Typ column now shows Czech display names (Zbroj, Artefakt, Komodita…) via a computed `ItemTypeDisplay` DTO property. Filter menus read the bound field — `CellDisplayTemplate` only fixes cells.
- **CVE** — bumps `System.Security.Cryptography.Xml` to `10.0.6` to clear `NU1903` audit errors (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf) that were breaking CI.

## Test plan

- [ ] Build passes on CI (Client CI + API CI)
- [ ] Log in on staging, leave tab idle >10 min, come back and click around — no redirect to login
- [ ] Open `/items`, click filter on Typ column — Czech labels in the popup
- [ ] Sort + group on Typ still work
- [ ] Hard-refresh (Ctrl+Shift+R) to bust PWA cache after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)