### PR TITLE
fix(auth): narrow refresh-dead policy + console diagnostics [v0.8.4]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/AuthEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/AuthEndpoints.cs
@@ -148,7 +148,27 @@ public static class AuthEndpoints
                     }));
 
                 if (!tokenResponse.IsSuccessStatusCode)
+                {
+                    // Forward the OAuth2 error body from the upstream identity provider so the
+                    // client can distinguish a definitively-dead refresh token (body contains
+                    // {"error":"invalid_grant"}) from a transient hiccup.
+                    var errorBody = await tokenResponse.Content.ReadAsStringAsync();
+                    if (!string.IsNullOrWhiteSpace(errorBody))
+                    {
+                        try
+                        {
+                            using var _ = System.Text.Json.JsonDocument.Parse(errorBody);
+                            return Results.Content(errorBody, "application/json",
+                                Encoding.UTF8, statusCode: StatusCodes.Status401Unauthorized);
+                        }
+                        catch (System.Text.Json.JsonException)
+                        {
+                            // Upstream didn't return JSON (e.g., HTML error page from a proxy).
+                            // Fall through to bare 401.
+                        }
+                    }
                     return Results.Unauthorized();
+                }
 
                 var tokenData = await tokenResponse.Content.ReadFromJsonAsync<OidcTokenResponse>();
                 if (tokenData?.AccessToken is null)

--- a/src/OvcinaHra.Client/Auth/AuthLog.cs
+++ b/src/OvcinaHra.Client/Auth/AuthLog.cs
@@ -1,0 +1,28 @@
+namespace OvcinaHra.Client.Auth;
+
+/// <summary>
+/// Lightweight structured logging helper for the client auth pipeline.
+///
+/// Emits a one-line event to the browser console so we can reconstruct why a
+/// user was forced back to /login in production. Kept in-process only —
+/// Console.WriteLine in Blazor WASM routes to the DevTools console.
+///
+/// Format: <c>[auth HH:mm:ss.fff] {event} key1=v1 key2=v2 ...</c>
+/// </summary>
+internal static class AuthLog
+{
+    public static void Event(string ev, params (string key, object? value)[] fields)
+    {
+        var ts = DateTime.UtcNow.ToString("HH:mm:ss.fff");
+        if (fields.Length == 0)
+        {
+            Console.WriteLine($"[auth {ts}] {ev}");
+            return;
+        }
+
+        var body = string.Join(
+            " ",
+            fields.Select(f => $"{f.key}={(f.value is null ? "null" : f.value)}"));
+        Console.WriteLine($"[auth {ts}] {ev} {body}");
+    }
+}

--- a/src/OvcinaHra.Client/Auth/AuthLog.cs
+++ b/src/OvcinaHra.Client/Auth/AuthLog.cs
@@ -7,7 +7,11 @@ namespace OvcinaHra.Client.Auth;
 /// user was forced back to /login in production. Kept in-process only —
 /// Console.WriteLine in Blazor WASM routes to the DevTools console.
 ///
-/// Format: <c>[auth HH:mm:ss.fff] {event} key1=v1 key2=v2 ...</c>
+/// Format: <c>[auth HH:mm:ss.fff] {event} key1=v1 key2="quoted value"</c>
+///
+/// Values that contain whitespace, quotes, <c>=</c>, or control characters are
+/// JSON-escaped and quoted so each <c>key=value</c> pair stays parseable even
+/// when a value includes spaces or newlines.
 /// </summary>
 internal static class AuthLog
 {
@@ -22,7 +26,42 @@ internal static class AuthLog
 
         var body = string.Join(
             " ",
-            fields.Select(f => $"{f.key}={(f.value is null ? "null" : f.value)}"));
+            fields.Select(f => $"{f.key}={FormatValue(f.value)}"));
         Console.WriteLine($"[auth {ts}] {ev} {body}");
+    }
+
+    private static string FormatValue(object? v)
+    {
+        if (v is null) return "null";
+        var s = v.ToString() ?? "null";
+        if (s.Length == 0) return "\"\"";
+
+        var needsQuote = false;
+        foreach (var ch in s)
+        {
+            if (ch <= ' ' || ch == '"' || ch == '\\' || ch == '=')
+            {
+                needsQuote = true;
+                break;
+            }
+        }
+        if (!needsQuote) return s;
+
+        var sb = new System.Text.StringBuilder(s.Length + 4);
+        sb.Append('"');
+        foreach (var ch in s)
+        {
+            switch (ch)
+            {
+                case '"': sb.Append("\\\""); break;
+                case '\\': sb.Append("\\\\"); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                default: sb.Append(ch); break;
+            }
+        }
+        sb.Append('"');
+        return sb.ToString();
     }
 }

--- a/src/OvcinaHra.Client/Auth/JwtAuthStateProvider.cs
+++ b/src/OvcinaHra.Client/Auth/JwtAuthStateProvider.cs
@@ -27,6 +27,7 @@ public class JwtAuthStateProvider : AuthenticationStateProvider
         var token = await GetTokenAsync();
         if (string.IsNullOrEmpty(token))
         {
+            AuthLog.Event("authstate.no_token");
             _http.DefaultRequestHeaders.Authorization = null;
             return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
         }
@@ -56,17 +57,34 @@ public class JwtAuthStateProvider : AuthenticationStateProvider
                     // Fire-and-forget; TryBootAsync is idempotent.
                     _ = _services.GetRequiredService<TokenRefreshService>().TryBootAsync();
 
+                    AuthLog.Event("authstate.ok",
+                        ("user", me.UserId),
+                        ("roles", me.Roles.Count));
                     return new AuthenticationState(
                         new ClaimsPrincipal(new ClaimsIdentity(claims, "oidc")));
                 }
+
+                AuthLog.Event("authstate.me_null_body", ("action", "clear"));
+            }
+            else
+            {
+                AuthLog.Event("authstate.me_failed",
+                    ("status", (int)response.StatusCode),
+                    ("action", "clear"));
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // API unreachable — treat as unauthenticated.
+            // API unreachable — treat as unauthenticated but DON'T clear tokens
+            // (the refresh timer may still recover us when the network comes back).
+            AuthLog.Event("authstate.me_threw",
+                ("type", ex.GetType().Name),
+                ("msg", ex.Message),
+                ("action", "keep_tokens_treat_unauth"));
+            return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
         }
 
-        // Token invalid or API down — clear stale tokens from localStorage.
+        // Token invalid response body — clear stale tokens from localStorage.
         await ClearTokenAsync();
         return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
     }

--- a/src/OvcinaHra.Client/Auth/JwtAuthStateProvider.cs
+++ b/src/OvcinaHra.Client/Auth/JwtAuthStateProvider.cs
@@ -57,9 +57,9 @@ public class JwtAuthStateProvider : AuthenticationStateProvider
                     // Fire-and-forget; TryBootAsync is idempotent.
                     _ = _services.GetRequiredService<TokenRefreshService>().TryBootAsync();
 
-                    AuthLog.Event("authstate.ok",
-                        ("user", me.UserId),
-                        ("roles", me.Roles.Count));
+                    // User id deliberately omitted — this log surfaces in the browser
+                    // console and may be captured in screenshots / shared bug reports.
+                    AuthLog.Event("authstate.ok", ("roles", me.Roles.Count));
                     return new AuthenticationState(
                         new ClaimsPrincipal(new ClaimsIdentity(claims, "oidc")));
                 }
@@ -77,9 +77,10 @@ public class JwtAuthStateProvider : AuthenticationStateProvider
         {
             // API unreachable — treat as unauthenticated but DON'T clear tokens
             // (the refresh timer may still recover us when the network comes back).
+            // ex.Message intentionally omitted — can leak URLs / sensitive detail
+            // into the browser console. Exception type + action is enough signal.
             AuthLog.Event("authstate.me_threw",
                 ("type", ex.GetType().Name),
-                ("msg", ex.Message),
                 ("action", "keep_tokens_treat_unauth"));
             return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
         }

--- a/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
+++ b/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
@@ -95,13 +95,20 @@ public class TokenRefreshService : IDisposable
             {
                 var expiry = GetJwtExpiry(currentToken);
                 if (expiry.HasValue && (expiry.Value - DateTimeOffset.UtcNow).TotalSeconds > 60)
+                {
+                    AuthLog.Event("refresh.skipped",
+                        ("reason", "already_fresh"),
+                        ("remaining_s", (int)(expiry.Value - DateTimeOffset.UtcNow).TotalSeconds));
                     return;
+                }
             }
 
             var refreshToken = await GetStoredRefreshTokenAsync();
 
             if (!string.IsNullOrEmpty(refreshToken))
             {
+                AuthLog.Event("refresh.start", ("path", "oidc"));
+
                 // Production OIDC path — stored refresh_token from registrace-ovcina.
                 using var response = await _http.PostAsJsonAsync("/api/auth/oidc-refresh",
                     new OidcRefreshRequestDto(refreshToken), cancellationToken);
@@ -115,24 +122,53 @@ public class TokenRefreshService : IDisposable
                         if (!string.IsNullOrEmpty(token.RefreshToken))
                             await SetStoredRefreshTokenAsync(token.RefreshToken);
                         ScheduleRefresh(token.ExpiresInSeconds);
+                        AuthLog.Event("refresh.ok",
+                            ("path", "oidc"),
+                            ("expires_in_s", token.ExpiresInSeconds),
+                            ("refresh_rotated", !string.IsNullOrEmpty(token.RefreshToken)));
                         return;
                     }
+
+                    // 2xx but empty/unparseable body — don't clear tokens, retry.
+                    AuthLog.Event("refresh.ok_null_body",
+                        ("path", "oidc"),
+                        ("action", "retry_in_30s"));
+                    ScheduleRetryAfterError();
+                    return;
                 }
 
-                if (IsExplicitAuthFailure(response.StatusCode))
+                // Non-success. Read the OAuth2 error code if any.
+                var bodyError = await TryReadOAuth2ErrorAsync(response, cancellationToken);
+
+                // Strict: only a 401 with explicit OAuth2 "invalid_grant" means the refresh
+                // token is truly dead. Anything else (400/403, 5xx, proxy errors, unknown 401)
+                // is treated as transient — we do NOT wipe the refresh token, we retry.
+                var isExplicitlyDead = response.StatusCode == HttpStatusCode.Unauthorized
+                                       && string.Equals(bodyError, "invalid_grant", StringComparison.Ordinal);
+
+                if (isExplicitlyDead)
                 {
-                    // Refresh token definitively rejected — clear it so we don't keep retrying.
+                    AuthLog.Event("refresh.explicit_failure",
+                        ("path", "oidc"),
+                        ("status", (int)response.StatusCode),
+                        ("error", bodyError),
+                        ("action", "clear_tokens"));
                     await ClearStoredRefreshTokenAsync();
                     await _authProvider.ClearTokenAsync();
                     return;
                 }
 
-                // Transient (5xx, 408, 429, or null body on 2xx) — keep the tokens, retry shortly.
+                AuthLog.Event("refresh.transient",
+                    ("path", "oidc"),
+                    ("status", (int)response.StatusCode),
+                    ("error", bodyError ?? "(none)"),
+                    ("action", "retry_in_30s"));
                 ScheduleRetryAfterError();
                 return;
             }
 
             // Dev path — self-issued token, no refresh_token involved.
+            AuthLog.Event("refresh.start", ("path", "dev"));
             using var devResponse = await _http.PostAsync("/api/auth/refresh", null, cancellationToken);
             if (devResponse.IsSuccessStatusCode)
             {
@@ -141,16 +177,30 @@ public class TokenRefreshService : IDisposable
                 {
                     await _authProvider.SetTokenAsync(token.Token);
                     ScheduleRefresh(token.ExpiresInSeconds);
+                    AuthLog.Event("refresh.ok",
+                        ("path", "dev"),
+                        ("expires_in_s", token.ExpiresInSeconds));
+                    return;
                 }
+                AuthLog.Event("refresh.ok_null_body", ("path", "dev"));
+            }
+            else
+            {
+                AuthLog.Event("refresh.dev_failed",
+                    ("status", (int)devResponse.StatusCode));
             }
         }
         catch (OperationCanceledException)
         {
             throw;
         }
-        catch
+        catch (Exception ex)
         {
-            // Network error — retry shortly.
+            // Network error — retry shortly. Keep tokens so we can recover when network returns.
+            AuthLog.Event("refresh.threw",
+                ("type", ex.GetType().Name),
+                ("msg", ex.Message),
+                ("action", "retry_in_30s"));
             ScheduleRetryAfterError();
         }
         finally
@@ -159,10 +209,31 @@ public class TokenRefreshService : IDisposable
         }
     }
 
-    private static bool IsExplicitAuthFailure(HttpStatusCode status) =>
-        status == HttpStatusCode.BadRequest
-        || status == HttpStatusCode.Unauthorized
-        || status == HttpStatusCode.Forbidden;
+    /// <summary>
+    /// Reads an OAuth2-style <c>{"error":"..."}</c> field from the response body,
+    /// returning null if the body isn't JSON or has no error field.
+    /// </summary>
+    private static async Task<string?> TryReadOAuth2ErrorAsync(
+        HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var raw = await response.Content.ReadAsStringAsync(cancellationToken);
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+            using var doc = JsonDocument.Parse(raw);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("error", out var err)
+                && err.ValueKind == JsonValueKind.String)
+            {
+                return err.GetString();
+            }
+        }
+        catch
+        {
+            // Non-JSON body or parse error — caller treats as transient.
+        }
+        return null;
+    }
 
     private void ScheduleRetryAfterError()
     {

--- a/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
+++ b/src/OvcinaHra.Client/Auth/TokenRefreshService.cs
@@ -197,9 +197,9 @@ public class TokenRefreshService : IDisposable
         catch (Exception ex)
         {
             // Network error — retry shortly. Keep tokens so we can recover when network returns.
+            // ex.Message intentionally omitted — can leak sensitive detail.
             AuthLog.Event("refresh.threw",
                 ("type", ex.GetType().Name),
-                ("msg", ex.Message),
                 ("action", "retry_in_30s"));
             ScheduleRetryAfterError();
         }

--- a/src/OvcinaHra.Client/Auth/UnauthorizedRedirectHandler.cs
+++ b/src/OvcinaHra.Client/Auth/UnauthorizedRedirectHandler.cs
@@ -51,6 +51,7 @@ public class UnauthorizedRedirectHandler : DelegatingHandler
         if (response.StatusCode != HttpStatusCode.Unauthorized || isTokenEndpoint)
             return response;
 
+        AuthLog.Event("401.intercepted", ("path", path), ("method", request.Method.Method));
         response.Dispose();
 
         var refresh = _services.GetRequiredService<TokenRefreshService>();
@@ -61,6 +62,9 @@ public class UnauthorizedRedirectHandler : DelegatingHandler
 
         if (string.IsNullOrEmpty(newToken))
         {
+            AuthLog.Event("401.force_logout",
+                ("path", path),
+                ("reason", "no_token_after_refresh"));
             _nav.NavigateTo("/login", forceLoad: true);
             return new HttpResponseMessage(HttpStatusCode.Unauthorized);
         }
@@ -70,7 +74,18 @@ public class UnauthorizedRedirectHandler : DelegatingHandler
 
         var retryResponse = await base.SendAsync(retry, cancellationToken);
         if (retryResponse.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            AuthLog.Event("401.force_logout",
+                ("path", path),
+                ("reason", "retry_also_401"));
             _nav.NavigateTo("/login", forceLoad: true);
+        }
+        else
+        {
+            AuthLog.Event("401.retry_ok",
+                ("path", path),
+                ("status", (int)retryResponse.StatusCode));
+        }
 
         return retryResponse;
     }

--- a/src/OvcinaHra.Client/Auth/UnauthorizedRedirectHandler.cs
+++ b/src/OvcinaHra.Client/Auth/UnauthorizedRedirectHandler.cs
@@ -65,6 +65,9 @@ public class UnauthorizedRedirectHandler : DelegatingHandler
             AuthLog.Event("401.force_logout",
                 ("path", path),
                 ("reason", "no_token_after_refresh"));
+            // Clear stored tokens + stop the refresh timer BEFORE navigating so the
+            // /login page doesn't inherit a zombie refresh loop against dead tokens.
+            await auth.ClearTokenAsync();
             _nav.NavigateTo("/login", forceLoad: true);
             return new HttpResponseMessage(HttpStatusCode.Unauthorized);
         }
@@ -78,6 +81,7 @@ public class UnauthorizedRedirectHandler : DelegatingHandler
             AuthLog.Event("401.force_logout",
                 ("path", path),
                 ("reason", "retry_also_401"));
+            await auth.ClearTokenAsync();
             _nav.NavigateTo("/login", forceLoad: true);
         }
         else

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.8.3</Version>
+    <Version>0.8.4</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Addresses the **primary root cause** from the auth audit (the "refresh all the time" behavior) plus adds the structured browser-console diagnostics we'll need to drive follow-up fixes with evidence rather than guesses.

## Primary fix — `TokenRefreshService.RefreshAsync`

Old `IsExplicitAuthFailure` treated **any** `400 | 401 | 403` on `/api/auth/oidc-refresh` as "refresh token permanently invalid" and wiped both tokens. A single transient hiccup (clock skew, 400 from a body proxy munged, 403 rate-limit, 401 without detail) would silently log the user out.

New policy — only a **401 + OAuth2 `error: "invalid_grant"` in the body** clears tokens. Everything else (including 400/403/any unknown 401) is transient → schedule 30s retry, refresh token stays.

Helper `TryReadOAuth2ErrorAsync` reads the standard OAuth2 `{"error":"..."}` field, tolerant of non-JSON bodies.

## Secondary fix — `JwtAuthStateProvider.GetAuthenticationStateAsync`

Previously cleared stored tokens on **any** exception from `/api/auth/me` (including transient network errors). Now keeps tokens on throw — reports unauthenticated for this check so the refresh timer / next call can still recover.

## Diagnostics — new `AuthLog` helper

Single-line `Console.WriteLine` events in DevTools console, keyed for easy grep:
```
[auth 14:02:33.157] refresh.explicit_failure path=oidc status=401 error=invalid_grant action=clear_tokens
[auth 14:02:34.221] 401.force_logout path=/api/items reason=retry_also_401
```

Coverage:
- `JwtAuthStateProvider`: `authstate.no_token | .ok | .me_failed | .me_null_body | .me_threw`
- `TokenRefreshService`: `refresh.start | .ok | .skipped | .ok_null_body | .explicit_failure | .transient | .dev_failed | .threw`
- `UnauthorizedRedirectHandler`: `401.intercepted | .retry_ok | .force_logout` (with `reason=no_token_after_refresh | retry_also_401`)

## Version

0.8.3 → **0.8.4** (patch)

## Follow-up — driven by what logs show, not guesses

- Pre-request token-freshness check in `ApiClient` (refresh before 401).
- Separate HttpClient for token endpoints (no bearer pollution on refresh calls).
- Cross-tab sync via `window.addEventListener('storage', ...)` — avoids rotated-refresh-token races.
- Soft re-auth modal instead of `forceLoad` to `/login` — preserves page/modal state.

## Test plan

- [ ] Force a 500 on the refresh endpoint (e.g., temporarily break backend) — verify user stays logged in, log shows `refresh.transient`, retries after 30s.
- [ ] Force a 401 with `{"error":"invalid_grant"}` body — verify user is cleared and redirected.
- [ ] Force a 401 with empty / non-JSON body — verify user **stays logged in** (treated as transient).
- [ ] Normal expiry cycle — verify `refresh.ok` with `expires_in_s` and `refresh_rotated=true`.
- [ ] Production session — collect DevTools console logs over a few hours to see which events actually fire during the reported re-auth incidents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)