### PR TITLE
fix: Czech enum filters across all grids [v0.4.7]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-    <Version>0.4.6</Version>
+    <Version>0.4.7</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Games/GameList.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameList.razor
@@ -20,9 +20,7 @@ else
             <DxGridDataColumn FieldName="Edition" Caption="Ročník" Width="100px" />
             <DxGridDataColumn FieldName="StartDate" Caption="Od" Width="120px" DisplayFormat="d.M.yyyy" />
             <DxGridDataColumn FieldName="EndDate" Caption="Do" Width="120px" DisplayFormat="d.M.yyyy" />
-            <DxGridDataColumn FieldName="Status" Caption="Stav" Width="140px">
-                <CellDisplayTemplate>@(((GameStatus)context.Value).GetDisplayName())</CellDisplayTemplate>
-            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="StatusDisplay" Caption="Stav" Width="140px" />
             <DxGridDataColumn FieldName="ExternalGameId" Caption="Registrace ID" Width="130px" Visible="false" />
         </Columns>
     </OvcinaGrid>

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
@@ -35,9 +35,7 @@ else
                 RowClick="@(e => OpenModal((MonsterListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="MonsterType" Caption="Typ" Width="130px">
-                <CellDisplayTemplate>@(((MonsterType)context.Value).GetDisplayName())</CellDisplayTemplate>
-            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="MonsterTypeDisplay" Caption="Typ" Width="130px" />
             <DxGridDataColumn FieldName="Category" Caption="Kategorie" Width="110px" />
             <DxGridDataColumn FieldName="Attack" Caption="Útok" Width="80px" />
             <DxGridDataColumn FieldName="Defense" Caption="Obrana" Width="80px" />

--- a/src/OvcinaHra.Client/Pages/Npcs/NpcList.razor
+++ b/src/OvcinaHra.Client/Pages/Npcs/NpcList.razor
@@ -48,9 +48,7 @@ else if (Catalog)
                 RowClick="@(e => OpenModal((NpcListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="Role" Caption="Role" Width="150px">
-                <CellDisplayTemplate>@(((NpcRole)context.Value).GetDisplayName())</CellDisplayTemplate>
-            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="RoleDisplay" Caption="Role" Width="150px" />
             <DxGridDataColumn FieldName="Description" Caption="Popis" />
             <DxGridDataColumn FieldName="BirthYear" Caption="Narozen" Width="100px" Visible="false" />
             <DxGridDataColumn FieldName="DeathYear" Caption="Stav" Width="130px">
@@ -93,9 +91,7 @@ else
                 RowClick="@(e => { var gn = (GameNpcDto)e.Grid.GetDataItem(e.VisibleIndex); var n = npcs.FirstOrDefault(x => x.Id == gn.NpcId); if (n is not null) OpenModal(n); })">
         <Columns>
             <DxGridDataColumn FieldName="NpcName" Caption="Název" />
-            <DxGridDataColumn FieldName="Role" Caption="Role" Width="150px">
-                <CellDisplayTemplate>@(((NpcRole)context.Value).GetDisplayName())</CellDisplayTemplate>
-            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="RoleDisplay" Caption="Role" Width="150px" />
             <DxGridDataColumn FieldName="PlayedByName" Caption="Hraje" Width="180px" />
             <DxGridDataColumn FieldName="PlayedByEmail" Caption="Email" Width="200px" Visible="false" />
         </Columns>

--- a/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
@@ -23,9 +23,7 @@ else if (Catalog)
                 RowClick="@(e => OpenModalFromCatalog((QuestCatalogDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" Width="220px" />
-            <DxGridDataColumn FieldName="QuestType" Caption="Typ" Width="130px">
-                <CellDisplayTemplate>@(((QuestType)context.Value).GetDisplayName())</CellDisplayTemplate>
-            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="QuestTypeDisplay" Caption="Typ" Width="130px" />
             <DxGridDataColumn FieldName="FullText" Caption="Herní text" />
             <DxGridDataColumn FieldName="Description" Caption="Organizátor" />
             <DxGridDataColumn FieldName="RewardSummary" Caption="Odměny" Width="220px" />
@@ -57,9 +55,7 @@ else
                 RowClick="@(e => OpenModal((QuestListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="QuestType" Caption="Typ" Width="140px">
-                <CellDisplayTemplate>@(((QuestType)context.Value).GetDisplayName())</CellDisplayTemplate>
-            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="QuestTypeDisplay" Caption="Typ" Width="140px" />
             <DxGridDataColumn FieldName="ChainOrder" Caption="Pořadí v řetězu" Width="140px" Visible="false" />
             <DxGridDataColumn FieldName="ParentQuestId" Caption="Nadřazený quest" Width="140px" Visible="false" />
             <DxGridDataColumn FieldName="GameId" Caption="Hra ID" Width="80px" />

--- a/src/OvcinaHra.Client/Pages/Tags/TagList.razor
+++ b/src/OvcinaHra.Client/Pages/Tags/TagList.razor
@@ -14,9 +14,7 @@ else
                 RowClick="@(e => OpenModal((TagDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="Kind" Caption="Druh" Width="140px">
-                <CellDisplayTemplate>@(((TagKind)context.Value).GetDisplayName())</CellDisplayTemplate>
-            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="KindDisplay" Caption="Druh" Width="140px" />
         </Columns>
     </OvcinaGrid>
 }

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -47,9 +47,7 @@ else
                         ShowGroupPanel="true">
                 <Columns>
                     <DxGridDataColumn FieldName="ItemName" Caption="Předmět" />
-                    <DxGridDataColumn FieldName="ItemType" Caption="Typ" Width="120px">
-                        <CellDisplayTemplate>@(((ItemType)context.Value).GetDisplayName())</CellDisplayTemplate>
-                    </DxGridDataColumn>
+                    <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="120px" />
                     <DxGridDataColumn FieldName="Count" Caption="Počet" Width="70px" />
                 </Columns>
             </OvcinaGrid>
@@ -104,9 +102,7 @@ else
                         ShowGroupPanel="true">
                 <Columns>
                     <DxGridDataColumn FieldName="Title" Caption="Název" />
-                    <DxGridDataColumn FieldName="Difficulty" Caption="Obtížnost" Width="130px">
-                        <CellDisplayTemplate>@(((TreasureQuestDifficulty)context.Value).GetDisplayName())</CellDisplayTemplate>
-                    </DxGridDataColumn>
+                    <DxGridDataColumn FieldName="DifficultyDisplay" Caption="Obtížnost" Width="130px" />
                     <DxGridDataColumn FieldName="LocationId" Caption="Lokace" Width="150px">
                         <CellDisplayTemplate>@GetLocationName((int?)context.Value)</CellDisplayTemplate>
                     </DxGridDataColumn>

--- a/src/OvcinaHra.Shared/Dtos/GameDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/GameDtos.cs
@@ -1,8 +1,14 @@
+using System.Text.Json.Serialization;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Shared.Dtos;
 
-public record GameListDto(int Id, string Name, int Edition, DateOnly StartDate, DateOnly EndDate, GameStatus Status, int? ExternalGameId);
+public record GameListDto(int Id, string Name, int Edition, DateOnly StartDate, DateOnly EndDate, GameStatus Status, int? ExternalGameId)
+{
+    [JsonIgnore]
+    public string StatusDisplay => Status.GetDisplayName();
+}
 
 public record GameDetailDto(
     int Id,

--- a/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
@@ -1,8 +1,14 @@
+using System.Text.Json.Serialization;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Shared.Dtos;
 
-public record MonsterListDto(int Id, string Name, MonsterType MonsterType, int Category, int Attack, int Defense, int Health);
+public record MonsterListDto(int Id, string Name, MonsterType MonsterType, int Category, int Attack, int Defense, int Health)
+{
+    [JsonIgnore]
+    public string MonsterTypeDisplay => MonsterType.GetDisplayName();
+}
 
 public record MonsterDetailDto(
     int Id,

--- a/src/OvcinaHra.Shared/Dtos/NpcDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/NpcDtos.cs
@@ -1,11 +1,17 @@
+using System.Text.Json.Serialization;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Shared.Dtos;
 
 // Catalog
 public record NpcListDto(
     int Id, string Name, NpcRole Role, string? Description,
-    int? BirthYear, int? DeathYear);
+    int? BirthYear, int? DeathYear)
+{
+    [JsonIgnore]
+    public string RoleDisplay => Role.GetDisplayName();
+}
 
 public record NpcDetailDto(
     int Id, string Name, NpcRole Role,
@@ -26,7 +32,11 @@ public record UpdateNpcDto(
 public record GameNpcDto(
     int GameId, int NpcId, string NpcName, NpcRole Role,
     int? PlayedByPersonId, string? PlayedByName, string? PlayedByEmail,
-    string? Notes);
+    string? Notes)
+{
+    [JsonIgnore]
+    public string RoleDisplay => Role.GetDisplayName();
+}
 
 public record CreateGameNpcDto(
     int GameId, int NpcId,

--- a/src/OvcinaHra.Shared/Dtos/QuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/QuestDtos.cs
@@ -1,8 +1,14 @@
+using System.Text.Json.Serialization;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Shared.Dtos;
 
-public record QuestListDto(int Id, string Name, QuestType QuestType, int? ChainOrder, int? ParentQuestId, int? GameId);
+public record QuestListDto(int Id, string Name, QuestType QuestType, int? ChainOrder, int? ParentQuestId, int? GameId)
+{
+    [JsonIgnore]
+    public string QuestTypeDisplay => QuestType.GetDisplayName();
+}
 
 public record QuestDetailDto(
     int Id,
@@ -58,6 +64,10 @@ public record AddQuestRewardDto(int ItemId, int Quantity = 1);
 public record QuestCatalogDto(
     int Id, string Name, QuestType QuestType,
     int? GameId, string? GameName, int? GameEdition,
-    string? Description, string? FullText, string? RewardSummary);
+    string? Description, string? FullText, string? RewardSummary)
+{
+    [JsonIgnore]
+    public string QuestTypeDisplay => QuestType.GetDisplayName();
+}
 public record QuestCopyResultDto(QuestListDto Quest, List<string> Warnings);
 public record MoveQuestToGameDto(int GameId);

--- a/src/OvcinaHra.Shared/Dtos/TagDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TagDtos.cs
@@ -1,8 +1,14 @@
+using System.Text.Json.Serialization;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Shared.Dtos;
 
-public record TagDto(int Id, string Name, TagKind Kind);
+public record TagDto(int Id, string Name, TagKind Kind)
+{
+    [JsonIgnore]
+    public string KindDisplay => Kind.GetDisplayName();
+}
 
 public record CreateTagDto(string Name, TagKind Kind);
 

--- a/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
@@ -1,10 +1,16 @@
+using System.Text.Json.Serialization;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Shared.Dtos;
 
 // --- TreasureQuest DTOs ---
 
-public record TreasureQuestListDto(int Id, string Title, TreasureQuestDifficulty Difficulty, int? LocationId, int? SecretStashId, int GameId);
+public record TreasureQuestListDto(int Id, string Title, TreasureQuestDifficulty Difficulty, int? LocationId, int? SecretStashId, int GameId)
+{
+    [JsonIgnore]
+    public string DifficultyDisplay => Difficulty.GetDisplayName();
+}
 
 public record TreasureQuestDetailDto(
     int Id, string Title, string? Clue, TreasureQuestDifficulty Difficulty,
@@ -24,7 +30,11 @@ public record AddTreasureItemDto(int ItemId, int Count = 1);
 
 // --- Treasure Pool DTOs ---
 
-public record TreasurePoolItemDto(int Id, int ItemId, string ItemName, ItemType ItemType, int Count, int GameId);
+public record TreasurePoolItemDto(int Id, int ItemId, string ItemName, ItemType ItemType, int Count, int GameId)
+{
+    [JsonIgnore]
+    public string ItemTypeDisplay => ItemType.GetDisplayName();
+}
 public record CreateTreasurePoolItemDto(int ItemId, int GameId, int Count = 1);
 
 // --- Treasure Planning DTOs ---


### PR DESCRIPTION
## Summary

Finishes what PR #26 started — every grid that still showed English enum names in the filter popup now shows Czech.

| Page | Enum | Computed property |
|---|---|---|
| Games | `GameStatus` | `StatusDisplay` |
| Monsters | `MonsterType` | `MonsterTypeDisplay` |
| NPCs (catalog + per-game) | `NpcRole` | `RoleDisplay` |
| Quests (catalog + per-game) | `QuestType` | `QuestTypeDisplay` |
| Tags | `TagKind` | `KindDisplay` |
| Treasures (pool + assigned) | `ItemType`, `TreasureQuestDifficulty` | `ItemTypeDisplay`, `DifficultyDisplay` |

## Why

DxGrid filter menus read the underlying field value, not `CellDisplayTemplate`. Binding to a pre-formatted string property fixes both cell rendering AND filter popup with one change.

## Shape of each change

- DTO: add `[JsonIgnore] public string XxxDisplay => Xxx.GetDisplayName();` (server payload unchanged)
- Razor: swap `FieldName="Xxx"` → `FieldName="XxxDisplay"`, drop `<CellDisplayTemplate>`

## Test plan

- [ ] CI passes
- [ ] On each page — open the filter popup on the Typ/Role/Druh/Stav/Obtížnost column, confirm Czech labels
- [ ] Sort + group by that column still work (now alphabetical by Czech name)
- [ ] Filtering actually filters rows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)