### PR TITLE
fix: Hra 'Dovednosti' nav routes to per-game skills [v0.6.1]

### DIFF
--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -1,4 +1,6 @@
 @using System.Reflection
+@inject GameContextService GameContext
+@implements IDisposable
 
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
@@ -55,11 +57,14 @@
                 <i class="bi bi-houses-fill"></i><span class="nav-label">Budovy</span>
             </NavLink>
         </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="skills">
-                <i class="bi bi-star-fill"></i><span class="nav-label">Dovednosti</span>
-            </NavLink>
-        </div>
+        @if (GameContext.SelectedGameId is int hraSkillsGameId)
+        {
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="@($"games/{hraSkillsGameId}/skills")">
+                    <i class="bi bi-star-fill"></i><span class="nav-label">Dovednosti</span>
+                </NavLink>
+            </div>
+        }
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="secret-stashes">
                 <i class="bi bi-lock-fill"></i><span class="nav-label">Tajné skrýše</span>
@@ -179,4 +184,19 @@
     private bool collapseNavMenu = true;
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
     private void ToggleNavMenu() => collapseNavMenu = !collapseNavMenu;
+
+    protected override void OnInitialized()
+    {
+        GameContext.OnGameChanged += OnGameChanged;
+    }
+
+    private async void OnGameChanged()
+    {
+        try { await InvokeAsync(StateHasChanged); } catch { /* nav menu best-effort refresh */ }
+    }
+
+    public void Dispose()
+    {
+        GameContext.OnGameChanged -= OnGameChanged;
+    }
 }

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

The Hra section's **Dovednosti** nav entry linked to `/skills` (world catalog) — per-game XP cost / level requirement weren't reachable from the sidebar.

Now:
- When a game is selected → entry links to `/games/{selectedGameId}/skills`
- When no game is selected → entry is hidden (Katalog světa's **Dovednosti** still links to `/skills` for browsing the catalog)

NavMenu subscribes to `GameContext.OnGameChanged` so the entry appears/disappears when the organizer switches games.

## Test plan

- [ ] CI passes
- [ ] With game 30 selected: click Dovednosti in Hra section → lands on `/games/30/skills` with XP column visible
- [ ] Clear the game selection → Hra Dovednosti entry disappears; Katalog světa Dovednosti still there
- [ ] Switch between games → nav entry href updates accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)