### PR TITLE
feat(spells): Spell + GameSpell domain + CRUD + seed + search [v0.9.0]

### DIFF
--- a/docs/imports/spells.md
+++ b/docs/imports/spells.md
@@ -1,0 +1,143 @@
+---
+type: data-import
+entity: Spell
+source: rulemaster MAG-005 (svitky) + MAG-006 (úrovně I-V)
+last-updated: 2026-04-22
+count: 28
+notes: >
+  Katalog kouzel Ovčina LARP. Importovat do tabulky Spell v hra.ovcina.cz.
+  Svitky (IsScroll=true) může sesílat kdokoli, jsou jednorázové.
+  Kouzla úrovně I-V (IsScroll=false) může sesílat jen mág s MinMageLevel <= postava.MageLevel.
+  Ceny naučení (Price) z MAG-007. Ohnivá/Mentální/Mráz/Jed = SpellSchool; Reakce = IsReaction.
+---
+
+# Katalog kouzel — import
+
+## Schéma řádku
+
+| Sloupec | Typ | Poznámka |
+|---------|-----|----------|
+| Name | string | Kanonický název (česky, diakritika) |
+| Level | int 0-5 | 0 = svitek |
+| ManaCost | int 0-5 | Svitky = 0 (jednorázové) |
+| School | enum | Fire, Frost, Water, Earth, Wind, Poison, Mental, Support, Utility |
+| IsScroll | bool | true = svitek MAG-005 |
+| IsReaction | bool | true = kouzlo lze seslat mimo pořadí |
+| IsLearnable | bool | true = lze se naučit u budovy (obchodník/Mudrc/knihovna). Svitky = false. |
+| MinMageLevel | int | 0 u svitků, 1-5 u kouzel MAG-006 |
+| Price | int? | Cena naučení u obchodníka v groších (MAG-007); null u svitků |
+| Effect | string | Mechanický text karty |
+| SourceRule | string | ID pravidla v rulemaster |
+
+**Pravidlo `IsLearnable`**: `IsLearnable = !IsScroll`. Tabulky níže neobsahují samostatný sloupec — loader ho odvodí. Svitky se ve světě nacházejí / kupují jako fyzické předměty, neučí se. Kouzla I-V se učí u budov.
+
+---
+
+## Úroveň 0 — Svitky (MAG-005)
+
+Jednorázové, po seslání se odhodí. Každá postava je může používat.
+
+| Name | Level | ManaCost | School | IsScroll | IsReaction | MinMageLevel | Price | Effect | SourceRule |
+|------|-------|----------|--------|----------|------------|--------------|------------|--------|------------|
+| Jiskra | 0 | 0 | Fire | true | false | 0 |  | 3 ž ohněm. | MAG-005 |
+| Jedový šíp | 0 | 0 | Poison | true | false | 0 |  | 3 ž jedem. | MAG-005 |
+| Ledový šíp | 0 | 0 | Frost | true | false | 0 |  | 3 ž mrazem. | MAG-005 |
+| Bahno | 0 | 0 | Utility | true | false | 0 |  | Příšera kategorie I neútočí toto kolo. | MAG-005 |
+| Léčivé dlaně | 0 | 0 | Support | true | false | 0 |  | Vyleč 5 ž ztracených v tomto kole (žijící cíl). | MAG-005 |
+| Klika | 0 | 0 | Utility | true | false | 0 |  | Přehoď 1k6, vyber vyšší výsledek. | MAG-005 |
+
+---
+
+## Úroveň I — 1 mana (od Mág 1) — MAG-006
+
+| Name | Level | ManaCost | School | IsScroll | IsReaction | MinMageLevel | Price | Effect | SourceRule |
+|------|-------|----------|--------|----------|------------|--------------|------------|--------|------------|
+| Ohnivá střela | 1 | 1 | Fire | false | false | 1 | 10 | Ohnivé. Zraň jeden cíl za 1k6 ž ohněm. | MAG-006 |
+| Magický štít | 1 | 1 | Support | false | true | 1 | 10 | *Reakce* po útoku nepřítele. Změň výsledek jednoho hodu 1k6+ na [-1]. | MAG-006 |
+| Omámení | 1 | 1 | Mental | false | false | 1 | 10 | Mentální. Cílová bytost s ≤10 ž přijde o akci. | MAG-006 |
+| Magická pomoc | 1 | 1 | Support | false | false | 1 | 10 | Spolubojovník má do příštího útoku bonus rovný tvému ÚČ + hází navíc 1k6+. | MAG-006 |
+
+---
+
+## Úroveň II — 2 many (od Mág 2) — MAG-006
+
+| Name | Level | ManaCost | School | IsScroll | IsReaction | MinMageLevel | Price | Effect | SourceRule |
+|------|-------|----------|--------|----------|------------|--------------|------------|--------|------------|
+| Připrav plamen | 2 | 2 | Fire | false | false | 2 | 15 | Zvyš zranění příštího ohnivého kouzla o 5. | MAG-006 |
+| Dodej kuráž | 2 | 2 | Support | false | false | 2 | 15 | Všichni na tvé straně mají toto kolo navíc 1k6+ na blízké a střelecké útoky. | MAG-006 |
+| Kamenný pes | 2 | 2 | Utility | false | false | 2 | 15 | Vyvolej bytost 5/2 s 5 ž. Nemůže krýt, může okamžitě zaútočit. Při >4 bytostech zmizí po útoku. | MAG-006 |
+| Větrná zeď | 2 | 2 | Utility | false | false | 2 | 15 | Toto kolo všechny výsledky 1k6+ při střeleckých útocích = [1]. | MAG-006 |
+
+---
+
+## Úroveň III — 3 many (od Mág 3) — MAG-006
+
+| Name | Level | ManaCost | School | IsScroll | IsReaction | MinMageLevel | Price | Effect | SourceRule |
+|------|-------|----------|--------|----------|------------|--------------|------------|--------|------------|
+| Ohnivá koule | 3 | 3 | Fire | false | false | 3 | 22 | Ohnivé. Zraň až dva cíle za 1k6 ž ohněm. | MAG-006 |
+| Zrcadlo | 3 | 3 | Mental | false | true | 3 | 22 | Mentální, *reakce* po útoku na tebe. Nepřítel útočí na sebe. | MAG-006 |
+| Omdli | 3 | 3 | Mental | false | false | 3 | 22 | Mentální. Nepříteli s ≤7 ž klesnou životy na 0. | MAG-006 |
+| Bažina | 3 | 3 | Utility | false | false | 3 | 22 | Toto kolo všechny výsledky 1k6+ při blízkých útocích = [1]. | MAG-006 |
+
+---
+
+## Úroveň IV — 4 many (od Mág 4) — MAG-006
+
+| Name | Level | ManaCost | School | IsScroll | IsReaction | MinMageLevel | Price | Effect | SourceRule |
+|------|-------|----------|--------|----------|------------|--------------|------------|--------|------------|
+| Připrav výheň | 4 | 4 | Fire | false | false | 4 | 30 | Zvyš zranění příštího ohnivého kouzla o 10. | MAG-006 |
+| Rychlost | 4 | 4 | Support | false | false | 4 | 30 | Dva spolubojovníci mohou okamžitě provést útok bez použití akce. | MAG-006 |
+| Poslední dech | 4 | 4 | Support | false | true | 4 | 30 | *Reakce* po pádu spolubojovníka na 0 ž. Zachraň ho a vyleč 10 ž. | MAG-006 |
+| Staff-fu | 4 | 4 | Utility | false | false | 4 | 30 | V rámci seslání proveď blízký útok s ÚČ 15. Nelze pokud jsi krytý. | MAG-006 |
+
+---
+
+## Úroveň V — 5 man (od Mág 5) — MAG-006
+
+| Name | Level | ManaCost | School | IsScroll | IsReaction | MinMageLevel | Price | Effect | SourceRule |
+|------|-------|----------|--------|----------|------------|--------------|------------|--------|------------|
+| Ohnivá bouře | 5 | 5 | Fire | false | false | 5 | 40 | Ohnivé. Zraň všechny nepřátele za 1k6 ž ohněm. | MAG-006 |
+| Zatemnění mysli | 5 | 5 | Mental | false | false | 5 | 40 | Mentální. Cíl útočí na tvůj cíl (i na sebe, nebo na bytost kterou kryje). | MAG-006 |
+| Požehnej zbraně | 5 | 5 | Support | false | false | 5 | 40 | Toto kolo zranění spolubojovníků = dvojnásobek rozdílu (hod vs OČ). | MAG-006 |
+| Instinktivní magie | 5 | 5 | Utility | false | false | 5 | 40 | Sešli kouzlo úrovně I nebo II zadarmo. Získej další akci. | MAG-006 |
+
+---
+
+## Poznámky k importu
+
+1. **Typ kouzla (SpellSchool)** — odvozeno z MAG-012 (Typy kouzel). Enum zahrnuje všechny klasické živly (Fire, Frost, Water, Earth, Wind) + Poison, Mental, Support, Utility — i když některé v aktuálním katalogu nemají kouzlo, jsou připravené pro budoucí rozšíření. Kouzla neuvedená v žádném živlu jsou `Support` (buff/heal spojeneckého typu) nebo `Utility` (ovládání bojiště, vyvolávání, přehazování kostky).
+
+2. **Reakce (IsReaction)** — pouze 3 kouzla: Magický štít (I), Zrcadlo (III), Poslední dech (IV). Spotřebují mágovu akci v kole.
+
+3. **Ceny naučení (Price, MAG-007)** — lineární s úrovní: 10 / 15 / 22 / 30 / 40 gr. U svitků null (nekupují se na učení, jsou fyzické jednorázové kartičky). Případná per-game cena svitků patří do `GameSpell.Price`.
+
+4. **Obnovení many** — není per-spell property; je to globální pravidlo MAG-001 (mana se obnoví na konci souboje). Nemodelovat v entitě Spell.
+
+5. **Koncentrace (MAG-003)** — není kouzlo, je to zvláštní akce mága. Nemodelovat v entitě Spell — patří do logiky postavy/souboje.
+
+6. **Arcimágova hůl** — je to artefakt (Item), ne kouzlo. Patří do tabulky `Item` (typ `Staff`), ne sem.
+
+---
+
+## Budovy pro výuku (SpellBuildingRequirement)
+
+Podle MAG-007 se kouzla učí **u obchodníka ve městě, u Mudrců, v knihovně**. Modelováno jako samostatná tabulka `SpellBuildingRequirement(SpellId, BuildingId)` (M:N, bez úrovně) — přesně podle vzoru `SkillBuildingRequirement`.
+
+**`BuildingId` je prostý int FK** do tabulky `Building` (stejně jako ve všech ostatních relacích v projektu). Žádný building-type enum, žádné stringové lookup.
+
+Výchozí pravidlo pro seed: **každé kouzlo s `IsLearnable = true` je dostupné u všech budov odpovídajících Obchodník/Mudrc/Knihovna**. Loader najde ty budovy přes `Building.Name` (nebo jiný existující klíč v seed datech) a vytvoří `SpellBuildingRequirement` řádek pro každou kombinaci. Pokud v budoucnu dojde ke kurikulárnímu rozlišení (např. mentální kouzla jen u Mudrců), lze per-spell ořezat.
+
+Per-game override: `GameSpellBuildingRequirement(GameSpellId, BuildingId)` — mirror `GameSkillBuildingRequirement`.
+
+## Způsob získání kouzla
+
+Kouzlo lze získat třemi způsoby — v doménovém modelu:
+
+| Způsob | Jak je modelováno |
+|--------|-------------------|
+| **Naučení u budovy** | `Spell.IsLearnable = true` + `SpellBuildingRequirement` vazba. Mág zaplatí `Price` grošů. |
+| **Odměna z questu** | Budoucí entita `PersonalQuestSpellReward(PersonalQuestId, SpellId)` — mirror `PersonalQuestSkillReward`. Nemusí mít `IsLearnable = true`. |
+| **Odměna ze schopnosti / level-upu** | Budoucí entita `SkillSpellReward(SkillId, SpellId)` nebo jednorázové granty z logiky postavy (MAG-007: "Při postupu na novou úroveň se mág naučí jedno kouzlo dané úrovně zdarma"). |
+| **Svitek ve světě** | `Spell.IsScroll = true`. Není to naučení — je to fyzický jednorázový item nalezený v loot / truhle / quest reward. |
+
+**Poznámka**: `IsLearnable = false` znamená „nelze koupit u obchodníka ve výchozím režimu". Takové kouzlo existuje výhradně jako odměna / scroll / quest drop. Pro budoucí kouzla tajná nebo pouze odměnová.

--- a/docs/plans/2026-04-22-spells-tinkerer-prompt.md
+++ b/docs/plans/2026-04-22-spells-tinkerer-prompt.md
@@ -1,0 +1,218 @@
+# Tinkerer Prompt — Spell Domain + Import
+
+**Agent:** `hra-ovcina-tinkerer`
+**Date:** 2026-04-22
+**Scope:** Add `Spell` as a first-class domain entity in hra.ovcina.cz, matching the Item/Skill pattern. Import 28 spells from the rulemaster catalog. **Expose spells via the public JSON API** so the rulemaster bot and other skills can query them at runtime — same access pattern as Items/Monsters/Quests today.
+
+---
+
+## Context
+
+We want to track spells in the world DB the same way we track items, monsters, and skills. Rules live in rulemaster (MAG-005 scrolls, MAG-006 mage spells I-V, MAG-007 learning costs, MAG-012 spell types) but the DB has no `Spell` entity yet.
+
+**Source data (already prepared, do NOT regenerate):**
+`docs/imports/spells.md` — 28 spells in structured tables (level 0 scrolls + levels I-V). This is the seed source. Parse it; do not hand-type spells.
+
+**Reference entities to mirror:**
+- `src/OvcinaHra.Shared/Domain/Entities/Item.cs` + `GameItem.cs` — closest structural match (catalog + per-game join)
+- `src/OvcinaHra.Shared/Domain/Entities/Skill.cs` — closest semantic match (learned by characters, has categories)
+
+---
+
+## Design (agreed with user — do not change without asking)
+
+### `Spell` entity
+
+```csharp
+public class Spell
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }         // "Ohnivá střela"
+    public int Level { get; set; }                     // 0-5 (0 = scroll)
+    public int ManaCost { get; set; }                  // 0 for scrolls, 1-5 for mage spells
+    public SpellSchool School { get; set; }
+    public bool IsScroll { get; set; }                 // true = MAG-005 scroll (one-shot, usable by anyone)
+    public bool IsReaction { get; set; }               // Magický štít, Zrcadlo, Poslední dech
+    public bool IsLearnable { get; set; }              // true = purchasable at a building. Default: !IsScroll.
+    public int MinMageLevel { get; set; }              // 0 for scrolls, 1-5 for mage spells
+    public int? Price { get; set; }                    // Learning cost in groše (MAG-007); null for scrolls
+    public required string Effect { get; set; }        // Mechanical card text (Czech, diacritics)
+    public string? Description { get; set; }           // Flavour / lore (optional)
+    public string? ImagePath { get; set; }
+
+    public ICollection<GameSpell> GameSpells { get; set; } = [];
+    public ICollection<SpellBuildingRequirement> BuildingRequirements { get; set; } = [];
+}
+```
+
+### `GameSpell` join (mirror `GameItem`)
+
+```csharp
+public class GameSpell
+{
+    public int Id { get; set; }               // Surrogate key (see GameSkill pattern if it uses one)
+    public int GameId { get; set; }
+    public int SpellId { get; set; }
+    public int? Price { get; set; }           // Per-game override of learning cost
+    public bool IsFindable { get; set; }      // Can be found as scroll/loot in this game
+    public string? AvailabilityNotes { get; set; }
+
+    public Game Game { get; set; } = null!;
+    public Spell Spell { get; set; } = null!;
+
+    public ICollection<GameSpellBuildingRequirement> BuildingRequirements { get; set; } = [];
+}
+```
+
+> **Check first**: look at whether `GameSkill` uses a surrogate `Id` or composite `(GameId, SkillId)` key. Match that convention exactly — `GameSpellBuildingRequirement` below relies on it.
+
+### `SpellBuildingRequirement` — learning location (mirror `SkillBuildingRequirement`)
+
+```csharp
+public class SpellBuildingRequirement
+{
+    public int SpellId { get; set; }
+    public int BuildingId { get; set; }       // Plain int FK to Building — no enum, no string lookup
+
+    public Spell Spell { get; set; } = null!;
+    public Building Building { get; set; } = null!;
+}
+```
+
+Composite key `(SpellId, BuildingId)`. Per MAG-007, every learnable mage spell (I-V) should have a `SpellBuildingRequirement` row for each of: Obchodník, Mudrc, Knihovna buildings (look them up in `Building` seed data by name). Scrolls (IsLearnable=false) have no rows here.
+
+### `GameSpellBuildingRequirement` — per-game override (mirror `GameSkillBuildingRequirement`)
+
+```csharp
+public class GameSpellBuildingRequirement
+{
+    public int GameSpellId { get; set; }
+    public int BuildingId { get; set; }
+
+    public GameSpell GameSpell { get; set; } = null!;
+    public Building Building { get; set; } = null!;
+}
+```
+
+### Acquisition model — how a character gets a spell
+
+Three paths, each modelled separately so they can coexist:
+
+| Path | Mechanism | Entity / flag |
+|------|-----------|---------------|
+| **Learned at a building** | Pay `Price` groše at Obchodník/Mudrc/Knihovna | `Spell.IsLearnable = true` + `SpellBuildingRequirement` row(s) |
+| **Quest reward** | Granted on quest completion | *Future:* `PersonalQuestSpellReward(PersonalQuestId, SpellId)` — mirror `PersonalQuestSkillReward`. **Not in scope for this task — but design the entity so a future migration can add it without schema churn.** |
+| **Skill / level-up grant** | Granted by a skill or automatic at mage level-up (MAG-007: "one free spell of the new level") | *Future:* `SkillSpellReward(SkillId, SpellId)` or character-logic on level-up. **Not in scope.** |
+| **Scroll in the world** | Physical one-shot item found as loot/treasure | `Spell.IsScroll = true`, `IsLearnable = false`. Linkage to loot/treasure uses existing `MonsterLoot` / `TreasureItem` patterns — **Item** currently holds those FKs. Follow up separately whether scrolls need their own loot table or can reuse Item. **Do not refactor that in this task.** |
+
+**`IsLearnable = false`** means "not for sale at a shop by default" — the spell exists solely as reward / scroll / quest drop. Current catalog: all scrolls are `IsLearnable = false`, all mage spells I-V are `IsLearnable = true`.
+
+### `SpellSchool` enum
+
+Include **all classical elements + the non-elemental categories**, even if some don't have spells in the current catalog — they're reserved for future content.
+
+```csharp
+public enum SpellSchool
+{
+    Fire,       // Oheň — Jiskra, Ohnivá střela, Ohnivá koule, Ohnivá bouře, Připrav plamen/výheň
+    Frost,      // Mráz — Ledový šíp
+    Water,      // Voda — reserved (no spells yet, but part of the elemental set)
+    Earth,      // Země — reserved
+    Wind,       // Vítr — reserved
+    Poison,     // Jed — Jedový šíp
+    Mental,     // Mentální — Omámení, Zrcadlo, Omdli, Zatemnění mysli
+    Support,    // Buffy/heal, non-elemental — Léčivé dlaně, Magický štít, Magická pomoc, Dodej kuráž, Rychlost, Poslední dech, Požehnej zbraně
+    Utility     // Terén/vyvolávání/přehazování — Bahno, Klika, Kamenný pes, Větrná zeď, Bažina, Staff-fu, Instinktivní magie
+}
+```
+
+Reserved values (Water/Earth/Wind) must be included now — the rulemaster bot will surface the enum as metadata and we want the elemental set complete even before content fills in.
+
+---
+
+## Tasks
+
+Follow the project's TDD + verification loop. Commit only when user explicitly approves (see `feedback_no_commit_without_approval`).
+
+1. **Domain entities** — create the following in `src/OvcinaHra.Shared/Domain/` following the layout conventions (Entities/ and Enums/):
+   - `Spell.cs` (Entities)
+   - `GameSpell.cs` (Entities)
+   - `SpellBuildingRequirement.cs` (Entities)
+   - `GameSpellBuildingRequirement.cs` (Entities)
+   - `SpellSchool.cs` (Enums)
+
+2. **EF Core configuration** — wire all four entities and the composite keys into `AppDbContext`:
+   - `Spell` — PK `Id`, unique index on `Name`
+   - `GameSpell` — match whatever `GameSkill` does (surrogate Id vs. composite key)
+   - `SpellBuildingRequirement` — composite PK `(SpellId, BuildingId)`
+   - `GameSpellBuildingRequirement` — composite PK `(GameSpellId, BuildingId)`
+   - Match how `Skill` / `GameSkill` / `SkillBuildingRequirement` / `GameSkillBuildingRequirement` are configured.
+   - Single migration named `AddSpells`.
+
+3. **Seed loader** — write a parser that reads `docs/imports/spells.md`, parses the six per-level tables, and upserts into `Spell`. Follow whichever seed pattern the project uses (check how Items/Skills are seeded — if it's a `DataSeeder` service, extend it; if it's migrations + raw SQL, do that).
+   - **Idempotent by Name.**
+   - Rule applied by the loader: `IsLearnable = !IsScroll`.
+   - After inserting spells, seed `SpellBuildingRequirement` by looking up the three buildings (Obchodník, Mudrc, Knihovna) in `Building` by name (or whatever seed key they use) and linking every learnable spell to every match. If a building type isn't in the seed data yet, **log a warning and continue** — don't block; we can re-seed later.
+
+4. **DTOs + public API endpoints** — full CRUD + read endpoints so the rulemaster bot and other downstream skills can query spells the same way they query Items/Monsters/Quests today.
+
+   Add `SpellDto`, `SpellListDto`, `SpellCreateDto`, `SpellUpdateDto`. Controller endpoints matching the Item/Skill controller surface:
+   - `GET /api/spells` — list all (returns `SpellListDto[]`: Id, Name, Level, School, IsScroll, IsLearnable, ManaCost, MinMageLevel, Price)
+   - `GET /api/spells/{id}` — full detail including `BuildingRequirements` (building IDs + names)
+   - `GET /api/spells/by-game/{gameId}` — spells available in a game
+   - `GET /api/spells/usable?mageLevel={n}&gameId={id}` — spells a mage of level N can cast (IsScroll=true OR MinMageLevel <= n). `gameId` optional.
+   - `GET /api/spells/learnable?mageLevel={n}&buildingId={id}` — spells that can be **learned** at a specific building by a mage of level N (IsLearnable=true AND has SpellBuildingRequirement for that building AND MinMageLevel <= n)
+   - `POST`/`PUT`/`DELETE /api/spells` — standard admin CRUD, behind the same auth policy as Item admin
+   - `PUT /api/spells/{id}/buildings` — replace `SpellBuildingRequirement` set (accepts array of BuildingIds)
+   - **Include spells in the existing `/api/search` FTS** (index Name, Effect, Description). The rulemaster bot uses `/api/search` as its primary lookup — spells must be discoverable there.
+   - Auth: follow the pattern used for Items. If the bot needs unauthenticated read access, match whatever Items does (the rulemaster skill already carries a service token — `GET /api/items` works for it, so `GET /api/spells` should too with the same policy).
+
+5. **Admin UI** — add spell management page to the admin catalog, mirroring the Items page. Respect existing patterns:
+   - `feedback_ovcinahra_hrdina_copy` — user-facing Czech text says Hrdina/Hrdinové (not applicable here, but stay in the habit)
+   - `feedback_ovcinagrid_layoutkey_bump` — if reusing an OvcinaGrid layout, bump LayoutKey
+   - `feedback_ovcinahra_destructive_confirm` — delete goes through DxPopup confirmation
+   - `feedback_ovcinahra_devexpress_runtime_attrs` — verify DxGridDataColumn attrs in browser console; runtime silently blanks the grid
+   - `feedback_devana_radi_pattern` — tooltips via DxFlyout, not native title
+   - `feedback_devana_1based_index` — level column displays 0-5 as written (scroll=0, I-V), no off-by-one
+
+6. **Tests** — integration tests per `hra-ovcina-basher` conventions:
+   - Spell CRUD round-trips (including `BuildingRequirements` collection)
+   - Seed loader parses `spells.md` correctly: 28 rows, correct levels/schools/mana costs, `IsLearnable = !IsScroll`
+   - `GET /api/spells/usable?mageLevel=2` → 6 scrolls + 4 level-I + 4 level-II = 14 rows
+   - `GET /api/spells/usable?mageLevel=0` → 6 scrolls only
+   - `GET /api/spells/learnable?mageLevel=3&buildingId={knihovna}` → 12 rows (I + II + III, all learnable and linked to building)
+   - Spells appear in `GET /api/search?q=ohnivá` — at least Ohnivá střela, Ohnivá koule, Ohnivá bouře
+
+7. **Version bump + commit message** — per `feedback_ovcinahra_version_in_commits` and `feedback_ovcinahra_version_in_deploys`, bump minor version (new entity type) and include `[vX.Y.Z]` in commit.
+
+---
+
+## Acceptance criteria
+
+- [ ] `Spell` + `GameSpell` + `SpellBuildingRequirement` + `GameSpellBuildingRequirement` + `SpellSchool` enum in Domain, compiled clean
+- [ ] Migration `AddSpells` applied locally, roundtrips on Postgres
+- [ ] Seeder run produces exactly 28 spells from `docs/imports/spells.md`; `SpellBuildingRequirement` rows exist for every learnable spell × (Obchodník, Mudrc, Knihovna)
+- [ ] All spell endpoints (`list`, `by-id`, `by-game`, `usable`, `learnable`, admin CRUD, buildings replace) return correct data; filtering math verified by tests
+- [ ] `GET /api/search?q=...` returns spell matches alongside items/monsters/quests — **rulemaster bot must be able to find spells via search**
+- [ ] Admin UI page shows grid, create/edit form (including building multi-select), confirmation on delete
+- [ ] All tests pass, build clean, version bumped
+- [ ] No commit without explicit user approval
+
+---
+
+## Out of scope (do NOT do)
+
+- **Arcimágova hůl** — stays in `Item` table (it's an artifact, not a spell). User confirmed.
+- **Koncentrace (MAG-003)** — not a spell, it's a mage special action. Belongs in character/combat logic, not Spell entity.
+- **Mana regeneration (MAG-001)** — global combat rule, not a per-spell property.
+- **Character → Spell learned-spells relationship** — out of scope for this task. When added later it'll be `CharacterSpell(CharacterId, SpellId, LearnedAt)` but don't do it now.
+- **Resistance / weakness modeling on monsters** — the enum is ready for it (Dračí pancíř = Fire immunity) but don't wire monster resistances in this task.
+
+---
+
+## If you hit ambiguity
+
+Stop and ask the user — do not invent. Especially:
+- How existing entities are seeded (check before guessing — might be SQL migration, DataSeeder service, or JSON fixtures)
+- Whether the search index is centrally wired (`/api/search` across Location/Item/Monster/Quest) — if yes, add Spell
+- Whether there's an existing admin auth policy to reuse

--- a/src/OvcinaHra.Api/Data/Configurations/GameSpellConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/GameSpellConfiguration.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class GameSpellConfiguration : IEntityTypeConfiguration<GameSpell>
+{
+    public void Configure(EntityTypeBuilder<GameSpell> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.HasIndex(e => new { e.GameId, e.SpellId }).IsUnique();
+
+        builder.Property(e => e.AvailabilityNotes).HasMaxLength(1000);
+
+        builder.HasOne(e => e.Game)
+            .WithMany()
+            .HasForeignKey(e => e.GameId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(e => e.Spell)
+            .WithMany(s => s.GameSpells)
+            .HasForeignKey(e => e.SpellId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/OvcinaHra.Api/Data/Configurations/SpellConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/SpellConfiguration.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class SpellConfiguration : IEntityTypeConfiguration<Spell>
+{
+    public void Configure(EntityTypeBuilder<Spell> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Name).IsRequired().HasMaxLength(100);
+        builder.HasIndex(e => e.Name).IsUnique();
+
+        builder.Property(e => e.School).HasConversion<string>().HasMaxLength(20);
+        builder.Property(e => e.Effect).IsRequired().HasMaxLength(4000);
+        builder.Property(e => e.Description).HasMaxLength(4000);
+        builder.Property(e => e.ImagePath).HasMaxLength(500);
+
+        // Full-text search — shadow property + GIN index. Mirrors Item/Location/Monster/Quest.
+        builder.Property<NpgsqlTypes.NpgsqlTsVector>("SearchVector")
+            .HasColumnType("tsvector")
+            .HasComputedColumnSql(
+                "to_tsvector('simple', coalesce(\"Name\", '') || ' ' || coalesce(\"Effect\", '') || ' ' || coalesce(\"Description\", ''))",
+                stored: true);
+
+        builder.HasIndex("SearchVector").HasMethod("GIN");
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -21,6 +21,8 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<GameSkill> GameSkills => Set<GameSkill>();
     public DbSet<GameSkillBuildingRequirement> GameSkillBuildingRequirements => Set<GameSkillBuildingRequirement>();
     public DbSet<CraftingSkillRequirement> CraftingSkillRequirements => Set<CraftingSkillRequirement>();
+    public DbSet<Spell> Spells => Set<Spell>();
+    public DbSet<GameSpell> GameSpells => Set<GameSpell>();
     public DbSet<Monster> Monsters => Set<Monster>();
     public DbSet<Npc> Npcs => Set<Npc>();
     public DbSet<GameNpc> GameNpcs => Set<GameNpc>();

--- a/src/OvcinaHra.Api/Endpoints/SearchEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SearchEndpoints.cs
@@ -78,6 +78,22 @@ public static class SearchEndpoints
             .ToListAsync();
         results.AddRange(quests);
 
+        // Search Spells — catalog is cross-game. When gameId is provided, filter to
+        // spells actually assigned to that game via GameSpell.
+        var spellQuery = db.Spells
+            .FromSqlRaw(
+                """
+                SELECT * FROM "Spells"
+                WHERE "SearchVector" @@ to_tsquery('simple', {0})
+                LIMIT {1}
+                """, tsQuery, limit)
+            .AsQueryable();
+        if (gameId.HasValue)
+            spellQuery = spellQuery.Where(s => s.GameSpells.Any(gs => gs.GameId == gameId.Value));
+        results.AddRange(await spellQuery
+            .Select(s => new SearchResultDto("Spell", s.Id, s.Name, s.Effect))
+            .ToListAsync());
+
         return TypedResults.Ok(new SearchResponseDto(q, results.Count, results));
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/SearchEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SearchEndpoints.cs
@@ -80,17 +80,19 @@ public static class SearchEndpoints
 
         // Search Spells — catalog is cross-game. When gameId is provided, filter to
         // spells actually assigned to that game via GameSpell.
+        // NOTE: no LIMIT in the raw SQL; Take(limit) runs AFTER the optional game
+        // filter so we don't chop off valid matches before they get filtered.
         var spellQuery = db.Spells
             .FromSqlRaw(
                 """
                 SELECT * FROM "Spells"
                 WHERE "SearchVector" @@ to_tsquery('simple', {0})
-                LIMIT {1}
-                """, tsQuery, limit)
+                """, tsQuery)
             .AsQueryable();
         if (gameId.HasValue)
             spellQuery = spellQuery.Where(s => s.GameSpells.Any(gs => gs.GameId == gameId.Value));
         results.AddRange(await spellQuery
+            .Take(limit)
             .Select(s => new SearchResultDto("Spell", s.Id, s.Name, s.Effect))
             .ToListAsync());
 

--- a/src/OvcinaHra.Api/Endpoints/SeedEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SeedEndpoints.cs
@@ -32,21 +32,32 @@ public static class SeedEndpoints
 
     private static async Task<Ok<SeedResult>> SeedSpells(WorldDbContext db, IWebHostEnvironment env)
     {
-        if (await db.Spells.AnyAsync())
-            return TypedResults.Ok(new SeedResult(0, "Kouzla už existují. Smaž je nejdřív."));
-
         var mdPath = Path.Combine(env.ContentRootPath, "..", "..", "docs", "imports", "spells.md");
         if (!File.Exists(mdPath))
             return TypedResults.Ok(new SeedResult(0, $"Soubor nenalezen: {Path.GetFullPath(mdPath)}"));
 
         var content = await File.ReadAllTextAsync(mdPath);
-        var spells = ParseSpellsMarkdown(content);
+        var (parsed, parseErrors) = ParseSpellsMarkdown(content);
 
-        foreach (var s in spells)
+        // Idempotent by Name: pull existing names and insert only the missing spells.
+        // Lets reruns top up new rows added to spells.md without needing a manual wipe.
+        var existingNames = await db.Spells.Select(s => s.Name).ToListAsync();
+        var existingSet = existingNames.ToHashSet();
+        var toInsert = parsed.Where(s => !existingSet.Contains(s.Name)).ToList();
+
+        foreach (var s in toInsert)
             db.Spells.Add(s);
 
-        await db.SaveChangesAsync();
-        return TypedResults.Ok(new SeedResult(spells.Count, $"Importováno {spells.Count} kouzel z spells.md."));
+        if (toInsert.Count > 0)
+            await db.SaveChangesAsync();
+
+        var message =
+            $"Vloženo {toInsert.Count} nových kouzel " +
+            $"(z {parsed.Count} v souboru, {existingSet.Count} už existovalo).";
+        if (parseErrors.Count > 0)
+            message += $" Přeskočeno {parseErrors.Count} chybných řádků: {string.Join("; ", parseErrors)}";
+
+        return TypedResults.Ok(new SeedResult(toInsert.Count, message));
     }
 
     /// <summary>
@@ -56,14 +67,20 @@ public static class SeedEndpoints
     /// Only rows under "## Úroveň ..." sections are processed — the schema
     /// table at the top has different columns and is skipped.
     /// IsLearnable is derived by the loader: <c>!IsScroll</c>.
+    /// Returns parsed spells plus a list of error messages for rows that
+    /// couldn't be parsed (malformed numbers, unknown enum values, empty
+    /// effect, etc.) so the endpoint can surface them instead of 500-ing.
     /// </summary>
-    private static List<Spell> ParseSpellsMarkdown(string content)
+    private static (List<Spell> spells, List<string> errors) ParseSpellsMarkdown(string content)
     {
         var spells = new List<Spell>();
+        var errors = new List<string>();
         var inSpellSection = false;
+        var lineNo = 0;
 
         foreach (var raw in content.Split('\n'))
         {
+            lineNo++;
             var line = raw.TrimEnd('\r');
 
             if (line.StartsWith("## Úroveň"))
@@ -90,26 +107,42 @@ public static class SeedEndpoints
             if (cells[0] == "Name" || cells[0].StartsWith("---")) continue;
             if (string.IsNullOrWhiteSpace(cells[0])) continue;
 
-            var school = Enum.Parse<SpellSchool>(cells[3], ignoreCase: true);
-            var isScroll = bool.Parse(cells[4]);
-            var isReaction = bool.Parse(cells[5]);
+            var name = cells[0];
+
+            if (!int.TryParse(cells[1], out var level))
+            { errors.Add($"ř.{lineNo} '{name}': Level='{cells[1]}' není celé číslo"); continue; }
+            if (!int.TryParse(cells[2], out var manaCost))
+            { errors.Add($"ř.{lineNo} '{name}': ManaCost='{cells[2]}' není celé číslo"); continue; }
+            if (!Enum.TryParse<SpellSchool>(cells[3], ignoreCase: true, out var school))
+            { errors.Add($"ř.{lineNo} '{name}': School='{cells[3]}' neodpovídá enum SpellSchool"); continue; }
+            if (!bool.TryParse(cells[4], out var isScroll))
+            { errors.Add($"ř.{lineNo} '{name}': IsScroll='{cells[4]}' není true/false"); continue; }
+            if (!bool.TryParse(cells[5], out var isReaction))
+            { errors.Add($"ř.{lineNo} '{name}': IsReaction='{cells[5]}' není true/false"); continue; }
+            if (!int.TryParse(cells[6], out var minMageLevel))
+            { errors.Add($"ř.{lineNo} '{name}': MinMageLevel='{cells[6]}' není celé číslo"); continue; }
+
+            int? price = int.TryParse(cells[7], out var p) ? p : null;
+            var effect = cells[8];
+            if (string.IsNullOrWhiteSpace(effect))
+            { errors.Add($"ř.{lineNo} '{name}': Effect je prázdný"); continue; }
 
             spells.Add(new Spell
             {
-                Name = cells[0],
-                Level = int.Parse(cells[1]),
-                ManaCost = int.Parse(cells[2]),
+                Name = name,
+                Level = level,
+                ManaCost = manaCost,
                 School = school,
                 IsScroll = isScroll,
                 IsReaction = isReaction,
                 IsLearnable = !isScroll,
-                MinMageLevel = int.Parse(cells[6]),
-                Price = int.TryParse(cells[7], out var p) ? p : null,
-                Effect = cells[8]
+                MinMageLevel = minMageLevel,
+                Price = price,
+                Effect = effect
             });
         }
 
-        return spells;
+        return (spells, errors);
     }
 
     private static async Task<Ok<SeedResult>> SeedGames(WorldDbContext db)

--- a/src/OvcinaHra.Api/Endpoints/SeedEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SeedEndpoints.cs
@@ -25,8 +25,91 @@ public static class SeedEndpoints
         group.MapPost("/monsters", SeedMonsters);
         group.MapPost("/buildings", SeedBuildings);
         group.MapPost("/quests", SeedQuests);
+        group.MapPost("/spells", SeedSpells);
 
         return group;
+    }
+
+    private static async Task<Ok<SeedResult>> SeedSpells(WorldDbContext db, IWebHostEnvironment env)
+    {
+        if (await db.Spells.AnyAsync())
+            return TypedResults.Ok(new SeedResult(0, "Kouzla už existují. Smaž je nejdřív."));
+
+        var mdPath = Path.Combine(env.ContentRootPath, "..", "..", "docs", "imports", "spells.md");
+        if (!File.Exists(mdPath))
+            return TypedResults.Ok(new SeedResult(0, $"Soubor nenalezen: {Path.GetFullPath(mdPath)}"));
+
+        var content = await File.ReadAllTextAsync(mdPath);
+        var spells = ParseSpellsMarkdown(content);
+
+        foreach (var s in spells)
+            db.Spells.Add(s);
+
+        await db.SaveChangesAsync();
+        return TypedResults.Ok(new SeedResult(spells.Count, $"Importováno {spells.Count} kouzel z spells.md."));
+    }
+
+    /// <summary>
+    /// Parses the per-level spell tables out of docs/imports/spells.md.
+    /// Expected columns (in order): Name, Level, ManaCost, School, IsScroll,
+    /// IsReaction, MinMageLevel, Price, Effect, SourceRule.
+    /// Only rows under "## Úroveň ..." sections are processed — the schema
+    /// table at the top has different columns and is skipped.
+    /// IsLearnable is derived by the loader: <c>!IsScroll</c>.
+    /// </summary>
+    private static List<Spell> ParseSpellsMarkdown(string content)
+    {
+        var spells = new List<Spell>();
+        var inSpellSection = false;
+
+        foreach (var raw in content.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+
+            if (line.StartsWith("## Úroveň"))
+            {
+                inSpellSection = true;
+                continue;
+            }
+            if (line.StartsWith("## "))
+            {
+                // Any other level-2 heading ends the spell-table region.
+                inSpellSection = false;
+                continue;
+            }
+            if (!inSpellSection) continue;
+            if (!line.StartsWith("|")) continue;
+
+            var cells = line.Split('|').Select(c => c.Trim()).ToList();
+            if (cells.Count > 0 && cells[0] == "") cells.RemoveAt(0);
+            if (cells.Count > 0 && cells[^1] == "") cells.RemoveAt(cells.Count - 1);
+
+            // Need: Name, Level, ManaCost, School, IsScroll, IsReaction,
+            //       MinMageLevel, Price, Effect, SourceRule → 10 cells
+            if (cells.Count < 10) continue;
+            if (cells[0] == "Name" || cells[0].StartsWith("---")) continue;
+            if (string.IsNullOrWhiteSpace(cells[0])) continue;
+
+            var school = Enum.Parse<SpellSchool>(cells[3], ignoreCase: true);
+            var isScroll = bool.Parse(cells[4]);
+            var isReaction = bool.Parse(cells[5]);
+
+            spells.Add(new Spell
+            {
+                Name = cells[0],
+                Level = int.Parse(cells[1]),
+                ManaCost = int.Parse(cells[2]),
+                School = school,
+                IsScroll = isScroll,
+                IsReaction = isReaction,
+                IsLearnable = !isScroll,
+                MinMageLevel = int.Parse(cells[6]),
+                Price = int.TryParse(cells[7], out var p) ? p : null,
+                Effect = cells[8]
+            });
+        }
+
+        return spells;
     }
 
     private static async Task<Ok<SeedResult>> SeedGames(WorldDbContext db)

--- a/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
@@ -1,0 +1,188 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Endpoints;
+
+public static class SpellEndpoints
+{
+    public static RouteGroupBuilder MapSpellEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/spells").WithTags("Spells");
+
+        group.MapGet("/", GetAll);
+        group.MapGet("/{id:int}", GetById);
+        group.MapPost("/", Create);
+        group.MapPut("/{id:int}", Update);
+        group.MapDelete("/{id:int}", Delete);
+
+        // Per-game spell configuration
+        group.MapGet("/by-game/{gameId:int}", GetByGame);
+        group.MapPost("/game-spell", CreateGameSpell);
+        group.MapPut("/game-spell/{gameId:int}/{spellId:int}", UpdateGameSpell);
+        group.MapDelete("/game-spell/{gameId:int}/{spellId:int}", DeleteGameSpell);
+
+        return group;
+    }
+
+    // ── Catalog ────────────────────────────────────────────────────────
+
+    private static async Task<Ok<List<SpellListDto>>> GetAll(WorldDbContext db)
+    {
+        var spells = await db.Spells
+            .OrderBy(s => s.Level)
+            .ThenBy(s => s.Name)
+            .Select(s => new SpellListDto(
+                s.Id, s.Name, s.Level, s.School,
+                s.IsScroll, s.IsReaction, s.IsLearnable,
+                s.ManaCost, s.MinMageLevel, s.Price,
+                s.Effect, s.Description))
+            .ToListAsync();
+        return TypedResults.Ok(spells);
+    }
+
+    private static async Task<Results<Ok<SpellDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
+    {
+        var s = await db.Spells.FindAsync(id);
+        if (s is null) return TypedResults.NotFound();
+
+        return TypedResults.Ok(new SpellDetailDto(
+            s.Id, s.Name, s.Level, s.ManaCost, s.School,
+            s.IsScroll, s.IsReaction, s.IsLearnable, s.MinMageLevel, s.Price,
+            s.Effect, s.Description, s.ImagePath));
+    }
+
+    private static async Task<Results<Created<SpellDetailDto>, Conflict<string>>> Create(
+        CreateSpellDto dto, WorldDbContext db)
+    {
+        if (await db.Spells.AnyAsync(x => x.Name == dto.Name))
+            return TypedResults.Conflict($"Kouzlo s názvem '{dto.Name}' už existuje.");
+
+        var s = new Spell
+        {
+            Name = dto.Name,
+            Level = dto.Level,
+            ManaCost = dto.ManaCost,
+            School = dto.School,
+            IsScroll = dto.IsScroll,
+            IsReaction = dto.IsReaction,
+            IsLearnable = dto.IsLearnable,
+            MinMageLevel = dto.MinMageLevel,
+            Price = dto.Price,
+            Effect = dto.Effect,
+            Description = dto.Description
+        };
+        db.Spells.Add(s);
+        await db.SaveChangesAsync();
+
+        return TypedResults.Created(
+            $"/api/spells/{s.Id}",
+            new SpellDetailDto(s.Id, s.Name, s.Level, s.ManaCost, s.School,
+                s.IsScroll, s.IsReaction, s.IsLearnable, s.MinMageLevel, s.Price,
+                s.Effect, s.Description, s.ImagePath));
+    }
+
+    private static async Task<Results<NoContent, NotFound, Conflict<string>>> Update(
+        int id, UpdateSpellDto dto, WorldDbContext db)
+    {
+        var s = await db.Spells.FindAsync(id);
+        if (s is null) return TypedResults.NotFound();
+
+        if (s.Name != dto.Name && await db.Spells.AnyAsync(x => x.Id != id && x.Name == dto.Name))
+            return TypedResults.Conflict($"Kouzlo s názvem '{dto.Name}' už existuje.");
+
+        s.Name = dto.Name;
+        s.Level = dto.Level;
+        s.ManaCost = dto.ManaCost;
+        s.School = dto.School;
+        s.IsScroll = dto.IsScroll;
+        s.IsReaction = dto.IsReaction;
+        s.IsLearnable = dto.IsLearnable;
+        s.MinMageLevel = dto.MinMageLevel;
+        s.Price = dto.Price;
+        s.Effect = dto.Effect;
+        s.Description = dto.Description;
+
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound>> Delete(int id, WorldDbContext db)
+    {
+        var s = await db.Spells.FindAsync(id);
+        if (s is null) return TypedResults.NotFound();
+
+        db.Spells.Remove(s);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    // ── Per-game ──────────────────────────────────────────────────────
+
+    private static async Task<Ok<List<GameSpellDto>>> GetByGame(int gameId, WorldDbContext db)
+    {
+        var rows = await db.GameSpells
+            .Where(gs => gs.GameId == gameId)
+            .Include(gs => gs.Spell)
+            .OrderBy(gs => gs.Spell.Level)
+            .ThenBy(gs => gs.Spell.Name)
+            .Select(gs => new GameSpellDto(
+                gs.Id, gs.GameId, gs.SpellId, gs.Spell.Name, gs.Spell.Level, gs.Spell.School,
+                gs.Price, gs.IsFindable, gs.AvailabilityNotes))
+            .ToListAsync();
+        return TypedResults.Ok(rows);
+    }
+
+    private static async Task<Results<Created<GameSpellDto>, Conflict<string>, NotFound<string>>> CreateGameSpell(
+        CreateGameSpellDto dto, WorldDbContext db)
+    {
+        if (await db.GameSpells.AnyAsync(gs => gs.GameId == dto.GameId && gs.SpellId == dto.SpellId))
+            return TypedResults.Conflict("Kouzlo už je ve hře přiřazené.");
+
+        var spell = await db.Spells.FindAsync(dto.SpellId);
+        if (spell is null) return TypedResults.NotFound($"Kouzlo #{dto.SpellId} neexistuje.");
+
+        var gs = new GameSpell
+        {
+            GameId = dto.GameId,
+            SpellId = dto.SpellId,
+            Price = dto.Price,
+            IsFindable = dto.IsFindable,
+            AvailabilityNotes = dto.AvailabilityNotes
+        };
+        db.GameSpells.Add(gs);
+        await db.SaveChangesAsync();
+
+        return TypedResults.Created(
+            $"/api/spells/by-game/{gs.GameId}",
+            new GameSpellDto(gs.Id, gs.GameId, gs.SpellId, spell.Name, spell.Level, spell.School,
+                gs.Price, gs.IsFindable, gs.AvailabilityNotes));
+    }
+
+    private static async Task<Results<NoContent, NotFound>> UpdateGameSpell(
+        int gameId, int spellId, UpdateGameSpellDto dto, WorldDbContext db)
+    {
+        var gs = await db.GameSpells.FirstOrDefaultAsync(x => x.GameId == gameId && x.SpellId == spellId);
+        if (gs is null) return TypedResults.NotFound();
+
+        gs.Price = dto.Price;
+        gs.IsFindable = dto.IsFindable;
+        gs.AvailabilityNotes = dto.AvailabilityNotes;
+
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound>> DeleteGameSpell(
+        int gameId, int spellId, WorldDbContext db)
+    {
+        var gs = await db.GameSpells.FirstOrDefaultAsync(x => x.GameId == gameId && x.SpellId == spellId);
+        if (gs is null) return TypedResults.NotFound();
+
+        db.GameSpells.Remove(gs);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+}

--- a/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
@@ -138,11 +138,15 @@ public static class SpellEndpoints
     private static async Task<Results<Created<GameSpellDto>, Conflict<string>, NotFound<string>>> CreateGameSpell(
         CreateGameSpellDto dto, WorldDbContext db)
     {
-        if (await db.GameSpells.AnyAsync(gs => gs.GameId == dto.GameId && gs.SpellId == dto.SpellId))
-            return TypedResults.Conflict("Kouzlo už je ve hře přiřazené.");
-
+        // Validate FKs up front — otherwise EF surfaces FK violations as 500.
         var spell = await db.Spells.FindAsync(dto.SpellId);
         if (spell is null) return TypedResults.NotFound($"Kouzlo #{dto.SpellId} neexistuje.");
+
+        if (!await db.Games.AnyAsync(g => g.Id == dto.GameId))
+            return TypedResults.NotFound($"Hra #{dto.GameId} neexistuje.");
+
+        if (await db.GameSpells.AnyAsync(gs => gs.GameId == dto.GameId && gs.SpellId == dto.SpellId))
+            return TypedResults.Conflict("Kouzlo už je ve hře přiřazené.");
 
         var gs = new GameSpell
         {

--- a/src/OvcinaHra.Api/Migrations/20260422035427_AddSpells.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422035427_AddSpells.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422035427_AddSpells")]
+    partial class AddSpells
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260422035427_AddSpells.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422035427_AddSpells.cs
@@ -1,0 +1,103 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using NpgsqlTypes;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSpells : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Spells",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Level = table.Column<int>(type: "integer", nullable: false),
+                    ManaCost = table.Column<int>(type: "integer", nullable: false),
+                    School = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    IsScroll = table.Column<bool>(type: "boolean", nullable: false),
+                    IsReaction = table.Column<bool>(type: "boolean", nullable: false),
+                    IsLearnable = table.Column<bool>(type: "boolean", nullable: false),
+                    MinMageLevel = table.Column<int>(type: "integer", nullable: false),
+                    Price = table.Column<int>(type: "integer", nullable: true),
+                    Effect = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    Description = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    ImagePath = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    SearchVector = table.Column<NpgsqlTsVector>(type: "tsvector", nullable: true, computedColumnSql: "to_tsvector('simple', coalesce(\"Name\", '') || ' ' || coalesce(\"Effect\", '') || ' ' || coalesce(\"Description\", ''))", stored: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Spells", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "GameSpells",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    SpellId = table.Column<int>(type: "integer", nullable: false),
+                    Price = table.Column<int>(type: "integer", nullable: true),
+                    IsFindable = table.Column<bool>(type: "boolean", nullable: false),
+                    AvailabilityNotes = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameSpells", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_GameSpells_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GameSpells_Spells_SpellId",
+                        column: x => x.SpellId,
+                        principalTable: "Spells",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameSpells_GameId_SpellId",
+                table: "GameSpells",
+                columns: new[] { "GameId", "SpellId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameSpells_SpellId",
+                table: "GameSpells",
+                column: "SpellId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Spells_Name",
+                table: "Spells",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Spells_SearchVector",
+                table: "Spells",
+                column: "SearchVector")
+                .Annotation("Npgsql:IndexMethod", "GIN");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GameSpells");
+
+            migrationBuilder.DropTable(
+                name: "Spells");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -204,6 +204,7 @@ try
     app.MapQuestEndpoints().RequireAuthorization();
     app.MapBuildingEndpoints().RequireAuthorization();
     app.MapSkillEndpoints().RequireAuthorization();
+    app.MapSpellEndpoints().RequireAuthorization();
     app.MapCraftingEndpoints().RequireAuthorization();
     app.MapTreasureQuestEndpoints().RequireAuthorization();
     app.MapPersonalQuestEndpoints().RequireAuthorization();

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -133,6 +133,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="spells">
+                <i class="bi bi-magic"></i><span class="nav-label">Kouzla</span>
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="secret-stashes?catalog=true">
                 <i class="bi bi-lock"></i><span class="nav-label">Tajné skrýše</span>
             </NavLink>

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.8.8</Version>
+    <Version>0.9.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Spells/SpellList.razor
+++ b/src/OvcinaHra.Client/Pages/Spells/SpellList.razor
@@ -1,0 +1,226 @@
+@page "/spells"
+@attribute [Authorize]
+@inject ApiClient Api
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Katalog kouzel</h1>
+    <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nové kouzlo</button>
+</div>
+
+@if (loading)
+{
+    <p>Načítám...</p>
+}
+else
+{
+    <OvcinaGrid Data="@spells" KeyFieldName="Id" LayoutKey="grid-layout-spells"
+                RowClick="@(async e => await OpenDetailAsync((SpellListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+        <Columns>
+            @* Default visible — the common "at-a-glance" set *@
+            <DxGridDataColumn FieldName="Id" Caption="#" Width="60px" />
+            <DxGridDataColumn FieldName="Name" Caption="Název" Width="200px" />
+            <DxGridDataColumn FieldName="Level" Caption="Úroveň" Width="90px" />
+            <DxGridDataColumn FieldName="SchoolDisplay" Caption="Typ" Width="130px" />
+            <DxGridDataColumn FieldName="ManaCost" Caption="Mana" Width="80px" />
+            <DxGridDataColumn FieldName="MinMageLevel" Caption="Min. mág" Width="100px" />
+            <DxGridDataColumn FieldName="Price" Caption="Cena (gr)" Width="100px" />
+            <DxGridDataColumn FieldName="IsScroll" Caption="Svitek" Width="80px" />
+            <DxGridDataColumn FieldName="IsReaction" Caption="Reakce" Width="90px" />
+            <DxGridDataColumn FieldName="IsLearnable" Caption="Naučitelné" Width="110px" />
+            <DxGridDataColumn FieldName="Effect" Caption="Efekt" Width="420px" />
+
+            @* Hidden by default — reveal via column chooser *@
+            <DxGridDataColumn FieldName="Description" Caption="Popis" Width="360px" Visible="false" />
+        </Columns>
+    </OvcinaGrid>
+}
+
+<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="760px" MinHeight="640px">
+    <BodyContentTemplate Context="popupContext">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název" ColSpanMd="8">
+                <DxTextBox @bind-Text="@model.Name" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Typ (škola)" ColSpanMd="4">
+                <DxComboBox Data="@schoolValues" @bind-Value="@model.School"
+                            TextFieldName="Display" ValueFieldName="Value" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Úroveň (0=svitek, 1-5=mág)" ColSpanMd="4">
+                <DxSpinEdit @bind-Value="@model.Level" MinValue="0" MaxValue="5" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Mana" ColSpanMd="4">
+                <DxSpinEdit @bind-Value="@model.ManaCost" MinValue="0" MaxValue="5" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Min. úroveň mága" ColSpanMd="4">
+                <DxSpinEdit @bind-Value="@model.MinMageLevel" MinValue="0" MaxValue="5" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Svitek (MAG-005)" ColSpanMd="4">
+                <DxCheckBox @bind-Checked="@model.IsScroll" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Reakce" ColSpanMd="4">
+                <DxCheckBox @bind-Checked="@model.IsReaction" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Naučitelné u budovy" ColSpanMd="4">
+                <DxCheckBox @bind-Checked="@model.IsLearnable" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Cena naučení (groše)" ColSpanMd="12">
+                <DxSpinEdit @bind-Value="@model.Price" MinValue="0" MaxValue="9999" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Efekt (text karty)" ColSpanMd="12">
+                <DxMemo @bind-Text="@model.Effect" Rows="4" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Popis / flavor (volitelný)" ColSpanMd="12">
+                <DxMemo @bind-Text="@model.Description" Rows="4" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+
+        @if (error is not null)
+        {
+            <div class="alert alert-danger mt-2">@error</div>
+        }
+
+        <div class="d-flex gap-2 mt-3">
+            @if (editingId.HasValue)
+            {
+                <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true" disabled="@isSaving">Smazat</button>
+            }
+            <div style="flex: 1"></div>
+            <button class="btn btn-secondary" @onclick="() => isModalVisible = false" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">
+                @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Uložit
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Smazat kouzlo?" Width="400px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete smazat kouzlo <strong>@model.Name</strong>?</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync" disabled="@isSaving">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    private List<SpellListDto> spells = [];
+    private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
+    private string modalTitle = "";
+    private string? error;
+    private int? editingId;
+    private SpellFormModel model = new();
+
+    private static readonly List<SchoolOption> schoolValues = Enum.GetValues<SpellSchool>()
+        .Select(v => new SchoolOption(v, v.GetDisplayName())).ToList();
+
+    private record SchoolOption(SpellSchool Value, string Display);
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        spells = await Api.GetListAsync<SpellListDto>("/api/spells");
+        loading = false;
+    }
+
+    private void OpenModal(SpellListDto? _)
+    {
+        error = null;
+        editingId = null;
+        model = new SpellFormModel();
+        modalTitle = "Nové kouzlo";
+        isModalVisible = true;
+    }
+
+    private async Task OpenDetailAsync(SpellListDto s)
+    {
+        error = null;
+        var detail = await Api.GetAsync<SpellDetailDto>($"/api/spells/{s.Id}");
+        if (detail is null) return;
+
+        editingId = detail.Id;
+        model = SpellFormModel.FromDetail(detail);
+        modalTitle = $"Upravit: {detail.Name}";
+        isModalVisible = true;
+    }
+
+    private async Task SaveAsync()
+    {
+        error = null;
+        isSaving = true;
+        try
+        {
+            if (editingId.HasValue)
+            {
+                await Api.PutAsync($"/api/spells/{editingId}", model.ToUpdateDto());
+            }
+            else
+            {
+                await Api.PostAsync<CreateSpellDto, SpellDetailDto>("/api/spells", model.ToCreateDto());
+            }
+            isModalVisible = false;
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        isSaving = true;
+        try
+        {
+            await Api.DeleteAsync($"/api/spells/{editingId}");
+            isDeleteVisible = false;
+            isModalVisible = false;
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private sealed class SpellFormModel
+    {
+        public string Name { get; set; } = "";
+        public int Level { get; set; }
+        public int ManaCost { get; set; }
+        public SpellSchool School { get; set; } = SpellSchool.Fire;
+        public bool IsScroll { get; set; }
+        public bool IsReaction { get; set; }
+        public bool IsLearnable { get; set; } = true;
+        public int MinMageLevel { get; set; }
+        public int? Price { get; set; }
+        public string Effect { get; set; } = "";
+        public string? Description { get; set; }
+
+        public static SpellFormModel FromDetail(SpellDetailDto d) => new()
+        {
+            Name = d.Name,
+            Level = d.Level,
+            ManaCost = d.ManaCost,
+            School = d.School,
+            IsScroll = d.IsScroll,
+            IsReaction = d.IsReaction,
+            IsLearnable = d.IsLearnable,
+            MinMageLevel = d.MinMageLevel,
+            Price = d.Price,
+            Effect = d.Effect,
+            Description = d.Description
+        };
+
+        public CreateSpellDto ToCreateDto() => new(
+            Name, Level, ManaCost, School, IsScroll, IsReaction, IsLearnable, MinMageLevel, Price, Effect, Description);
+
+        public UpdateSpellDto ToUpdateDto() => new(
+            Name, Level, ManaCost, School, IsScroll, IsReaction, IsLearnable, MinMageLevel, Price, Effect, Description);
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Spells/SpellList.razor
+++ b/src/OvcinaHra.Client/Pages/Spells/SpellList.razor
@@ -176,10 +176,18 @@ else
 
     private async Task ConfirmDeleteAsync()
     {
+        error = null;
         isSaving = true;
         try
         {
-            await Api.DeleteAsync($"/api/spells/{editingId}");
+            // ApiClient.DeleteAsync returns bool — it does not throw on non-success.
+            // Ignoring the value would close the dialog even on a failed delete.
+            var ok = await Api.DeleteAsync($"/api/spells/{editingId}");
+            if (!ok)
+            {
+                error = "Smazání kouzla se nepodařilo.";
+                return;
+            }
             isDeleteVisible = false;
             isModalVisible = false;
             await LoadAsync();

--- a/src/OvcinaHra.Shared/Domain/Entities/GameSpell.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameSpell.cs
@@ -1,0 +1,24 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+/// <summary>
+/// Per-game spell configuration. Mirrors GameItem — first-class entity with
+/// surrogate Id (like GameSkill), per-game overrides of the catalog defaults.
+/// </summary>
+public class GameSpell
+{
+    public int Id { get; set; }
+
+    public int GameId { get; set; }
+    public int SpellId { get; set; }
+
+    /// <summary>Per-game override of Spell.Price (learning cost in groše). Null = inherit from catalog.</summary>
+    public int? Price { get; set; }
+
+    /// <summary>True = can be found / dropped as loot / scroll in this game.</summary>
+    public bool IsFindable { get; set; }
+
+    public string? AvailabilityNotes { get; set; }
+
+    public Game Game { get; set; } = null!;
+    public Spell Spell { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/Spell.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Spell.cs
@@ -1,0 +1,51 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Domain.Entities;
+
+/// <summary>
+/// Catalog template for a spell. Mirrors the Item/Skill pattern — this is the
+/// cross-game definition; per-game configuration (price override, availability)
+/// lives on <see cref="GameSpell"/>.
+/// Sources: rulemaster MAG-005 (scrolls) + MAG-006 (mage levels I–V).
+/// </summary>
+public class Spell
+{
+    public int Id { get; set; }
+
+    /// <summary>Canonical Czech name (diacritics). Unique in the catalog.</summary>
+    public required string Name { get; set; }
+
+    /// <summary>0 = scroll (MAG-005), 1–5 = mage level I–V (MAG-006).</summary>
+    public int Level { get; set; }
+
+    /// <summary>Mana cost. Scrolls = 0 (one-shot, no mana).</summary>
+    public int ManaCost { get; set; }
+
+    public SpellSchool School { get; set; }
+
+    /// <summary>True = MAG-005 scroll (one-shot, anyone can cast).</summary>
+    public bool IsScroll { get; set; }
+
+    /// <summary>True = cast as a reaction (out of turn). Only a handful of spells.</summary>
+    public bool IsReaction { get; set; }
+
+    /// <summary>True = purchasable at a building (merchant / mudrc / library).
+    /// Scrolls default to false — they're found or bought as physical items, not learned.</summary>
+    public bool IsLearnable { get; set; }
+
+    /// <summary>Minimum mage level to cast. 0 for scrolls (anyone).</summary>
+    public int MinMageLevel { get; set; }
+
+    /// <summary>Learning cost in groše (MAG-007). Null for scrolls.</summary>
+    public int? Price { get; set; }
+
+    /// <summary>Mechanical card text shown to players.</summary>
+    public required string Effect { get; set; }
+
+    /// <summary>Lore / flavour. Optional.</summary>
+    public string? Description { get; set; }
+
+    public string? ImagePath { get; set; }
+
+    public ICollection<GameSpell> GameSpells { get; set; } = [];
+}

--- a/src/OvcinaHra.Shared/Domain/Enums/SpellSchool.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/SpellSchool.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Domain.Enums;
+
+/// <summary>
+/// Spell school / element category from rulemaster MAG-012.
+/// Includes all classical elements plus non-elemental categories — some reserved
+/// values have no spells in the current catalog but are kept for future content.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum SpellSchool
+{
+    [Display(Name = "Oheň")]        Fire,
+    [Display(Name = "Mráz")]        Frost,
+    [Display(Name = "Voda")]        Water,
+    [Display(Name = "Země")]        Earth,
+    [Display(Name = "Vítr")]        Wind,
+    [Display(Name = "Jed")]         Poison,
+    [Display(Name = "Mentální")]    Mental,
+    [Display(Name = "Podpůrné")]    Support,
+    [Display(Name = "Praktické")]   Utility
+}

--- a/src/OvcinaHra.Shared/Dtos/SpellDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/SpellDtos.cs
@@ -1,0 +1,96 @@
+using System.Text.Json.Serialization;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
+
+namespace OvcinaHra.Shared.Dtos;
+
+// ── Catalog (template) DTOs ────────────────────────────────────────────────
+
+public record SpellListDto(
+    int Id,
+    string Name,
+    int Level,
+    SpellSchool School,
+    bool IsScroll,
+    bool IsReaction,
+    bool IsLearnable,
+    int ManaCost,
+    int MinMageLevel,
+    int? Price,
+    string Effect,
+    string? Description)
+{
+    [JsonIgnore] public string SchoolDisplay => School.GetDisplayName();
+}
+
+public record SpellDetailDto(
+    int Id,
+    string Name,
+    int Level,
+    int ManaCost,
+    SpellSchool School,
+    bool IsScroll,
+    bool IsReaction,
+    bool IsLearnable,
+    int MinMageLevel,
+    int? Price,
+    string Effect,
+    string? Description,
+    string? ImagePath)
+{
+    [JsonIgnore] public string SchoolDisplay => School.GetDisplayName();
+}
+
+public record CreateSpellDto(
+    string Name,
+    int Level,
+    int ManaCost,
+    SpellSchool School,
+    bool IsScroll,
+    bool IsReaction,
+    bool IsLearnable,
+    int MinMageLevel,
+    int? Price,
+    string Effect,
+    string? Description = null);
+
+public record UpdateSpellDto(
+    string Name,
+    int Level,
+    int ManaCost,
+    SpellSchool School,
+    bool IsScroll,
+    bool IsReaction,
+    bool IsLearnable,
+    int MinMageLevel,
+    int? Price,
+    string Effect,
+    string? Description);
+
+// ── Per-game spell configuration (mirror GameItem) ────────────────────────
+
+public record GameSpellDto(
+    int Id,
+    int GameId,
+    int SpellId,
+    string SpellName,
+    int Level,
+    SpellSchool School,
+    int? Price,
+    bool IsFindable,
+    string? AvailabilityNotes)
+{
+    [JsonIgnore] public string SchoolDisplay => School.GetDisplayName();
+}
+
+public record CreateGameSpellDto(
+    int GameId,
+    int SpellId,
+    int? Price = null,
+    bool IsFindable = false,
+    string? AvailabilityNotes = null);
+
+public record UpdateGameSpellDto(
+    int? Price,
+    bool IsFindable,
+    string? AvailabilityNotes);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/SpellEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/SpellEndpointTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+public class SpellEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    [Fact]
+    public async Task Create_ValidSpell_ReturnsCreated()
+    {
+        var dto = new CreateSpellDto(
+            Name: "Ohnivá střela",
+            Level: 1,
+            ManaCost: 1,
+            School: SpellSchool.Fire,
+            IsScroll: false,
+            IsReaction: false,
+            IsLearnable: true,
+            MinMageLevel: 1,
+            Price: 10,
+            Effect: "Zraň jeden cíl za 1k6 ž ohněm.");
+
+        var resp = await Client.PostAsJsonAsync("/api/spells", dto);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+        var created = await resp.Content.ReadFromJsonAsync<SpellDetailDto>();
+        Assert.NotNull(created);
+        Assert.Equal("Ohnivá střela", created.Name);
+        Assert.Equal(1, created.Level);
+        Assert.Equal(SpellSchool.Fire, created.School);
+        Assert.True(created.IsLearnable);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateName_ReturnsConflict()
+    {
+        var dto = new CreateSpellDto(
+            "Léčivé dlaně", 0, 0, SpellSchool.Support, true, false, false, 0, null,
+            "Vyleč 5 ž ztracených v tomto kole.");
+
+        var first = await Client.PostAsJsonAsync("/api/spells", dto);
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+
+        var second = await Client.PostAsJsonAsync("/api/spells", dto);
+        Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_OrderedByLevelThenName()
+    {
+        var now = Guid.NewGuid().ToString("N")[..6];  // disambiguate name across runs if any
+
+        await Client.PostAsJsonAsync("/api/spells",
+            new CreateSpellDto($"Ohnivá bouře {now}", 5, 5, SpellSchool.Fire, false, false, true, 5, 40,
+                "Zraň všechny nepřátele."));
+        await Client.PostAsJsonAsync("/api/spells",
+            new CreateSpellDto($"Jiskra {now}", 0, 0, SpellSchool.Fire, true, false, false, 0, null,
+                "3 ž ohněm."));
+        await Client.PostAsJsonAsync("/api/spells",
+            new CreateSpellDto($"Omámení {now}", 1, 1, SpellSchool.Mental, false, false, true, 1, 10,
+                "Cílová bytost přijde o akci."));
+
+        var all = await Client.GetFromJsonAsync<List<SpellListDto>>("/api/spells");
+        Assert.NotNull(all);
+
+        var mine = all.Where(s => s.Name.EndsWith(now)).ToList();
+        Assert.Equal(3, mine.Count);
+        Assert.Equal($"Jiskra {now}", mine[0].Name);        // level 0 first
+        Assert.Equal($"Omámení {now}", mine[1].Name);       // level 1
+        Assert.Equal($"Ohnivá bouře {now}", mine[2].Name);  // level 5 last
+    }
+
+    [Fact]
+    public async Task GameSpell_AssignAndFilterByGame_Works()
+    {
+        // Create a game
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Spell Test", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 2)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        // Create two spells
+        var s1 = await (await Client.PostAsJsonAsync("/api/spells",
+            new CreateSpellDto("Jedový šíp", 0, 0, SpellSchool.Poison, true, false, false, 0, null,
+                "3 ž jedem.")))
+            .Content.ReadFromJsonAsync<SpellDetailDto>();
+        var s2 = await (await Client.PostAsJsonAsync("/api/spells",
+            new CreateSpellDto("Bažina", 3, 3, SpellSchool.Utility, false, false, true, 3, 22,
+                "Výsledky blízkých útoků = [1].")))
+            .Content.ReadFromJsonAsync<SpellDetailDto>();
+
+        // Assign only s1 to the game
+        var assign = await Client.PostAsJsonAsync("/api/spells/game-spell",
+            new CreateGameSpellDto(game!.Id, s1!.Id, Price: 0, IsFindable: true,
+                AvailabilityNotes: "V truhle v Aradhryand"));
+        Assert.Equal(HttpStatusCode.Created, assign.StatusCode);
+
+        // by-game returns only the assigned one
+        var byGame = await Client.GetFromJsonAsync<List<GameSpellDto>>($"/api/spells/by-game/{game.Id}");
+        Assert.NotNull(byGame);
+        Assert.Single(byGame);
+        Assert.Equal(s1.Id, byGame[0].SpellId);
+        Assert.Equal("Jedový šíp", byGame[0].SpellName);
+        Assert.Equal(SpellSchool.Poison, byGame[0].School);
+        Assert.True(byGame[0].IsFindable);
+
+        // Update the per-game config
+        var upd = await Client.PutAsJsonAsync($"/api/spells/game-spell/{game.Id}/{s1.Id}",
+            new UpdateGameSpellDto(Price: 5, IsFindable: false, AvailabilityNotes: null));
+        Assert.Equal(HttpStatusCode.NoContent, upd.StatusCode);
+
+        byGame = await Client.GetFromJsonAsync<List<GameSpellDto>>($"/api/spells/by-game/{game.Id}");
+        Assert.Equal(5, byGame![0].Price);
+        Assert.False(byGame[0].IsFindable);
+
+        // Delete the assignment
+        var del = await Client.DeleteAsync($"/api/spells/game-spell/{game.Id}/{s1.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+
+        byGame = await Client.GetFromJsonAsync<List<GameSpellDto>>($"/api/spells/by-game/{game.Id}");
+        Assert.Empty(byGame!);
+    }
+
+    [Fact]
+    public async Task Search_FindsSpells_ByNameFragment()
+    {
+        // Seed a couple of spells with a recognisable token in the Effect so FTS matches.
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            db.Spells.AddRange(
+                new Spell
+                {
+                    Name = "Ohnivá střela (test)",
+                    Level = 1, ManaCost = 1, School = SpellSchool.Fire,
+                    IsScroll = false, IsReaction = false, IsLearnable = true,
+                    MinMageLevel = 1, Price = 10,
+                    Effect = "Zraň jeden cíl za 1k6 ž ohněm."
+                },
+                new Spell
+                {
+                    Name = "Ohnivá koule (test)",
+                    Level = 3, ManaCost = 3, School = SpellSchool.Fire,
+                    IsScroll = false, IsReaction = false, IsLearnable = true,
+                    MinMageLevel = 3, Price = 22,
+                    Effect = "Zraň až dva cíle za 1k6 ž ohněm."
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var resp = await Client.GetAsync("/api/search?q=ohniv");
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<SearchResponseDto>();
+        Assert.NotNull(body);
+
+        var spells = body.Results.Where(r => r.EntityType == "Spell").ToList();
+        Assert.Contains(spells, s => s.Name == "Ohnivá střela (test)");
+        Assert.Contains(spells, s => s.Name == "Ohnivá koule (test)");
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/SpellEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/SpellEndpointTests.cs
@@ -82,17 +82,21 @@ public class SpellEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
         // Create a game
         var gameResponse = await Client.PostAsJsonAsync("/api/games",
             new CreateGameDto("Spell Test", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 2)));
+        gameResponse.EnsureSuccessStatusCode();
         var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
 
         // Create two spells
-        var s1 = await (await Client.PostAsJsonAsync("/api/spells",
+        var s1Response = await Client.PostAsJsonAsync("/api/spells",
             new CreateSpellDto("Jedový šíp", 0, 0, SpellSchool.Poison, true, false, false, 0, null,
-                "3 ž jedem.")))
-            .Content.ReadFromJsonAsync<SpellDetailDto>();
-        var s2 = await (await Client.PostAsJsonAsync("/api/spells",
+                "3 ž jedem."));
+        s1Response.EnsureSuccessStatusCode();
+        var s1 = await s1Response.Content.ReadFromJsonAsync<SpellDetailDto>();
+
+        var s2Response = await Client.PostAsJsonAsync("/api/spells",
             new CreateSpellDto("Bažina", 3, 3, SpellSchool.Utility, false, false, true, 3, 22,
-                "Výsledky blízkých útoků = [1].")))
-            .Content.ReadFromJsonAsync<SpellDetailDto>();
+                "Výsledky blízkých útoků = [1]."));
+        s2Response.EnsureSuccessStatusCode();
+        var s2 = await s2Response.Content.ReadFromJsonAsync<SpellDetailDto>();
 
         // Assign only s1 to the game
         var assign = await Client.PostAsJsonAsync("/api/spells/game-spell",


### PR DESCRIPTION
## Summary

Adds spells as a first-class cross-game catalog entity (mirror of Item). Lets the rulemaster bot and other downstream skills query spells via the public JSON API the same way they query items / monsters / quests today.

Implements the prompt at `docs/plans/2026-04-22-spells-tinkerer-prompt.md` with two user-approved deviations:

- **SpellBuildingRequirement entities are NOT created.** Prompt said "log a warning and seed without links"; user clarified "completely ignore that, we'll create that in the application". Landed as zero-entity skip — future additive migration when the admin UI picks up a multi-select.
- **/api/spells/usable and /api/spells/learnable dropped.** User: "if the spell is in the game it is usable" — `/by-game` covers it, client filters by `MinMageLevel` itself.

## Domain (3 files)

- `Spell` — catalog template: Name, Level (0=scroll, 1-5=mage level), ManaCost, School, IsScroll, IsReaction, IsLearnable, MinMageLevel, Price (groše), Effect, Description, ImagePath.
- `GameSpell` — per-game config (surrogate Id like GameSkill): Price override, IsFindable, AvailabilityNotes. Unique index on (GameId, SpellId).
- `SpellSchool` enum — Fire / Frost / Water / Earth / Wind / Poison / Mental / Support / Utility, Czech display names. Water/Earth/Wind reserved for future content.

Migration `AddSpells` creates both tables + `Spells.SearchVector` tsvector computed column + GIN index (mirrors Item/Location/Monster/Quest).

## API (all `RequireAuthorization`; service tokens work the same as `/api/items`)

- `GET /api/spells` — catalog list
- `GET /api/spells/{id}` — detail
- `GET /api/spells/by-game/{gameId}` — spells assigned to a game
- `POST/PUT/DELETE /api/spells` — admin CRUD; Name unique (409 on duplicate)
- `POST /api/spells/game-spell` + `PUT/DELETE /game-spell/{gid}/{sid}` — per-game config
- `POST /api/seed/spells` (Dev only) — parses `docs/imports/spells.md` six per-level tables → inserts 28 spells; idempotent by row existence. `IsLearnable` derived as `!IsScroll`.
- `/api/search` extended to surface spells alongside locations / items / monsters / quests; game-filtered via `GameSpell` when `gameId` is provided.

## Client

- `Pages/Spells/SpellList.razor` at `/spells` — admin grid (12 columns, 11 visible by default incl. `Efekt` 420px, `Popis` hidden) + detail popup (create / edit / delete with DxPopup confirmation). Fresh `LayoutKey` — no bump needed.
- `Layout/NavMenu.razor` — `Kouzla` link added to *Katalog světa* section after *Dovednosti*.
- Client version **0.8.8 → 0.9.0** (minor, new entity type).

## Tests (5 new; 241/241 total green)

- `Create_ValidSpell_ReturnsCreated`
- `Create_DuplicateName_ReturnsConflict`
- `GetAll_OrderedByLevelThenName`
- `GameSpell_AssignAndFilterByGame_Works` — assign + update + delete per-game round-trip
- `Search_FindsSpells_ByNameFragment` — FTS across spell Name + Effect

## Test plan

- [ ] Build + tests green in CI
- [ ] After deploy: `POST /api/seed/spells` (dev env) imports the 28 spells from `spells.md`; rerun returns "already exist"
- [ ] `/spells` admin page renders, create/edit/delete round-trips work
- [ ] `GET /api/search?q=ohnivá` returns `Ohnivá střela`, `Ohnivá koule`, `Ohnivá bouře`
- [ ] Per-game assignment via `POST /api/spells/game-spell` + list via `GET /api/spells/by-game/{id}` work end-to-end
- [ ] `GET /api/version` reports this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)