### PR TITLE
fix(locations): null-guard Skrýše/Questy cell templates [v0.8.3]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.8.2</Version>
+    <Version>0.8.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -79,74 +79,80 @@ else
                 <DxGridDataColumn FieldName="Stashes" Caption="Skrýše" Width="500px" AllowSort="false" AllowGroup="false">
                     <CellDisplayTemplate>
                         @{
-                            var loc = (LocationListDto)context.DataItem;
+                            var loc = context.DataItem as LocationListDto;
                         }
-                        @foreach (var stash in loc.Stashes)
+                        @if (loc is not null)
                         {
-                            <div class="location-stash-card mb-2">
-                                <div><strong>@stash.Name</strong></div>
-                                @if (!string.IsNullOrWhiteSpace(stash.Description))
-                                {
-                                    <div class="text-muted small" style="white-space: pre-wrap">@stash.Description</div>
-                                }
-                                @foreach (var tq in stash.TreasureQuests)
-                                {
-                                    <div class="ps-2 mt-1 small">
-                                        <span class="badge bg-warning text-dark me-1">Poklad</span><strong>@tq.Title</strong>
-                                        @if (!string.IsNullOrWhiteSpace(tq.Clue))
-                                        {
-                                            <span class="text-muted"> — @tq.Clue</span>
-                                        }
-                                    </div>
-                                }
-                            </div>
+                            @foreach (var stash in loc.Stashes ?? [])
+                            {
+                                <div class="location-stash-card mb-2">
+                                    <div><strong>@stash.Name</strong></div>
+                                    @if (!string.IsNullOrWhiteSpace(stash.Description))
+                                    {
+                                        <div class="text-muted small" style="white-space: pre-wrap">@stash.Description</div>
+                                    }
+                                    @foreach (var tq in stash.TreasureQuests ?? [])
+                                    {
+                                        <div class="ps-2 mt-1 small">
+                                            <span class="badge bg-warning text-dark me-1">Poklad</span><strong>@tq.Title</strong>
+                                            @if (!string.IsNullOrWhiteSpace(tq.Clue))
+                                            {
+                                                <span class="text-muted"> — @tq.Clue</span>
+                                            }
+                                        </div>
+                                    }
+                                </div>
+                            }
                         }
                     </CellDisplayTemplate>
                 </DxGridDataColumn>
                 <DxGridDataColumn FieldName="Quests" Caption="Questy" Width="600px" AllowSort="false" AllowGroup="false">
                     <CellDisplayTemplate>
                         @{
-                            var loc = (LocationListDto)context.DataItem;
+                            var loc = context.DataItem as LocationListDto;
                         }
-                        @foreach (var quest in loc.Quests)
+                        @if (loc is not null)
                         {
-                            <div class="location-quest-card mb-2">
-                                <div>
-                                    <strong>@quest.Name</strong>
-                                    <span class="badge bg-info text-dark ms-1">@quest.QuestTypeDisplay</span>
+                            @foreach (var quest in loc.Quests ?? [])
+                            {
+                                <div class="location-quest-card mb-2">
+                                    <div>
+                                        <strong>@quest.Name</strong>
+                                        <span class="badge bg-info text-dark ms-1">@quest.QuestTypeDisplay</span>
+                                    </div>
+                                    @{
+                                        var body = !string.IsNullOrWhiteSpace(quest.FullText) ? quest.FullText : quest.Description;
+                                    }
+                                    @if (!string.IsNullOrWhiteSpace(body))
+                                    {
+                                        <div class="small" style="white-space: pre-wrap">@body</div>
+                                    }
+                                    @{
+                                        var parts = new List<string>();
+                                        if (quest.RewardXp.HasValue) parts.Add($"{quest.RewardXp} XP");
+                                        if (quest.RewardMoney.HasValue) parts.Add($"{quest.RewardMoney} grošů");
+                                        foreach (var itm in quest.ItemRewards ?? []) parts.Add($"{itm.ItemName} ×{itm.Quantity}");
+                                        if (!string.IsNullOrWhiteSpace(quest.RewardNotes)) parts.Add(quest.RewardNotes!);
+                                    }
+                                    @if (parts.Count > 0)
+                                    {
+                                        <div class="text-muted small"><em>Odměna:</em> @string.Join(", ", parts)</div>
+                                    }
                                 </div>
-                                @{
-                                    var body = !string.IsNullOrWhiteSpace(quest.FullText) ? quest.FullText : quest.Description;
-                                }
-                                @if (!string.IsNullOrWhiteSpace(body))
-                                {
-                                    <div class="small" style="white-space: pre-wrap">@body</div>
-                                }
-                                @{
-                                    var parts = new List<string>();
-                                    if (quest.RewardXp.HasValue) parts.Add($"{quest.RewardXp} XP");
-                                    if (quest.RewardMoney.HasValue) parts.Add($"{quest.RewardMoney} grošů");
-                                    foreach (var itm in quest.ItemRewards) parts.Add($"{itm.ItemName} ×{itm.Quantity}");
-                                    if (!string.IsNullOrWhiteSpace(quest.RewardNotes)) parts.Add(quest.RewardNotes!);
-                                }
-                                @if (parts.Count > 0)
-                                {
-                                    <div class="text-muted small"><em>Odměna:</em> @string.Join(", ", parts)</div>
-                                }
-                            </div>
-                        }
-                        @foreach (var tq in loc.LocationTreasureQuests)
-                        {
-                            <div class="location-quest-card mb-2">
-                                <div>
-                                    <strong>@tq.Title</strong>
-                                    <span class="badge bg-warning text-dark ms-1">Poklad</span>
+                            }
+                            @foreach (var tq in loc.LocationTreasureQuests ?? [])
+                            {
+                                <div class="location-quest-card mb-2">
+                                    <div>
+                                        <strong>@tq.Title</strong>
+                                        <span class="badge bg-warning text-dark ms-1">Poklad</span>
+                                    </div>
+                                    @if (!string.IsNullOrWhiteSpace(tq.Clue))
+                                    {
+                                        <div class="small" style="white-space: pre-wrap">@tq.Clue</div>
+                                    }
                                 </div>
-                                @if (!string.IsNullOrWhiteSpace(tq.Clue))
-                                {
-                                    <div class="small" style="white-space: pre-wrap">@tq.Clue</div>
-                                }
-                            </div>
+                            }
                         }
                     </CellDisplayTemplate>
                 </DxGridDataColumn>


### PR DESCRIPTION
## Summary

Production hit `NullReferenceException` in `LocationList.BuildRenderTree` on the game-view grid immediately after the Skrýše/Questy columns started rendering (PR #40). Stack trace pointed at an anonymous lambda inside a `CellDisplayTemplate`.

Most likely cause: DxGrid invokes `CellDisplayTemplate` for non-data rows too (group header, filter row, potential edit stubs). For those rows `context.DataItem` isn't a `LocationListDto`, so the direct `(LocationListDto)context.DataItem` cast produced a null reference that the first `foreach (var stash in loc.Stashes)` then dereferenced.

## Fix (both structured columns)

- Safe cast: `context.DataItem as LocationListDto` instead of the direct cast.
- Wrap the entire template body in `@if (loc is not null)` — DxGrid gets an empty cell for non-data rows rather than a fatal render exception.
- Null-coalesce every collection access (`loc.Stashes`, `loc.Quests`, `loc.LocationTreasureQuests`, `stash.TreasureQuests`, `quest.ItemRewards`) with `?? []`. Server currently always `.ToList()`s; this is belt-and-suspenders against any server-side projection surprise (e.g., future edits, edge cases in EF).

## Separate follow-up (not in this PR)

User also saw an SRI integrity failure on `appsettings.json` in the service worker:

```
Failed to find a valid digest in the 'integrity' attribute for resource 'https://hra.ovcina.cz/appsettings.json' ... The resource has been blocked.
```

That's a PWA manifest/asset-hash mismatch — separate from the render crash. Deploy-hygiene bug, tends to self-heal on next clean deploy; if it persists after this lands, we check the pipeline.

## Version

0.8.2 → **0.8.3** (patch)

## Test plan

- [ ] Game view `/locations` — Skrýše + Questy columns render with card content.
- [ ] No `NullReferenceException` in DevTools console.
- [ ] Grouping or filtering by an unrelated column (e.g. Oblast) doesn't crash the grid.
- [ ] Catalog view `/locations?catalog=true` — unchanged, no Skrýše/Questy columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)