### PR TITLE
feat: items grid — catalog/game split, context menu, recipe summary [v0.5.2]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -115,7 +115,11 @@ public static class ItemEndpoints
             .Include(r => r.SkillRequirements).ThenInclude(s => s.Skill)
             .ToListAsync();
 
-        var summaryByItemId = recipes.ToDictionary(r => r.OutputItemId, BuildRecipeSummary);
+        // GroupBy is defensive — schema doesn't prevent multiple recipes for the same OutputItemId
+        // in a single game, and ToDictionary would throw on duplicates.
+        var summaryByItemId = recipes
+            .GroupBy(r => r.OutputItemId)
+            .ToDictionary(g => g.Key, g => BuildRecipeSummary(g.First()));
 
         var result = gameItems
             .Select(gi => new GameItemListDto(

--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -102,19 +102,54 @@ public static class ItemEndpoints
 
     private static async Task<Ok<List<GameItemListDto>>> GetByGame(int gameId, WorldDbContext db)
     {
-        var items = await db.GameItems
+        var gameItems = await db.GameItems
             .Where(gi => gi.GameId == gameId)
             .Include(gi => gi.Item)
             .OrderBy(gi => gi.Item.Name)
+            .ToListAsync();
+
+        var recipes = await db.CraftingRecipes
+            .Where(r => r.GameId == gameId)
+            .Include(r => r.Ingredients).ThenInclude(i => i.Item)
+            .Include(r => r.BuildingRequirements).ThenInclude(b => b.Building)
+            .Include(r => r.SkillRequirements).ThenInclude(s => s.Skill)
+            .ToListAsync();
+
+        var summaryByItemId = recipes.ToDictionary(r => r.OutputItemId, BuildRecipeSummary);
+
+        var result = gameItems
             .Select(gi => new GameItemListDto(
                 gi.Item.Id, gi.Item.Name, gi.Item.ItemType, gi.Item.Effect, gi.Item.PhysicalForm,
                 gi.Item.IsCraftable,
                 gi.Item.ClassRequirements.Warrior, gi.Item.ClassRequirements.Archer,
                 gi.Item.ClassRequirements.Mage, gi.Item.ClassRequirements.Thief,
                 gi.Item.IsUnique, gi.Item.IsLimited, gi.Item.ImagePath,
-                gi.GameId, gi.Price, gi.StockCount, gi.IsSold, gi.SaleCondition, gi.IsFindable))
-            .ToListAsync();
-        return TypedResults.Ok(items);
+                gi.GameId, gi.Price, gi.StockCount, gi.IsSold, gi.SaleCondition, gi.IsFindable,
+                summaryByItemId.GetValueOrDefault(gi.ItemId)))
+            .ToList();
+
+        return TypedResults.Ok(result);
+    }
+
+    private static string? BuildRecipeSummary(CraftingRecipe r)
+    {
+        var parts = new List<string>();
+        if (r.Ingredients.Count > 0)
+        {
+            parts.Add(string.Join(", ",
+                r.Ingredients.OrderBy(i => i.Item.Name).Select(i => $"{i.Quantity}× {i.Item.Name}")));
+        }
+        if (r.BuildingRequirements.Count > 0)
+        {
+            parts.Add(string.Join(", ",
+                r.BuildingRequirements.OrderBy(b => b.Building.Name).Select(b => b.Building.Name)));
+        }
+        if (r.SkillRequirements.Count > 0)
+        {
+            parts.Add(string.Join(", ",
+                r.SkillRequirements.OrderBy(s => s.Skill.Name).Select(s => s.Skill.Name)));
+        }
+        return parts.Count > 0 ? string.Join(" │ ", parts) : null;
     }
 
     private static async Task<Results<Created<GameItemDto>, Conflict>> CreateGameItem(CreateGameItemDto dto, WorldDbContext db)

--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -38,7 +38,11 @@ public static class ItemEndpoints
     {
         var items = await db.Items
             .OrderBy(i => i.Name)
-            .Select(i => new ItemListDto(i.Id, i.Name, i.ItemType, i.Effect, i.IsCraftable, i.IsUnique, i.IsLimited))
+            .Select(i => new ItemListDto(
+                i.Id, i.Name, i.ItemType, i.Effect, i.PhysicalForm, i.IsCraftable,
+                i.ClassRequirements.Warrior, i.ClassRequirements.Archer,
+                i.ClassRequirements.Mage, i.ClassRequirements.Thief,
+                i.IsUnique, i.IsLimited, i.ImagePath))
             .ToListAsync();
         return TypedResults.Ok(items);
     }
@@ -96,15 +100,19 @@ public static class ItemEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Ok<List<GameItemDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<GameItemListDto>>> GetByGame(int gameId, WorldDbContext db)
     {
         var items = await db.GameItems
             .Where(gi => gi.GameId == gameId)
             .Include(gi => gi.Item)
             .OrderBy(gi => gi.Item.Name)
-            .Select(gi => new GameItemDto(
-                gi.GameId, gi.ItemId, gi.Item.Name,
-                gi.Price, gi.StockCount, gi.IsSold, gi.SaleCondition, gi.IsFindable))
+            .Select(gi => new GameItemListDto(
+                gi.Item.Id, gi.Item.Name, gi.Item.ItemType, gi.Item.Effect, gi.Item.PhysicalForm,
+                gi.Item.IsCraftable,
+                gi.Item.ClassRequirements.Warrior, gi.Item.ClassRequirements.Archer,
+                gi.Item.ClassRequirements.Mage, gi.Item.ClassRequirements.Thief,
+                gi.Item.IsUnique, gi.Item.IsLimited, gi.Item.ImagePath,
+                gi.GameId, gi.Price, gi.StockCount, gi.IsSold, gi.SaleCondition, gi.IsFindable))
             .ToListAsync();
         return TypedResults.Ok(items);
     }
@@ -176,7 +184,11 @@ public static class ItemEndpoints
             var required = cr.GetRequirement(playerClass);
             return required > 0 && level >= required;
         })
-        .Select(i => new ItemListDto(i.Id, i.Name, i.ItemType, i.Effect, i.IsCraftable, i.IsUnique, i.IsLimited))
+        .Select(i => new ItemListDto(
+            i.Id, i.Name, i.ItemType, i.Effect, i.PhysicalForm, i.IsCraftable,
+            i.ClassRequirements.Warrior, i.ClassRequirements.Archer,
+            i.ClassRequirements.Mage, i.ClassRequirements.Thief,
+            i.IsUnique, i.IsLimited, i.ImagePath))
         .OrderBy(i => i.Name)
         .ToList();
 

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.5.0</Version>
+    <Version>0.5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -14,7 +14,7 @@
             <button class="btn btn-sm @(Catalog ? "btn-primary" : "btn-outline-primary")"
                     @onclick='() => Nav.NavigateTo("/items?catalog=true")'>Katalog</button>
         </div>
-        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nový předmět</button>
+        <button class="btn btn-primary" @onclick="() => OpenModal((ItemListDto?)null)">+ Nový předmět</button>
     </div>
 </div>
 
@@ -22,7 +22,7 @@
 {
     <p>Načítám...</p>
 }
-else if (!Catalog && items.Count == 0)
+else if (!Catalog && gameItems.Count == 0)
 {
     <div class="text-center text-muted py-5">
         <i class="bi bi-box-seam fs-1 d-block mb-2"></i>
@@ -30,15 +30,20 @@ else if (!Catalog && items.Count == 0)
         <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/items?catalog=true")'>Otevřít katalog</button>
     </div>
 }
-else
+else if (Catalog)
 {
-    <OvcinaGrid Data="@items" KeyFieldName="Id" LayoutKey="grid-layout-items"
+    <OvcinaGrid Data="@catalogItems" KeyFieldName="Id" LayoutKey="grid-layout-items-catalog"
                 RowClick="@(e => OpenModal((ItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
+            <DxGridDataColumn FieldName="Id" Caption="#" Width="60px" Visible="false" />
             <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="Effect" Caption="Efekt" />
             <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="150px" />
-
+            <DxGridDataColumn FieldName="Effect" Caption="Efekt" />
+            <DxGridDataColumn FieldName="PhysicalFormDisplay" Caption="Fyzická forma" Width="150px" Visible="false" />
+            <DxGridDataColumn FieldName="ReqWarrior" Caption="Váleč." Width="80px" Visible="false" />
+            <DxGridDataColumn FieldName="ReqArcher" Caption="Střelec" Width="80px" Visible="false" />
+            <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="80px" Visible="false" />
+            <DxGridDataColumn FieldName="ReqThief" Caption="Zloděj" Width="80px" Visible="false" />
             <DxGridDataColumn FieldName="IsCraftable" Caption="Vyrobitelný" Width="120px">
                 <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
             </DxGridDataColumn>
@@ -48,28 +53,85 @@ else
             <DxGridDataColumn FieldName="IsLimited" Caption="Limitovaný" Width="110px" Visible="false">
                 <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
             </DxGridDataColumn>
-            @if (Catalog)
-            {
-                <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false">
-                    <CellDisplayTemplate>
-                        @{
-                            var itemId = (int)context.Value;
-                            if (assignedItemIds.Contains(itemId))
-                            {
-                                <button class="btn btn-sm btn-outline-danger" @onclick:stopPropagation="true"
-                                        @onclick="() => UnassignItemAsync(itemId)">Odebrat</button>
-                            }
-                            else
-                            {
-                                <button class="btn btn-sm btn-outline-success" @onclick:stopPropagation="true"
-                                        @onclick="() => AssignItemAsync(itemId)">Přidat</button>
-                            }
+            <DxGridDataColumn FieldName="HasImage" Caption="Obrázek" Width="100px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false" AllowFilter="false">
+                <CellDisplayTemplate>
+                    @{
+                        var itemId = (int)context.Value;
+                        if (assignedItemIds.Contains(itemId))
+                        {
+                            <button class="btn btn-sm btn-outline-danger" @onclick:stopPropagation="true"
+                                    @onclick="() => UnassignItemAsync(itemId)">Odebrat</button>
                         }
-                    </CellDisplayTemplate>
-                </DxGridDataColumn>
-            }
+                        else
+                        {
+                            <button class="btn btn-sm btn-outline-success" @onclick:stopPropagation="true"
+                                    @onclick="() => AssignItemAsync(itemId)">Přidat</button>
+                        }
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
         </Columns>
     </OvcinaGrid>
+}
+else
+{
+    <OvcinaGrid Data="@gameItems" KeyFieldName="Id" LayoutKey="grid-layout-items-game"
+                RowClick="@(e => OpenModal((GameItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+        <Columns>
+            <DxGridDataColumn FieldName="" Caption="" Width="40px" AllowSort="false" AllowGroup="false" AllowFilter="false" FixedPosition="GridColumnFixedPosition.Left">
+                <CellDisplayTemplate>
+                    @{
+                        var gi = (GameItemListDto)context.DataItem;
+                    }
+                    <button class="btn btn-sm btn-link p-0 text-muted" @onclick="async e => await ShowContextMenu(e, gi)" @onclick:stopPropagation="true">
+                        <i class="bi bi-three-dots-vertical"></i>
+                    </button>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Id" Caption="#" Width="60px" Visible="false" />
+            <DxGridDataColumn FieldName="Name" Caption="Název" />
+            <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="150px" />
+            <DxGridDataColumn FieldName="Effect" Caption="Efekt" />
+            <DxGridDataColumn FieldName="Price" Caption="Cena" Width="90px" />
+            <DxGridDataColumn FieldName="StockCount" Caption="Skladem" Width="110px" />
+            <DxGridDataColumn FieldName="IsSold" Caption="Prodávaný" Width="110px">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="IsFindable" Caption="Nalezitelný" Width="110px">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="SaleCondition" Caption="Podmínka prodeje" Width="240px" Visible="false" />
+            <DxGridDataColumn FieldName="PhysicalFormDisplay" Caption="Fyzická forma" Width="150px" Visible="false" />
+            <DxGridDataColumn FieldName="ReqWarrior" Caption="Váleč." Width="80px" Visible="false" />
+            <DxGridDataColumn FieldName="ReqArcher" Caption="Střelec" Width="80px" Visible="false" />
+            <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="80px" Visible="false" />
+            <DxGridDataColumn FieldName="ReqThief" Caption="Zloděj" Width="80px" Visible="false" />
+            <DxGridDataColumn FieldName="IsCraftable" Caption="Vyrobitelný" Width="120px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="IsUnique" Caption="Unikátní" Width="100px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="IsLimited" Caption="Limitovaný" Width="110px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="HasImage" Caption="Obrázek" Width="100px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+        </Columns>
+    </OvcinaGrid>
+
+    <DxContextMenu @ref="contextMenu" ItemClick="OnContextMenuItemClick">
+        <Items>
+            <DxContextMenuItem Text="Upravit" IconCssClass="bi bi-pencil-fill" Name="edit" />
+            <DxContextMenuItem Text="Otevřít recept" IconCssClass="bi bi-hammer" Name="recipe" Enabled="@contextMenuTargetIsCraftable" />
+            <DxContextMenuItem BeginGroup="true" Text="Odebrat z hry" IconCssClass="bi bi-x-circle" Name="unassign" />
+            <DxContextMenuItem Text="Smazat" IconCssClass="bi bi-trash-fill" CssClass="text-danger" Name="delete" />
+        </Items>
+    </DxContextMenu>
 }
 
 <DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="900px">
@@ -283,8 +345,15 @@ else
     [SupplyParameterFromQuery]
     public bool Catalog { get; set; }
 
-    private List<ItemListDto> items = [];
+    private List<ItemListDto> catalogItems = [];
+    private List<GameItemListDto> gameItems = [];
     private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
+
+    // Context menu state (in-game view only)
+    private DxContextMenu? contextMenu;
+    private int? contextMenuTargetId;
+    private string contextMenuTargetName = "";
+    private bool contextMenuTargetIsCraftable;
     private string modalTitle = "", name = "";
     private string? error, effect;
     private int? editingId;
@@ -348,23 +417,23 @@ else
     private async Task LoadAsync()
     {
         loading = true;
-        var allItemsList = await Api.GetListAsync<ItemListDto>("/api/items");
 
         if (!Catalog && GameContext.SelectedGameId is int gid)
         {
-            // Game mode: only show items assigned to the current game
-            var gameItems = await Api.GetListAsync<GameItemDto>($"/api/items/by-game/{gid}");
-            assignedItemIds = gameItems.Select(gi => gi.ItemId).ToHashSet();
-            items = allItemsList.Where(i => assignedItemIds.Contains(i.Id)).ToList();
+            // Game mode: grid is populated by the merged per-game shape directly.
+            gameItems = await Api.GetListAsync<GameItemListDto>($"/api/items/by-game/{gid}");
+            assignedItemIds = gameItems.Select(gi => gi.Id).ToHashSet();
+            catalogItems = [];
         }
         else
         {
-            items = allItemsList;
+            catalogItems = await Api.GetListAsync<ItemListDto>("/api/items");
+            gameItems = [];
             if (Catalog && GameContext.SelectedGameId is int catalogGid)
             {
-                // Catalog mode: load assigned IDs for assign/unassign column
-                var gameItems = await Api.GetListAsync<GameItemDto>($"/api/items/by-game/{catalogGid}");
-                assignedItemIds = gameItems.Select(gi => gi.ItemId).ToHashSet();
+                // Catalog mode: load assigned IDs for the Přidat/Odebrat column
+                var linked = await Api.GetListAsync<GameItemListDto>($"/api/items/by-game/{catalogGid}");
+                assignedItemIds = linked.Select(gi => gi.Id).ToHashSet();
             }
         }
 
@@ -383,12 +452,57 @@ else
         }
         else
         {
-            editingId = item.Id; name = item.Name; itemType = item.ItemType;
-            isCraftable = item.IsCraftable; isUnique = item.IsUnique; isLimited = item.IsLimited;
-            modalTitle = $"Upravit: {item.Name}";
-            _ = LoadDetailAsync(item.Id);
+            OpenExistingModal(item.Id, item.Name, item.ItemType, item.IsCraftable, item.IsUnique, item.IsLimited);
+            return;
         }
         isModalVisible = true;
+    }
+
+    private void OpenModal(GameItemListDto item)
+    {
+        error = null;
+        OpenExistingModal(item.Id, item.Name, item.ItemType, item.IsCraftable, item.IsUnique, item.IsLimited);
+    }
+
+    private void OpenExistingModal(int id, string itemName, ItemType type, bool craftable, bool unique, bool limited)
+    {
+        editingId = id; name = itemName; itemType = type;
+        isCraftable = craftable; isUnique = unique; isLimited = limited;
+        modalTitle = $"Upravit: {itemName}";
+        _ = LoadDetailAsync(id);
+        isModalVisible = true;
+    }
+
+    private async Task ShowContextMenu(Microsoft.AspNetCore.Components.Web.MouseEventArgs e, GameItemListDto gi)
+    {
+        contextMenuTargetId = gi.Id;
+        contextMenuTargetName = gi.Name;
+        contextMenuTargetIsCraftable = gi.IsCraftable;
+        await contextMenu!.ShowAsync(e);
+    }
+
+    private async Task OnContextMenuItemClick(ContextMenuItemClickEventArgs e)
+    {
+        if (contextMenuTargetId is null) return;
+        var id = contextMenuTargetId.Value;
+
+        switch (e.ItemInfo?.Name)
+        {
+            case "edit":
+            case "recipe":
+                var target = gameItems.FirstOrDefault(x => x.Id == id);
+                if (target is not null) OpenModal(target);
+                break;
+            case "unassign":
+                await UnassignItemAsync(id);
+                break;
+            case "delete":
+                // Delegate to the existing delete flow — the popup needs editingId + name set.
+                editingId = id;
+                name = contextMenuTargetName;
+                isDeleteVisible = true;
+                break;
+        }
     }
 
     private async Task LoadDetailAsync(int id)

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -22,6 +22,14 @@
 {
     <p>Načítám...</p>
 }
+else if (!Catalog && GameContext.SelectedGameId is null)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-controller fs-1 d-block mb-2"></i>
+        <p>Vyber nejprve hru z přepínače nahoře, nebo otevři katalog všech předmětů.</p>
+        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/items?catalog=true")'>Otevřít katalog</button>
+    </div>
+}
 else if (!Catalog && gameItems.Count == 0)
 {
     <div class="text-center text-muted py-5">
@@ -646,8 +654,8 @@ else
         var gameId = GameContext.SelectedGameId;
         if (gameId is null) { gameItemLoading = false; return; }
 
-        var gameItems = await Api.GetListAsync<GameItemDto>($"/api/items/by-game/{gameId}");
-        var gi = gameItems.FirstOrDefault(g => g.ItemId == itemId);
+        var itemsInGame = await Api.GetListAsync<GameItemListDto>($"/api/items/by-game/{gameId}");
+        var gi = itemsInGame.FirstOrDefault(g => g.Id == itemId);
         if (gi is not null)
         {
             gameItemExists = true;

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -95,6 +95,7 @@ else
             <DxGridDataColumn FieldName="Name" Caption="Název" />
             <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="150px" />
             <DxGridDataColumn FieldName="Effect" Caption="Efekt" />
+            <DxGridDataColumn FieldName="RecipeSummary" Caption="Recept" Width="340px" />
             <DxGridDataColumn FieldName="Price" Caption="Cena" Width="90px" />
             <DxGridDataColumn FieldName="StockCount" Caption="Skladem" Width="110px" />
             <DxGridDataColumn FieldName="IsSold" Caption="Prodávaný" Width="110px">

--- a/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
@@ -4,10 +4,64 @@ using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Shared.Dtos;
 
-public record ItemListDto(int Id, string Name, ItemType ItemType, string? Effect, bool IsCraftable, bool IsUnique, bool IsLimited)
+public record ItemListDto(
+    int Id,
+    string Name,
+    ItemType ItemType,
+    string? Effect,
+    PhysicalForm? PhysicalForm,
+    bool IsCraftable,
+    int ReqWarrior,
+    int ReqArcher,
+    int ReqMage,
+    int ReqThief,
+    bool IsUnique,
+    bool IsLimited,
+    string? ImagePath)
 {
     [JsonIgnore]
     public string ItemTypeDisplay => ItemType.GetDisplayName();
+
+    [JsonIgnore]
+    public string PhysicalFormDisplay => PhysicalForm.HasValue ? PhysicalForm.Value.GetDisplayName() : "";
+
+    [JsonIgnore]
+    public bool HasImage => !string.IsNullOrEmpty(ImagePath);
+}
+
+/// <summary>
+/// Flat merged shape used by the "Jen tato hra" items grid — combines all catalog
+/// item fields with this game's GameItem configuration (price, stock, sale flags).
+/// </summary>
+public record GameItemListDto(
+    int Id,
+    string Name,
+    ItemType ItemType,
+    string? Effect,
+    PhysicalForm? PhysicalForm,
+    bool IsCraftable,
+    int ReqWarrior,
+    int ReqArcher,
+    int ReqMage,
+    int ReqThief,
+    bool IsUnique,
+    bool IsLimited,
+    string? ImagePath,
+    int GameId,
+    int? Price,
+    int? StockCount,
+    bool IsSold,
+    string? SaleCondition,
+    bool IsFindable)
+{
+    [JsonIgnore]
+    public string ItemTypeDisplay => ItemType.GetDisplayName();
+
+    [JsonIgnore]
+    public string PhysicalFormDisplay => PhysicalForm.HasValue ? PhysicalForm.Value.GetDisplayName() : "";
+
+    [JsonIgnore]
+    public bool HasImage => !string.IsNullOrEmpty(ImagePath);
 }
 
 public record ItemDetailDto(

--- a/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
@@ -52,7 +52,8 @@ public record GameItemListDto(
     int? StockCount,
     bool IsSold,
     string? SaleCondition,
-    bool IsFindable)
+    bool IsFindable,
+    string? RecipeSummary)
 {
     [JsonIgnore]
     public string ItemTypeDisplay => ItemType.GetDisplayName();


### PR DESCRIPTION
## Summary

Three tightly-coupled improvements to the Items grid so organizers can do more without drilling into popups.

### 1. Catalog / game view split
Same page (`/items`), two completely different grid renderings based on the `?catalog=true` flag. Each is strongly typed and carries its own `LayoutKey` — the old shared `grid-layout-items` key is gone, so everyone gets fresh defaults on first load.

**Catalog view** (`?catalog=true`) binds `ItemListDto` with 13 columns (Id, Název, Typ, Efekt, Fyzická forma, Req×4, Vyrobitelný, Unikátní, Limitovaný, Obrázek) + Přidat/Odebrat action column. LayoutKey: `grid-layout-items-catalog`.

**Game view** (default "Jen tato hra") binds **new** `GameItemListDto` — all catalog columns plus:
- Cena (Price)
- Skladem (StockCount)
- Prodávaný (IsSold) — Ano/Ne
- Nalezitelný (IsFindable) — Ano/Ne
- Podmínka prodeje (hidden by default)
- **Recept** — per-game recipe summary (see §3)

LayoutKey: `grid-layout-items-game`.

Obrázek column stays hidden by default in both views per user instruction (thumbnails bloat rows, image is one row-click away).

### 2. Game-view context menu (three-dots column)
New leftmost column on the game grid only, same pattern as LocationList:

| Item | Icon | Action | When enabled |
|---|---|---|---|
| Upravit | bi-pencil-fill | Open popup | always |
| Otevřít recept | bi-hammer | Open popup (recipe card renders inside) | only if `IsCraftable` |
| Odebrat z hry | bi-x-circle | Unassign item from current game | always |
| Smazat | bi-trash-fill (text-danger) | Delete from catalog (confirm popup) | always |

### 3. Recipe summary column
Read-only `Recept` column right after Efekt in the game view. Server builds the string via:
```
3× Dřevo, 2× Železo │ Kovárna │ Válečnictví
(ingredients, comma-separated) │ (buildings) │ (skills)
```
Empty sections are omitted; items without a recipe show empty. Organizer still edits the recipe through the popup's existing Recept card.

## Server-side changes

- `ItemListDto` extended with `PhysicalForm`, `ReqWarrior/Archer/Mage/Thief`, `ImagePath`; plus `[JsonIgnore]` computed `ItemTypeDisplay`, `PhysicalFormDisplay`, `HasImage`.
- New `GameItemListDto` — flat record merging Item + GameItem + `RecipeSummary`. Returned by `/api/items/by-game/{gid}`.
- `/api/items` and `/api/items/usable` project the richer `ItemListDto`.
- `GetByGame` now runs a JOIN for items + a second query for craftable-recipe details, merging a summary string per ItemId. No N+1.

## Version

Bumped client to **0.5.2**.

## Test plan

- [ ] CI passes
- [ ] `/items?catalog=true` — catalog columns visible; Přidat/Odebrat works
- [ ] `/items` (game view) — game columns visible, context menu opens, each menu item works, Otevřít recept disabled for non-craftable rows
- [ ] Recept column displays correct summary strings for craftable items with a recipe; empty for the rest
- [ ] Column chooser can reveal/hide hidden columns independently per view (different LayoutKeys)
- [ ] Switching between Catalog ↔ Jen tato hra via the buttons doesn't trip layout state

🤖 Generated with [Claude Code](https://claude.com/claude-code)