### PR TITLE
fix(imagepicker): confirm before removing an existing image [v0.9.2]

### DIFF
--- a/src/OvcinaHra.Client/Components/ImagePicker.razor
+++ b/src/OvcinaHra.Client/Components/ImagePicker.razor
@@ -7,7 +7,7 @@
         {
             <img src="@currentUrl" alt="@Alt" class="image-picker-img" />
             <button type="button" class="image-picker-delete"
-                    @onclick="DeleteImage" @onclick:stopPropagation="true"
+                    @onclick="PromptDelete" @onclick:stopPropagation="true"
                     disabled="@isWorking" title="Odebrat obrázek">&#10005;</button>
         }
         else
@@ -37,6 +37,16 @@
     }
 </div>
 
+<DxPopup @bind-Visible="@isDeleteConfirmVisible" HeaderText="Odebrat obrázek?" Width="400px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete odebrat tento obrázek?</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isDeleteConfirmVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync" disabled="@isWorking">Odebrat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @code {
     [Inject] private ApiClient Api { get; set; } = null!;
 
@@ -51,6 +61,7 @@
     private string? currentUrl;
     private string? errorMessage;
     private bool isWorking;
+    private bool isDeleteConfirmVisible;
 
     private string parsedAspect = "1 / 1";
 
@@ -139,6 +150,14 @@
         {
             isWorking = false;
         }
+    }
+
+    private void PromptDelete() => isDeleteConfirmVisible = true;
+
+    private async Task ConfirmDeleteAsync()
+    {
+        isDeleteConfirmVisible = false;
+        await DeleteImage();
     }
 
     private async Task DeleteImage()

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Routes the ImagePicker X button through a `DxPopup` confirmation (`Odebrat obrázek?`) before deleting — matches the project's destructive-action confirmation rule
- Version bump 0.9.1 → 0.9.2

## Test plan
- [ ] Open any page with an image (Location, Item, Monster, Spell, …)
- [ ] Click the X on an existing image → confirmation popup appears
- [ ] Click Zrušit → image stays
- [ ] Click Odebrat → image is removed
- [ ] Upload a new image, then remove — same confirm flow