### PR TITLE
feat(locations): game-view grid enrichment [v0.8.0]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -38,9 +38,9 @@ public static class LocationEndpoints
                 l.Coordinates != null ? l.Coordinates.Longitude : (decimal?)null,
                 l.ParentLocationId,
                 l.Description, l.Details, l.GamePotential, l.NpcInfo, l.SetupNotes,
-                new List<LocationStashDto>(),
-                new List<LocationQuestDto>(),
-                new List<LocationTreasureQuestDto>()))
+                Array.Empty<LocationStashDto>(),
+                Array.Empty<LocationQuestDto>(),
+                Array.Empty<LocationTreasureQuestDto>()))
             .ToListAsync();
 
         return TypedResults.Ok(locations);
@@ -128,57 +128,55 @@ public static class LocationEndpoints
 
     private static async Task<Ok<List<LocationListDto>>> GetByGame(int gameId, WorldDbContext db)
     {
-        var locations = await db.Locations
+        var dtos = await db.Locations
             .Where(l => l.GameLocations.Any(gl => gl.GameId == gameId))
-            .Include(l => l.GameSecretStashes)
-                .ThenInclude(gss => gss.SecretStash)
-                    .ThenInclude(s => s.TreasureQuests)
-            .Include(l => l.QuestLocations)
-                .ThenInclude(ql => ql.Quest)
-                    .ThenInclude(q => q.QuestRewards)
-                        .ThenInclude(qr => qr.Item)
-            .Include(l => l.TreasureQuests)
             .OrderBy(l => l.Name)
+            .Select(l => new LocationListDto(
+                l.Id, l.Name, l.LocationKind,
+                l.Region,
+                l.Coordinates != null ? l.Coordinates.Latitude : (decimal?)null,
+                l.Coordinates != null ? l.Coordinates.Longitude : (decimal?)null,
+                l.ParentLocationId,
+                l.Description, l.Details, l.GamePotential, l.NpcInfo, l.SetupNotes,
+                Stashes: l.GameSecretStashes
+                    .Where(gss => gss.GameId == gameId)
+                    .OrderBy(gss => gss.SecretStash.Name)
+                    .Select(gss => new LocationStashDto(
+                        gss.SecretStashId,
+                        gss.SecretStash.Name,
+                        gss.SecretStash.Description,
+                        gss.SecretStash.TreasureQuests
+                            .Where(tq => tq.GameId == gameId)
+                            .OrderBy(tq => tq.Title)
+                            .ThenBy(tq => tq.Id)
+                            .Select(tq => new LocationTreasureQuestDto(tq.Id, tq.Title, tq.Clue, tq.Difficulty))
+                            .ToList()))
+                    .ToList(),
+                Quests: l.QuestLocations
+                    .Where(ql => ql.Quest.GameId == null || ql.Quest.GameId == gameId)
+                    .OrderBy(ql => ql.Quest.Name)
+                    .Select(ql => new LocationQuestDto(
+                        ql.QuestId,
+                        ql.Quest.Name,
+                        ql.Quest.QuestType,
+                        ql.Quest.Description,
+                        ql.Quest.FullText,
+                        ql.Quest.RewardXp,
+                        ql.Quest.RewardMoney,
+                        ql.Quest.RewardNotes,
+                        ql.Quest.QuestRewards
+                            .OrderBy(qr => qr.Item.Name)
+                            .Select(qr => new LocationQuestRewardItemDto(qr.ItemId, qr.Item.Name, qr.Quantity))
+                            .ToList()))
+                    .ToList(),
+                LocationTreasureQuests: l.TreasureQuests
+                    .Where(tq => tq.GameId == gameId)
+                    .OrderBy(tq => tq.Title)
+                    .ThenBy(tq => tq.Id)
+                    .Select(tq => new LocationTreasureQuestDto(tq.Id, tq.Title, tq.Clue, tq.Difficulty))
+                    .ToList()
+            ))
             .ToListAsync();
-
-        var dtos = locations.Select(l => new LocationListDto(
-            l.Id, l.Name, l.LocationKind,
-            l.Region,
-            l.Coordinates?.Latitude,
-            l.Coordinates?.Longitude,
-            l.ParentLocationId,
-            l.Description, l.Details, l.GamePotential, l.NpcInfo, l.SetupNotes,
-            Stashes: l.GameSecretStashes
-                .Where(gss => gss.GameId == gameId)
-                .Select(gss => new LocationStashDto(
-                    gss.SecretStashId,
-                    gss.SecretStash.Name,
-                    gss.SecretStash.Description,
-                    gss.SecretStash.TreasureQuests
-                        .Where(tq => tq.GameId == gameId)
-                        .Select(tq => new LocationTreasureQuestDto(tq.Id, tq.Title, tq.Clue, tq.Difficulty))
-                        .ToList()))
-                .ToList(),
-            Quests: l.QuestLocations
-                .Where(ql => ql.Quest.GameId == null || ql.Quest.GameId == gameId)
-                .Select(ql => new LocationQuestDto(
-                    ql.QuestId,
-                    ql.Quest.Name,
-                    ql.Quest.QuestType,
-                    ql.Quest.Description,
-                    ql.Quest.FullText,
-                    ql.Quest.RewardXp,
-                    ql.Quest.RewardMoney,
-                    ql.Quest.RewardNotes,
-                    ql.Quest.QuestRewards
-                        .Select(qr => new LocationQuestRewardItemDto(qr.ItemId, qr.Item.Name, qr.Quantity))
-                        .ToList()))
-                .ToList(),
-            LocationTreasureQuests: l.TreasureQuests
-                .Where(tq => tq.GameId == gameId)
-                .Select(tq => new LocationTreasureQuestDto(tq.Id, tq.Title, tq.Clue, tq.Difficulty))
-                .ToList()
-        )).ToList();
 
         return TypedResults.Ok(dtos);
     }

--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -36,7 +36,11 @@ public static class LocationEndpoints
                 l.Region,
                 l.Coordinates != null ? l.Coordinates.Latitude : (decimal?)null,
                 l.Coordinates != null ? l.Coordinates.Longitude : (decimal?)null,
-                l.ParentLocationId))
+                l.ParentLocationId,
+                l.Description, l.Details, l.GamePotential, l.NpcInfo, l.SetupNotes,
+                new List<LocationStashDto>(),
+                new List<LocationQuestDto>(),
+                new List<LocationTreasureQuestDto>()))
             .ToListAsync();
 
         return TypedResults.Ok(locations);
@@ -126,16 +130,57 @@ public static class LocationEndpoints
     {
         var locations = await db.Locations
             .Where(l => l.GameLocations.Any(gl => gl.GameId == gameId))
+            .Include(l => l.GameSecretStashes)
+                .ThenInclude(gss => gss.SecretStash)
+                    .ThenInclude(s => s.TreasureQuests)
+            .Include(l => l.QuestLocations)
+                .ThenInclude(ql => ql.Quest)
+                    .ThenInclude(q => q.QuestRewards)
+                        .ThenInclude(qr => qr.Item)
+            .Include(l => l.TreasureQuests)
             .OrderBy(l => l.Name)
-            .Select(l => new LocationListDto(
-                l.Id, l.Name, l.LocationKind,
-                l.Region,
-                l.Coordinates != null ? l.Coordinates.Latitude : (decimal?)null,
-                l.Coordinates != null ? l.Coordinates.Longitude : (decimal?)null,
-                l.ParentLocationId))
             .ToListAsync();
 
-        return TypedResults.Ok(locations);
+        var dtos = locations.Select(l => new LocationListDto(
+            l.Id, l.Name, l.LocationKind,
+            l.Region,
+            l.Coordinates?.Latitude,
+            l.Coordinates?.Longitude,
+            l.ParentLocationId,
+            l.Description, l.Details, l.GamePotential, l.NpcInfo, l.SetupNotes,
+            Stashes: l.GameSecretStashes
+                .Where(gss => gss.GameId == gameId)
+                .Select(gss => new LocationStashDto(
+                    gss.SecretStashId,
+                    gss.SecretStash.Name,
+                    gss.SecretStash.Description,
+                    gss.SecretStash.TreasureQuests
+                        .Where(tq => tq.GameId == gameId)
+                        .Select(tq => new LocationTreasureQuestDto(tq.Id, tq.Title, tq.Clue, tq.Difficulty))
+                        .ToList()))
+                .ToList(),
+            Quests: l.QuestLocations
+                .Where(ql => ql.Quest.GameId == null || ql.Quest.GameId == gameId)
+                .Select(ql => new LocationQuestDto(
+                    ql.QuestId,
+                    ql.Quest.Name,
+                    ql.Quest.QuestType,
+                    ql.Quest.Description,
+                    ql.Quest.FullText,
+                    ql.Quest.RewardXp,
+                    ql.Quest.RewardMoney,
+                    ql.Quest.RewardNotes,
+                    ql.Quest.QuestRewards
+                        .Select(qr => new LocationQuestRewardItemDto(qr.ItemId, qr.Item.Name, qr.Quantity))
+                        .ToList()))
+                .ToList(),
+            LocationTreasureQuests: l.TreasureQuests
+                .Where(tq => tq.GameId == gameId)
+                .Select(tq => new LocationTreasureQuestDto(tq.Id, tq.Title, tq.Clue, tq.Difficulty))
+                .ToList()
+        )).ToList();
+
+        return TypedResults.Ok(dtos);
     }
 
     private static async Task<Results<Created, Conflict>> AssignToGame(GameLocationDto dto, WorldDbContext db)

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -35,7 +35,7 @@ else if (!Catalog && locations.Count == 0)
 }
 else
 {
-    <OvcinaGrid Data="@locations" KeyFieldName="Id" LayoutKey="grid-layout-locations"
+    <OvcinaGrid Data="@locations" KeyFieldName="Id" LayoutKey="grid-layout-locations-v2"
                 RowClick="@(async e => await locationPopup.OpenAsync(((LocationListDto)e.Grid.GetDataItem(e.VisibleIndex)).Id))">
         <Columns>
             <DxGridDataColumn FieldName="" Caption="" Width="40px" AllowSort="false" FixedPosition="GridColumnFixedPosition.Left">
@@ -72,6 +72,88 @@ else
                     }
                 </CellDisplayTemplate>
             </DxGridDataColumn>
+            <DxGridDataColumn FieldName="GamePotential" Caption="Herní potenciál" Width="260px" />
+            <DxGridDataColumn FieldName="SetupNotes" Caption="Přípravné poznámky" Width="220px" />
+            @if (!Catalog)
+            {
+                <DxGridDataColumn FieldName="Stashes" Caption="Skrýše" Width="500px" AllowSort="false" AllowFilter="false">
+                    <CellDisplayTemplate>
+                        @{
+                            var loc = (LocationListDto)context.DataItem;
+                        }
+                        @foreach (var stash in loc.Stashes)
+                        {
+                            <div class="location-stash-card mb-2">
+                                <div><strong>@stash.Name</strong></div>
+                                @if (!string.IsNullOrWhiteSpace(stash.Description))
+                                {
+                                    <div class="text-muted small" style="white-space: pre-wrap">@stash.Description</div>
+                                }
+                                @foreach (var tq in stash.TreasureQuests)
+                                {
+                                    <div class="ps-2 mt-1 small">
+                                        <span class="badge bg-warning text-dark me-1">Poklad</span><strong>@tq.Title</strong>
+                                        @if (!string.IsNullOrWhiteSpace(tq.Clue))
+                                        {
+                                            <span class="text-muted"> — @tq.Clue</span>
+                                        }
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </CellDisplayTemplate>
+                </DxGridDataColumn>
+                <DxGridDataColumn FieldName="Quests" Caption="Questy" Width="600px" AllowSort="false" AllowFilter="false">
+                    <CellDisplayTemplate>
+                        @{
+                            var loc = (LocationListDto)context.DataItem;
+                        }
+                        @foreach (var quest in loc.Quests)
+                        {
+                            <div class="location-quest-card mb-2">
+                                <div>
+                                    <strong>@quest.Name</strong>
+                                    <span class="badge bg-info text-dark ms-1">@quest.QuestTypeDisplay</span>
+                                </div>
+                                @{
+                                    var body = !string.IsNullOrWhiteSpace(quest.FullText) ? quest.FullText : quest.Description;
+                                }
+                                @if (!string.IsNullOrWhiteSpace(body))
+                                {
+                                    <div class="small" style="white-space: pre-wrap">@body</div>
+                                }
+                                @{
+                                    var parts = new List<string>();
+                                    if (quest.RewardXp.HasValue) parts.Add($"{quest.RewardXp} XP");
+                                    if (quest.RewardMoney.HasValue) parts.Add($"{quest.RewardMoney} grošů");
+                                    foreach (var itm in quest.ItemRewards) parts.Add($"{itm.ItemName} ×{itm.Quantity}");
+                                    if (!string.IsNullOrWhiteSpace(quest.RewardNotes)) parts.Add(quest.RewardNotes!);
+                                }
+                                @if (parts.Count > 0)
+                                {
+                                    <div class="text-muted small"><em>Odměna:</em> @string.Join(", ", parts)</div>
+                                }
+                            </div>
+                        }
+                        @foreach (var tq in loc.LocationTreasureQuests)
+                        {
+                            <div class="location-quest-card mb-2">
+                                <div>
+                                    <strong>@tq.Title</strong>
+                                    <span class="badge bg-warning text-dark ms-1">Poklad</span>
+                                </div>
+                                @if (!string.IsNullOrWhiteSpace(tq.Clue))
+                                {
+                                    <div class="small" style="white-space: pre-wrap">@tq.Clue</div>
+                                }
+                            </div>
+                        }
+                    </CellDisplayTemplate>
+                </DxGridDataColumn>
+            }
+            <DxGridDataColumn FieldName="Description" Caption="Popis" Width="300px" Visible="false" />
+            <DxGridDataColumn FieldName="Details" Caption="Podrobnosti" Width="300px" Visible="false" />
+            <DxGridDataColumn FieldName="NpcInfo" Caption="NPC" Width="220px" Visible="false" />
             <DxGridDataColumn FieldName="Latitude" Caption="Šířka" Width="120px" DisplayFormat="F5" Visible="false" />
             <DxGridDataColumn FieldName="Longitude" Caption="Délka" Width="120px" DisplayFormat="F5" Visible="false" />
             @if (Catalog)

--- a/src/OvcinaHra.Shared/Domain/Enums/QuestType.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/QuestType.cs
@@ -19,5 +19,8 @@ public enum QuestType
     Penance,
 
     [Display(Name = "Časový")]
-    Timed
+    Timed,
+
+    [Display(Name = "Lokační")]
+    Location
 }

--- a/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
@@ -11,10 +11,54 @@ public record LocationListDto(
     string? Region,
     decimal? Latitude,
     decimal? Longitude,
-    int? ParentLocationId)
+    int? ParentLocationId,
+    string? Description,
+    string? Details,
+    string? GamePotential,
+    string? NpcInfo,
+    string? SetupNotes,
+    IReadOnlyList<LocationStashDto> Stashes,
+    IReadOnlyList<LocationQuestDto> Quests,
+    IReadOnlyList<LocationTreasureQuestDto> LocationTreasureQuests)
 {
     [JsonIgnore]
     public string LocationKindDisplay => LocationKind.GetDisplayName();
+}
+
+public record LocationStashDto(
+    int Id,
+    string Name,
+    string? Description,
+    IReadOnlyList<LocationTreasureQuestDto> TreasureQuests);
+
+public record LocationQuestDto(
+    int Id,
+    string Name,
+    QuestType QuestType,
+    string? Description,
+    string? FullText,
+    int? RewardXp,
+    int? RewardMoney,
+    string? RewardNotes,
+    IReadOnlyList<LocationQuestRewardItemDto> ItemRewards)
+{
+    [JsonIgnore]
+    public string QuestTypeDisplay => QuestType.GetDisplayName();
+}
+
+public record LocationQuestRewardItemDto(
+    int ItemId,
+    string ItemName,
+    int Quantity);
+
+public record LocationTreasureQuestDto(
+    int Id,
+    string Title,
+    string? Clue,
+    TreasureQuestDifficulty Difficulty)
+{
+    [JsonIgnore]
+    public string DifficultyDisplay => Difficulty.GetDisplayName();
 }
 
 public record LocationDetailDto(

--- a/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
@@ -1,7 +1,11 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Domain.ValueObjects;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
@@ -150,5 +154,147 @@ public class LocationEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         var locations = await Client.GetFromJsonAsync<List<LocationListDto>>("/api/locations");
         var dol = locations!.First(l => l.Name == "Dol");
         Assert.Equal("Úpatí Osamělé hory", dol.Region);
+    }
+
+    [Fact]
+    public async Task GetAll_CatalogView_StashQuestListsEmpty()
+    {
+        await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Katalog lokace", LocationKind.PointOfInterest,
+                Description: "Popis", GamePotential: "Záměr", SetupNotes: "Postavit"));
+
+        var locations = await Client.GetFromJsonAsync<List<LocationListDto>>("/api/locations");
+        var loc = locations!.First(l => l.Name == "Katalog lokace");
+        Assert.Equal("Popis", loc.Description);
+        Assert.Equal("Záměr", loc.GamePotential);
+        Assert.Equal("Postavit", loc.SetupNotes);
+        Assert.Empty(loc.Stashes);
+        Assert.Empty(loc.Quests);
+        Assert.Empty(loc.LocationTreasureQuests);
+    }
+
+    [Fact]
+    public async Task GetByGame_LocationWithStashesAndQuests_ReturnsEnrichedDto()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Enrich Test", 1, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Dol u řeky", LocationKind.PointOfInterest, 49.5m, 17.1m,
+                Description: "Tichý dol",
+                GamePotential: "Skrýše, setkání",
+                SetupNotes: "Postavit mostek"));
+        var loc = await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        await Client.PostAsJsonAsync("/api/locations/by-game",
+            new GameLocationDto(game!.Id, loc!.Id));
+
+        int stashId, questId, locationTreasureId, stashTreasureId, itemId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+
+            var stash = new SecretStash { Name = "Skrýš u kořene", Description = "Pod kořenem starého dubu" };
+            var item = new Item
+            {
+                Name = "Lektvar zdraví",
+                ItemType = ItemType.Potion,
+                ClassRequirements = new ClassRequirements(0, 0, 0, 0)
+            };
+            db.SecretStashes.Add(stash);
+            db.Items.Add(item);
+            await db.SaveChangesAsync();
+
+            db.GameSecretStashes.Add(new GameSecretStash
+            {
+                GameId = game.Id,
+                SecretStashId = stash.Id,
+                LocationId = loc.Id
+            });
+
+            var quest = new Quest
+            {
+                Name = "Najít kámen",
+                QuestType = QuestType.Location,
+                Description = "Najít ztracený kámen",
+                FullText = "Dlouhá verze úkolu",
+                RewardXp = 50,
+                RewardMoney = 20,
+                RewardNotes = "Bonus poznámka",
+                QuestRewards = [new QuestReward { ItemId = item.Id, Quantity = 2 }]
+            };
+            db.Quests.Add(quest);
+            await db.SaveChangesAsync();
+
+            db.QuestLocationLinks.Add(new QuestLocationLink
+            {
+                QuestId = quest.Id,
+                LocationId = loc.Id
+            });
+
+            var locTreasure = new TreasureQuest
+            {
+                Title = "Poklad v dole",
+                Clue = "Pod velkým kamenem",
+                Difficulty = TreasureQuestDifficulty.Midgame,
+                LocationId = loc.Id,
+                GameId = game.Id
+            };
+            var stashTreasure = new TreasureQuest
+            {
+                Title = "Poklad ve skrýši",
+                Clue = "V dřevěné krabici",
+                Difficulty = TreasureQuestDifficulty.Early,
+                SecretStashId = stash.Id,
+                GameId = game.Id
+            };
+            db.TreasureQuests.AddRange(locTreasure, stashTreasure);
+            await db.SaveChangesAsync();
+
+            stashId = stash.Id;
+            questId = quest.Id;
+            locationTreasureId = locTreasure.Id;
+            stashTreasureId = stashTreasure.Id;
+            itemId = item.Id;
+        }
+
+        var gameLocations = await Client.GetFromJsonAsync<List<LocationListDto>>(
+            $"/api/locations/by-game/{game.Id}");
+        Assert.NotNull(gameLocations);
+        Assert.Single(gameLocations);
+        var dto = gameLocations[0];
+
+        Assert.Equal("Dol u řeky", dto.Name);
+        Assert.Equal("Tichý dol", dto.Description);
+        Assert.Equal("Skrýše, setkání", dto.GamePotential);
+        Assert.Equal("Postavit mostek", dto.SetupNotes);
+
+        Assert.Single(dto.Stashes);
+        var stashDto = dto.Stashes[0];
+        Assert.Equal(stashId, stashDto.Id);
+        Assert.Equal("Skrýš u kořene", stashDto.Name);
+        Assert.Equal("Pod kořenem starého dubu", stashDto.Description);
+        Assert.Single(stashDto.TreasureQuests);
+        Assert.Equal(stashTreasureId, stashDto.TreasureQuests[0].Id);
+        Assert.Equal("Poklad ve skrýši", stashDto.TreasureQuests[0].Title);
+
+        Assert.Single(dto.Quests);
+        var questDto = dto.Quests[0];
+        Assert.Equal(questId, questDto.Id);
+        Assert.Equal("Najít kámen", questDto.Name);
+        Assert.Equal(QuestType.Location, questDto.QuestType);
+        Assert.Equal("Dlouhá verze úkolu", questDto.FullText);
+        Assert.Equal(50, questDto.RewardXp);
+        Assert.Equal(20, questDto.RewardMoney);
+        Assert.Equal("Bonus poznámka", questDto.RewardNotes);
+        Assert.Single(questDto.ItemRewards);
+        Assert.Equal(itemId, questDto.ItemRewards[0].ItemId);
+        Assert.Equal("Lektvar zdraví", questDto.ItemRewards[0].ItemName);
+        Assert.Equal(2, questDto.ItemRewards[0].Quantity);
+
+        Assert.Single(dto.LocationTreasureQuests);
+        Assert.Equal(locationTreasureId, dto.LocationTreasureQuests[0].Id);
+        Assert.Equal("Poklad v dole", dto.LocationTreasureQuests[0].Title);
     }
 }


### PR DESCRIPTION
## Summary

Split the Locations grid into a richer game view vs. the catalog view, and add the `QuestType.Location` ("Lokační") enum value.

**Grid columns** (both views):
- **Visible by default:** Herní potenciál, Přípravné poznámky
- **Hidden (reveal via column chooser):** Popis, Podrobnosti, NPC

**Game view only — new wide structured columns:**
- **Skrýše** — one card per assigned `GameSecretStash` at the location, showing stash name + description, with any stash-nested `TreasureQuest` folded in as a "Poklad" sub-row.
- **Questy** — one card per Quest linked via `QuestLocationLink`, showing name + type badge + `FullText` (fallback `Description`) + formatted reward line (`RewardXp`, `RewardMoney`, `QuestRewards` items, `RewardNotes`). Location-level `TreasureQuest`s (not on a stash) fold into the same column with a "Poklad" badge.

**Server:** `GET /api/locations/by-game/{id}` now `.Include()`s nested navs and projects the enrichment. Catalog endpoint returns the same `LocationListDto` with empty stash/quest lists.

**Quest scoping:** a quest link surfaces if `Quest.GameId` is null (global catalog quest) or matches the requested `gameId`.

**Layout key** bumped `grid-layout-locations` → `grid-layout-locations-v2` so browsers drop stale column filters.

**Version:** 0.7.0 → 0.8.0.

## Test plan

- [x] `GetByGame_LocationWithStashesAndQuests_ReturnsEnrichedDto` — Testcontainers covers full shape, including TreasureQuest on stash vs on location.
- [x] `GetAll_CatalogView_StashQuestListsEmpty` — catalog returns empty enrichment lists.
- [x] Full API test suite 236/236 green.
- [ ] Manual smoke — open a game, visit `/locations`, verify Skrýše + Questy cards render for a location that has both, verify catalog view doesn't show those two columns.

## Follow-up (not in this PR)

- Location detail popup: make assigned stashes visible and editable (add/remove at-location + edit stash description). Will ship on its own branch as v0.8.1+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)