### PR TITLE
fix(locations): remove invalid AllowFilter attribute [v0.8.2]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.8.1</Version>
+    <Version>0.8.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -76,7 +76,7 @@ else
             <DxGridDataColumn FieldName="SetupNotes" Caption="Přípravné poznámky" Width="220px" />
             @if (!Catalog)
             {
-                <DxGridDataColumn FieldName="Stashes" Caption="Skrýše" Width="500px" AllowSort="false" AllowFilter="false">
+                <DxGridDataColumn FieldName="Stashes" Caption="Skrýše" Width="500px" AllowSort="false" AllowGroup="false">
                     <CellDisplayTemplate>
                         @{
                             var loc = (LocationListDto)context.DataItem;
@@ -103,7 +103,7 @@ else
                         }
                     </CellDisplayTemplate>
                 </DxGridDataColumn>
-                <DxGridDataColumn FieldName="Quests" Caption="Questy" Width="600px" AllowSort="false" AllowFilter="false">
+                <DxGridDataColumn FieldName="Quests" Caption="Questy" Width="600px" AllowSort="false" AllowGroup="false">
                     <CellDisplayTemplate>
                         @{
                             var loc = (LocationListDto)context.DataItem;


### PR DESCRIPTION
## Summary

DxGridDataColumn in DevExpress.Blazor 25.2.5 throws at runtime when given `AllowFilter="false"`:

```
fail: DevExpress.Blazor.Internal.NestedSettingsHelper.SettingsRenderer[0]
  System.InvalidOperationException: Object of type
  'DevExpress.Blazor.DxGridDataColumn' does not have a property matching
  the name 'AllowFilter'.
```

PR #38 added this attribute to the Skrýše and Questy columns on the game-view Locations grid. Compilation succeeded (Razor accepts any attribute name); the exception fires during parameter binding at render, which crashes the grid's column init and left the page with **no columns visible at all in game view**. Catalog view was unaffected because those columns are gated `@if (!Catalog)`.

Fix: replace `AllowFilter="false"` with `AllowGroup="false"` on both structured display columns. Grouping a `List<>`-typed column is meaningless anyway, so this is the intent-preserving replacement.

## Observation for follow-up (not in this PR)

`ItemList.razor` and `GameSkills.razor` also use `AllowFilter="false"` on DxGridDataColumn. They haven't been reported as broken, but by the same logic they could be silently throwing. Worth a separate audit / smoke-test sweep once this lands.

## Version

0.8.1 → **0.8.2** (patch)

## Test plan

- [ ] After deploy, open `/locations` in game view — Skrýše + Questy column headers appear.
- [ ] Catalog view stays clean (no Skrýše/Questy columns as designed).
- [ ] Open DevTools console — no `DevExpress.Blazor.Internal.NestedSettingsHelper.SettingsRenderer` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)