### PR TITLE
fix: align Katalog světa nav to Hra + add Dovednosti [v0.5.3]

### DIFF
--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -98,11 +98,6 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
-            <NavLink class="nav-link" href="buildings?catalog=true">
-                <i class="bi bi-houses"></i><span class="nav-label">Budovy</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
             <NavLink class="nav-link" href="monsters?catalog=true">
                 <img src="img/troll.svg" class="nav-icon-svg" alt="" /><span class="nav-label">Příšery</span>
             </NavLink>
@@ -110,6 +105,16 @@
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="quests?catalog=true">
                 <i class="bi bi-journal-text"></i><span class="nav-label">Questy</span>
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="buildings?catalog=true">
+                <i class="bi bi-houses"></i><span class="nav-label">Budovy</span>
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="skills">
+                <i class="bi bi-star"></i><span class="nav-label">Dovednosti</span>
             </NavLink>
         </div>
         <div class="nav-item px-3">

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.5.2</Version>
+    <Version>0.5.3</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- The **Katalog světa** section was missing **Dovednosti** entirely — adds it (links to `/skills`, the world skills catalog).
- Reorders the catalog entries so entities that appear in both **Hra** and **Katalog světa** line up in the same order. No more Budovy sitting oddly between Předměty and Příšery in one section but not the other.

## New Katalog světa order

Lokace → Předměty → Příšery → Questy → Budovy → **Dovednosti** → Tajné skrýše → NPC

Matches the corresponding subset of the Hra order. Per-game-only entries (Časová osa, Poklady, Postavy, Události) remain in the Hra section only.

## Version

Bumped to **0.5.3**.

## Test plan

- [ ] CI passes
- [ ] Ctrl+Shift+R on `hra.ovcina.cz`, verify Dovednosti appears in both sections
- [ ] Catalog Dovednosti link loads `/skills` (world catalog)
- [ ] Visual ordering between the two sections matches for shared entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)