### PR TITLE
fix(nav): surface per-game links on first load + reorder Hra section [v0.9.3]

### DIFF
--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -28,6 +28,26 @@
 
         <div class="oh-nav-section-label">Hra</div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="timeline">
+                <i class="bi bi-clock-fill"></i><span class="nav-label">Časová osa</span>
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="treasures">
+                <i class="bi bi-safe-fill"></i><span class="nav-label">Poklady</span>
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="characters">
+                <i class="bi bi-person-fill"></i><span class="nav-label">Postavy</span>
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="events">
+                <i class="bi bi-calendar-event-fill"></i><span class="nav-label">Události</span>
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="locations">
                 <i class="bi bi-geo-alt-fill"></i><span class="nav-label">Lokace</span>
             </NavLink>
@@ -79,28 +99,8 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
-            <NavLink class="nav-link" href="timeline">
-                <i class="bi bi-clock-fill"></i><span class="nav-label">Časová osa</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="treasures">
-                <i class="bi bi-safe-fill"></i><span class="nav-label">Poklady</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="characters">
-                <i class="bi bi-person-fill"></i><span class="nav-label">Postavy</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
             <NavLink class="nav-link" href="npcs">
                 <i class="bi bi-person-badge-fill"></i><span class="nav-label">NPC</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="events">
-                <i class="bi bi-calendar-event-fill"></i><span class="nav-label">Události</span>
             </NavLink>
         </div>
 

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.9.2</Version>
+    <Version>0.9.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Services/GameContextService.cs
+++ b/src/OvcinaHra.Client/Services/GameContextService.cs
@@ -24,6 +24,7 @@ public class GameContextService
     public async Task InitializeAsync()
     {
         if (_initialized) return;
+        var becameSet = false;
         try
         {
             var games = await _api.GetListAsync<GameListDto>("/api/games");
@@ -32,10 +33,12 @@ public class GameContextService
             {
                 _selectedGameId = active.Id;
                 _gameName = $"{active.Name} (#{active.Edition})";
+                becameSet = true;
             }
         }
         catch { /* offline or API unavailable */ }
         _initialized = true;
+        if (becameSet) OnGameChanged?.Invoke();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- **Bug fix:** Per-game nav links (Dovednosti, Kouzla) did not appear on first app load. Root cause: `GameContextService.InitializeAsync` set the active game but never fired `OnGameChanged`, so NavMenu's subscribed re-render never triggered. Only `RefreshAsync` fired the event.
- **UX reorder:** In the Hra section, the 4 items without a Katalog mirror (Časová osa, Poklady, Postavy, Události) now sit at the top, directly under the "Hra" caption. Remaining items follow in the same order as Katalog světa, keeping the two lists visually aligned.
- Version bump 0.9.2 → 0.9.3.

## Test plan
- [ ] Load the app with an active game in DB; confirm **Dovednosti** and **Kouzla** appear under Hra on first load (no manual refresh needed)
- [ ] Confirm Hra section order: Časová osa → Poklady → Postavy → Události → Lokace → … → NPC
- [ ] Confirm Katalog světa section unchanged
- [ ] `/games/{id}/spells` "Přidat kouzlo" button opens add popup and assigns a spell