### PR TITLE
fix(deploy): stop mutating appsettings.json post-publish — unsticks PWA service worker [v0.8.6]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,6 @@ jobs:
           build-args: |
             DEVEXPRESS_NUGET_SOURCE=${{ secrets.DEVEXPRESS_NUGET_SOURCE }}
             DEVEXPRESS_LICENSE_CONTENT=${{ secrets.DEVEXPRESS_LICENSE_CONTENT }}
-            API_BASE_URL=${{ secrets.API_BASE_URL }}
 
       - name: Azure Login
         uses: azure/login@v2

--- a/src/OvcinaHra.Client/Dockerfile
+++ b/src/OvcinaHra.Client/Dockerfile
@@ -1,7 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG DEVEXPRESS_NUGET_SOURCE
 ARG DEVEXPRESS_LICENSE_CONTENT
-ARG API_BASE_URL=https://localhost:5280
 WORKDIR /src
 
 COPY ["global.json", "."]
@@ -25,10 +24,13 @@ COPY src/ src/
 
 RUN dotnet publish src/OvcinaHra.Client/OvcinaHra.Client.csproj -c Release -o /app/publish --no-restore
 
-# Inject production API URL into the published appsettings.json
-RUN if [ "${API_BASE_URL}" != "https://localhost:5280" ]; then \
-      sed -i "s|https://localhost:5280|${API_BASE_URL}|g" /app/publish/wwwroot/appsettings.json; \
-    fi
+# IMPORTANT: do NOT modify /app/publish/wwwroot/appsettings.json after this point.
+# `dotnet publish` has already emitted service-worker-assets.js with SHA-256
+# integrity hashes for every static asset. Post-publish mutation breaks SRI and
+# leaves the PWA service worker stuck in the "installing" state. Production
+# configuration (ApiBaseUrl, OidcAuthority, OidcClientId) lives in
+# appsettings.Production.json, which Blazor WASM merges over the base file at
+# runtime when HostEnvironment.Environment == "Production".
 
 FROM nginx:alpine AS final
 

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.8.5</Version>
+    <Version>0.8.6</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Symptom

Every browser visiting `hra.ovcina.cz` has been logging this for days:

```
Failed to find a valid digest in the 'integrity' attribute for resource
'https://hra.ovcina.cz/appsettings.json' with computed SHA-256 integrity
'PBJwAibqi4edwiJdwkcKfpDICDkXi5FGZVTq8TSbjpI='. The resource has been blocked.
service-worker.js:28 Uncaught (in promise) TypeError: Failed to fetch.
SRI's integrity checks failed.
```

Effect: the Blazor WASM PWA service worker **can never complete install**, so the previously-activated SW keeps serving the old cached bundle forever. This is also why earlier client fixes (grid columns, auth, etc.) appeared not to reach production even after successful deploys.

## Root cause

`src/OvcinaHra.Client/Dockerfile` mutated the file **after** `dotnet publish` had already hashed it into `service-worker-assets.js`:

```dockerfile
RUN dotnet publish ...                                         # emits SRI manifest with SHA-256 of
                                                               # the UNMODIFIED appsettings.json
RUN if [ "${API_BASE_URL}" != "https://localhost:5280" ]; then
      sed -i "s|https://localhost:5280|${API_BASE_URL}|g" \
        /app/publish/wwwroot/appsettings.json                  # ← invalidates the hash the manifest records
    fi
```

Confirmed evidence:

- Browser computed `sha256-PBJwAibq...` for the live file (post-sed content).
- Manifest recorded `sha256-WrHvmmV5...` (pre-sed content).
- Git source `src/OvcinaHra.Client/wwwroot/appsettings.json` hashes to the same `sha256-WrHvmmV5...` — so the manifest is correct; the **served file is wrong**.

## Fix

1. Drop the sed block + `ARG API_BASE_URL` from `src/OvcinaHra.Client/Dockerfile`. Added a WARNING comment to keep future contributors from re-introducing post-publish mutation.
2. Drop `API_BASE_URL=${{ secrets.API_BASE_URL }}` from `.github/workflows/deploy.yml` — no longer used.
3. Rely on `src/OvcinaHra.Client/wwwroot/appsettings.Production.json` (already in source control) which Blazor WASM merges over the base file in Production. Program.cs line 22 already reads the final value through `IConfiguration`:

```csharp
var apiBaseUrl = builder.Configuration["ApiBaseUrl"] ?? builder.HostEnvironment.BaseAddress;
```

4. Version bump 0.8.5 → **0.8.6**.

## Expected recovery

Once this deploys:

- Fresh build produces a manifest whose hashes match every file on disk.
- Existing users' stuck service workers retry install on the next navigation, find matching hashes, activate the new SW, and the new bundle becomes visible.
- Users whose SW is deeply stuck can unstick with one hard reload / DevTools → Application → Service Workers → Unregister.

## Test plan

- [ ] Build passes CI.
- [ ] After merge + deploy: console on `hra.ovcina.cz` no longer logs the SRI/`Failed to fetch` errors.
- [ ] Users see v0.8.6 (or whatever deploys after this) rather than the stale bundle.
- [ ] Skrýše/Questy columns on `/locations` game view actually render for end users (they should — the code is correct on main since #40/#41, just gated by the stuck SW).
- [ ] `ApiBaseUrl` at runtime is `https://api.hra.ovcina.cz` (verify: Network tab shows API calls going to that host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)