### PR TITLE
fix(grids): remove invalid AllowFilter app-wide [v0.8.5]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.8.4</Version>
+    <Version>0.8.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Games/GameSkills.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameSkills.razor
@@ -54,7 +54,7 @@ else
                         @(lvl.HasValue ? lvl.Value.ToString() : "Bez požadavku")
                     </CellDisplayTemplate>
                 </DxGridDataColumn>
-                <DxGridDataColumn Caption="" Width="60px" AllowSort="false" AllowGroup="false" AllowFilter="false">
+                <DxGridDataColumn Caption="" Width="60px" AllowSort="false" AllowGroup="false">
                     <CellDisplayTemplate>
                         @{
                             var row = (GameSkillDto)context.DataItem;

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -64,7 +64,7 @@ else if (Catalog)
             <DxGridDataColumn FieldName="HasImage" Caption="Obrázek" Width="100px" Visible="false">
                 <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false" AllowFilter="false">
+            <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>
                     @{
                         var itemId = (int)context.Value;
@@ -89,7 +89,7 @@ else
     <OvcinaGrid Data="@gameItems" KeyFieldName="Id" LayoutKey="grid-layout-items-game"
                 RowClick="@(e => OpenModal((GameItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
-            <DxGridDataColumn FieldName="" Caption="" Width="40px" AllowSort="false" AllowGroup="false" AllowFilter="false" FixedPosition="GridColumnFixedPosition.Left">
+            <DxGridDataColumn FieldName="" Caption="" Width="40px" AllowSort="false" AllowGroup="false" FixedPosition="GridColumnFixedPosition.Left">
                 <CellDisplayTemplate>
                     @{
                         var gi = (GameItemListDto)context.DataItem;

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
@@ -70,7 +70,7 @@ else if (Catalog)
             <DxGridDataColumn FieldName="HasImage" Caption="Obrázek" Width="100px" Visible="false">
                 <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false" AllowFilter="false">
+            <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>
                     @{
                         var pqId = (int)context.Value;
@@ -95,7 +95,7 @@ else
     <OvcinaGrid Data="@gameItems" KeyFieldName="Id" LayoutKey="grid-layout-personal-quests-game"
                 RowClick="@(e => OpenModal((GamePersonalQuestListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
-            <DxGridDataColumn FieldName="" Caption="" Width="40px" AllowSort="false" AllowGroup="false" AllowFilter="false" FixedPosition="GridColumnFixedPosition.Left">
+            <DxGridDataColumn FieldName="" Caption="" Width="40px" AllowSort="false" AllowGroup="false" FixedPosition="GridColumnFixedPosition.Left">
                 <CellDisplayTemplate>
                     @{
                         var gi = (GamePersonalQuestListDto)context.DataItem;

--- a/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
@@ -29,7 +29,7 @@ else if (Catalog)
             <DxGridDataColumn FieldName="RewardSummary" Caption="Odměny" Width="220px" />
             <DxGridDataColumn FieldName="CatalogAction" Caption="Akce" Width="110px"
                               UnboundType="GridUnboundColumnType.String"
-                              AllowSort="false" AllowGroup="false" AllowFilter="false">
+                              AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>
                     @{
                         var q = (QuestCatalogDto)context.DataItem;


### PR DESCRIPTION
## Summary

Same runtime bug that killed the Locations Skrýše/Questy columns (fixed in #40) was still lurking on four other pages. DxGridDataColumn in DevExpress.Blazor 25.2.5 does not expose an `AllowFilter` parameter, so every `<DxGridDataColumn ... AllowFilter=\"false\">` throws at render:

```
System.InvalidOperationException: Object of type 'DevExpress.Blazor.DxGridDataColumn' does not have a property matching the name 'AllowFilter'.
```

Exception surfaces via `DevExpress.Blazor.Internal.NestedSettingsHelper.SettingsRenderer` — the grid renders empty, user sees a blank list with no in-page error.

## Changes

Stripped `AllowFilter=\"false\"` from every `DxGridDataColumn` on:

- `Pages/Games/GameSkills.razor`
- `Pages/Items/ItemList.razor` (2 columns)
- `Pages/PersonalQuests/PersonalQuestList.razor` (2 columns)
- `Pages/Quests/QuestList.razor`

Kept `AllowSort=\"false\"` / `AllowGroup=\"false\"` where present — those are valid parameters.

Grepped the whole `src/` tree; **no further `AllowFilter` usages remain**.

Version 0.8.4 → **0.8.5** (patch).

## Test plan

- [ ] `/items` game view — grid renders with columns.
- [ ] `/games/{id}/skills` — grid renders.
- [ ] `/personal-quests` both views — grids render.
- [ ] `/quests` — grid renders.
- [ ] No `DevExpress.Blazor.Internal.NestedSettingsHelper.SettingsRenderer` exceptions in DevTools console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)