### PR TITLE
feat: PersonalQuest domain (catalog + per-game + character assignment) [v0.6.0]

### DIFF
--- a/docs/plans/2026-04-19-personal-quest-domain-design.md
+++ b/docs/plans/2026-04-19-personal-quest-domain-design.md
@@ -1,0 +1,204 @@
+# PersonalQuest Domain — Design
+
+> Date: 2026-04-19
+> Status: Ready for implementation planning
+> Related: follows the Item/Skill catalog pattern established by PRs #30 (Skills) and #32 (Items grid split)
+
+## Overview
+
+A **PersonalQuest** is a per-character mini-quest (e.g. "Druid", "Artefaktor", "Tajnou cestou") sold to players at merchants, costing XP to start and rewarding Skills, Items, or flavour text on completion. Organizers need to:
+
+- Maintain a **world-level catalog** of quest templates (Name, Description, class restrictions, difficulty, card text, linked rewards).
+- Opt templates into a given **game** with per-game config (XP cost, per-kingdom availability).
+- **Assign** a quest to a character in a game (max one per character; `CompletedAtUtc` tracked for future reporting).
+
+The feature follows the same catalog/game split pattern the app already uses for Items and Skills, so organizers browsing `/personal-quests` see the same UX they already know.
+
+## Entities
+
+### `PersonalQuest` (catalog)
+
+| Field | Type | Purpose |
+|---|---|---|
+| `Id` | `int`, PK | identity |
+| `Name` | `string`, required, unique, max 200 | Název |
+| `Description` | `string?`, max 500 | Popis — short public tagline |
+| `Difficulty` | `TreasureQuestDifficulty` enum (stored as string) | Obtížnost — reused existing enum (Lehká / Střední / Těžká) |
+| `AllowWarrior` | `bool`, default `false` | class matrix bit 1 |
+| `AllowArcher` | `bool`, default `false` | bit 2 |
+| `AllowMage` | `bool`, default `false` | bit 3 |
+| `AllowThief` | `bool`, default `false` | bit 4 — all four `false` = no restriction |
+| `QuestCardText` | `string?` | Kartička questu — multi-step task text (plain markdown, printer parses later) |
+| `RewardCardText` | `string?` | Kartičky odměn — how the rewards work mechanically |
+| `RewardNote` | `string?` | Ostatní odměny — freeform for rewards not linked to Skills/Items |
+| `Notes` | `string?` | Poznámky — organizer-only |
+| `ImagePath` | `string?` | blob key, resolved to SAS URL on read |
+
+Navigation:
+
+- `SkillRewards` → `PersonalQuestSkillReward[]`
+- `ItemRewards` → `PersonalQuestItemReward[]`
+- `GameLinks` → `GamePersonalQuest[]`
+- `CharacterAssignments` → `CharacterPersonalQuest[]`
+
+Unique index on `Name`.
+
+### `PersonalQuestSkillReward` (link table)
+
+```
+PersonalQuestId   PK, FK → PersonalQuest, cascade
+SkillId           PK, FK → Skill,          restrict
+```
+
+Deleting a `PersonalQuest` removes its skill-reward links. Deleting a `Skill` is blocked if any quest still references it (restrict protects reward definitions).
+
+### `PersonalQuestItemReward` (link table)
+
+```
+PersonalQuestId   PK, FK → PersonalQuest, cascade
+ItemId            PK, FK → Item,          restrict
+Quantity          int, default 1, CHECK >= 1
+```
+
+Same cascade/restrict semantics.
+
+### `GamePersonalQuest` (per-game config)
+
+```
+GameId              PK, FK → Game,          cascade
+PersonalQuestId     PK, FK → PersonalQuest, cascade
+XpCost              int, CHECK >= 0
+PerKingdomLimit     int?, CHECK IS NULL OR >= 1   -- null = unlimited
+```
+
+Mirrors `GameItem` / `GameSkill`. Organizer creates a row by opting a quest into a game. Total game-wide availability = `PerKingdomLimit × number_of_kingdoms`, derived — not stored.
+
+### `CharacterPersonalQuest` (assignment)
+
+```
+CharacterId        PK, FK → Character, cascade    -- one-to-one: a character has at most 1 personal quest
+PersonalQuestId    FK → PersonalQuest, restrict
+AssignedAtUtc      DateTime, default now()
+CompletedAtUtc     DateTime?                      -- null until organizer marks complete
+```
+
+PK = `CharacterId` natively enforces the "one personal quest per character per game" rule (since Character already has a `GameId`, this is implicitly per-game).
+
+## API endpoints
+
+Grouped under `/api/personal-quests` (minimal API `MapGroup`, following `ItemEndpoints.cs` layout):
+
+| Verb | Route | DTO in → out |
+|---|---|---|
+| GET | `/` | — → `List<PersonalQuestListDto>` |
+| GET | `/{id}` | — → `PersonalQuestDetailDto` |
+| POST | `/` | `CreatePersonalQuestDto` → `PersonalQuestDetailDto` |
+| PUT | `/{id}` | `UpdatePersonalQuestDto` → `NoContent` |
+| DELETE | `/{id}` | — → `NoContent` |
+| GET | `/by-game/{gameId}` | — → `List<GamePersonalQuestListDto>` (merged: catalog + GPQ + RewardSummary) |
+| POST | `/game-link` | `CreateGamePersonalQuestDto` → `GamePersonalQuestDto` |
+| PUT | `/game-link/{gameId}/{pqId}` | `UpdateGamePersonalQuestDto` → `NoContent` |
+| DELETE | `/game-link/{gameId}/{pqId}` | — → `NoContent` |
+| POST | `/{id}/skill-rewards` | `{ SkillId }` → 201 |
+| DELETE | `/{id}/skill-rewards/{skillId}` | — → `NoContent` |
+| POST | `/{id}/item-rewards` | `{ ItemId, Quantity }` → 201 |
+| DELETE | `/{id}/item-rewards/{itemId}` | — → `NoContent` |
+
+Character-assignment endpoints ship in a follow-up PR together with the UI.
+
+### DTO shape notes
+
+- `PersonalQuestListDto` — positional params for all catalog columns, plus `[JsonIgnore]` computed `ClassRestrictionDisplay` (`"Válečník, Mág"` or `"Všechna povolání"`) and `DifficultyDisplay` (via `GetDisplayName()`), plus `HasImage` computed.
+- `GamePersonalQuestListDto` — catalog fields + `XpCost`, `PerKingdomLimit`, `RewardSummary` (string, `"Dovednost druid │ Kouzlo Léčivá dlaň ×1"`, server-built by joining skill + item rewards).
+- Reward summary format matches the item-recipe summary shipped in PR #32.
+
+## UI
+
+### Route
+
+`/personal-quests` — accepts `?catalog=true`. Default view (no query) is "Jen tato hra".
+
+### Nav
+
+Added to both sections at matching positions (right after `Questy`):
+
+- **Hra** section: `NavLink href="personal-quests"` → "Osobní questy", icon `bi bi-person-workspace`
+- **Katalog světa** section: `NavLink href="personal-quests?catalog=true"` → "Osobní questy", same icon
+
+### Two grid views (catalog / game), same split pattern as `/items`
+
+**Common columns — identical order in both views:**
+
+| # | Field | Default visible? |
+|---|---|---|
+| 1 | `Id` | hidden |
+| 2 | `Name` | **visible** |
+| 3 | `ClassRestrictionDisplay` | **visible** |
+| 4 | `AllowWarrior` | hidden |
+| 5 | `AllowArcher` | hidden |
+| 6 | `AllowMage` | hidden |
+| 7 | `AllowThief` | hidden |
+| 8 | `DifficultyDisplay` | **visible** |
+| 9 | `Description` | **visible** |
+| 10 | `RewardSummary` | **visible** |
+| 11 | `RewardNote` | hidden |
+| 12 | `QuestCardText` | hidden |
+| 13 | `RewardCardText` | hidden |
+| 14 | `Notes` | hidden |
+| 15 | `HasImage` | hidden |
+
+**Catalog-only extras (appended):** `Přidat/Odebrat` action column (same UX as `/items?catalog=true`).
+
+**Game-only extras (appended):**
+
+| # | Field | Default visible? |
+|---|---|---|
+| 16 | `XpCost` | **visible** |
+| 17 | `PerKingdomLimit` | **visible** |
+
+**Game-only prefix (leftmost, fixed):** three-dots context menu with items:
+
+- **Upravit** (bi-pencil-fill) — opens detail popup
+- **Odebrat z hry** (bi-x-circle) — removes the GamePersonalQuest row (keeps catalog entry)
+- **Smazat** (bi-trash-fill, text-danger) — deletes the catalog entry (confirm popup)
+
+LayoutKeys: `grid-layout-personal-quests-catalog` and `grid-layout-personal-quests-game`.
+
+### Detail popup (DxPopup, width ~900px)
+
+`DxFormLayout`:
+
+- Název (text)
+- Popis (text)
+- Obtížnost (combobox)
+- Povolání — group of 4 checkboxes (Válečník, Střelec, Mág, Zloděj)
+- Kartička questu (DxMemo)
+- Kartičky odměn (DxMemo)
+- Ostatní odměny (textbox)
+- Poznámky (DxMemo)
+- ImagePicker (if editing)
+
+**Rewards card** (only when editing):
+- Dovednosti — chip list with `DxComboBox` picker + add button
+- Předměty — chip list with `DxComboBox` picker + qty `DxSpinEdit` + add button
+
+**Per-game card** (only when a game is selected and not in catalog mode, same pattern as Item popup):
+- XP za získání (`DxSpinEdit`, MinValue=0)
+- Limit na království (`DxSpinEdit`, MinValue=1, NullText="(neomezeno)")
+- "Přidat do hry" / "Odebrat z hry" / "Uložit nastavení" buttons
+
+## Deferred (explicitly NOT in this PR)
+
+1. **Character assignment UI** — data table ships; form/page to pick a quest for a character comes next.
+2. **Completion tracking UI** — `CompletedAtUtc` exists; no toggle or report yet.
+3. **Card printing** — `QuestCardText` stays plain markdown; printer is a separate project.
+4. **Merchant/Kingdom modelling** — `PerKingdomLimit` is a number, no `Kingdom` or `Merchant` entity; enforcement is organizational.
+5. **Per-kingdom-per-quest stocking lists** — implied by the `PerKingdomLimit` int but not persisted per kingdom.
+
+## Migration
+
+EF Core migration `AddPersonalQuestDomain` creates four new tables (`PersonalQuests`, `PersonalQuestSkillRewards`, `PersonalQuestItemRewards`, `GamePersonalQuests`, `CharacterPersonalQuests`). All additive, no modifications to existing tables. Safe to deploy to production with `db.Database.MigrateAsync()` on API startup.
+
+## Versioning
+
+Client version bump **0.5.3 → 0.6.0** (new domain entity = minor version bump, per project convention).

--- a/docs/plans/2026-04-19-personal-quest-domain-implementation.md
+++ b/docs/plans/2026-04-19-personal-quest-domain-implementation.md
@@ -1,0 +1,907 @@
+# PersonalQuest Domain Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship the PersonalQuest domain end-to-end — catalog + per-game config + character-assignment data model + two grid views + detail popup — per the design at `docs/plans/2026-04-19-personal-quest-domain-design.md`.
+
+**Architecture:** Follow the Item/Skill catalog + per-game join pattern the app already uses (PRs #30 Skills and #32 Items). Entities + EF configs + a single additive migration server-side; a Client razor page with catalog/game grid split, shared DTOs, and a `PersonalQuestService` API wrapper.
+
+**Tech Stack:** .NET 10, EF Core + Npgsql, ASP.NET Core minimal APIs (TypedResults), xUnit + Testcontainers-PostgreSQL integration tests, Blazor WASM PWA, DevExpress DxGrid / DxPopup / DxFormLayout.
+
+**Repo / branch:** `C:/Users/TomášPajonk/source/repos/timurlain/ovcinahra` on `feat/personal-quest-domain` (design doc already committed).
+
+**Commit convention:** Czech-friendly, `[v0.6.0]` suffix on the final commit that merges. Every task commit should be conventional (`feat(pq):`, `test(pq):`, `chore(pq):`).
+
+**Version bump at end:** Client 0.5.3 → **0.6.0** (minor — new domain entity).
+
+---
+
+## Phase 0 — Preflight
+
+### Task 0.1: Confirm working tree is clean on the branch
+
+**Step 1:** Verify we're on `feat/personal-quest-domain` and it's clean.
+```bash
+git branch --show-current     # expect: feat/personal-quest-domain
+git status --short            # expect: empty
+git log --oneline -2          # expect: design doc on top of e4d99f5 / 35d678c / 3897c57 era main
+```
+If not clean, stash or commit first — do NOT start implementation on a dirty tree.
+
+### Task 0.2: Verify existing tests still pass on this base
+
+**Step 1:** Run the API integration tests once as a baseline (Docker Desktop must be running for Testcontainers).
+```bash
+cd C:/Users/TomášPajonk/source/repos/timurlain/ovcinahra
+dotnet test tests/OvcinaHra.Api.Tests -c Release --nologo
+```
+Expected: all green (176+ tests passing). If anything already fails, stop and investigate — don't start layering on a broken base.
+
+---
+
+## Phase 1 — Shared entities
+
+All entity files live under `src/OvcinaHra.Shared/Domain/Entities/`.
+
+### Task 1.1: `PersonalQuest` entity (catalog)
+
+**Files:**
+- Create: `src/OvcinaHra.Shared/Domain/Entities/PersonalQuest.cs`
+
+**Step 1:** Write the entity — per design doc § *Entities → PersonalQuest (catalog)*.
+
+```csharp
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class PersonalQuest
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public string? Description { get; set; }
+    public TreasureQuestDifficulty Difficulty { get; set; }
+
+    public bool AllowWarrior { get; set; }
+    public bool AllowArcher { get; set; }
+    public bool AllowMage { get; set; }
+    public bool AllowThief { get; set; }
+
+    public string? QuestCardText { get; set; }
+    public string? RewardCardText { get; set; }
+    public string? RewardNote { get; set; }
+    public string? Notes { get; set; }
+    public string? ImagePath { get; set; }
+
+    public ICollection<PersonalQuestSkillReward> SkillRewards { get; set; } = [];
+    public ICollection<PersonalQuestItemReward> ItemRewards { get; set; } = [];
+    public ICollection<GamePersonalQuest> GameLinks { get; set; } = [];
+    public ICollection<CharacterPersonalQuest> CharacterAssignments { get; set; } = [];
+}
+```
+
+**Step 2:** Don't build yet — the navigation types don't exist. Next tasks add them.
+
+### Task 1.2: Three remaining simple entities in one batch
+
+**Files:**
+- Create: `src/OvcinaHra.Shared/Domain/Entities/PersonalQuestSkillReward.cs`
+- Create: `src/OvcinaHra.Shared/Domain/Entities/PersonalQuestItemReward.cs`
+- Create: `src/OvcinaHra.Shared/Domain/Entities/GamePersonalQuest.cs`
+- Create: `src/OvcinaHra.Shared/Domain/Entities/CharacterPersonalQuest.cs`
+
+**Step 1:** Write each, small files, one at a time.
+
+```csharp
+// PersonalQuestSkillReward.cs
+namespace OvcinaHra.Shared.Domain.Entities;
+public class PersonalQuestSkillReward
+{
+    public int PersonalQuestId { get; set; }
+    public int SkillId { get; set; }
+
+    public PersonalQuest PersonalQuest { get; set; } = null!;
+    public Skill Skill { get; set; } = null!;
+}
+```
+
+```csharp
+// PersonalQuestItemReward.cs
+namespace OvcinaHra.Shared.Domain.Entities;
+public class PersonalQuestItemReward
+{
+    public int PersonalQuestId { get; set; }
+    public int ItemId { get; set; }
+    public int Quantity { get; set; } = 1;
+
+    public PersonalQuest PersonalQuest { get; set; } = null!;
+    public Item Item { get; set; } = null!;
+}
+```
+
+```csharp
+// GamePersonalQuest.cs
+namespace OvcinaHra.Shared.Domain.Entities;
+public class GamePersonalQuest
+{
+    public int GameId { get; set; }
+    public int PersonalQuestId { get; set; }
+    public int XpCost { get; set; }
+    public int? PerKingdomLimit { get; set; }
+
+    public Game Game { get; set; } = null!;
+    public PersonalQuest PersonalQuest { get; set; } = null!;
+}
+```
+
+```csharp
+// CharacterPersonalQuest.cs
+namespace OvcinaHra.Shared.Domain.Entities;
+public class CharacterPersonalQuest
+{
+    public int CharacterId { get; set; }   // PK, one-to-one: a character has at most 1
+    public int PersonalQuestId { get; set; }
+    public DateTime AssignedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime? CompletedAtUtc { get; set; }
+
+    public Character Character { get; set; } = null!;
+    public PersonalQuest PersonalQuest { get; set; } = null!;
+}
+```
+
+**Step 2:** Build to confirm Shared compiles.
+```bash
+dotnet build src/OvcinaHra.Shared/OvcinaHra.Shared.csproj -c Release --nologo -v:q
+```
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+**Step 3:** Commit.
+```bash
+git add src/OvcinaHra.Shared/Domain/Entities/PersonalQuest*.cs \
+        src/OvcinaHra.Shared/Domain/Entities/GamePersonalQuest.cs \
+        src/OvcinaHra.Shared/Domain/Entities/CharacterPersonalQuest.cs
+git commit -m "feat(pq): add PersonalQuest + reward/link entities"
+```
+
+---
+
+## Phase 2 — EF Core configurations
+
+All config files live under `src/OvcinaHra.Api/Data/Configurations/`.
+
+### Task 2.1: `PersonalQuestConfiguration`
+
+**Files:**
+- Create: `src/OvcinaHra.Api/Data/Configurations/PersonalQuestConfiguration.cs`
+
+**Step 1:** Write:
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class PersonalQuestConfiguration : IEntityTypeConfiguration<PersonalQuest>
+{
+    public void Configure(EntityTypeBuilder<PersonalQuest> b)
+    {
+        b.HasKey(e => e.Id);
+        b.Property(e => e.Name).IsRequired().HasMaxLength(200);
+        b.HasIndex(e => e.Name).IsUnique();
+        b.Property(e => e.Description).HasMaxLength(500);
+        b.Property(e => e.Difficulty).HasConversion<string>().HasMaxLength(20);
+    }
+}
+```
+
+### Task 2.2: Reward / join / assignment configurations
+
+**Files:** one file each under `Data/Configurations/`.
+
+**Step 1:** Write:
+
+```csharp
+// PersonalQuestSkillRewardConfiguration.cs
+public class PersonalQuestSkillRewardConfiguration : IEntityTypeConfiguration<PersonalQuestSkillReward>
+{
+    public void Configure(EntityTypeBuilder<PersonalQuestSkillReward> b)
+    {
+        b.HasKey(e => new { e.PersonalQuestId, e.SkillId });
+        b.HasOne(e => e.PersonalQuest).WithMany(q => q.SkillRewards)
+            .HasForeignKey(e => e.PersonalQuestId).OnDelete(DeleteBehavior.Cascade);
+        b.HasOne(e => e.Skill).WithMany()
+            .HasForeignKey(e => e.SkillId).OnDelete(DeleteBehavior.Restrict);
+    }
+}
+```
+
+```csharp
+// PersonalQuestItemRewardConfiguration.cs
+public class PersonalQuestItemRewardConfiguration : IEntityTypeConfiguration<PersonalQuestItemReward>
+{
+    public void Configure(EntityTypeBuilder<PersonalQuestItemReward> b)
+    {
+        b.HasKey(e => new { e.PersonalQuestId, e.ItemId });
+        b.Property(e => e.Quantity).HasDefaultValue(1);
+        b.ToTable(t => t.HasCheckConstraint("CK_PQItemReward_Qty_Positive", "\"Quantity\" >= 1"));
+        b.HasOne(e => e.PersonalQuest).WithMany(q => q.ItemRewards)
+            .HasForeignKey(e => e.PersonalQuestId).OnDelete(DeleteBehavior.Cascade);
+        b.HasOne(e => e.Item).WithMany()
+            .HasForeignKey(e => e.ItemId).OnDelete(DeleteBehavior.Restrict);
+    }
+}
+```
+
+```csharp
+// GamePersonalQuestConfiguration.cs
+public class GamePersonalQuestConfiguration : IEntityTypeConfiguration<GamePersonalQuest>
+{
+    public void Configure(EntityTypeBuilder<GamePersonalQuest> b)
+    {
+        b.HasKey(e => new { e.GameId, e.PersonalQuestId });
+        b.HasOne(e => e.Game).WithMany()
+            .HasForeignKey(e => e.GameId).OnDelete(DeleteBehavior.Cascade);
+        b.HasOne(e => e.PersonalQuest).WithMany(q => q.GameLinks)
+            .HasForeignKey(e => e.PersonalQuestId).OnDelete(DeleteBehavior.Cascade);
+        b.HasIndex(e => e.GameId);
+        b.ToTable(t =>
+        {
+            t.HasCheckConstraint("CK_GamePersonalQuest_XpCost_NonNegative", "\"XpCost\" >= 0");
+            t.HasCheckConstraint("CK_GamePersonalQuest_PKL_Positive",
+                "\"PerKingdomLimit\" IS NULL OR \"PerKingdomLimit\" >= 1");
+        });
+    }
+}
+```
+
+```csharp
+// CharacterPersonalQuestConfiguration.cs
+public class CharacterPersonalQuestConfiguration : IEntityTypeConfiguration<CharacterPersonalQuest>
+{
+    public void Configure(EntityTypeBuilder<CharacterPersonalQuest> b)
+    {
+        b.HasKey(e => e.CharacterId);        // one-to-one: a character has at most 1 PQ
+        b.HasOne(e => e.Character).WithMany()
+            .HasForeignKey(e => e.CharacterId).OnDelete(DeleteBehavior.Cascade);
+        b.HasOne(e => e.PersonalQuest).WithMany(q => q.CharacterAssignments)
+            .HasForeignKey(e => e.PersonalQuestId).OnDelete(DeleteBehavior.Restrict);
+    }
+}
+```
+
+### Task 2.3: Register DbSets on `WorldDbContext`
+
+**Files:**
+- Modify: `src/OvcinaHra.Api/Data/WorldDbContext.cs`
+
+**Step 1:** Add five `DbSet` properties next to the existing ones, alphabetically grouped with the Skill/Game DbSets.
+```csharp
+public DbSet<PersonalQuest> PersonalQuests => Set<PersonalQuest>();
+public DbSet<PersonalQuestSkillReward> PersonalQuestSkillRewards => Set<PersonalQuestSkillReward>();
+public DbSet<PersonalQuestItemReward> PersonalQuestItemRewards => Set<PersonalQuestItemReward>();
+public DbSet<GamePersonalQuest> GamePersonalQuests => Set<GamePersonalQuest>();
+public DbSet<CharacterPersonalQuest> CharacterPersonalQuests => Set<CharacterPersonalQuest>();
+```
+
+**Step 2:** Build (just the API project) to confirm the configs compile + register.
+```bash
+dotnet build src/OvcinaHra.Api/OvcinaHra.Api.csproj -c Release --nologo -v:q
+```
+Expected: green.
+
+**Step 3:** Commit.
+```bash
+git add src/OvcinaHra.Api/Data/Configurations/PersonalQuest*.cs \
+        src/OvcinaHra.Api/Data/Configurations/GamePersonalQuest*.cs \
+        src/OvcinaHra.Api/Data/Configurations/CharacterPersonalQuest*.cs \
+        src/OvcinaHra.Api/Data/WorldDbContext.cs
+git commit -m "feat(pq): EF Core configurations + DbSet registrations"
+```
+
+---
+
+## Phase 3 — Migration
+
+### Task 3.1: Generate the `AddPersonalQuestDomain` migration
+
+**Files:**
+- Create (auto-generated): `src/OvcinaHra.Api/Migrations/YYYYMMDD_AddPersonalQuestDomain*.cs`
+- Modify (auto-generated): `src/OvcinaHra.Api/Migrations/WorldDbContextModelSnapshot.cs`
+
+**Step 1:** Run the tool.
+```bash
+cd src/OvcinaHra.Api
+dotnet ef migrations add AddPersonalQuestDomain --project OvcinaHra.Api.csproj
+cd ../..
+```
+Expected: two new files + updated snapshot.
+
+**Step 2:** Open the generated `*_AddPersonalQuestDomain.cs` and verify the `Up()` body:
+- Creates `PersonalQuests`, `PersonalQuestSkillRewards`, `PersonalQuestItemRewards`, `GamePersonalQuests`, `CharacterPersonalQuests`
+- Adds the 3 CHECK constraints (XpCost, PerKingdomLimit, Quantity)
+- Adds unique index on `PersonalQuests(Name)`
+- **No modifications to existing tables** — it's purely additive
+
+**Step 3:** Build full solution so the generated code compiles.
+```bash
+cd C:/Users/TomášPajonk/source/repos/timurlain/ovcinahra
+dotnet build OvcinaHra.slnx -c Release --nologo -v:q
+```
+Expected: green.
+
+**Step 4:** Commit.
+```bash
+git add src/OvcinaHra.Api/Migrations/
+git commit -m "feat(pq): EF migration AddPersonalQuestDomain (additive)"
+```
+
+---
+
+## Phase 4 — DTOs
+
+All DTOs go into `src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs` (one file, per project convention — cf. `ItemDtos.cs`).
+
+### Task 4.1: Write the DTO file
+
+**Files:**
+- Create: `src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs`
+
+**Step 1:** Write all DTOs in one go (record, computed `[JsonIgnore]` props, patterns lifted from `ItemDtos.cs` + `GameItemListDto`):
+
+```csharp
+using System.Text.Json.Serialization;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
+
+namespace OvcinaHra.Shared.Dtos;
+
+public record PersonalQuestListDto(
+    int Id,
+    string Name,
+    string? Description,
+    TreasureQuestDifficulty Difficulty,
+    bool AllowWarrior,
+    bool AllowArcher,
+    bool AllowMage,
+    bool AllowThief,
+    string? QuestCardText,
+    string? RewardCardText,
+    string? RewardNote,
+    string? Notes,
+    string? ImagePath,
+    IReadOnlyList<int> SkillRewardIds,
+    IReadOnlyList<PersonalQuestItemRewardSummary> ItemRewards)
+{
+    [JsonIgnore]
+    public string DifficultyDisplay => Difficulty.GetDisplayName();
+
+    [JsonIgnore]
+    public string ClassRestrictionDisplay
+    {
+        get
+        {
+            if (!AllowWarrior && !AllowArcher && !AllowMage && !AllowThief)
+                return "Všechna povolání";
+            var parts = new List<string>();
+            if (AllowWarrior) parts.Add(PlayerClass.Warrior.GetDisplayName());
+            if (AllowArcher) parts.Add(PlayerClass.Archer.GetDisplayName());
+            if (AllowMage) parts.Add(PlayerClass.Mage.GetDisplayName());
+            if (AllowThief) parts.Add(PlayerClass.Thief.GetDisplayName());
+            return string.Join(", ", parts);
+        }
+    }
+
+    [JsonIgnore]
+    public bool HasImage => !string.IsNullOrEmpty(ImagePath);
+}
+
+public record PersonalQuestItemRewardSummary(int ItemId, string ItemName, int Quantity);
+
+public record PersonalQuestDetailDto(
+    int Id,
+    string Name,
+    string? Description,
+    TreasureQuestDifficulty Difficulty,
+    bool AllowWarrior,
+    bool AllowArcher,
+    bool AllowMage,
+    bool AllowThief,
+    string? QuestCardText,
+    string? RewardCardText,
+    string? RewardNote,
+    string? Notes,
+    string? ImagePath,
+    List<SkillRewardDto> SkillRewards,
+    List<ItemRewardDto> ItemRewards);
+
+public record SkillRewardDto(int SkillId, string SkillName);
+public record ItemRewardDto(int ItemId, string ItemName, int Quantity);
+
+public record CreatePersonalQuestDto(
+    string Name,
+    TreasureQuestDifficulty Difficulty,
+    string? Description = null,
+    bool AllowWarrior = false,
+    bool AllowArcher = false,
+    bool AllowMage = false,
+    bool AllowThief = false,
+    string? QuestCardText = null,
+    string? RewardCardText = null,
+    string? RewardNote = null,
+    string? Notes = null);
+
+public record UpdatePersonalQuestDto(
+    string Name,
+    TreasureQuestDifficulty Difficulty,
+    string? Description,
+    bool AllowWarrior,
+    bool AllowArcher,
+    bool AllowMage,
+    bool AllowThief,
+    string? QuestCardText,
+    string? RewardCardText,
+    string? RewardNote,
+    string? Notes);
+
+public record GamePersonalQuestListDto(
+    int Id,            // PersonalQuest.Id, matches the ListDto for popup reuse
+    string Name,
+    string? Description,
+    TreasureQuestDifficulty Difficulty,
+    bool AllowWarrior,
+    bool AllowArcher,
+    bool AllowMage,
+    bool AllowThief,
+    string? QuestCardText,
+    string? RewardCardText,
+    string? RewardNote,
+    string? Notes,
+    string? ImagePath,
+    int GameId,
+    int XpCost,
+    int? PerKingdomLimit,
+    string? RewardSummary)
+{
+    [JsonIgnore]
+    public string DifficultyDisplay => Difficulty.GetDisplayName();
+
+    [JsonIgnore]
+    public string ClassRestrictionDisplay
+    {
+        get
+        {
+            if (!AllowWarrior && !AllowArcher && !AllowMage && !AllowThief)
+                return "Všechna povolání";
+            var parts = new List<string>();
+            if (AllowWarrior) parts.Add(PlayerClass.Warrior.GetDisplayName());
+            if (AllowArcher) parts.Add(PlayerClass.Archer.GetDisplayName());
+            if (AllowMage) parts.Add(PlayerClass.Mage.GetDisplayName());
+            if (AllowThief) parts.Add(PlayerClass.Thief.GetDisplayName());
+            return string.Join(", ", parts);
+        }
+    }
+
+    [JsonIgnore]
+    public bool HasImage => !string.IsNullOrEmpty(ImagePath);
+}
+
+public record CreateGamePersonalQuestDto(int GameId, int PersonalQuestId,
+    int XpCost = 0, int? PerKingdomLimit = null);
+
+public record UpdateGamePersonalQuestDto(int XpCost, int? PerKingdomLimit);
+
+public record AddSkillRewardDto(int SkillId);
+public record AddItemRewardDto(int ItemId, int Quantity = 1);
+```
+
+**Step 2:** Build.
+```bash
+dotnet build src/OvcinaHra.Shared/OvcinaHra.Shared.csproj -c Release --nologo -v:q
+```
+Expected: green.
+
+**Step 3:** Commit.
+```bash
+git add src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
+git commit -m "feat(pq): DTOs (List/Detail/Create/Update + per-game + reward)"
+```
+
+---
+
+## Phase 5 — Endpoints (TDD)
+
+Endpoints live in `src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs`; tests in `tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs`.
+
+Follow the existing `ItemEndpoints.cs` / `ItemEndpointTests.cs` pattern. Register the group in `Program.cs` via `routes.MapPersonalQuestEndpoints()` alongside `MapItemEndpoints()`.
+
+### Task 5.1: Scaffold + first failing test (list-empty)
+
+**Files:**
+- Create: `src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs`
+- Create: `tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs`
+- Modify: `src/OvcinaHra.Api/Program.cs` — add `routes.MapPersonalQuestEndpoints();`
+
+**Step 1:** Write the endpoint scaffold with just the group + `GetAll`.
+```csharp
+public static class PersonalQuestEndpoints
+{
+    public static RouteGroupBuilder MapPersonalQuestEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/personal-quests").WithTags("PersonalQuests");
+        group.MapGet("/", GetAll);
+        return group;
+    }
+
+    private static async Task<Ok<List<PersonalQuestListDto>>> GetAll(WorldDbContext db)
+    {
+        var quests = await db.PersonalQuests
+            .AsNoTracking()
+            .Include(q => q.SkillRewards)
+            .Include(q => q.ItemRewards).ThenInclude(r => r.Item)
+            .OrderBy(q => q.Name)
+            .ToListAsync();
+
+        return TypedResults.Ok(quests.Select(ToListDto).ToList());
+    }
+
+    private static PersonalQuestListDto ToListDto(PersonalQuest q) => new(
+        q.Id, q.Name, q.Description, q.Difficulty,
+        q.AllowWarrior, q.AllowArcher, q.AllowMage, q.AllowThief,
+        q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
+        q.SkillRewards.Select(sr => sr.SkillId).ToList(),
+        q.ItemRewards.Select(ir => new PersonalQuestItemRewardSummary(ir.ItemId, ir.Item.Name, ir.Quantity)).ToList());
+}
+```
+
+**Step 2:** Write first integration test — mirror `ItemEndpointTests` / `SkillEndpointTests`, use the existing `WebApplicationFixture`.
+
+```csharp
+public class PersonalQuestEndpointTests(WebApplicationFixture fx) : IClassFixture<WebApplicationFixture>
+{
+    [Fact]
+    public async Task GetAll_Empty_ReturnsEmptyList()
+    {
+        var client = fx.CreateClient();
+        var response = await client.GetFromJsonAsync<List<PersonalQuestListDto>>("/api/personal-quests");
+        Assert.NotNull(response);
+        Assert.Empty(response);
+    }
+}
+```
+
+**Step 3:** Run the test.
+```bash
+dotnet test tests/OvcinaHra.Api.Tests -c Release --nologo \
+  --filter "FullyQualifiedName~PersonalQuestEndpointTests.GetAll_Empty"
+```
+Expected: PASS (DB is empty on a fresh container).
+
+**Step 4:** Commit.
+```bash
+git add src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs \
+        src/OvcinaHra.Api/Program.cs \
+        tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+git commit -m "feat(pq): GET /api/personal-quests (empty-list smoke test)"
+```
+
+### Task 5.2: POST + GET-by-id + DELETE (catalog CRUD)
+
+Follow the same TDD beat for each method:
+
+1. Write failing test (e.g. `Create_WithValidDto_ReturnsCreatedWithId`, `GetById_NotFound_Returns404`, `Delete_Cascades_RemovesRewards`).
+2. Run — expect red.
+3. Implement the endpoint method in `PersonalQuestEndpoints.cs`.
+4. Run — expect green.
+5. Commit each endpoint method + its test as a single commit, e.g. `test(pq): failing Create test` then `feat(pq): POST /api/personal-quests`.
+
+**Endpoint signatures to add:**
+```csharp
+group.MapGet("/{id:int}", GetById);
+group.MapPost("/", Create);
+group.MapPut("/{id:int}", Update);
+group.MapDelete("/{id:int}", Delete);
+```
+
+Look at `ItemEndpoints.cs` for the `ToDetailDto` / `FindAsync` / `db.Items.Remove` shape.
+
+**Important:** `GetById` must include `SkillRewards.Skill` + `ItemRewards.Item` to populate the DetailDto's friendly names.
+
+### Task 5.3: Per-game endpoints + `RewardSummary` computation
+
+**Endpoint signatures:**
+```csharp
+group.MapGet("/by-game/{gameId:int}", GetByGame);
+group.MapPost("/game-link", CreateGameLink);
+group.MapPut("/game-link/{gameId:int}/{pqId:int}", UpdateGameLink);
+group.MapDelete("/game-link/{gameId:int}/{pqId:int}", DeleteGameLink);
+```
+
+**`GetByGame`** — joins GamePersonalQuests with PersonalQuests + Skills + Items to build `GamePersonalQuestListDto` with the computed `RewardSummary`. Mirrors `ItemEndpoints.GetByGame` (which joins crafting recipes).
+
+```csharp
+private static async Task<Ok<List<GamePersonalQuestListDto>>> GetByGame(int gameId, WorldDbContext db)
+{
+    var gpqs = await db.GamePersonalQuests
+        .AsNoTracking()
+        .Where(g => g.GameId == gameId)
+        .Include(g => g.PersonalQuest).ThenInclude(q => q.SkillRewards).ThenInclude(sr => sr.Skill)
+        .Include(g => g.PersonalQuest).ThenInclude(q => q.ItemRewards).ThenInclude(ir => ir.Item)
+        .OrderBy(g => g.PersonalQuest.Name)
+        .ToListAsync();
+
+    return TypedResults.Ok(gpqs.Select(ToGameListDto).ToList());
+}
+
+private static GamePersonalQuestListDto ToGameListDto(GamePersonalQuest g)
+{
+    var q = g.PersonalQuest;
+    return new(
+        q.Id, q.Name, q.Description, q.Difficulty,
+        q.AllowWarrior, q.AllowArcher, q.AllowMage, q.AllowThief,
+        q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
+        g.GameId, g.XpCost, g.PerKingdomLimit,
+        BuildRewardSummary(q));
+}
+
+private static string? BuildRewardSummary(PersonalQuest q)
+{
+    var parts = new List<string>();
+    if (q.SkillRewards.Count > 0)
+        parts.Add(string.Join(", ", q.SkillRewards.OrderBy(s => s.Skill.Name).Select(s => s.Skill.Name)));
+    if (q.ItemRewards.Count > 0)
+        parts.Add(string.Join(", ",
+            q.ItemRewards.OrderBy(i => i.Item.Name).Select(i => $"{i.Item.Name} ×{i.Quantity}")));
+    return parts.Count > 0 ? string.Join(" │ ", parts) : null;
+}
+```
+
+**Tests — one beat per endpoint:**
+- `GetByGame_Empty_Returns404OrEmpty` (choose one and stick to it — mirror the items tests)
+- `CreateGameLink_Persists_Returns201`
+- `UpdateGameLink_TunesXpCost`
+- `DeleteGameLink_RemovesConfig_KeepsCatalogEntry`
+- `GetByGame_WithRewards_BuildsSummary` — the most valuable test; asserts the string format `"Druid │ Léčivá dlaň ×1"`
+
+Commit each TDD beat.
+
+### Task 5.4: Reward add/remove endpoints
+
+**Endpoint signatures:**
+```csharp
+group.MapPost("/{id:int}/skill-rewards", AddSkillReward);
+group.MapDelete("/{id:int}/skill-rewards/{skillId:int}", RemoveSkillReward);
+group.MapPost("/{id:int}/item-rewards", AddItemReward);
+group.MapDelete("/{id:int}/item-rewards/{itemId:int}", RemoveItemReward);
+```
+
+**Tests** (one per verb):
+- `AddSkillReward_Persists_Returns201_AndSecondPostIsConflict`
+- `AddItemReward_StoresQuantity`
+- `RemoveSkillReward_Idempotent_NoContentWhenAlreadyGone`
+
+Commit each beat.
+
+### Task 5.5: Full test suite green
+
+**Step 1:** Run the whole test suite end-to-end.
+```bash
+dotnet test tests/OvcinaHra.Api.Tests -c Release --nologo
+```
+Expected: all green. Expect 10–15 new PersonalQuest tests + existing 176+ still passing.
+
+**Step 2:** If anything is red, fix the cause (do NOT skip tests) before moving on.
+
+---
+
+## Phase 6 — Client
+
+### Task 6.1: `PersonalQuestService` API wrapper
+
+**Files:**
+- Create: `src/OvcinaHra.Client/Services/PersonalQuestService.cs`
+- Modify: `src/OvcinaHra.Client/Program.cs` — `builder.Services.AddScoped<PersonalQuestService>();`
+
+**Step 1:** Wrap all endpoints. Mirror `SkillService.cs` — simple `ApiClient` delegation, no state. Example:
+```csharp
+public class PersonalQuestService(ApiClient api)
+{
+    public Task<List<PersonalQuestListDto>> GetAllAsync() => api.GetListAsync<PersonalQuestListDto>("/api/personal-quests");
+    public Task<PersonalQuestDetailDto?> GetByIdAsync(int id) => api.GetAsync<PersonalQuestDetailDto>($"/api/personal-quests/{id}");
+    // ...etc
+}
+```
+
+**Step 2:** Build Client.
+```bash
+dotnet build src/OvcinaHra.Client/OvcinaHra.Client.csproj -c Release --nologo -v:q
+```
+
+**Step 3:** Commit.
+```bash
+git add src/OvcinaHra.Client/Services/PersonalQuestService.cs src/OvcinaHra.Client/Program.cs
+git commit -m "feat(pq): client service wrapper + DI registration"
+```
+
+### Task 6.2: Nav entries in both sections
+
+**Files:**
+- Modify: `src/OvcinaHra.Client/Layout/NavMenu.razor`
+
+**Step 1:** Add the Hra entry right after the Questy entry:
+```razor
+<div class="nav-item px-3">
+    <NavLink class="nav-link" href="personal-quests">
+        <i class="bi bi-person-workspace"></i><span class="nav-label">Osobní questy</span>
+    </NavLink>
+</div>
+```
+
+**Step 2:** Add the identical entry in **Katalog světa** right after `quests?catalog=true`, using `href="personal-quests?catalog=true"` and the same icon / label — matches design § *Nav*.
+
+**Step 3:** Commit.
+```bash
+git add src/OvcinaHra.Client/Layout/NavMenu.razor
+git commit -m "feat(pq): add Osobní questy nav entries (Hra + Katalog světa)"
+```
+
+### Task 6.3: `PersonalQuestList.razor` — skeleton + catalog grid
+
+**Files:**
+- Create: `src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor`
+
+**Step 1:** Scaffold the page modelled exactly on `Pages/Items/ItemList.razor` (post PR #32). Top-level:
+- `@page "/personal-quests"`, `[SupplyParameterFromQuery] public bool Catalog { get; set; }`
+- Czech header "Katalog osobních questů" / "Osobní questy" — mirror the Items header
+- "Jen tato hra" / "Katalog" button toggle
+- "+ Nový osobní quest" button → `OpenModal((PersonalQuestListDto?)null)`
+- `@if (loading)`, `else if (!Catalog && GameContext.SelectedGameId is null)`, `else if (!Catalog && gameItems.Count == 0)`, `else if (Catalog) { /* catalog grid */ }`, `else { /* game grid + context menu */ }`
+
+**Step 2:** Implement ONLY the catalog grid first — column list per design § *UI → Two grid views*. LayoutKey `grid-layout-personal-quests-catalog`. Use the same visible/hidden default scheme.
+
+**Step 3:** Wire `LoadAsync` to populate `catalogItems` via `PersonalQuestSvc.GetAllAsync()`.
+
+**Step 4:** Run `devStart.bat` and visually spot-check `/personal-quests?catalog=true` loads (empty). Hit `+ Nový` — popup should open (even if form is a stub).
+
+**Step 5:** Commit `feat(pq): catalog grid skeleton` — WIP popup OK.
+
+### Task 6.4: Detail popup form + rewards pickers
+
+**Step 1:** Flesh the popup. `DxFormLayout` with all catalog fields per design § *Detail popup*. Use `DxComboBox` for `Difficulty`, 4 `DxCheckBox` for class matrix, `DxTextBox`/`DxMemo` for text fields, `ImagePicker` for the image.
+
+**Step 2:** Below the form layout, add the **Rewards card** (only when `editingId.HasValue`):
+- Skills: list of chips (name + `×` remove button), `DxComboBox` with all `SkillListDto`s except already-added + `Přidat` button → calls `PersonalQuestSvc.AddSkillRewardAsync(id, skillId)`
+- Items: same pattern with `DxSpinEdit` for quantity
+
+**Step 3:** `Save` button → POST on new, PUT on existing. On success: close + reload.
+
+**Step 4:** `Delete` button + confirm popup (mirror Items page exactly).
+
+**Step 5:** Test end-to-end locally: create quest, attach 1 skill + 1 item, save, reopen, verify state round-trips.
+
+**Step 6:** Commit `feat(pq): detail popup with rewards pickers`.
+
+### Task 6.5: Game-view grid + context menu + per-game card
+
+**Step 1:** Game grid: column list per design + three-dots fixed-left column + `DxContextMenu` with **Upravit / Odebrat z hry / Smazat** items. Mirror the post-PR-#32 Items game grid exactly. LayoutKey `grid-layout-personal-quests-game`.
+
+**Step 2:** In the popup (only when `!Catalog && SelectedGameId.HasValue && editingId.HasValue`), render the **Per-game card**:
+- `DxSpinEdit` for `XpCost` (MinValue 0)
+- `DxSpinEdit` for `PerKingdomLimit` (MinValue 1, `NullText="(neomezeno)"`)
+- "Přidat do hry" button (creates GPQ) OR "Uložit nastavení" + "Odebrat z hry" buttons (updates/deletes GPQ)
+
+**Step 3:** `LoadAsync` in game mode calls `PersonalQuestSvc.GetByGameAsync(gid)` and populates `gameItems: List<GamePersonalQuestListDto>`. Catalog-mode catalog/assignment works identically to the `ItemList` pattern.
+
+**Step 4:** Test locally: assign a quest to the current game, tune XpCost, verify grid updates, open context menu, unassign, reassign.
+
+**Step 5:** Commit `feat(pq): game-view grid + context menu + per-game card`.
+
+### Task 6.6: `ToolSearch`-style catalog `Přidat/Odebrat` column
+
+Only needed if Catalog view should be able to opt quests in/out of the current game — yes per design. Column definition lifted straight from `ItemList.razor`. Wire `AssignAsync` / `UnassignAsync` → `CreateGameLinkAsync(gid, id, xpCost=0, pkl=null)` / `DeleteGameLinkAsync(gid, id)`.
+
+Commit `feat(pq): catalog Přidat/Odebrat column`.
+
+---
+
+## Phase 7 — Finalize
+
+### Task 7.1: Version bump + final solution build
+
+**Files:**
+- Modify: `src/OvcinaHra.Client/OvcinaHra.Client.csproj` — `<Version>0.5.3</Version>` → `<Version>0.6.0</Version>`.
+
+**Step 1:** Edit the csproj.
+
+**Step 2:** Full solution build.
+```bash
+dotnet build OvcinaHra.slnx -c Release --nologo -v:q
+```
+Expected: green, 0 warnings.
+
+**Step 3:** Full test suite one more time.
+```bash
+dotnet test tests/OvcinaHra.Api.Tests -c Release --nologo
+```
+Expected: green.
+
+**Step 4:** Commit.
+```bash
+git add src/OvcinaHra.Client/OvcinaHra.Client.csproj
+git commit -m "chore(pq): version bump 0.5.3 -> 0.6.0"
+```
+
+### Task 7.2: Push + PR
+
+**Step 1:** Push the branch.
+```bash
+git push -u origin feat/personal-quest-domain
+```
+
+**Step 2:** Open the PR.
+```bash
+gh pr create --title "feat: PersonalQuest domain (catalog + per-game + character assignment) [v0.6.0]" \
+  --body "$(cat <<'EOF'
+## Summary
+
+First shipping cut of the PersonalQuest domain — world-level catalog of per-character mini-quests, per-game config, and a character-assignment table ready for a follow-up UI. Design doc: `docs/plans/2026-04-19-personal-quest-domain-design.md`.
+
+## Server
+
+- 4 new entities + 1 link: `PersonalQuest`, `PersonalQuestSkillReward`, `PersonalQuestItemReward`, `GamePersonalQuest`, `CharacterPersonalQuest`.
+- EF migration `AddPersonalQuestDomain` — additive only, no modifications to existing tables. Auto-applied at API startup via `db.Database.MigrateAsync()`.
+- Endpoints under `/api/personal-quests` (CRUD + per-game link + reward add/remove).
+- Testcontainers-PostgreSQL integration tests for every endpoint.
+
+## Client
+
+- `/personal-quests` page with catalog/game grid split (same UX as `/items`).
+- Nav entries added in Hra and Katalog světa at matching positions.
+- Detail popup: form + rewards pickers (skills + items with quantity) + per-game config card.
+- Server-computed `RewardSummary` string for at-a-glance game-view rows.
+
+## Deferred (explicit)
+
+- Character-assignment UI (data ships; form/page follows).
+- Completion-tracking toggle.
+- Card printing.
+- Kingdom/Merchant entities.
+
+## Test plan
+
+- [ ] CI passes (API CI + Client CI)
+- [ ] Manually: create a "Druid" quest in the catalog, attach Dovednost Druid (skill) + Léčivá dlaň (item), add to game 30, verify RewardSummary renders
+- [ ] Switch Katalog ↔ Jen tato hra — both grids work, LayoutKeys persist independently
+- [ ] Context menu on game view: Upravit / Odebrat z hry / Smazat all work
+- [ ] Nav: Dovednosti entries visible in both Hra and Katalog světa
+- [ ] Migration applies cleanly against prod on deploy
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 3:** Watch CI; address Copilot comments; merge when green.
+
+---
+
+## Cross-cutting reminders
+
+- **Czech UI / English code** — page routes, identifiers, method names all English; every user-facing string Czech with proper diacritics. Keep `PlayerClass` display names stable.
+- **LayoutKey bump rule** — if you change grid columns later, increment the key suffix per `feedback_ovcinagrid_layoutkey_bump`.
+- **No N+1 queries** — `Include().ThenInclude()` for all reward navigation reads.
+- **Guard tests** — every endpoint gets at least a happy-path test; 404 and conflict cases for mutations.
+- **Don't commit without explicit approval** when working with subagents — per `feedback_no_commit_without_approval`.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/plans/2026-04-19-personal-quest-domain-implementation.md`.
+
+Two execution options:
+
+1. **Subagent-Driven (this session)** — I dispatch fresh subagents per task, review between tasks, fast iteration.
+2. **Parallel Session (separate)** — Open a new session in the branch, use `superpowers:executing-plans` to batch through with checkpoints.
+
+Which approach?

--- a/docs/plans/2026-04-19-skills-copy-on-assign-design.md
+++ b/docs/plans/2026-04-19-skills-copy-on-assign-design.md
@@ -1,0 +1,187 @@
+# Skills Copy-on-Assign — Design
+
+**Date:** 2026-04-19
+**Status:** Approved — ready for implementation plan
+**Supersedes:** `docs/plans/2026-04-19-skills-page-pattern-align-design.md` (same branch, scoped only to UI alignment — rendered obsolete after this broader decision). The original skills-domain design (`docs/plans/2026-04-19-skills-domain-design.md`) also no longer reflects reality; it should get a pointer to this document after merge.
+
+## Goal
+
+Make each game's `GameSkill` a **standalone editable copy** of a catalog `Skill` template, not a pure reference. An organizer can freely customize the Effect text, Name, Building requirements, XP cost and level requirement for the skill as it appears in their specific game, without that edit rippling to other games or back to the library template.
+
+## Why (Copilot review triggered a deeper rethink)
+
+PR #34 review flagged the NavMenu as having two "Dovednosti" links that both point at the global catalog — a pattern inconsistency with Items/Monsters (which use a single `?catalog=true`-toggled page). Investigating why Skills were split revealed the real issue: the data model treats `GameSkill` as a pure pointer to a global `Skill`, so editing the catalog's Effect ripples to every game using that skill. That doesn't match how organizers think ("I want a slightly different Effect wording for this particular game"). Rather than paper over the inconsistency, this design embraces the split and makes it meaningful — **catalog = library of templates, game-skill = the game's own editable copy.**
+
+## Non-goals
+
+- **No backward-compat fuss.** No production data yet, so the migration can be a clean replace of the current `AddSkillsDomain` migration file rather than a multi-step transform.
+- Skills image upload (endpoint still missing for `"skills"` entity type) — separate future ticket.
+- Template versioning / "update all copies from template" button — not asked for; YAGNI.
+
+## Data model
+
+### Entities
+
+**`Skill`** — the catalog template. **Unchanged.**
+- `Id`, `Name`, `ClassRestriction: PlayerClass?`, `Effect?`, `RequirementNotes?`, `ImagePath?`, `BuildingRequirements` (join to `Building`).
+
+**`GameSkill`** — now a first-class entity, the per-game copy.
+- `Id` (surrogate PK — NEW)
+- `GameId` (FK)
+- `TemplateSkillId` (FK to `Skill`, nullable — `null` when created via "Vlastní" flow)
+- `Name`, `ClassRestriction`, `Effect`, `RequirementNotes`, `ImagePath` (copied from template on assign; independently editable afterward)
+- `XpCost: int`, `LevelRequirement: int?`
+- Navigation: `Game`, `Skill` (template), `BuildingRequirements` (new join)
+
+**`GameSkillBuildingRequirement`** — new join table
+- Composite PK `(GameSkillId, BuildingId)`
+
+**`CraftingSkillRequirement`** — migrates its reference
+- `CraftingRecipeId`, **`GameSkillId`** (renamed from `SkillId`; now points to per-game `GameSkill`, not to global `Skill`)
+- The "skill must be in the game" constraint is now a plain FK + the recipe's game matching the GameSkill's game — enforced server-side at recipe save.
+
+### Constraints
+
+- `GameSkill (GameId, Name)` — unique. One game cannot have two skills with the same name.
+- `GameSkill.XpCost >= 0` — CHECK, same as today.
+- `GameSkill.LevelRequirement IS NULL OR >= 0` — CHECK, same.
+- `Skill.OnDelete` → `SetNull` on `GameSkill.TemplateSkillId`. Template can be deleted even while copies reference it; the copies just lose their provenance pointer.
+- `CraftingRecipe.OnDelete` → cascade to `CraftingSkillRequirements`.
+- `GameSkill.OnDelete` → restrict. If any `CraftingSkillRequirement` points at it, deletion returns 409 (handled at endpoint level with a Czech message).
+
+## Migration
+
+Single replacement migration. No backfill SQL because no production data.
+
+1. **Delete** the existing `src/OvcinaHra.Api/Migrations/20260419045332_AddSkillsDomain.cs` (+ Designer file).
+2. **Regenerate** a fresh migration `AddSkillsDomain` that defines the final shape: `Skills`, `SkillBuildingRequirements` (unchanged), new-shape `GameSkills` (first-class entity), new `GameSkillBuildingRequirements`, new-shape `CraftingSkillRequirements` (pointing to `GameSkillId`).
+3. Dev DB reset: `dotnet ef database drop --force && dotnet ef database update`.
+
+This is clean precisely because there is no prod data to preserve. The migration is a single self-contained snapshot of the final schema.
+
+## API
+
+### Catalog template endpoints — unchanged
+
+- `GET /api/skills`, `GET /api/skills/{id}`, `POST /api/skills`, `PUT /api/skills/{id}`, `DELETE /api/skills/{id}`.
+- `DELETE` is permitted even if copies reference the template (FK uses `SetNull`).
+
+### Per-game skill endpoints — reshaped
+
+| Method | Route | Purpose |
+|---|---|---|
+| GET | `/api/games/{gameId}/skills` | list all GameSkills for the game |
+| GET | `/api/games/{gameId}/skills/{gameSkillId}` | single GameSkill detail |
+| POST | `/api/games/{gameId}/skills` | add from template OR create custom. Body has optional `TemplateSkillId` (null = custom) + all full fields. Server validates FK + uniqueness; request body wins on all values. |
+| PUT | `/api/games/{gameId}/skills/{gameSkillId}` | update all fields (Name, Class, Effect, Notes, BuildingIds, XpCost, Level) |
+| DELETE | `/api/games/{gameId}/skills/{gameSkillId}` | remove from game; 409 if a recipe in this game requires it |
+
+### Recipe endpoints
+
+- `CraftingRecipeDto.RequiredSkillIds` is now **`IReadOnlyList<int>` of `GameSkill.Id`s**, not template `Skill.Id`s. Callers adjust.
+- Validation on recipe save: each id must be a `GameSkill` with matching `GameId`. Simpler than before — no existence + in-game membership check; just a filtered FK.
+
+### DTOs
+
+```csharp
+public record GameSkillDto(
+    int Id,
+    int GameId,
+    int? TemplateSkillId,
+    string Name,
+    PlayerClass? ClassRestriction,
+    string? Effect,
+    string? RequirementNotes,
+    string? ImagePath,
+    int XpCost,
+    int? LevelRequirement,
+    IReadOnlyList<int> BuildingRequirementIds);
+
+public record CreateGameSkillRequest(
+    int? TemplateSkillId,
+    string Name,
+    PlayerClass? ClassRestriction,
+    string? Effect,
+    string? RequirementNotes,
+    IReadOnlyList<int> BuildingRequirementIds,
+    int XpCost,
+    int? LevelRequirement);
+
+public record UpdateGameSkillRequest(
+    string Name,
+    PlayerClass? ClassRestriction,
+    string? Effect,
+    string? RequirementNotes,
+    IReadOnlyList<int> BuildingRequirementIds,
+    int XpCost,
+    int? LevelRequirement);
+```
+
+## UI
+
+### `/skills` — "Knihovna dovedností" (Library)
+
+- Grid: Název, Povolání, Efekt, Požadované budovy, Poznámka.
+- Detail popup: Name, Typ (class/Dobrodruh toggle), Effect, Notes, Building list, Image (stub).
+- **No XP/Level fields anywhere** — those belong to GameSkill.
+- Info banner at top: *"Tyto dovednosti jsou šablony. Při přidání do hry se vytvoří kopie, kterou lze pro danou hru upravit nezávisle."*
+- Create / edit / delete — all affect the template only.
+
+### `/games/{gameId}/skills` — "Dovednosti ve hře"
+
+- Grid of `GameSkillDto`. Columns: Název, Povolání, XP, Úroveň, action column with row delete.
+- Row click → detail popup with **all fields editable** (Name, Class, Effect, Notes, Buildings, XP, Level). Above the form, a small info line: *"Šablona: Tichý úder (Knihovna)"* or *"Vlastní (bez šablony)"* or *"Šablona: (odstraněná)"* if TemplateSkillId became null after template deletion.
+- Add button "+ Přidat dovednost" opens a small chooser popup:
+  - **Ze šablony** → `DxComboBox` of templates not already in game → confirm → opens full edit popup pre-filled with template values → organizer tweaks XP/Level + any field → save creates the GameSkill.
+  - **Vlastní** → opens full edit popup empty, no template → organizer fills in everything → save creates GameSkill with `TemplateSkillId = null`.
+- Row delete = remove-from-game; 409 blocked if a recipe in this game requires the skill.
+
+### NavMenu
+
+- **Hra → Dovednosti** — `href` computed at render time from `GameContextService.SelectedGameId`:
+  - Active game: `/games/{gameId}/skills`
+  - No active game: disabled link OR navigates to a small "Žádná aktivní hra — Otevřít knihovnu" page. Simplest is to hide the link when no active game.
+- **Katalog světa → Dovednosti** — `/skills` (template library).
+- A one-line HTML comment next to both entries explains why these point to different resources:
+  ```html
+  <!-- Skills are copy-on-assign: catalog = templates, per-game = editable copies. Intentional asymmetry with Items. -->
+  ```
+
+### Recipe editor
+
+- "Požadované dovednosti" block in the item-edit dialog already queries `GameSkillDto` for the current game. After the data-model change the DTO is still there and the endpoint is still there; the id it writes into `RequiredSkillIds` is now a GameSkill.Id instead of a template Skill.Id. No UI change needed in the crafting dialog — it just works with the new meaning.
+
+## Testing
+
+**API integration tests** (Testcontainers):
+
+- `SkillEndpointsTests` (existing 16) — mostly pass as-is (template CRUD unchanged); drop the test that asserted "delete blocked when a game references" (that rule is gone), adjust any seed helpers that assumed old GameSkill shape.
+- `GameSkillEndpointsTests` — rewrite for new shape:
+  - `Post_AddsFromTemplate_CopiesAllFields` (required)
+  - `Post_CreatesCustom_NoTemplate` (required)
+  - `Put_UpdatesGameSkillFields_TemplateUnaffected` — key isolation test
+  - `DeleteTemplate_NullsOutTemplateSkillIdOnCopies` — cascade-null behavior
+  - `Delete_GameSkill_BlockedWhenRecipeRequires_Returns409`
+  - `Post_DuplicateNameInSameGame_Returns409`
+  - Validation: XpCost / LevelRequirement non-negative.
+- `CraftingEndpointTests` — the 4 skill-related tests get updated seeds (recipe `RequiredSkillIds` now = GameSkill IDs, not template IDs). Logic-level assertions stay; only fixture setup changes.
+
+**E2E Playwright** — `SkillsManagementTests.cs` updates seed to create template → assign to game → require in recipe using the new endpoints.
+
+**Manual smoke:**
+1. Create template in `/skills` → open game → add from template → edit GameSkill's Effect → reload → verify template's Effect is unchanged (copy semantics).
+2. Edit template's Effect in `/skills` → verify existing GameSkill copies are unaffected.
+3. Create "Vlastní" skill in game (no template) → `TemplateSkillId = null`.
+4. Delete template while a GameSkill references it → GameSkill stays, its `TemplateSkillId` becomes null, info line shows "Šablona: (odstraněná)".
+5. Require GameSkill in recipe → remove from game → 409.
+6. NavMenu from Hra section → lands on `/games/{activeGameId}/skills`. From Katalog světa → lands on `/skills`.
+
+## Versioning & rollout
+
+- Version bump to `0.6.0` — domain/API shape changed (breaking at the contract level). Minor bump, not patch.
+- Single PR from branch `feat/skills-page-align-with-catalog-pattern` (branch may want a rename to `feat/skills-copy-on-assign` to reflect the real scope — implementation plan decides).
+- Post-merge: add a superseded-by note at the top of `docs/plans/2026-04-19-skills-domain-design.md` pointing here.
+
+## Open questions
+
+None — all six design sections locked during brainstorming.

--- a/src/OvcinaHra.Api/Data/Configurations/CharacterPersonalQuestConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/CharacterPersonalQuestConfiguration.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class CharacterPersonalQuestConfiguration : IEntityTypeConfiguration<CharacterPersonalQuest>
+{
+    public void Configure(EntityTypeBuilder<CharacterPersonalQuest> b)
+    {
+        b.HasKey(e => e.CharacterId);        // one-to-one: a character has at most 1 PQ
+        b.HasOne(e => e.Character).WithMany()
+            .HasForeignKey(e => e.CharacterId).OnDelete(DeleteBehavior.Cascade);
+        b.HasOne(e => e.PersonalQuest).WithMany(q => q.CharacterAssignments)
+            .HasForeignKey(e => e.PersonalQuestId).OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/OvcinaHra.Api/Data/Configurations/GamePersonalQuestConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/GamePersonalQuestConfiguration.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class GamePersonalQuestConfiguration : IEntityTypeConfiguration<GamePersonalQuest>
+{
+    public void Configure(EntityTypeBuilder<GamePersonalQuest> b)
+    {
+        b.HasKey(e => new { e.GameId, e.PersonalQuestId });
+        b.HasOne(e => e.Game).WithMany()
+            .HasForeignKey(e => e.GameId).OnDelete(DeleteBehavior.Cascade);
+        b.HasOne(e => e.PersonalQuest).WithMany(q => q.GameLinks)
+            .HasForeignKey(e => e.PersonalQuestId).OnDelete(DeleteBehavior.Cascade);
+        b.HasIndex(e => e.GameId);
+        b.ToTable(t =>
+        {
+            t.HasCheckConstraint("CK_GamePersonalQuest_XpCost_NonNegative", "\"XpCost\" >= 0");
+            t.HasCheckConstraint("CK_GamePersonalQuest_PKL_Positive",
+                "\"PerKingdomLimit\" IS NULL OR \"PerKingdomLimit\" >= 1");
+        });
+    }
+}

--- a/src/OvcinaHra.Api/Data/Configurations/PersonalQuestConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/PersonalQuestConfiguration.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class PersonalQuestConfiguration : IEntityTypeConfiguration<PersonalQuest>
+{
+    public void Configure(EntityTypeBuilder<PersonalQuest> b)
+    {
+        b.HasKey(e => e.Id);
+        b.Property(e => e.Name).IsRequired().HasMaxLength(200);
+        b.HasIndex(e => e.Name).IsUnique();
+        b.Property(e => e.Description).HasMaxLength(500);
+        b.Property(e => e.Difficulty).HasConversion<string>().HasMaxLength(20);
+    }
+}

--- a/src/OvcinaHra.Api/Data/Configurations/PersonalQuestItemRewardConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/PersonalQuestItemRewardConfiguration.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class PersonalQuestItemRewardConfiguration : IEntityTypeConfiguration<PersonalQuestItemReward>
+{
+    public void Configure(EntityTypeBuilder<PersonalQuestItemReward> b)
+    {
+        b.HasKey(e => new { e.PersonalQuestId, e.ItemId });
+        b.Property(e => e.Quantity).HasDefaultValue(1);
+        b.ToTable(t => t.HasCheckConstraint("CK_PQItemReward_Qty_Positive", "\"Quantity\" >= 1"));
+        b.HasOne(e => e.PersonalQuest).WithMany(q => q.ItemRewards)
+            .HasForeignKey(e => e.PersonalQuestId).OnDelete(DeleteBehavior.Cascade);
+        b.HasOne(e => e.Item).WithMany()
+            .HasForeignKey(e => e.ItemId).OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/OvcinaHra.Api/Data/Configurations/PersonalQuestSkillRewardConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/PersonalQuestSkillRewardConfiguration.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class PersonalQuestSkillRewardConfiguration : IEntityTypeConfiguration<PersonalQuestSkillReward>
+{
+    public void Configure(EntityTypeBuilder<PersonalQuestSkillReward> b)
+    {
+        b.HasKey(e => new { e.PersonalQuestId, e.SkillId });
+        b.HasOne(e => e.PersonalQuest).WithMany(q => q.SkillRewards)
+            .HasForeignKey(e => e.PersonalQuestId).OnDelete(DeleteBehavior.Cascade);
+        b.HasOne(e => e.Skill).WithMany()
+            .HasForeignKey(e => e.SkillId).OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -46,6 +46,11 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<GameEventLocation> GameEventLocations => Set<GameEventLocation>();
     public DbSet<GameEventQuest> GameEventQuests => Set<GameEventQuest>();
     public DbSet<GameEventNpc> GameEventNpcs => Set<GameEventNpc>();
+    public DbSet<PersonalQuest> PersonalQuests => Set<PersonalQuest>();
+    public DbSet<PersonalQuestSkillReward> PersonalQuestSkillRewards => Set<PersonalQuestSkillReward>();
+    public DbSet<PersonalQuestItemReward> PersonalQuestItemRewards => Set<PersonalQuestItemReward>();
+    public DbSet<GamePersonalQuest> GamePersonalQuests => Set<GamePersonalQuest>();
+    public DbSet<CharacterPersonalQuest> CharacterPersonalQuests => Set<CharacterPersonalQuest>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -16,6 +16,7 @@ public static class PersonalQuestEndpoints
         group.MapGet("/{id:int}", GetById);
         group.MapPost("/", Create);
         group.MapPut("/{id:int}", Update);
+        group.MapDelete("/{id:int}", Delete);
 
         return group;
     }
@@ -83,6 +84,16 @@ public static class PersonalQuestEndpoints
         q.RewardNote = dto.RewardNote;
         q.Notes = dto.Notes;
 
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound>> Delete(int id, WorldDbContext db)
+    {
+        var q = await db.PersonalQuests.FindAsync(id);
+        if (q is null) return TypedResults.NotFound();
+
+        db.PersonalQuests.Remove(q);
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -13,6 +13,7 @@ public static class PersonalQuestEndpoints
         var group = routes.MapGroup("/api/personal-quests").WithTags("PersonalQuests");
 
         group.MapGet("/", GetAll);
+        group.MapPost("/", Create);
 
         return group;
     }
@@ -28,6 +29,35 @@ public static class PersonalQuestEndpoints
 
         return TypedResults.Ok(quests.Select(ToListDto).ToList());
     }
+
+    private static async Task<Created<PersonalQuestDetailDto>> Create(CreatePersonalQuestDto dto, WorldDbContext db)
+    {
+        var q = new PersonalQuest
+        {
+            Name = dto.Name,
+            Difficulty = dto.Difficulty,
+            Description = dto.Description,
+            AllowWarrior = dto.AllowWarrior,
+            AllowArcher = dto.AllowArcher,
+            AllowMage = dto.AllowMage,
+            AllowThief = dto.AllowThief,
+            QuestCardText = dto.QuestCardText,
+            RewardCardText = dto.RewardCardText,
+            RewardNote = dto.RewardNote,
+            Notes = dto.Notes
+        };
+        db.PersonalQuests.Add(q);
+        await db.SaveChangesAsync();
+
+        return TypedResults.Created($"/api/personal-quests/{q.Id}", ToDetailDto(q));
+    }
+
+    private static PersonalQuestDetailDto ToDetailDto(PersonalQuest q) => new(
+        q.Id, q.Name, q.Description, q.Difficulty,
+        q.AllowWarrior, q.AllowArcher, q.AllowMage, q.AllowThief,
+        q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
+        q.SkillRewards.Select(sr => new SkillRewardDto(sr.SkillId, sr.Skill?.Name ?? string.Empty)).ToList(),
+        q.ItemRewards.Select(ir => new ItemRewardDto(ir.ItemId, ir.Item?.Name ?? string.Empty, ir.Quantity)).ToList());
 
     private static PersonalQuestListDto ToListDto(PersonalQuest q) => new(
         q.Id, q.Name, q.Description, q.Difficulty,

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -37,7 +37,7 @@ public static class PersonalQuestEndpoints
     {
         var quests = await db.PersonalQuests
             .AsNoTracking()
-            .Include(q => q.SkillRewards)
+            .Include(q => q.SkillRewards).ThenInclude(sr => sr.Skill)
             .Include(q => q.ItemRewards).ThenInclude(r => r.Item)
             .OrderBy(q => q.Name)
             .ToListAsync();
@@ -122,7 +122,8 @@ public static class PersonalQuestEndpoints
         q.AllowWarrior, q.AllowArcher, q.AllowMage, q.AllowThief,
         q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
         q.SkillRewards.Select(sr => sr.SkillId).ToList(),
-        q.ItemRewards.Select(ir => new PersonalQuestItemRewardSummary(ir.ItemId, ir.Item.Name, ir.Quantity)).ToList());
+        q.ItemRewards.Select(ir => new PersonalQuestItemRewardSummary(ir.ItemId, ir.Item.Name, ir.Quantity)).ToList(),
+        BuildRewardSummary(q));
 
     // ---------- Per-game link endpoints ----------
 

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -24,6 +24,12 @@ public static class PersonalQuestEndpoints
         group.MapPut("/game-link/{gameId:int}/{pqId:int}", UpdateGameLink);
         group.MapDelete("/game-link/{gameId:int}/{pqId:int}", DeleteGameLink);
 
+        // Reward link endpoints
+        group.MapPost("/{id:int}/skill-rewards", AddSkillReward);
+        group.MapDelete("/{id:int}/skill-rewards/{skillId:int}", RemoveSkillReward);
+        group.MapPost("/{id:int}/item-rewards", AddItemReward);
+        group.MapDelete("/{id:int}/item-rewards/{itemId:int}", RemoveItemReward);
+
         return group;
     }
 
@@ -206,4 +212,70 @@ public static class PersonalQuestEndpoints
         return parts.Count > 0 ? string.Join(" │ ", parts) : null;
     }
 
+    // ---------- Reward link endpoints ----------
+
+    private static async Task<Results<Created, NotFound, Conflict>> AddSkillReward(
+        int id, AddSkillRewardDto dto, WorldDbContext db)
+    {
+        var quest = await db.PersonalQuests.FindAsync(id);
+        if (quest is null) return TypedResults.NotFound();
+
+        var exists = await db.PersonalQuestSkillRewards
+            .AnyAsync(sr => sr.PersonalQuestId == id && sr.SkillId == dto.SkillId);
+        if (exists) return TypedResults.Conflict();
+
+        db.PersonalQuestSkillRewards.Add(new PersonalQuestSkillReward
+        {
+            PersonalQuestId = id,
+            SkillId = dto.SkillId
+        });
+        await db.SaveChangesAsync();
+
+        return TypedResults.Created($"/api/personal-quests/{id}/skill-rewards/{dto.SkillId}");
+    }
+
+    private static async Task<NoContent> RemoveSkillReward(int id, int skillId, WorldDbContext db)
+    {
+        var sr = await db.PersonalQuestSkillRewards
+            .FirstOrDefaultAsync(r => r.PersonalQuestId == id && r.SkillId == skillId);
+        if (sr is not null)
+        {
+            db.PersonalQuestSkillRewards.Remove(sr);
+            await db.SaveChangesAsync();
+        }
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<Created, NotFound, Conflict>> AddItemReward(
+        int id, AddItemRewardDto dto, WorldDbContext db)
+    {
+        var quest = await db.PersonalQuests.FindAsync(id);
+        if (quest is null) return TypedResults.NotFound();
+
+        var exists = await db.PersonalQuestItemRewards
+            .AnyAsync(ir => ir.PersonalQuestId == id && ir.ItemId == dto.ItemId);
+        if (exists) return TypedResults.Conflict();
+
+        db.PersonalQuestItemRewards.Add(new PersonalQuestItemReward
+        {
+            PersonalQuestId = id,
+            ItemId = dto.ItemId,
+            Quantity = dto.Quantity
+        });
+        await db.SaveChangesAsync();
+
+        return TypedResults.Created($"/api/personal-quests/{id}/item-rewards/{dto.ItemId}");
+    }
+
+    private static async Task<NoContent> RemoveItemReward(int id, int itemId, WorldDbContext db)
+    {
+        var ir = await db.PersonalQuestItemRewards
+            .FirstOrDefaultAsync(r => r.PersonalQuestId == id && r.ItemId == itemId);
+        if (ir is not null)
+        {
+            db.PersonalQuestItemRewards.Remove(ir);
+            await db.SaveChangesAsync();
+        }
+        return TypedResults.NoContent();
+    }
 }

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -15,6 +15,7 @@ public static class PersonalQuestEndpoints
         group.MapGet("/", GetAll);
         group.MapGet("/{id:int}", GetById);
         group.MapPost("/", Create);
+        group.MapPut("/{id:int}", Update);
 
         return group;
     }
@@ -63,6 +64,27 @@ public static class PersonalQuestEndpoints
         await db.SaveChangesAsync();
 
         return TypedResults.Created($"/api/personal-quests/{q.Id}", ToDetailDto(q));
+    }
+
+    private static async Task<Results<NoContent, NotFound>> Update(int id, UpdatePersonalQuestDto dto, WorldDbContext db)
+    {
+        var q = await db.PersonalQuests.FindAsync(id);
+        if (q is null) return TypedResults.NotFound();
+
+        q.Name = dto.Name;
+        q.Difficulty = dto.Difficulty;
+        q.Description = dto.Description;
+        q.AllowWarrior = dto.AllowWarrior;
+        q.AllowArcher = dto.AllowArcher;
+        q.AllowMage = dto.AllowMage;
+        q.AllowThief = dto.AllowThief;
+        q.QuestCardText = dto.QuestCardText;
+        q.RewardCardText = dto.RewardCardText;
+        q.RewardNote = dto.RewardNote;
+        q.Notes = dto.Notes;
+
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
     }
 
     private static PersonalQuestDetailDto ToDetailDto(PersonalQuest q) => new(

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -18,6 +18,12 @@ public static class PersonalQuestEndpoints
         group.MapPut("/{id:int}", Update);
         group.MapDelete("/{id:int}", Delete);
 
+        // Per-game link endpoints
+        group.MapGet("/by-game/{gameId:int}", GetByGame);
+        group.MapPost("/game-link", CreateGameLink);
+        group.MapPut("/game-link/{gameId:int}/{pqId:int}", UpdateGameLink);
+        group.MapDelete("/game-link/{gameId:int}/{pqId:int}", DeleteGameLink);
+
         return group;
     }
 
@@ -111,4 +117,93 @@ public static class PersonalQuestEndpoints
         q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
         q.SkillRewards.Select(sr => sr.SkillId).ToList(),
         q.ItemRewards.Select(ir => new PersonalQuestItemRewardSummary(ir.ItemId, ir.Item.Name, ir.Quantity)).ToList());
+
+    // ---------- Per-game link endpoints ----------
+
+    private static async Task<Ok<List<GamePersonalQuestListDto>>> GetByGame(int gameId, WorldDbContext db)
+    {
+        var gpqs = await db.GamePersonalQuests
+            .AsNoTracking()
+            .Where(g => g.GameId == gameId)
+            .Include(g => g.PersonalQuest).ThenInclude(q => q.SkillRewards).ThenInclude(sr => sr.Skill)
+            .Include(g => g.PersonalQuest).ThenInclude(q => q.ItemRewards).ThenInclude(ir => ir.Item)
+            .OrderBy(g => g.PersonalQuest.Name)
+            .ToListAsync();
+
+        return TypedResults.Ok(gpqs.Select(ToGameListDto).ToList());
+    }
+
+    private static async Task<Results<Created<GamePersonalQuestDto>, Conflict>> CreateGameLink(
+        CreateGamePersonalQuestDto dto, WorldDbContext db)
+    {
+        var exists = await db.GamePersonalQuests
+            .AnyAsync(g => g.GameId == dto.GameId && g.PersonalQuestId == dto.PersonalQuestId);
+        if (exists) return TypedResults.Conflict();
+
+        var gpq = new GamePersonalQuest
+        {
+            GameId = dto.GameId,
+            PersonalQuestId = dto.PersonalQuestId,
+            XpCost = dto.XpCost,
+            PerKingdomLimit = dto.PerKingdomLimit
+        };
+        db.GamePersonalQuests.Add(gpq);
+        await db.SaveChangesAsync();
+
+        return TypedResults.Created(
+            $"/api/personal-quests/game-link/{gpq.GameId}/{gpq.PersonalQuestId}",
+            new GamePersonalQuestDto(gpq.GameId, gpq.PersonalQuestId, gpq.XpCost, gpq.PerKingdomLimit));
+    }
+
+    private static async Task<Results<NoContent, NotFound>> UpdateGameLink(
+        int gameId, int pqId, UpdateGamePersonalQuestDto dto, WorldDbContext db)
+    {
+        var gpq = await db.GamePersonalQuests.FindAsync(gameId, pqId);
+        if (gpq is null) return TypedResults.NotFound();
+
+        gpq.XpCost = dto.XpCost;
+        gpq.PerKingdomLimit = dto.PerKingdomLimit;
+        await db.SaveChangesAsync();
+
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound>> DeleteGameLink(
+        int gameId, int pqId, WorldDbContext db)
+    {
+        var gpq = await db.GamePersonalQuests.FindAsync(gameId, pqId);
+        if (gpq is null) return TypedResults.NotFound();
+
+        db.GamePersonalQuests.Remove(gpq);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static GamePersonalQuestListDto ToGameListDto(GamePersonalQuest g)
+    {
+        var q = g.PersonalQuest;
+        return new GamePersonalQuestListDto(
+            q.Id, q.Name, q.Description, q.Difficulty,
+            q.AllowWarrior, q.AllowArcher, q.AllowMage, q.AllowThief,
+            q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
+            g.GameId, g.XpCost, g.PerKingdomLimit,
+            BuildRewardSummary(q));
+    }
+
+    private static string? BuildRewardSummary(PersonalQuest q)
+    {
+        var parts = new List<string>();
+        if (q.SkillRewards.Count > 0)
+        {
+            parts.Add(string.Join(", ",
+                q.SkillRewards.OrderBy(s => s.Skill.Name).Select(s => s.Skill.Name)));
+        }
+        if (q.ItemRewards.Count > 0)
+        {
+            parts.Add(string.Join(", ",
+                q.ItemRewards.OrderBy(i => i.Item.Name).Select(i => $"{i.Item.Name} ×{i.Quantity}")));
+        }
+        return parts.Count > 0 ? string.Join(" │ ", parts) : null;
+    }
+
 }

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -13,6 +13,7 @@ public static class PersonalQuestEndpoints
         var group = routes.MapGroup("/api/personal-quests").WithTags("PersonalQuests");
 
         group.MapGet("/", GetAll);
+        group.MapGet("/{id:int}", GetById);
         group.MapPost("/", Create);
 
         return group;
@@ -28,6 +29,18 @@ public static class PersonalQuestEndpoints
             .ToListAsync();
 
         return TypedResults.Ok(quests.Select(ToListDto).ToList());
+    }
+
+    private static async Task<Results<Ok<PersonalQuestDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
+    {
+        var q = await db.PersonalQuests
+            .AsNoTracking()
+            .Include(pq => pq.SkillRewards).ThenInclude(sr => sr.Skill)
+            .Include(pq => pq.ItemRewards).ThenInclude(ir => ir.Item)
+            .FirstOrDefaultAsync(pq => pq.Id == id);
+        if (q is null) return TypedResults.NotFound();
+
+        return TypedResults.Ok(ToDetailDto(q));
     }
 
     private static async Task<Created<PersonalQuestDetailDto>> Create(CreatePersonalQuestDto dto, WorldDbContext db)

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -235,15 +235,13 @@ public static class PersonalQuestEndpoints
         return TypedResults.Created($"/api/personal-quests/{id}/skill-rewards/{dto.SkillId}");
     }
 
-    private static async Task<NoContent> RemoveSkillReward(int id, int skillId, WorldDbContext db)
+    private static async Task<Results<NoContent, NotFound>> RemoveSkillReward(int id, int skillId, WorldDbContext db)
     {
-        var sr = await db.PersonalQuestSkillRewards
-            .FirstOrDefaultAsync(r => r.PersonalQuestId == id && r.SkillId == skillId);
-        if (sr is not null)
-        {
-            db.PersonalQuestSkillRewards.Remove(sr);
-            await db.SaveChangesAsync();
-        }
+        var sr = await db.PersonalQuestSkillRewards.FindAsync(id, skillId);
+        if (sr is null) return TypedResults.NotFound();
+
+        db.PersonalQuestSkillRewards.Remove(sr);
+        await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }
 
@@ -268,15 +266,13 @@ public static class PersonalQuestEndpoints
         return TypedResults.Created($"/api/personal-quests/{id}/item-rewards/{dto.ItemId}");
     }
 
-    private static async Task<NoContent> RemoveItemReward(int id, int itemId, WorldDbContext db)
+    private static async Task<Results<NoContent, NotFound>> RemoveItemReward(int id, int itemId, WorldDbContext db)
     {
-        var ir = await db.PersonalQuestItemRewards
-            .FirstOrDefaultAsync(r => r.PersonalQuestId == id && r.ItemId == itemId);
-        if (ir is not null)
-        {
-            db.PersonalQuestItemRewards.Remove(ir);
-            await db.SaveChangesAsync();
-        }
+        var ir = await db.PersonalQuestItemRewards.FindAsync(id, itemId);
+        if (ir is null) return TypedResults.NotFound();
+
+        db.PersonalQuestItemRewards.Remove(ir);
+        await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Endpoints;
+
+public static class PersonalQuestEndpoints
+{
+    public static RouteGroupBuilder MapPersonalQuestEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/personal-quests").WithTags("PersonalQuests");
+
+        group.MapGet("/", GetAll);
+
+        return group;
+    }
+
+    private static async Task<Ok<List<PersonalQuestListDto>>> GetAll(WorldDbContext db)
+    {
+        var quests = await db.PersonalQuests
+            .AsNoTracking()
+            .Include(q => q.SkillRewards)
+            .Include(q => q.ItemRewards).ThenInclude(r => r.Item)
+            .OrderBy(q => q.Name)
+            .ToListAsync();
+
+        return TypedResults.Ok(quests.Select(ToListDto).ToList());
+    }
+
+    private static PersonalQuestListDto ToListDto(PersonalQuest q) => new(
+        q.Id, q.Name, q.Description, q.Difficulty,
+        q.AllowWarrior, q.AllowArcher, q.AllowMage, q.AllowThief,
+        q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
+        q.SkillRewards.Select(sr => sr.SkillId).ToList(),
+        q.ItemRewards.Select(ir => new PersonalQuestItemRewardSummary(ir.ItemId, ir.Item.Name, ir.Quantity)).ToList());
+}

--- a/src/OvcinaHra.Api/Migrations/20260419165216_AddPersonalQuestDomain.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260419165216_AddPersonalQuestDomain.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419165216_AddPersonalQuestDomain")]
+    partial class AddPersonalQuestDomain
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260419165216_AddPersonalQuestDomain.cs
+++ b/src/OvcinaHra.Api/Migrations/20260419165216_AddPersonalQuestDomain.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPersonalQuestDomain : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PersonalQuests",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    Difficulty = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    AllowWarrior = table.Column<bool>(type: "boolean", nullable: false),
+                    AllowArcher = table.Column<bool>(type: "boolean", nullable: false),
+                    AllowMage = table.Column<bool>(type: "boolean", nullable: false),
+                    AllowThief = table.Column<bool>(type: "boolean", nullable: false),
+                    QuestCardText = table.Column<string>(type: "text", nullable: true),
+                    RewardCardText = table.Column<string>(type: "text", nullable: true),
+                    RewardNote = table.Column<string>(type: "text", nullable: true),
+                    Notes = table.Column<string>(type: "text", nullable: true),
+                    ImagePath = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PersonalQuests", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "GamePersonalQuests",
+                columns: table => new
+                {
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    PersonalQuestId = table.Column<int>(type: "integer", nullable: false),
+                    XpCost = table.Column<int>(type: "integer", nullable: false),
+                    PerKingdomLimit = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GamePersonalQuests", x => new { x.GameId, x.PersonalQuestId });
+                    table.CheckConstraint("CK_GamePersonalQuest_PKL_Positive", "\"PerKingdomLimit\" IS NULL OR \"PerKingdomLimit\" >= 1");
+                    table.CheckConstraint("CK_GamePersonalQuest_XpCost_NonNegative", "\"XpCost\" >= 0");
+                    table.ForeignKey(
+                        name: "FK_GamePersonalQuests_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GamePersonalQuests_PersonalQuests_PersonalQuestId",
+                        column: x => x.PersonalQuestId,
+                        principalTable: "PersonalQuests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CharacterPersonalQuests",
+                columns: table => new
+                {
+                    CharacterId = table.Column<int>(type: "integer", nullable: false),
+                    PersonalQuestId = table.Column<int>(type: "integer", nullable: false),
+                    AssignedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CompletedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CharacterPersonalQuests", x => x.CharacterId);
+                    table.ForeignKey(
+                        name: "FK_CharacterPersonalQuests_Characters_CharacterId",
+                        column: x => x.CharacterId,
+                        principalTable: "Characters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CharacterPersonalQuests_PersonalQuests_PersonalQuestId",
+                        column: x => x.PersonalQuestId,
+                        principalTable: "PersonalQuests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PersonalQuestItemRewards",
+                columns: table => new
+                {
+                    PersonalQuestId = table.Column<int>(type: "integer", nullable: false),
+                    ItemId = table.Column<int>(type: "integer", nullable: false),
+                    Quantity = table.Column<int>(type: "integer", nullable: false, defaultValue: 1)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PersonalQuestItemRewards", x => new { x.PersonalQuestId, x.ItemId });
+                    table.CheckConstraint("CK_PQItemReward_Qty_Positive", "\"Quantity\" >= 1");
+                    table.ForeignKey(
+                        name: "FK_PersonalQuestItemRewards_Items_ItemId",
+                        column: x => x.ItemId,
+                        principalTable: "Items",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_PersonalQuestItemRewards_PersonalQuests_PersonalQuestId",
+                        column: x => x.PersonalQuestId,
+                        principalTable: "PersonalQuests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PersonalQuestSkillRewards",
+                columns: table => new
+                {
+                    PersonalQuestId = table.Column<int>(type: "integer", nullable: false),
+                    SkillId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PersonalQuestSkillRewards", x => new { x.PersonalQuestId, x.SkillId });
+                    table.ForeignKey(
+                        name: "FK_PersonalQuestSkillRewards_PersonalQuests_PersonalQuestId",
+                        column: x => x.PersonalQuestId,
+                        principalTable: "PersonalQuests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PersonalQuestSkillRewards_Skills_SkillId",
+                        column: x => x.SkillId,
+                        principalTable: "Skills",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GamePersonalQuests_GameId",
+                table: "GamePersonalQuests",
+                column: "GameId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GamePersonalQuests_PersonalQuestId",
+                table: "GamePersonalQuests",
+                column: "PersonalQuestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CharacterPersonalQuests_PersonalQuestId",
+                table: "CharacterPersonalQuests",
+                column: "PersonalQuestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersonalQuestItemRewards_ItemId",
+                table: "PersonalQuestItemRewards",
+                column: "ItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersonalQuests_Name",
+                table: "PersonalQuests",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersonalQuestSkillRewards_SkillId",
+                table: "PersonalQuestSkillRewards",
+                column: "SkillId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GamePersonalQuests");
+
+            migrationBuilder.DropTable(
+                name: "CharacterPersonalQuests");
+
+            migrationBuilder.DropTable(
+                name: "PersonalQuestItemRewards");
+
+            migrationBuilder.DropTable(
+                name: "PersonalQuestSkillRewards");
+
+            migrationBuilder.DropTable(
+                name: "PersonalQuests");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -195,6 +195,7 @@ try
     app.MapSkillEndpoints().RequireAuthorization();
     app.MapCraftingEndpoints().RequireAuthorization();
     app.MapTreasureQuestEndpoints().RequireAuthorization();
+    app.MapPersonalQuestEndpoints().RequireAuthorization();
     app.MapTreasurePlanningEndpoints().RequireAuthorization();
     app.MapTimelineEndpoints().RequireAuthorization();
     app.MapGameEventEndpoints();

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -46,6 +46,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="personal-quests">
+                <i class="bi bi-person-workspace"></i><span class="nav-label">Osobní questy</span>
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="buildings">
                 <i class="bi bi-houses-fill"></i><span class="nav-label">Budovy</span>
             </NavLink>
@@ -105,6 +110,11 @@
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="quests?catalog=true">
                 <i class="bi bi-journal-text"></i><span class="nav-label">Questy</span>
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="personal-quests?catalog=true">
+                <i class="bi bi-person-workspace"></i><span class="nav-label">Osobní questy</span>
             </NavLink>
         </div>
         <div class="nav-item px-3">

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.5.3</Version>
+    <Version>0.6.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
@@ -630,9 +630,11 @@ else
         try
         {
             await PqSvc.UpdateGameLinkAsync(GameContext.SelectedGameId.Value, editingId.Value, gpqXpCost, gpqPerKingdomLimit);
+            await LoadGamePersonalQuestAsync(editingId.Value);
+            await LoadAsync();
         }
         catch (Exception ex) { error = ex.Message; }
-        finally { isSaving = false; }
+        finally { isSaving = false; StateHasChanged(); }
     }
 
     private async Task RemoveGamePersonalQuestAsync()
@@ -643,6 +645,7 @@ else
         {
             await PqSvc.DeleteGameLinkAsync(GameContext.SelectedGameId.Value, editingId.Value);
             gpqExists = false;
+            await LoadAsync();
         }
         catch (Exception ex) { error = ex.Message; }
         finally { isSaving = false; StateHasChanged(); }

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
@@ -1,9 +1,11 @@
 @page "/personal-quests"
 @attribute [Authorize]
 @implements IDisposable
+@inject ApiClient Api
 @inject GameContextService GameContext
 @inject NavigationManager Nav
 @inject PersonalQuestService PqSvc
+@inject SkillService SkillSvc
 
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">@(Catalog ? "Katalog osobních questů" : "Osobní questy")</h1>
@@ -93,6 +95,200 @@ else
     <p>Game grid here — Batch E2</p>
 }
 
+<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="900px">
+    <BodyContentTemplate Context="popupContext">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                <DxTextBox @bind-Text="@name" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Obtížnost" ColSpanMd="6">
+                <DxComboBox Data="@difficultyValues" @bind-Value="@difficulty"
+                            TextFieldName="Display" ValueFieldName="Value" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
+                <DxTextBox @bind-Text="@description" />
+            </DxFormLayoutItem>
+            <DxFormLayoutGroup Caption="Povolání" ColSpanMd="12">
+                <DxFormLayoutItem Caption="" ColSpanMd="3">
+                    <DxCheckBox @bind-Checked="@allowWarrior">@PlayerClass.Warrior.GetDisplayName()</DxCheckBox>
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="" ColSpanMd="3">
+                    <DxCheckBox @bind-Checked="@allowArcher">@PlayerClass.Archer.GetDisplayName()</DxCheckBox>
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="" ColSpanMd="3">
+                    <DxCheckBox @bind-Checked="@allowMage">@PlayerClass.Mage.GetDisplayName()</DxCheckBox>
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="" ColSpanMd="3">
+                    <DxCheckBox @bind-Checked="@allowThief">@PlayerClass.Thief.GetDisplayName()</DxCheckBox>
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+            <DxFormLayoutItem Caption="Kartička questu" ColSpanMd="12">
+                <DxMemo @bind-Text="@questCardText" Rows="5" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Kartičky odměn" ColSpanMd="12">
+                <DxMemo @bind-Text="@rewardCardText" Rows="5" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Ostatní odměny" ColSpanMd="12">
+                <DxTextBox @bind-Text="@rewardNote" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
+                <DxMemo @bind-Text="@notes" Rows="3" />
+            </DxFormLayoutItem>
+            @if (editingId.HasValue)
+            {
+                <DxFormLayoutItem Caption="Obrázek" ColSpanMd="12">
+                    <ImagePicker EntityType="personal-quests" EntityId="editingId.Value" Alt="Obrázek osobního questu" />
+                </DxFormLayoutItem>
+            }
+        </DxFormLayout>
+
+        @* Rewards card — only for existing quests *@
+        @if (editingId.HasValue)
+        {
+            <div class="mt-3 p-3 border rounded" style="background: var(--oh-surface);">
+                <h6 class="mb-2"><i class="bi bi-gift-fill me-1"></i> Odměny</h6>
+
+                <div class="mb-3">
+                    <strong class="small">Dovednosti:</strong>
+                    @if (detailSkillRewards.Count > 0)
+                    {
+                        <div class="mt-1 mb-2">
+                            @foreach (var sr in detailSkillRewards)
+                            {
+                                <span class="badge bg-secondary me-1">
+                                    @sr.SkillName
+                                    <button class="btn btn-sm btn-link text-white p-0 ms-1"
+                                            @onclick="() => RemoveSkillRewardAsync(sr.SkillId)">
+                                        <i class="bi bi-x"></i>
+                                    </button>
+                                </span>
+                            }
+                        </div>
+                    }
+                    else
+                    {
+                        <span class="text-muted small ms-2">Žádné dovednosti.</span>
+                    }
+                    <div class="d-flex gap-2 align-items-end mt-1">
+                        <div style="flex:1">
+                            <DxComboBox Data="@SkillsNotYetAdded" @bind-Value="@newSkillId"
+                                        TextFieldName="Name" ValueFieldName="Id"
+                                        NullText="(přidat dovednost)" SearchMode="ListSearchMode.AutoSearch" />
+                        </div>
+                        <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                                disabled="@(newSkillId is null)"
+                                @onclick="AddSkillRewardAsync">
+                            <i class="bi bi-plus me-1"></i>Přidat
+                        </button>
+                    </div>
+                </div>
+
+                <div class="mb-1">
+                    <strong class="small">Předměty:</strong>
+                    @if (detailItemRewards.Count > 0)
+                    {
+                        <div class="mt-1 mb-2">
+                            @foreach (var ir in detailItemRewards)
+                            {
+                                <span class="badge bg-secondary me-1">
+                                    @ir.ItemName ×@ir.Quantity
+                                    <button class="btn btn-sm btn-link text-white p-0 ms-1"
+                                            @onclick="() => RemoveItemRewardAsync(ir.ItemId)">
+                                        <i class="bi bi-x"></i>
+                                    </button>
+                                </span>
+                            }
+                        </div>
+                    }
+                    else
+                    {
+                        <span class="text-muted small ms-2">Žádné předměty.</span>
+                    }
+                    <div class="d-flex gap-2 align-items-end mt-1">
+                        <div style="flex:1">
+                            <DxComboBox Data="@ItemsNotYetAdded" @bind-Value="@newItemId"
+                                        TextFieldName="Name" ValueFieldName="Id"
+                                        NullText="(přidat předmět)" SearchMode="ListSearchMode.AutoSearch" />
+                        </div>
+                        <div style="width:70px">
+                            <DxSpinEdit @bind-Value="@newItemQuantity" MinValue="1" />
+                        </div>
+                        <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                                disabled="@(newItemId is null)"
+                                @onclick="AddItemRewardAsync">
+                            <i class="bi bi-plus me-1"></i>Přidat
+                        </button>
+                    </div>
+                </div>
+            </div>
+        }
+
+        @* Per-game config card — only when editing + game selected + game view *@
+        @if (editingId.HasValue && !Catalog && GameContext.SelectedGameId.HasValue)
+        {
+            <div class="mt-3 p-3 border rounded" style="background: var(--oh-primary-surface);">
+                <h6 class="mb-2"><i class="bi bi-controller me-1"></i> Nastavení pro aktuální hru</h6>
+                @if (gpqLoading)
+                {
+                    <p class="text-muted small">Načítám...</p>
+                }
+                else if (!gpqExists)
+                {
+                    <p class="text-muted small mb-2">Quest není přiřazen k této hře.</p>
+                    <DxFormLayout>
+                        <DxFormLayoutItem Caption="XP cena" ColSpanMd="6">
+                            <DxSpinEdit @bind-Value="@gpqXpCost" MinValue="0" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Limit na království" ColSpanMd="6">
+                            <DxSpinEdit @bind-Value="@gpqPerKingdomLimit" MinValue="1" NullText="(neomezeno)" />
+                        </DxFormLayoutItem>
+                    </DxFormLayout>
+                    <button class="btn btn-outline-primary btn-sm mt-2" @onclick="AddGamePersonalQuestAsync">
+                        <i class="bi bi-plus-circle me-1"></i>Přidat do hry
+                    </button>
+                }
+                else
+                {
+                    <DxFormLayout>
+                        <DxFormLayoutItem Caption="XP cena" ColSpanMd="6">
+                            <DxSpinEdit @bind-Value="@gpqXpCost" MinValue="0" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Limit na království" ColSpanMd="6">
+                            <DxSpinEdit @bind-Value="@gpqPerKingdomLimit" MinValue="1" NullText="(neomezeno)" />
+                        </DxFormLayoutItem>
+                    </DxFormLayout>
+                    <div class="d-flex gap-2 mt-2">
+                        <button class="btn btn-sm btn-primary" @onclick="SaveGamePersonalQuestAsync" disabled="@isSaving">Uložit nastavení</button>
+                        <button class="btn btn-sm btn-outline-danger" @onclick="RemoveGamePersonalQuestAsync" disabled="@isSaving">Odebrat z hry</button>
+                    </div>
+                }
+            </div>
+        }
+
+        @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
+
+        <div class="d-flex gap-2 mt-3">
+            @if (editingId.HasValue)
+            {
+                <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true" disabled="@isSaving">Smazat</button>
+            }
+            <div style="flex: 1"></div>
+            <button class="btn btn-secondary" @onclick="() => isModalVisible = false" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">Uložit</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete smazat osobní quest <strong>@name</strong>?</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @code {
     [SupplyParameterFromQuery]
     public bool Catalog { get; set; }
@@ -100,7 +296,42 @@ else
     private List<PersonalQuestListDto> catalogItems = [];
     private List<GamePersonalQuestListDto> gameItems = [];
     private HashSet<int> assignedItemIds = [];
-    private bool loading = true;
+    private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
+
+    // Lookup lists for combo boxes
+    private List<SkillDto> allSkills = [];
+    private List<ItemListDto> allItems = [];
+
+    // Form state
+    private string modalTitle = "", name = "";
+    private string? error, description, questCardText, rewardCardText, rewardNote, notes;
+    private int? editingId;
+    private TreasureQuestDifficulty difficulty = TreasureQuestDifficulty.Start;
+    private bool allowWarrior, allowArcher, allowMage, allowThief;
+
+    // Reward pickers
+    private List<SkillRewardDto> detailSkillRewards = [];
+    private List<ItemRewardDto> detailItemRewards = [];
+    private int? newSkillId;
+    private int? newItemId;
+    private int newItemQuantity = 1;
+
+    // Per-game config
+    private bool gpqLoading, gpqExists;
+    private int gpqXpCost;
+    private int? gpqPerKingdomLimit;
+
+    private static readonly List<EnumItem<TreasureQuestDifficulty>> difficultyValues =
+        Enum.GetValues<TreasureQuestDifficulty>()
+            .Select(v => new EnumItem<TreasureQuestDifficulty>(v, v.GetDisplayName())).ToList();
+
+    record EnumItem<T>(T Value, string Display);
+
+    private List<SkillDto> SkillsNotYetAdded =>
+        allSkills.Where(s => !detailSkillRewards.Any(sr => sr.SkillId == s.Id)).ToList();
+
+    private List<ItemListDto> ItemsNotYetAdded =>
+        allItems.Where(i => !detailItemRewards.Any(ir => ir.ItemId == i.Id)).ToList();
 
     private bool _previousCatalog;
 
@@ -110,6 +341,8 @@ else
         _previousCatalog = Catalog;
         GameContext.OnGameChanged += OnGameChanged;
         await LoadAsync();
+        allItems = await Api.GetListAsync<ItemListDto>("/api/items");
+        allSkills = (await SkillSvc.GetAllAsync()).ToList();
     }
 
     protected override async Task OnParametersSetAsync()
@@ -153,8 +386,184 @@ else
         loading = false;
     }
 
-    // Popup + detail flow comes in Batch E2.
-    private void OpenModal(PersonalQuestListDto? item) { /* Batch E2 */ }
+    private void OpenModal(PersonalQuestListDto? item)
+    {
+        error = null;
+        if (item is null)
+        {
+            ResetForm();
+            modalTitle = "Nový osobní quest";
+        }
+        else
+        {
+            OpenExistingModal(item.Id, item.Name);
+            return;
+        }
+        isModalVisible = true;
+    }
+
+    private void OpenModal(GamePersonalQuestListDto item)
+    {
+        error = null;
+        OpenExistingModal(item.Id, item.Name);
+    }
+
+    private void OpenExistingModal(int id, string questName)
+    {
+        editingId = id;
+        name = questName;
+        modalTitle = $"Upravit: {questName}";
+        _ = LoadDetailAsync(id);
+        isModalVisible = true;
+    }
+
+    private void ResetForm()
+    {
+        editingId = null;
+        name = "";
+        description = null;
+        difficulty = TreasureQuestDifficulty.Start;
+        allowWarrior = allowArcher = allowMage = allowThief = false;
+        questCardText = rewardCardText = rewardNote = notes = null;
+        detailSkillRewards = [];
+        detailItemRewards = [];
+        newSkillId = null;
+        newItemId = null;
+        newItemQuantity = 1;
+        gpqExists = false;
+        gpqXpCost = 0;
+        gpqPerKingdomLimit = null;
+    }
+
+    private async Task LoadDetailAsync(int id)
+    {
+        var d = await PqSvc.GetByIdAsync(id);
+        if (d is not null)
+        {
+            description = d.Description;
+            difficulty = d.Difficulty;
+            allowWarrior = d.AllowWarrior;
+            allowArcher = d.AllowArcher;
+            allowMage = d.AllowMage;
+            allowThief = d.AllowThief;
+            questCardText = d.QuestCardText;
+            rewardCardText = d.RewardCardText;
+            rewardNote = d.RewardNote;
+            notes = d.Notes;
+            detailSkillRewards = d.SkillRewards.ToList();
+            detailItemRewards = d.ItemRewards.ToList();
+        }
+        await LoadGamePersonalQuestAsync(id);
+        StateHasChanged();
+    }
+
+    private async Task LoadGamePersonalQuestAsync(int pqId)
+    {
+        gpqExists = false;
+        gpqLoading = true;
+        var gameId = GameContext.SelectedGameId;
+        if (gameId is null) { gpqLoading = false; return; }
+
+        var list = await PqSvc.GetByGameAsync(gameId.Value);
+        var gpq = list.FirstOrDefault(g => g.Id == pqId);
+        if (gpq is not null)
+        {
+            gpqExists = true;
+            gpqXpCost = gpq.XpCost;
+            gpqPerKingdomLimit = gpq.PerKingdomLimit;
+        }
+        else
+        {
+            gpqXpCost = 0;
+            gpqPerKingdomLimit = null;
+        }
+        gpqLoading = false;
+    }
+
+    private async Task AddSkillRewardAsync()
+    {
+        if (editingId is null || newSkillId is null) return;
+        try
+        {
+            await PqSvc.AddSkillRewardAsync(editingId.Value, newSkillId.Value);
+            newSkillId = null;
+            await LoadDetailAsync(editingId.Value);
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task RemoveSkillRewardAsync(int skillId)
+    {
+        if (editingId is null) return;
+        try
+        {
+            await PqSvc.RemoveSkillRewardAsync(editingId.Value, skillId);
+            await LoadDetailAsync(editingId.Value);
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task AddItemRewardAsync()
+    {
+        if (editingId is null || newItemId is null) return;
+        try
+        {
+            await PqSvc.AddItemRewardAsync(editingId.Value, newItemId.Value, newItemQuantity);
+            newItemId = null;
+            newItemQuantity = 1;
+            await LoadDetailAsync(editingId.Value);
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task RemoveItemRewardAsync(int itemId)
+    {
+        if (editingId is null) return;
+        try
+        {
+            await PqSvc.RemoveItemRewardAsync(editingId.Value, itemId);
+            await LoadDetailAsync(editingId.Value);
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task AddGamePersonalQuestAsync()
+    {
+        if (editingId is null || GameContext.SelectedGameId is null) return;
+        isSaving = true;
+        try
+        {
+            await PqSvc.CreateGameLinkAsync(GameContext.SelectedGameId.Value, editingId.Value, gpqXpCost, gpqPerKingdomLimit);
+            await LoadGamePersonalQuestAsync(editingId.Value);
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; StateHasChanged(); }
+    }
+
+    private async Task SaveGamePersonalQuestAsync()
+    {
+        if (editingId is null || GameContext.SelectedGameId is null) return;
+        isSaving = true;
+        try
+        {
+            await PqSvc.UpdateGameLinkAsync(GameContext.SelectedGameId.Value, editingId.Value, gpqXpCost, gpqPerKingdomLimit);
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task RemoveGamePersonalQuestAsync()
+    {
+        if (editingId is null || GameContext.SelectedGameId is null) return;
+        isSaving = true;
+        try
+        {
+            await PqSvc.DeleteGameLinkAsync(GameContext.SelectedGameId.Value, editingId.Value);
+            gpqExists = false;
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; StateHasChanged(); }
+    }
 
     private async Task AssignToGameAsync(int pqId)
     {
@@ -170,5 +579,46 @@ else
         await PqSvc.DeleteGameLinkAsync(GameContext.SelectedGameId.Value, pqId);
         await LoadAsync();
         StateHasChanged();
+    }
+
+    private async Task SaveAsync()
+    {
+        error = null;
+        isSaving = true;
+        try
+        {
+            if (editingId.HasValue)
+            {
+                await PqSvc.UpdateAsync(editingId.Value,
+                    new UpdatePersonalQuestDto(name, difficulty, description,
+                        allowWarrior, allowArcher, allowMage, allowThief,
+                        questCardText, rewardCardText, rewardNote, notes));
+            }
+            else
+            {
+                var created = await PqSvc.CreateAsync(
+                    new CreatePersonalQuestDto(name, difficulty, description,
+                        allowWarrior, allowArcher, allowMage, allowThief,
+                        questCardText, rewardCardText, rewardNote, notes));
+                if (!Catalog && GameContext.SelectedGameId is int gid && created is not null)
+                    await PqSvc.CreateGameLinkAsync(gid, created.Id);
+            }
+            isModalVisible = false;
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        try
+        {
+            await PqSvc.DeleteAsync(editingId!.Value);
+            isDeleteVisible = false;
+            isModalVisible = false;
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
     }
 }

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
@@ -1,6 +1,6 @@
 @page "/personal-quests"
 @attribute [Authorize]
-@inject ApiClient Api
+@implements IDisposable
 @inject GameContextService GameContext
 @inject NavigationManager Nav
 @inject PersonalQuestService PqSvc
@@ -60,6 +60,7 @@ else if (Catalog)
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="DifficultyDisplay" Caption="Obtížnost" Width="130px" />
             <DxGridDataColumn FieldName="Description" Caption="Popis" />
+            <DxGridDataColumn FieldName="RewardSummary" Caption="Odměny" Width="340px" />
             <DxGridDataColumn FieldName="RewardNote" Caption="Ostatní odměny" Visible="false" />
             <DxGridDataColumn FieldName="QuestCardText" Caption="Kartička questu" Visible="false" />
             <DxGridDataColumn FieldName="RewardCardText" Caption="Kartičky odměn" Visible="false" />
@@ -107,6 +108,7 @@ else
     {
         await GameContext.InitializeAsync();
         _previousCatalog = Catalog;
+        GameContext.OnGameChanged += OnGameChanged;
         await LoadAsync();
     }
 
@@ -118,6 +120,10 @@ else
             await LoadAsync();
         }
     }
+
+    private async void OnGameChanged() { await LoadAsync(); StateHasChanged(); }
+
+    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
 
     private async Task LoadAsync()
     {

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
@@ -1,0 +1,168 @@
+@page "/personal-quests"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject GameContextService GameContext
+@inject NavigationManager Nav
+@inject PersonalQuestService PqSvc
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">@(Catalog ? "Katalog osobních questů" : "Osobní questy")</h1>
+    <div class="d-flex gap-2">
+        <div class="d-flex gap-2">
+            <button class="btn btn-sm @(Catalog ? "btn-outline-primary" : "btn-primary")"
+                    @onclick='() => Nav.NavigateTo("/personal-quests")'>Jen tato hra</button>
+            <button class="btn btn-sm @(Catalog ? "btn-primary" : "btn-outline-primary")"
+                    @onclick='() => Nav.NavigateTo("/personal-quests?catalog=true")'>Katalog</button>
+        </div>
+        <button class="btn btn-primary" @onclick="() => OpenModal((PersonalQuestListDto?)null)">+ Nový osobní quest</button>
+    </div>
+</div>
+
+@if (loading)
+{
+    <p>Načítám...</p>
+}
+else if (!Catalog && GameContext.SelectedGameId is null)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-controller fs-1 d-block mb-2"></i>
+        <p>Vyber nejprve hru z přepínače nahoře, nebo otevři katalog všech osobních questů.</p>
+        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/personal-quests?catalog=true")'>Otevřít katalog</button>
+    </div>
+}
+else if (!Catalog && gameItems.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-person-workspace fs-1 d-block mb-2"></i>
+        <p>Žádné osobní questy přiřazené k této hře.</p>
+        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/personal-quests?catalog=true")'>Otevřít katalog</button>
+    </div>
+}
+else if (Catalog)
+{
+    <OvcinaGrid Data="@catalogItems" KeyFieldName="Id" LayoutKey="grid-layout-personal-quests-catalog"
+                RowClick="@(e => OpenModal((PersonalQuestListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+        <Columns>
+            <DxGridDataColumn FieldName="Id" Caption="#" Width="60px" Visible="false" />
+            <DxGridDataColumn FieldName="Name" Caption="Název" />
+            <DxGridDataColumn FieldName="ClassRestrictionDisplay" Caption="Povolání" Width="180px" />
+            <DxGridDataColumn FieldName="AllowWarrior" Caption="Váleč." Width="80px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="AllowArcher" Caption="Střelec" Width="80px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="AllowMage" Caption="Mág" Width="80px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="AllowThief" Caption="Zloděj" Width="80px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="DifficultyDisplay" Caption="Obtížnost" Width="130px" />
+            <DxGridDataColumn FieldName="Description" Caption="Popis" />
+            <DxGridDataColumn FieldName="RewardNote" Caption="Ostatní odměny" Visible="false" />
+            <DxGridDataColumn FieldName="QuestCardText" Caption="Kartička questu" Visible="false" />
+            <DxGridDataColumn FieldName="RewardCardText" Caption="Kartičky odměn" Visible="false" />
+            <DxGridDataColumn FieldName="Notes" Caption="Poznámky" Visible="false" />
+            <DxGridDataColumn FieldName="HasImage" Caption="Obrázek" Width="100px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false" AllowFilter="false">
+                <CellDisplayTemplate>
+                    @{
+                        var pqId = (int)context.Value;
+                        if (assignedItemIds.Contains(pqId))
+                        {
+                            <button class="btn btn-sm btn-outline-danger" @onclick:stopPropagation="true"
+                                    @onclick="() => UnassignFromGameAsync(pqId)">Odebrat</button>
+                        }
+                        else
+                        {
+                            <button class="btn btn-sm btn-outline-success" @onclick:stopPropagation="true"
+                                    @onclick="() => AssignToGameAsync(pqId)">Přidat</button>
+                        }
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+        </Columns>
+    </OvcinaGrid>
+}
+else
+{
+    <p>Game grid here — Batch E2</p>
+}
+
+@code {
+    [SupplyParameterFromQuery]
+    public bool Catalog { get; set; }
+
+    private List<PersonalQuestListDto> catalogItems = [];
+    private List<GamePersonalQuestListDto> gameItems = [];
+    private HashSet<int> assignedItemIds = [];
+    private bool loading = true;
+
+    private bool _previousCatalog;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        _previousCatalog = Catalog;
+        await LoadAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Catalog != _previousCatalog)
+        {
+            _previousCatalog = Catalog;
+            await LoadAsync();
+        }
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+
+        if (!Catalog && GameContext.SelectedGameId is int gid)
+        {
+            gameItems = await PqSvc.GetByGameAsync(gid);
+            assignedItemIds = gameItems.Select(gi => gi.Id).ToHashSet();
+            catalogItems = [];
+        }
+        else
+        {
+            catalogItems = await PqSvc.GetAllAsync();
+            gameItems = [];
+            if (Catalog && GameContext.SelectedGameId is int catalogGid)
+            {
+                var linked = await PqSvc.GetByGameAsync(catalogGid);
+                assignedItemIds = linked.Select(gi => gi.Id).ToHashSet();
+            }
+            else
+            {
+                assignedItemIds = [];
+            }
+        }
+
+        loading = false;
+    }
+
+    // Popup + detail flow comes in Batch E2.
+    private void OpenModal(PersonalQuestListDto? item) { /* Batch E2 */ }
+
+    private async Task AssignToGameAsync(int pqId)
+    {
+        if (GameContext.SelectedGameId is null) return;
+        await PqSvc.CreateGameLinkAsync(GameContext.SelectedGameId.Value, pqId);
+        await LoadAsync();
+        StateHasChanged();
+    }
+
+    private async Task UnassignFromGameAsync(int pqId)
+    {
+        if (GameContext.SelectedGameId is null) return;
+        await PqSvc.DeleteGameLinkAsync(GameContext.SelectedGameId.Value, pqId);
+        await LoadAsync();
+        StateHasChanged();
+    }
+}

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
@@ -92,7 +92,56 @@ else if (Catalog)
 }
 else
 {
-    <p>Game grid here — Batch E2</p>
+    <OvcinaGrid Data="@gameItems" KeyFieldName="Id" LayoutKey="grid-layout-personal-quests-game"
+                RowClick="@(e => OpenModal((GamePersonalQuestListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+        <Columns>
+            <DxGridDataColumn FieldName="" Caption="" Width="40px" AllowSort="false" AllowGroup="false" AllowFilter="false" FixedPosition="GridColumnFixedPosition.Left">
+                <CellDisplayTemplate>
+                    @{
+                        var gi = (GamePersonalQuestListDto)context.DataItem;
+                    }
+                    <button class="btn btn-sm btn-link p-0 text-muted" @onclick="async e => await ShowContextMenu(e, gi)" @onclick:stopPropagation="true">
+                        <i class="bi bi-three-dots-vertical"></i>
+                    </button>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Id" Caption="#" Width="60px" Visible="false" />
+            <DxGridDataColumn FieldName="Name" Caption="Název" />
+            <DxGridDataColumn FieldName="ClassRestrictionDisplay" Caption="Povolání" Width="180px" />
+            <DxGridDataColumn FieldName="AllowWarrior" Caption="Váleč." Width="80px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="AllowArcher" Caption="Střelec" Width="80px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="AllowMage" Caption="Mág" Width="80px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="AllowThief" Caption="Zloděj" Width="80px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="DifficultyDisplay" Caption="Obtížnost" Width="130px" />
+            <DxGridDataColumn FieldName="Description" Caption="Popis" />
+            <DxGridDataColumn FieldName="RewardSummary" Caption="Odměny" Width="340px" />
+            <DxGridDataColumn FieldName="RewardNote" Caption="Ostatní odměny" Visible="false" />
+            <DxGridDataColumn FieldName="QuestCardText" Caption="Kartička questu" Visible="false" />
+            <DxGridDataColumn FieldName="RewardCardText" Caption="Kartičky odměn" Visible="false" />
+            <DxGridDataColumn FieldName="Notes" Caption="Poznámky" Visible="false" />
+            <DxGridDataColumn FieldName="HasImage" Caption="Obrázek" Width="100px" Visible="false">
+                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="XpCost" Caption="XP cena" Width="100px" />
+            <DxGridDataColumn FieldName="PerKingdomLimit" Caption="Limit / království" Width="150px" />
+        </Columns>
+    </OvcinaGrid>
+
+    <DxContextMenu @ref="contextMenu" ItemClick="OnContextMenuItemClick">
+        <Items>
+            <DxContextMenuItem Text="Upravit" IconCssClass="bi bi-pencil-fill" Name="edit" />
+            <DxContextMenuItem Text="Odebrat z hry" IconCssClass="bi bi-x-circle" Name="unassign" />
+            <DxContextMenuItem BeginGroup="true" Text="Smazat" IconCssClass="bi bi-trash-fill" CssClass="text-danger" Name="delete" />
+        </Items>
+    </DxContextMenu>
 }
 
 <DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="900px">
@@ -302,6 +351,11 @@ else
     private List<SkillDto> allSkills = [];
     private List<ItemListDto> allItems = [];
 
+    // Context menu (game view only)
+    private DxContextMenu? contextMenu;
+    private int? contextMenuTargetId;
+    private string contextMenuTargetName = "";
+
     // Form state
     private string modalTitle = "", name = "";
     private string? error, description, questCardText, rewardCardText, rewardNote, notes;
@@ -478,6 +532,35 @@ else
             gpqPerKingdomLimit = null;
         }
         gpqLoading = false;
+    }
+
+    private async Task ShowContextMenu(Microsoft.AspNetCore.Components.Web.MouseEventArgs e, GamePersonalQuestListDto gi)
+    {
+        contextMenuTargetId = gi.Id;
+        contextMenuTargetName = gi.Name;
+        await contextMenu!.ShowAsync(e);
+    }
+
+    private async Task OnContextMenuItemClick(ContextMenuItemClickEventArgs e)
+    {
+        if (contextMenuTargetId is null) return;
+        var id = contextMenuTargetId.Value;
+
+        switch (e.ItemInfo?.Name)
+        {
+            case "edit":
+                var target = gameItems.FirstOrDefault(x => x.Id == id);
+                if (target is not null) OpenModal(target);
+                break;
+            case "unassign":
+                await UnassignFromGameAsync(id);
+                break;
+            case "delete":
+                editingId = id;
+                name = contextMenuTargetName;
+                isDeleteVisible = true;
+                break;
+        }
     }
 
     private async Task AddSkillRewardAsync()

--- a/src/OvcinaHra.Client/Program.cs
+++ b/src/OvcinaHra.Client/Program.cs
@@ -34,6 +34,7 @@ builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredServ
 builder.Services.AddScoped<TokenRefreshService>();
 builder.Services.AddScoped<GameContextService>();
 builder.Services.AddScoped<SkillService>();
+builder.Services.AddScoped<PersonalQuestService>();
 builder.Services.AddAuthorizationCore();
 builder.Services.AddLocalization();
 builder.Services.AddSingleton(typeof(IDxLocalizationService), typeof(LocalizationService));

--- a/src/OvcinaHra.Client/Services/PersonalQuestService.cs
+++ b/src/OvcinaHra.Client/Services/PersonalQuestService.cs
@@ -1,0 +1,71 @@
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Client.Services;
+
+/// <summary>
+/// API client wrapper for /api/personal-quests endpoints (catalog CRUD, per-game links,
+/// and reward links). Mirrors the <see cref="SkillService"/> shape — injected
+/// <see cref="ApiClient"/>, scoped lifetime.
+/// </summary>
+public class PersonalQuestService
+{
+    private readonly ApiClient _api;
+
+    public PersonalQuestService(ApiClient api)
+    {
+        _api = api;
+    }
+
+    // ---- Catalog CRUD ----
+
+    public Task<List<PersonalQuestListDto>> GetAllAsync()
+        => _api.GetListAsync<PersonalQuestListDto>("/api/personal-quests");
+
+    public Task<PersonalQuestDetailDto?> GetByIdAsync(int id)
+        => _api.GetAsync<PersonalQuestDetailDto>($"/api/personal-quests/{id}");
+
+    public Task<PersonalQuestDetailDto?> CreateAsync(CreatePersonalQuestDto dto)
+        => _api.PostAsync<CreatePersonalQuestDto, PersonalQuestDetailDto>("/api/personal-quests", dto);
+
+    public Task UpdateAsync(int id, UpdatePersonalQuestDto dto)
+        => _api.PutAsync($"/api/personal-quests/{id}", dto);
+
+    public Task<bool> DeleteAsync(int id)
+        => _api.DeleteAsync($"/api/personal-quests/{id}");
+
+    // ---- Per-game link ----
+
+    public Task<List<GamePersonalQuestListDto>> GetByGameAsync(int gameId)
+        => _api.GetListAsync<GamePersonalQuestListDto>($"/api/personal-quests/by-game/{gameId}");
+
+    public Task<GamePersonalQuestDto?> CreateGameLinkAsync(int gameId, int pqId, int xpCost = 0, int? perKingdomLimit = null)
+        => _api.PostAsync<CreateGamePersonalQuestDto, GamePersonalQuestDto>(
+            "/api/personal-quests/game-link",
+            new CreateGamePersonalQuestDto(gameId, pqId, xpCost, perKingdomLimit));
+
+    public Task UpdateGameLinkAsync(int gameId, int pqId, int xpCost, int? perKingdomLimit)
+        => _api.PutAsync(
+            $"/api/personal-quests/game-link/{gameId}/{pqId}",
+            new UpdateGamePersonalQuestDto(xpCost, perKingdomLimit));
+
+    public Task<bool> DeleteGameLinkAsync(int gameId, int pqId)
+        => _api.DeleteAsync($"/api/personal-quests/game-link/{gameId}/{pqId}");
+
+    // ---- Reward links ----
+
+    public Task AddSkillRewardAsync(int pqId, int skillId)
+        => _api.PostAsync<AddSkillRewardDto>(
+            $"/api/personal-quests/{pqId}/skill-rewards",
+            new AddSkillRewardDto(skillId));
+
+    public Task<bool> RemoveSkillRewardAsync(int pqId, int skillId)
+        => _api.DeleteAsync($"/api/personal-quests/{pqId}/skill-rewards/{skillId}");
+
+    public Task AddItemRewardAsync(int pqId, int itemId, int quantity)
+        => _api.PostAsync<AddItemRewardDto>(
+            $"/api/personal-quests/{pqId}/item-rewards",
+            new AddItemRewardDto(itemId, quantity));
+
+    public Task<bool> RemoveItemRewardAsync(int pqId, int itemId)
+        => _api.DeleteAsync($"/api/personal-quests/{pqId}/item-rewards/{itemId}");
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/CharacterPersonalQuest.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/CharacterPersonalQuest.cs
@@ -1,0 +1,12 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class CharacterPersonalQuest
+{
+    public int CharacterId { get; set; }   // PK, one-to-one: a character has at most 1
+    public int PersonalQuestId { get; set; }
+    public DateTime AssignedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime? CompletedAtUtc { get; set; }
+
+    public Character Character { get; set; } = null!;
+    public PersonalQuest PersonalQuest { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/GamePersonalQuest.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GamePersonalQuest.cs
@@ -1,0 +1,12 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class GamePersonalQuest
+{
+    public int GameId { get; set; }
+    public int PersonalQuestId { get; set; }
+    public int XpCost { get; set; }
+    public int? PerKingdomLimit { get; set; }
+
+    public Game Game { get; set; } = null!;
+    public PersonalQuest PersonalQuest { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/PersonalQuest.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/PersonalQuest.cs
@@ -1,0 +1,27 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class PersonalQuest
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public string? Description { get; set; }
+    public TreasureQuestDifficulty Difficulty { get; set; }
+
+    public bool AllowWarrior { get; set; }
+    public bool AllowArcher { get; set; }
+    public bool AllowMage { get; set; }
+    public bool AllowThief { get; set; }
+
+    public string? QuestCardText { get; set; }
+    public string? RewardCardText { get; set; }
+    public string? RewardNote { get; set; }
+    public string? Notes { get; set; }
+    public string? ImagePath { get; set; }
+
+    public ICollection<PersonalQuestSkillReward> SkillRewards { get; set; } = [];
+    public ICollection<PersonalQuestItemReward> ItemRewards { get; set; } = [];
+    public ICollection<GamePersonalQuest> GameLinks { get; set; } = [];
+    public ICollection<CharacterPersonalQuest> CharacterAssignments { get; set; } = [];
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/PersonalQuestItemReward.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/PersonalQuestItemReward.cs
@@ -1,0 +1,11 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class PersonalQuestItemReward
+{
+    public int PersonalQuestId { get; set; }
+    public int ItemId { get; set; }
+    public int Quantity { get; set; } = 1;
+
+    public PersonalQuest PersonalQuest { get; set; } = null!;
+    public Item Item { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/PersonalQuestSkillReward.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/PersonalQuestSkillReward.cs
@@ -1,0 +1,10 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class PersonalQuestSkillReward
+{
+    public int PersonalQuestId { get; set; }
+    public int SkillId { get; set; }
+
+    public PersonalQuest PersonalQuest { get; set; } = null!;
+    public Skill Skill { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
@@ -1,0 +1,143 @@
+using System.Text.Json.Serialization;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
+
+namespace OvcinaHra.Shared.Dtos;
+
+public record PersonalQuestListDto(
+    int Id,
+    string Name,
+    string? Description,
+    TreasureQuestDifficulty Difficulty,
+    bool AllowWarrior,
+    bool AllowArcher,
+    bool AllowMage,
+    bool AllowThief,
+    string? QuestCardText,
+    string? RewardCardText,
+    string? RewardNote,
+    string? Notes,
+    string? ImagePath,
+    IReadOnlyList<int> SkillRewardIds,
+    IReadOnlyList<PersonalQuestItemRewardSummary> ItemRewards)
+{
+    [JsonIgnore]
+    public string DifficultyDisplay => Difficulty.GetDisplayName();
+
+    [JsonIgnore]
+    public string ClassRestrictionDisplay
+    {
+        get
+        {
+            if (!AllowWarrior && !AllowArcher && !AllowMage && !AllowThief)
+                return "Všechna povolání";
+            var parts = new List<string>();
+            if (AllowWarrior) parts.Add(PlayerClass.Warrior.GetDisplayName());
+            if (AllowArcher) parts.Add(PlayerClass.Archer.GetDisplayName());
+            if (AllowMage) parts.Add(PlayerClass.Mage.GetDisplayName());
+            if (AllowThief) parts.Add(PlayerClass.Thief.GetDisplayName());
+            return string.Join(", ", parts);
+        }
+    }
+
+    [JsonIgnore]
+    public bool HasImage => !string.IsNullOrEmpty(ImagePath);
+}
+
+public record PersonalQuestItemRewardSummary(int ItemId, string ItemName, int Quantity);
+
+public record PersonalQuestDetailDto(
+    int Id,
+    string Name,
+    string? Description,
+    TreasureQuestDifficulty Difficulty,
+    bool AllowWarrior,
+    bool AllowArcher,
+    bool AllowMage,
+    bool AllowThief,
+    string? QuestCardText,
+    string? RewardCardText,
+    string? RewardNote,
+    string? Notes,
+    string? ImagePath,
+    List<SkillRewardDto> SkillRewards,
+    List<ItemRewardDto> ItemRewards);
+
+public record SkillRewardDto(int SkillId, string SkillName);
+public record ItemRewardDto(int ItemId, string ItemName, int Quantity);
+
+public record CreatePersonalQuestDto(
+    string Name,
+    TreasureQuestDifficulty Difficulty,
+    string? Description = null,
+    bool AllowWarrior = false,
+    bool AllowArcher = false,
+    bool AllowMage = false,
+    bool AllowThief = false,
+    string? QuestCardText = null,
+    string? RewardCardText = null,
+    string? RewardNote = null,
+    string? Notes = null);
+
+public record UpdatePersonalQuestDto(
+    string Name,
+    TreasureQuestDifficulty Difficulty,
+    string? Description,
+    bool AllowWarrior,
+    bool AllowArcher,
+    bool AllowMage,
+    bool AllowThief,
+    string? QuestCardText,
+    string? RewardCardText,
+    string? RewardNote,
+    string? Notes);
+
+public record GamePersonalQuestListDto(
+    int Id,            // PersonalQuest.Id, matches the ListDto for popup reuse
+    string Name,
+    string? Description,
+    TreasureQuestDifficulty Difficulty,
+    bool AllowWarrior,
+    bool AllowArcher,
+    bool AllowMage,
+    bool AllowThief,
+    string? QuestCardText,
+    string? RewardCardText,
+    string? RewardNote,
+    string? Notes,
+    string? ImagePath,
+    int GameId,
+    int XpCost,
+    int? PerKingdomLimit,
+    string? RewardSummary)
+{
+    [JsonIgnore]
+    public string DifficultyDisplay => Difficulty.GetDisplayName();
+
+    [JsonIgnore]
+    public string ClassRestrictionDisplay
+    {
+        get
+        {
+            if (!AllowWarrior && !AllowArcher && !AllowMage && !AllowThief)
+                return "Všechna povolání";
+            var parts = new List<string>();
+            if (AllowWarrior) parts.Add(PlayerClass.Warrior.GetDisplayName());
+            if (AllowArcher) parts.Add(PlayerClass.Archer.GetDisplayName());
+            if (AllowMage) parts.Add(PlayerClass.Mage.GetDisplayName());
+            if (AllowThief) parts.Add(PlayerClass.Thief.GetDisplayName());
+            return string.Join(", ", parts);
+        }
+    }
+
+    [JsonIgnore]
+    public bool HasImage => !string.IsNullOrEmpty(ImagePath);
+}
+
+public record CreateGamePersonalQuestDto(int GameId, int PersonalQuestId,
+    int XpCost = 0, int? PerKingdomLimit = null);
+
+public record UpdateGamePersonalQuestDto(int XpCost, int? PerKingdomLimit);
+
+public record AddSkillRewardDto(int SkillId);
+public record AddItemRewardDto(int ItemId, int Quantity = 1);

--- a/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
@@ -134,6 +134,12 @@ public record GamePersonalQuestListDto(
     public bool HasImage => !string.IsNullOrEmpty(ImagePath);
 }
 
+public record GamePersonalQuestDto(
+    int GameId,
+    int PersonalQuestId,
+    int XpCost,
+    int? PerKingdomLimit);
+
 public record CreateGamePersonalQuestDto(int GameId, int PersonalQuestId,
     int XpCost = 0, int? PerKingdomLimit = null);
 

--- a/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
@@ -19,7 +19,8 @@ public record PersonalQuestListDto(
     string? Notes,
     string? ImagePath,
     IReadOnlyList<int> SkillRewardIds,
-    IReadOnlyList<PersonalQuestItemRewardSummary> ItemRewards)
+    IReadOnlyList<PersonalQuestItemRewardSummary> ItemRewards,
+    string? RewardSummary = null)
 {
     [JsonIgnore]
     public string DifficultyDisplay => Difficulty.GetDisplayName();

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -105,4 +105,63 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
         var response = await Client.GetAsync("/api/personal-quests/99999");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
+
+    [Fact]
+    public async Task Update_ChangesFields_Persists()
+    {
+        // Arrange — create via POST
+        var createDto = new CreatePersonalQuestDto(
+            Name: "Původní název",
+            Difficulty: TreasureQuestDifficulty.Start,
+            Description: "Původní popis",
+            AllowWarrior: true);
+        var createResponse = await Client.PostAsJsonAsync("/api/personal-quests", createDto);
+        var created = await createResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        // Act — PUT with changed fields
+        var updateDto = new UpdatePersonalQuestDto(
+            Name: "Nový název",
+            Difficulty: TreasureQuestDifficulty.Lategame,
+            Description: "Nový popis",
+            AllowWarrior: false,
+            AllowArcher: true,
+            AllowMage: true,
+            AllowThief: false,
+            QuestCardText: "Karta úkolu",
+            RewardCardText: "Karta odměny",
+            RewardNote: "Poznámka k odměně",
+            Notes: "Interní poznámky");
+        var response = await Client.PutAsJsonAsync($"/api/personal-quests/{created!.Id}", updateDto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var reloaded = await Client.GetFromJsonAsync<PersonalQuestDetailDto>($"/api/personal-quests/{created.Id}");
+        Assert.NotNull(reloaded);
+        Assert.Equal("Nový název", reloaded.Name);
+        Assert.Equal(TreasureQuestDifficulty.Lategame, reloaded.Difficulty);
+        Assert.Equal("Nový popis", reloaded.Description);
+        Assert.False(reloaded.AllowWarrior);
+        Assert.True(reloaded.AllowArcher);
+        Assert.True(reloaded.AllowMage);
+        Assert.False(reloaded.AllowThief);
+        Assert.Equal("Karta úkolu", reloaded.QuestCardText);
+        Assert.Equal("Karta odměny", reloaded.RewardCardText);
+        Assert.Equal("Poznámka k odměně", reloaded.RewardNote);
+        Assert.Equal("Interní poznámky", reloaded.Notes);
+    }
+
+    [Fact]
+    public async Task Update_NotFound_Returns404()
+    {
+        var updateDto = new UpdatePersonalQuestDto(
+            Name: "Neexistující",
+            Difficulty: TreasureQuestDifficulty.Early,
+            Description: null,
+            AllowWarrior: false, AllowArcher: false, AllowMage: false, AllowThief: false,
+            QuestCardText: null, RewardCardText: null, RewardNote: null, Notes: null);
+
+        var response = await Client.PutAsJsonAsync("/api/personal-quests/99999", updateDto);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -164,4 +164,88 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
         var response = await Client.PutAsJsonAsync("/api/personal-quests/99999", updateDto);
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
+
+    [Fact]
+    public async Task Delete_ExistingId_Removes()
+    {
+        var createDto = new CreatePersonalQuestDto(
+            Name: "K smazání",
+            Difficulty: TreasureQuestDifficulty.Early);
+        var createResponse = await Client.PostAsJsonAsync("/api/personal-quests", createDto);
+        var created = await createResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        var response = await Client.DeleteAsync($"/api/personal-quests/{created!.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var getResponse = await Client.GetAsync($"/api/personal-quests/{created.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_NotFound_Returns404()
+    {
+        var response = await Client.DeleteAsync("/api/personal-quests/99999");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_Cascades_RemovesRewards()
+    {
+        // Arrange — quest with 1 skill reward + 1 item reward
+        int questId;
+        int skillId;
+        int itemId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var skill = new Skill { Name = "Stopovačství" };
+            var item = new Item
+            {
+                Name = "Luk strážce",
+                ItemType = ItemType.Weapon,
+                ClassRequirements = new ClassRequirements(0, 0, 0, 0)
+            };
+            db.Skills.Add(skill);
+            db.Items.Add(item);
+            await db.SaveChangesAsync();
+
+            var quest = new PersonalQuest
+            {
+                Name = "Kaskáda testu",
+                Difficulty = TreasureQuestDifficulty.Midgame,
+                SkillRewards = [new PersonalQuestSkillReward { SkillId = skill.Id }],
+                ItemRewards = [new PersonalQuestItemReward { ItemId = item.Id, Quantity = 1 }]
+            };
+            db.PersonalQuests.Add(quest);
+            await db.SaveChangesAsync();
+            questId = quest.Id;
+            skillId = skill.Id;
+            itemId = item.Id;
+        }
+
+        // Act — delete via API
+        var response = await Client.DeleteAsync($"/api/personal-quests/{questId}");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        // Assert — quest gone, rewards gone, but Skill + Item themselves remain
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+
+            Assert.Null(await db.PersonalQuests.FindAsync(questId));
+
+            var skillRewards = await db.PersonalQuestSkillRewards
+                .Where(sr => sr.PersonalQuestId == questId)
+                .ToListAsync();
+            Assert.Empty(skillRewards);
+
+            var itemRewards = await db.PersonalQuestItemRewards
+                .Where(ir => ir.PersonalQuestId == questId)
+                .ToListAsync();
+            Assert.Empty(itemRewards);
+
+            Assert.NotNull(await db.Skills.FindAsync(skillId));
+            Assert.NotNull(await db.Items.FindAsync(itemId));
+        }
+    }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -19,4 +19,36 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
         Assert.NotNull(quests);
         Assert.Empty(quests);
     }
+
+    [Fact]
+    public async Task Create_WithValidDto_ReturnsCreatedWithId()
+    {
+        var dto = new CreatePersonalQuestDto(
+            Name: "Zachránit vesničany",
+            Difficulty: TreasureQuestDifficulty.Midgame,
+            Description: "Najdi a osvoboď unesené vesničany z lupičského tábora.",
+            AllowWarrior: true,
+            AllowThief: true,
+            QuestCardText: "Lupiči unesli vesničany!",
+            RewardCardText: "Vděčnost vesnice",
+            RewardNote: "Vděčnost starosty",
+            Notes: "Pro úroveň 2+");
+
+        var response = await Client.PostAsJsonAsync("/api/personal-quests", dto);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(response.Headers.Location);
+
+        var created = await response.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+        Assert.NotNull(created);
+        Assert.True(created.Id > 0);
+        Assert.Equal("Zachránit vesničany", created.Name);
+        Assert.Equal(TreasureQuestDifficulty.Midgame, created.Difficulty);
+        Assert.True(created.AllowWarrior);
+        Assert.False(created.AllowMage);
+        Assert.True(created.AllowThief);
+        Assert.Equal("Vděčnost starosty", created.RewardNote);
+        Assert.Empty(created.SkillRewards);
+        Assert.Empty(created.ItemRewards);
+    }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -554,7 +554,7 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
     }
 
     [Fact]
-    public async Task RemoveSkillReward_NotLinked_ReturnsNoContent()
+    public async Task RemoveSkillReward_NotLinked_Returns404()
     {
         var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
             new CreatePersonalQuestDto(Name: "Idempotent", Difficulty: TreasureQuestDifficulty.Early));
@@ -562,7 +562,7 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
 
         var response = await Client.DeleteAsync(
             $"/api/personal-quests/{quest!.Id}/skill-rewards/99999");
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -1,0 +1,22 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    [Fact]
+    public async Task GetAll_Empty_ReturnsEmptyList()
+    {
+        var quests = await Client.GetFromJsonAsync<List<PersonalQuestListDto>>("/api/personal-quests");
+        Assert.NotNull(quests);
+        Assert.Empty(quests);
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -6,6 +6,7 @@ using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Domain.ValueObjects;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
@@ -50,5 +51,58 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
         Assert.Equal("Vděčnost starosty", created.RewardNote);
         Assert.Empty(created.SkillRewards);
         Assert.Empty(created.ItemRewards);
+    }
+
+    [Fact]
+    public async Task GetById_Found_ReturnsWithRewards()
+    {
+        // Arrange — create a skill + item + quest with both reward types via direct DB insert
+        int questId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var skill = new Skill { Name = "Léčivá dlaň" };
+            var item = new Item
+            {
+                Name = "Lektvar léčení",
+                ItemType = ItemType.Potion,
+                ClassRequirements = new ClassRequirements(0, 0, 0, 0)
+            };
+            db.Skills.Add(skill);
+            db.Items.Add(item);
+            await db.SaveChangesAsync();
+
+            var quest = new PersonalQuest
+            {
+                Name = "Hrdinský čin",
+                Difficulty = TreasureQuestDifficulty.Early,
+                AllowWarrior = true,
+                SkillRewards = [new PersonalQuestSkillReward { SkillId = skill.Id }],
+                ItemRewards = [new PersonalQuestItemReward { ItemId = item.Id, Quantity = 2 }]
+            };
+            db.PersonalQuests.Add(quest);
+            await db.SaveChangesAsync();
+            questId = quest.Id;
+        }
+
+        // Act
+        var result = await Client.GetFromJsonAsync<PersonalQuestDetailDto>($"/api/personal-quests/{questId}");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(questId, result.Id);
+        Assert.Equal("Hrdinský čin", result.Name);
+        var skillReward = Assert.Single(result.SkillRewards);
+        Assert.Equal("Léčivá dlaň", skillReward.SkillName);
+        var itemReward = Assert.Single(result.ItemRewards);
+        Assert.Equal("Lektvar léčení", itemReward.ItemName);
+        Assert.Equal(2, itemReward.Quantity);
+    }
+
+    [Fact]
+    public async Task GetById_NotFound_Returns404()
+    {
+        var response = await Client.GetAsync("/api/personal-quests/99999");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -248,4 +248,212 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
             Assert.NotNull(await db.Items.FindAsync(itemId));
         }
     }
+
+    // ======================================================================
+    // Batch D — Per-game link endpoints
+    // ======================================================================
+
+    [Fact]
+    public async Task GetByGame_Empty_ReturnsEmptyList()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var result = await Client.GetFromJsonAsync<List<GamePersonalQuestListDto>>(
+            $"/api/personal-quests/by-game/{game!.Id}");
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByGame_WithRewards_BuildsSummary()
+    {
+        // Arrange — seed a game, a PQ with 1 skill + 1 item reward (qty 2), and the GPQ link
+        int gameId;
+        int questId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+
+            var skill = new Skill { Name = "Druid" };
+            var item = new Item
+            {
+                Name = "Léčivá dlaň",
+                ItemType = ItemType.Potion,
+                ClassRequirements = new ClassRequirements(0, 0, 0, 0)
+            };
+            db.Skills.Add(skill);
+            db.Items.Add(item);
+
+            var game = new Game
+            {
+                Name = "Hra s odměnami",
+                Edition = 1,
+                StartDate = new DateOnly(2026, 6, 1),
+                EndDate = new DateOnly(2026, 6, 3)
+            };
+            db.Games.Add(game);
+
+            var quest = new PersonalQuest
+            {
+                Name = "Úkol druida",
+                Difficulty = TreasureQuestDifficulty.Early,
+                AllowMage = true,
+                SkillRewards = [new PersonalQuestSkillReward { Skill = skill }],
+                ItemRewards = [new PersonalQuestItemReward { Item = item, Quantity = 2 }]
+            };
+            db.PersonalQuests.Add(quest);
+            await db.SaveChangesAsync();
+
+            db.GamePersonalQuests.Add(new GamePersonalQuest
+            {
+                GameId = game.Id,
+                PersonalQuestId = quest.Id,
+                XpCost = 15,
+                PerKingdomLimit = 1
+            });
+            await db.SaveChangesAsync();
+
+            gameId = game.Id;
+            questId = quest.Id;
+        }
+
+        // Act
+        var result = await Client.GetFromJsonAsync<List<GamePersonalQuestListDto>>(
+            $"/api/personal-quests/by-game/{gameId}");
+
+        // Assert
+        Assert.NotNull(result);
+        var row = Assert.Single(result);
+        Assert.Equal(questId, row.Id);
+        Assert.Equal("Úkol druida", row.Name);
+        Assert.Equal(gameId, row.GameId);
+        Assert.Equal(15, row.XpCost);
+        Assert.Equal(1, row.PerKingdomLimit);
+        Assert.Equal("Druid │ Léčivá dlaň ×2", row.RewardSummary);
+    }
+
+    [Fact]
+    public async Task CreateGameLink_Persists_Returns201()
+    {
+        // Arrange — game + quest
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Hra link", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(Name: "Linkovaný úkol", Difficulty: TreasureQuestDifficulty.Early));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        // Act
+        var response = await Client.PostAsJsonAsync("/api/personal-quests/game-link",
+            new CreateGamePersonalQuestDto(game!.Id, quest!.Id, XpCost: 20, PerKingdomLimit: 2));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var created = await response.Content.ReadFromJsonAsync<GamePersonalQuestDto>();
+        Assert.NotNull(created);
+        Assert.Equal(game.Id, created.GameId);
+        Assert.Equal(quest.Id, created.PersonalQuestId);
+        Assert.Equal(20, created.XpCost);
+        Assert.Equal(2, created.PerKingdomLimit);
+
+        // Verify it shows up in by-game
+        var list = await Client.GetFromJsonAsync<List<GamePersonalQuestListDto>>(
+            $"/api/personal-quests/by-game/{game.Id}");
+        Assert.NotNull(list);
+        Assert.Single(list);
+    }
+
+    [Fact]
+    public async Task CreateGameLink_DuplicatePair_ReturnsConflict()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Hra dup", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(Name: "Duplikát", Difficulty: TreasureQuestDifficulty.Early));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        var dto = new CreateGamePersonalQuestDto(game!.Id, quest!.Id, XpCost: 5, PerKingdomLimit: null);
+
+        var first = await Client.PostAsJsonAsync("/api/personal-quests/game-link", dto);
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+
+        var second = await Client.PostAsJsonAsync("/api/personal-quests/game-link", dto);
+        Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateGameLink_TunesXpCost()
+    {
+        // Arrange — game + quest + link (XpCost=10)
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Hra update", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(Name: "Ladit", Difficulty: TreasureQuestDifficulty.Early));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        await Client.PostAsJsonAsync("/api/personal-quests/game-link",
+            new CreateGamePersonalQuestDto(game!.Id, quest!.Id, XpCost: 10, PerKingdomLimit: null));
+
+        // Act — update XpCost to 25
+        var response = await Client.PutAsJsonAsync(
+            $"/api/personal-quests/game-link/{game.Id}/{quest.Id}",
+            new UpdateGamePersonalQuestDto(XpCost: 25, PerKingdomLimit: 3));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var list = await Client.GetFromJsonAsync<List<GamePersonalQuestListDto>>(
+            $"/api/personal-quests/by-game/{game.Id}");
+        var row = Assert.Single(list!);
+        Assert.Equal(25, row.XpCost);
+        Assert.Equal(3, row.PerKingdomLimit);
+    }
+
+    [Fact]
+    public async Task UpdateGameLink_NotFound_Returns404()
+    {
+        var response = await Client.PutAsJsonAsync(
+            "/api/personal-quests/game-link/99999/99999",
+            new UpdateGamePersonalQuestDto(XpCost: 1, PerKingdomLimit: null));
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteGameLink_RemovesConfig_KeepsCatalogEntry()
+    {
+        // Arrange
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Hra unlink", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(Name: "Ponechat v katalogu", Difficulty: TreasureQuestDifficulty.Early));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        await Client.PostAsJsonAsync("/api/personal-quests/game-link",
+            new CreateGamePersonalQuestDto(game!.Id, quest!.Id));
+
+        // Act
+        var response = await Client.DeleteAsync(
+            $"/api/personal-quests/game-link/{game.Id}/{quest.Id}");
+
+        // Assert — link gone
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var list = await Client.GetFromJsonAsync<List<GamePersonalQuestListDto>>(
+            $"/api/personal-quests/by-game/{game.Id}");
+        Assert.NotNull(list);
+        Assert.Empty(list);
+
+        // Assert — catalog entry still exists
+        var catalogGet = await Client.GetAsync($"/api/personal-quests/{quest.Id}");
+        Assert.Equal(HttpStatusCode.OK, catalogGet.StatusCode);
+    }
+
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -456,4 +456,187 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
         Assert.Equal(HttpStatusCode.OK, catalogGet.StatusCode);
     }
 
+    // ======================================================================
+    // Batch D — Reward link endpoints
+    // ======================================================================
+
+    [Fact]
+    public async Task AddSkillReward_Persists_Returns201()
+    {
+        // Arrange — skill + quest
+        int skillId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var skill = new Skill { Name = "Mrštnost" };
+            db.Skills.Add(skill);
+            await db.SaveChangesAsync();
+            skillId = skill.Id;
+        }
+
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(Name: "Skillová odměna", Difficulty: TreasureQuestDifficulty.Early));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        // Act
+        var response = await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest!.Id}/skill-rewards",
+            new AddSkillRewardDto(skillId));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var reloaded = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+            $"/api/personal-quests/{quest.Id}");
+        var reward = Assert.Single(reloaded!.SkillRewards);
+        Assert.Equal(skillId, reward.SkillId);
+        Assert.Equal("Mrštnost", reward.SkillName);
+    }
+
+    [Fact]
+    public async Task AddSkillReward_Duplicate_ReturnsConflict()
+    {
+        int skillId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var skill = new Skill { Name = "Síla" };
+            db.Skills.Add(skill);
+            await db.SaveChangesAsync();
+            skillId = skill.Id;
+        }
+
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(Name: "Duplikátní skill", Difficulty: TreasureQuestDifficulty.Early));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        var first = await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest!.Id}/skill-rewards",
+            new AddSkillRewardDto(skillId));
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+
+        var second = await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest.Id}/skill-rewards",
+            new AddSkillRewardDto(skillId));
+        Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
+    }
+
+    [Fact]
+    public async Task RemoveSkillReward_Existing_Removes()
+    {
+        int skillId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var skill = new Skill { Name = "Odstranit" };
+            db.Skills.Add(skill);
+            await db.SaveChangesAsync();
+            skillId = skill.Id;
+        }
+
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(Name: "K odebrání skillu", Difficulty: TreasureQuestDifficulty.Early));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest!.Id}/skill-rewards",
+            new AddSkillRewardDto(skillId));
+
+        // Act
+        var response = await Client.DeleteAsync(
+            $"/api/personal-quests/{quest.Id}/skill-rewards/{skillId}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var reloaded = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+            $"/api/personal-quests/{quest.Id}");
+        Assert.Empty(reloaded!.SkillRewards);
+    }
+
+    [Fact]
+    public async Task RemoveSkillReward_NotLinked_ReturnsNoContent()
+    {
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(Name: "Idempotent", Difficulty: TreasureQuestDifficulty.Early));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        var response = await Client.DeleteAsync(
+            $"/api/personal-quests/{quest!.Id}/skill-rewards/99999");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddItemReward_StoresQuantity()
+    {
+        int itemId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var item = new Item
+            {
+                Name = "Lektvar síly",
+                ItemType = ItemType.Potion,
+                ClassRequirements = new ClassRequirements(0, 0, 0, 0)
+            };
+            db.Items.Add(item);
+            await db.SaveChangesAsync();
+            itemId = item.Id;
+        }
+
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(Name: "Item odměna", Difficulty: TreasureQuestDifficulty.Early));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        // Act — add with qty 3
+        var response = await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest!.Id}/item-rewards",
+            new AddItemRewardDto(itemId, Quantity: 3));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var reloaded = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+            $"/api/personal-quests/{quest.Id}");
+        var reward = Assert.Single(reloaded!.ItemRewards);
+        Assert.Equal(itemId, reward.ItemId);
+        Assert.Equal("Lektvar síly", reward.ItemName);
+        Assert.Equal(3, reward.Quantity);
+    }
+
+    [Fact]
+    public async Task RemoveItemReward_Existing_Removes()
+    {
+        int itemId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var item = new Item
+            {
+                Name = "K odebrání",
+                ItemType = ItemType.Potion,
+                ClassRequirements = new ClassRequirements(0, 0, 0, 0)
+            };
+            db.Items.Add(item);
+            await db.SaveChangesAsync();
+            itemId = item.Id;
+        }
+
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(Name: "K odebrání itemu", Difficulty: TreasureQuestDifficulty.Early));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest!.Id}/item-rewards",
+            new AddItemRewardDto(itemId, Quantity: 1));
+
+        // Act
+        var response = await Client.DeleteAsync(
+            $"/api/personal-quests/{quest.Id}/item-rewards/{itemId}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var reloaded = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+            $"/api/personal-quests/{quest.Id}");
+        Assert.Empty(reloaded!.ItemRewards);
+    }
 }


### PR DESCRIPTION
## Summary

First shipping cut of the PersonalQuest domain — world-level catalog of per-character mini-quests, per-game config (XpCost + PerKingdomLimit), and a character-assignment data table ready for a follow-up UI.

**Design doc:** \`docs/plans/2026-04-19-personal-quest-domain-design.md\`
**Implementation plan:** \`docs/plans/2026-04-19-personal-quest-domain-implementation.md\`

## Server

- 5 new entities: \`PersonalQuest\`, \`PersonalQuestSkillReward\`, \`PersonalQuestItemReward\`, \`GamePersonalQuest\`, \`CharacterPersonalQuest\`
- EF migration \`AddPersonalQuestDomain\` — purely additive, 5 new tables + unique index on \`PersonalQuests.Name\` + 3 CHECK constraints. No modifications to existing tables. Auto-applies on API startup via \`db.Database.MigrateAsync()\`.
- 13 endpoints under \`/api/personal-quests\`:
  - Catalog CRUD: GET list / GET by id / POST / PUT / DELETE (cascades to reward links)
  - Per-game link: GET by-game (with server-built \`RewardSummary\` string) / POST / PUT / DELETE
  - Reward links: POST + DELETE for skill-rewards and item-rewards
- 22 new Testcontainers-PostgreSQL integration tests (all 226 passing, 0 failed).

## Client

- \`/personal-quests\` page with catalog/game grid split (same UX as \`/items\`).
- Nav entries added in both Hra and Katalog světa sections at matching positions (after Questy), with \`bi-person-workspace\` icon and label **Osobní questy**.
- Detail popup: full form (Název, Obtížnost, Popis, 4× Povolání checkboxes, Kartička questu, Kartičky odměn, Ostatní odměny, Poznámky, Obrázek) + rewards pickers (skills combobox + chips; items combobox + qty + chips) + per-game config card (XpCost + PerKingdomLimit).
- Server-computed \`RewardSummary\` string (\`"Druid │ Léčivá dlaň ×2"\`) on both the catalog and game-view grids for at-a-glance rows.
- Context menu on the game grid: **Upravit** / **Odebrat z hry** / **Smazat**.
- Catalog grid has Přidat/Odebrat action column for opting quests into the current game.
- \`grid-layout-personal-quests-catalog\` and \`grid-layout-personal-quests-game\` LayoutKeys — fresh defaults, no stale filters.

## Deferred (explicit)

- **Character-assignment UI** — data table ships; form/page to pick a quest for a character comes in a follow-up PR.
- **Completion-tracking UI** — \`CompletedAtUtc\` column exists; no toggle or report yet.
- **Card printing** — \`QuestCardText\` stays plain markdown; printer is a separate project.
- **Kingdom/Merchant entities** — \`PerKingdomLimit\` is a plain int; enforcement is organizational.

## Test plan

- [ ] CI passes (API CI + Client CI)
- [ ] Manually: create a **Druid** quest in the catalog, attach *Dovednost Druid* (skill) + *Léčivá dlaň* (item ×1), add to game 30, verify \`RewardSummary\` renders as \`\"Dovednost Druid │ Léčivá dlaň ×1\"\`
- [ ] Switch Katalog ↔ Jen tato hra — both grids work, LayoutKeys persist independently
- [ ] Context menu on game view: Upravit / Odebrat z hry / Smazat all work
- [ ] Empty-states: (a) no game selected shows \"Vyber hru\" prompt, (b) game selected but no quests assigned shows \"Otevřít katalog\" button
- [ ] Nav: **Osobní questy** visible in both Hra and Katalog světa
- [ ] Migration applies cleanly against prod on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)