### PR TITLE
feat(deploy): /api/version + revision health gate [v0.8.8]

### DIFF
--- a/.github/scripts/wait-for-containerapp-revision.sh
+++ b/.github/scripts/wait-for-containerapp-revision.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Polls an Azure Container App's latest revision until it is Running + Healthy,
+# or exits non-zero on a definitive failure or timeout.
+#
+# Usage: wait-for-containerapp-revision.sh <container-app-name> <resource-group>
+#
+# Why: `az containerapp update` returns as soon as the update is submitted;
+# if the new revision fails to start (image pull error, migration crash,
+# container exits at boot, ...) the previous revision keeps serving traffic
+# silently, while the deploy action exits 0. Without this poll the workflow
+# badge goes green while production stays stale.
+
+set -e
+
+APP=${1:?usage: $0 <container-app-name> <resource-group>}
+RG=${2:?usage: $0 <container-app-name> <resource-group>}
+
+ATTEMPTS=30
+SLEEP_SECONDS=10
+
+echo "Polling latest revision of $APP (up to $((ATTEMPTS * SLEEP_SECONDS))s)..."
+for i in $(seq 1 "$ATTEMPTS"); do
+  REV=$(az containerapp show --name "$APP" --resource-group "$RG" \
+    --query properties.latestRevisionName -o tsv)
+  STATE=$(az containerapp revision show --name "$APP" --resource-group "$RG" \
+    --revision "$REV" --query properties.runningState -o tsv 2>/dev/null || echo "Unknown")
+  HEALTH=$(az containerapp revision show --name "$APP" --resource-group "$RG" \
+    --revision "$REV" --query properties.healthState -o tsv 2>/dev/null || echo "Unknown")
+  echo "attempt $i: revision=$REV state=$STATE health=$HEALTH"
+
+  if [ "$STATE" = "ActivationFailed" ]; then
+    echo "::error::$APP revision $REV failed to activate."
+    echo "Last 100 lines of container console logs:"
+    az containerapp logs show --name "$APP" --resource-group "$RG" \
+      --revision "$REV" --type console --tail 100 --format text || true
+    exit 1
+  fi
+
+  if { [ "$STATE" = "Running" ] || [ "$STATE" = "RunningAtMaxScale" ]; } \
+     && [ "$HEALTH" = "Healthy" ]; then
+    echo "::notice::$APP revision $REV is $STATE / $HEALTH"
+    exit 0
+  fi
+
+  sleep "$SLEEP_SECONDS"
+done
+
+echo "::error::Timed out waiting for $APP revision $REV to become Running+Healthy."
+exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
           build-args: |
             DEVEXPRESS_NUGET_SOURCE=${{ secrets.DEVEXPRESS_NUGET_SOURCE }}
             DEVEXPRESS_LICENSE_CONTENT=${{ secrets.DEVEXPRESS_LICENSE_CONTENT }}
+            GIT_SHA=${{ github.sha }}
 
       - name: Build and push Client image
         uses: docker/build-push-action@v6
@@ -71,3 +72,78 @@ jobs:
           resourceGroup: ${{ env.RESOURCE_GROUP }}
           containerAppName: ${{ env.CLIENT_CONTAINER_APP }}
           imageToDeploy: ${{ env.CLIENT_IMAGE }}:${{ github.sha }}
+
+      # Post-deploy verification — Azure's deploy action returns as soon as it
+      # submits the update; a revision that fails to start (image pull error,
+      # migration crash on the API, etc.) keeps the previous revision serving
+      # traffic silently. Poll the latest revision until it's Running+Healthy
+      # or fail the job so the workflow badge reflects reality.
+      - name: Wait for API revision to become Running+Healthy
+        run: |
+          set -e
+          APP=${{ env.API_CONTAINER_APP }}
+          RG=${{ env.RESOURCE_GROUP }}
+          echo "Polling latest revision of $APP..."
+          for i in $(seq 1 30); do
+            REV=$(az containerapp show --name $APP --resource-group $RG --query properties.latestRevisionName -o tsv)
+            STATE=$(az containerapp revision show --name $APP --resource-group $RG --revision $REV --query properties.runningState -o tsv 2>/dev/null || echo "Unknown")
+            HEALTH=$(az containerapp revision show --name $APP --resource-group $RG --revision $REV --query properties.healthState -o tsv 2>/dev/null || echo "Unknown")
+            echo "attempt $i: revision=$REV state=$STATE health=$HEALTH"
+            if [ "$STATE" = "ActivationFailed" ]; then
+              echo "::error::$APP revision $REV failed to activate."
+              echo "Last 100 lines of console logs:"
+              az containerapp logs show --name $APP --resource-group $RG --revision $REV --type console --tail 100 --format text || true
+              exit 1
+            fi
+            if { [ "$STATE" = "Running" ] || [ "$STATE" = "RunningAtMaxScale" ]; } && [ "$HEALTH" = "Healthy" ]; then
+              echo "::notice::$APP revision $REV is $STATE / $HEALTH"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Timed out waiting for $APP revision $REV to become Running+Healthy."
+          exit 1
+
+      - name: Wait for Client revision to become Running+Healthy
+        run: |
+          set -e
+          APP=${{ env.CLIENT_CONTAINER_APP }}
+          RG=${{ env.RESOURCE_GROUP }}
+          echo "Polling latest revision of $APP..."
+          for i in $(seq 1 30); do
+            REV=$(az containerapp show --name $APP --resource-group $RG --query properties.latestRevisionName -o tsv)
+            STATE=$(az containerapp revision show --name $APP --resource-group $RG --revision $REV --query properties.runningState -o tsv 2>/dev/null || echo "Unknown")
+            HEALTH=$(az containerapp revision show --name $APP --resource-group $RG --revision $REV --query properties.healthState -o tsv 2>/dev/null || echo "Unknown")
+            echo "attempt $i: revision=$REV state=$STATE health=$HEALTH"
+            if [ "$STATE" = "ActivationFailed" ]; then
+              echo "::error::$APP revision $REV failed to activate."
+              az containerapp logs show --name $APP --resource-group $RG --revision $REV --type console --tail 100 --format text || true
+              exit 1
+            fi
+            if { [ "$STATE" = "Running" ] || [ "$STATE" = "RunningAtMaxScale" ]; } && [ "$HEALTH" = "Healthy" ]; then
+              echo "::notice::$APP revision $REV is $STATE / $HEALTH"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Timed out waiting for $APP revision $REV to become Running+Healthy."
+          exit 1
+
+      - name: Verify /api/version matches the deployed commit
+        run: |
+          set -e
+          # Give envoy a moment to switch traffic to the new revision
+          sleep 5
+          EXPECTED=${{ github.sha }}
+          echo "Expecting commit=$EXPECTED"
+          for i in $(seq 1 10); do
+            BODY=$(curl -sf https://api.hra.ovcina.cz/api/version || echo "")
+            echo "attempt $i: $BODY"
+            if echo "$BODY" | grep -q "\"commit\":\"$EXPECTED\""; then
+              echo "::notice::/api/version reports commit=$EXPECTED"
+              exit 0
+            fi
+            sleep 6
+          done
+          echo "::error::/api/version never reported the expected commit ($EXPECTED)."
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,13 @@ jobs:
           containerAppName: ${{ env.API_CONTAINER_APP }}
           imageToDeploy: ${{ env.API_IMAGE }}:${{ github.sha }}
 
+      # Fail-fast: if the API revision can't start (migration crash, image pull
+      # error, etc.) don't let the Client deploy proceed against a half-broken
+      # backend. Azure's deploy-action returns as soon as it submits the update,
+      # so we poll here to reflect the real activation outcome.
+      - name: Wait for API revision to become Running+Healthy
+        run: bash .github/scripts/wait-for-containerapp-revision.sh "${{ env.API_CONTAINER_APP }}" "${{ env.RESOURCE_GROUP }}"
+
       - name: Deploy Client to Azure Container Apps
         uses: azure/container-apps-deploy-action@v2
         with:
@@ -73,61 +80,8 @@ jobs:
           containerAppName: ${{ env.CLIENT_CONTAINER_APP }}
           imageToDeploy: ${{ env.CLIENT_IMAGE }}:${{ github.sha }}
 
-      # Post-deploy verification — Azure's deploy action returns as soon as it
-      # submits the update; a revision that fails to start (image pull error,
-      # migration crash on the API, etc.) keeps the previous revision serving
-      # traffic silently. Poll the latest revision until it's Running+Healthy
-      # or fail the job so the workflow badge reflects reality.
-      - name: Wait for API revision to become Running+Healthy
-        run: |
-          set -e
-          APP=${{ env.API_CONTAINER_APP }}
-          RG=${{ env.RESOURCE_GROUP }}
-          echo "Polling latest revision of $APP..."
-          for i in $(seq 1 30); do
-            REV=$(az containerapp show --name $APP --resource-group $RG --query properties.latestRevisionName -o tsv)
-            STATE=$(az containerapp revision show --name $APP --resource-group $RG --revision $REV --query properties.runningState -o tsv 2>/dev/null || echo "Unknown")
-            HEALTH=$(az containerapp revision show --name $APP --resource-group $RG --revision $REV --query properties.healthState -o tsv 2>/dev/null || echo "Unknown")
-            echo "attempt $i: revision=$REV state=$STATE health=$HEALTH"
-            if [ "$STATE" = "ActivationFailed" ]; then
-              echo "::error::$APP revision $REV failed to activate."
-              echo "Last 100 lines of console logs:"
-              az containerapp logs show --name $APP --resource-group $RG --revision $REV --type console --tail 100 --format text || true
-              exit 1
-            fi
-            if { [ "$STATE" = "Running" ] || [ "$STATE" = "RunningAtMaxScale" ]; } && [ "$HEALTH" = "Healthy" ]; then
-              echo "::notice::$APP revision $REV is $STATE / $HEALTH"
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "::error::Timed out waiting for $APP revision $REV to become Running+Healthy."
-          exit 1
-
       - name: Wait for Client revision to become Running+Healthy
-        run: |
-          set -e
-          APP=${{ env.CLIENT_CONTAINER_APP }}
-          RG=${{ env.RESOURCE_GROUP }}
-          echo "Polling latest revision of $APP..."
-          for i in $(seq 1 30); do
-            REV=$(az containerapp show --name $APP --resource-group $RG --query properties.latestRevisionName -o tsv)
-            STATE=$(az containerapp revision show --name $APP --resource-group $RG --revision $REV --query properties.runningState -o tsv 2>/dev/null || echo "Unknown")
-            HEALTH=$(az containerapp revision show --name $APP --resource-group $RG --revision $REV --query properties.healthState -o tsv 2>/dev/null || echo "Unknown")
-            echo "attempt $i: revision=$REV state=$STATE health=$HEALTH"
-            if [ "$STATE" = "ActivationFailed" ]; then
-              echo "::error::$APP revision $REV failed to activate."
-              az containerapp logs show --name $APP --resource-group $RG --revision $REV --type console --tail 100 --format text || true
-              exit 1
-            fi
-            if { [ "$STATE" = "Running" ] || [ "$STATE" = "RunningAtMaxScale" ]; } && [ "$HEALTH" = "Healthy" ]; then
-              echo "::notice::$APP revision $REV is $STATE / $HEALTH"
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "::error::Timed out waiting for $APP revision $REV to become Running+Healthy."
-          exit 1
+        run: bash .github/scripts/wait-for-containerapp-revision.sh "${{ env.CLIENT_CONTAINER_APP }}" "${{ env.RESOURCE_GROUP }}"
 
       - name: Verify /api/version matches the deployed commit
         run: |

--- a/src/OvcinaHra.Api/Dockerfile
+++ b/src/OvcinaHra.Api/Dockerfile
@@ -25,9 +25,12 @@ COPY src/ src/
 RUN dotnet publish src/OvcinaHra.Api/OvcinaHra.Api.csproj -c Release -o /app/publish --no-restore /p:UseAppHost=false
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+ARG GIT_SHA=unknown
 WORKDIR /app
 
 ENV ASPNETCORE_URLS=http://+:8080
+# Propagate the build-time commit SHA to the runtime so /api/version can report it.
+ENV GIT_SHA=$GIT_SHA
 EXPOSE 8080
 
 COPY --from=build /app/publish .

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -172,10 +172,10 @@ try
 
     app.MapHealthChecks("/health").AllowAnonymous();
 
-    // Diagnostic endpoint — returns the git SHA embedded at container build time
-    // (via Dockerfile ARG GIT_SHA → ENV) plus container start time. Lets us detect
-    // a stale image surviving a "green" deploy workflow, which happened once
-    // (see PR #44 / memory: no-post-publish-mutation + silent-revision-failure).
+    // Deployment diagnostic — returns the commit SHA and container start time so
+    // operators can confirm the deployed image matches the expected build. In CI
+    // the SHA is injected via Dockerfile ARG GIT_SHA → ENV; locally it reports
+    // "unknown".
     var apiStartedUtc = DateTimeOffset.UtcNow;
     app.MapGet("/api/version", () => Results.Ok(new
     {

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -172,6 +172,17 @@ try
 
     app.MapHealthChecks("/health").AllowAnonymous();
 
+    // Diagnostic endpoint — returns the git SHA embedded at container build time
+    // (via Dockerfile ARG GIT_SHA → ENV) plus container start time. Lets us detect
+    // a stale image surviving a "green" deploy workflow, which happened once
+    // (see PR #44 / memory: no-post-publish-mutation + silent-revision-failure).
+    var apiStartedUtc = DateTimeOffset.UtcNow;
+    app.MapGet("/api/version", () => Results.Ok(new
+    {
+        commit = Environment.GetEnvironmentVariable("GIT_SHA") ?? "unknown",
+        startedUtc = apiStartedUtc
+    })).AllowAnonymous();
+
     // Auth — dev token only in Development, refresh always available
     app.MapAuthEndpoints(builder.Configuration, app.Environment.IsDevelopment());
 

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.8.7</Version>
+    <Version>0.8.8</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Prevents recurrence of the "workflow green, production silently stale" incident that just cost us 2 days (PRs #40–#44 didn't reach users because API revisions were `ActivationFailed` while `az containerapp update` still exited 0 and the workflow showed a green checkmark).

Three diagnostic changes:

### 1. `/api/version` endpoint

Anonymous endpoint on the API that returns the commit SHA embedded at container build time plus the container boot timestamp:

```json
{ "commit": "70d8093f...", "startedUtc": "2026-04-21T07:15:04Z" }
```

Implementation: Dockerfile `ARG GIT_SHA` → `ENV GIT_SHA` → `Environment.GetEnvironmentVariable` in Program.cs. Defaults to `"unknown"` outside CI so local dev is unaffected.

Usage: `curl https://api.hra.ovcina.cz/api/version` any time there's a suspicion that old code is running — one-shot answer.

### 2. Workflow waits for revisions to reach Running+Healthy

After each `azure/container-apps-deploy-action` step, a new step polls the container app's latest revision until it's `Running` (or `RunningAtMaxScale`) AND `HealthState == Healthy`, or fails the job on `ActivationFailed` with the last 100 lines of container console logs dumped into the job output. 30 × 10s = 5 min max per app.

Runs for both API and Client apps.

### 3. Post-deploy `/api/version` assertion

Final workflow step `curl`s `/api/version` and verifies the reported `commit` matches `github.sha`. Catches the even-more-subtle case where the revision is healthy but traffic hasn't flipped to it for any reason.

## Version

0.8.7 → **0.8.8** (patch — infrastructure-only).

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: deploy workflow runs end-to-end, both wait steps complete, final `/api/version` check passes.
- [ ] `curl https://api.hra.ovcina.cz/api/version` returns `commit` = the merged commit SHA.

## What this would have caught

- The 2-day outage: migration crash at `Program.cs:116` would have surfaced as `ActivationFailed` + console log dump in the workflow run ~1 minute after each failing deploy, instead of a green checkmark.
- The `appsettings.json` SRI mismatch earlier: if the Client revision had ever failed to start it would have shown here too.
- Any future "image pulled but traffic didn't switch" scenario: caught by the `/api/version` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)