### PR TITLE
fix: item Cena auto-toggles Prodávaný [v0.5.1]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -232,7 +232,10 @@ else
                 {
                     <DxFormLayout>
                         <DxFormLayoutItem Caption="Cena" ColSpanMd="4">
-                            <DxSpinEdit @bind-Value="@giPrice" MinValue="0" NullText="(žádná)" />
+                            <DxSpinEdit Value="@giPrice"
+                                        ValueExpression="@(() => giPrice)"
+                                        ValueChanged="@((int? v) => { giPrice = v; giIsSold = v.HasValue; })"
+                                        MinValue="0" NullText="(žádná)" />
                         </DxFormLayoutItem>
                         <DxFormLayoutItem Caption="Počet na skladě" ColSpanMd="4">
                             <DxSpinEdit @bind-Value="@giStockCount" MinValue="0" NullText="(neomezeno)" />


### PR DESCRIPTION
## Summary

On the Item detail popup's **Nastavení pro aktuální hru** card, the **Cena** SpinEdit now drives the **Prodávaný** checkbox:

- Typing any price (including 0) → Prodávaný = true
- Clearing the price (→ null) → Prodávaný = false

The organizer can still manually toggle Prodávaný afterwards — only price changes cause the automatic coupling.

## Implementation

Swapped `@bind-Value` on the price `DxSpinEdit` for explicit `Value` + `ValueExpression` + `ValueChanged`, setting `giIsSold = v.HasValue` in the handler.

## Test plan

- [ ] CI passes
- [ ] Open an item on `/items`, pick a game-assigned one, open its "Nastavení pro aktuální hru"
- [ ] Type a price → Prodávaný auto-ticks
- [ ] Clear the price → Prodávaný auto-unticks
- [ ] Save, reopen, verify both fields persisted correctly
- [ ] Manually toggle Prodávaný with a price still set — change sticks until next price edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)