### PR TITLE
feat(buildings): Poznámky + ImagePicker [v0.9.4]

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/BuildingConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/BuildingConfiguration.cs
@@ -10,6 +10,7 @@ public class BuildingConfiguration : IEntityTypeConfiguration<Building>
     {
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Name).IsRequired().HasMaxLength(200);
+        builder.Property(e => e.Notes).HasMaxLength(1000);
         builder.HasOne(e => e.Location).WithMany(l => l.Buildings).HasForeignKey(e => e.LocationId);
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
@@ -56,7 +56,7 @@ public static class BuildingEndpoints
     {
         var b = await db.Buildings.FindAsync(id);
         if (b is null) return TypedResults.NotFound();
-        return TypedResults.Ok(new BuildingDetailDto(b.Id, b.Name, b.Description, b.ImagePath, b.LocationId, b.IsPrebuilt));
+        return TypedResults.Ok(new BuildingDetailDto(b.Id, b.Name, b.Description, b.Notes, b.ImagePath, b.LocationId, b.IsPrebuilt));
     }
 
     private static async Task<Created<BuildingDetailDto>> Create(CreateBuildingDto dto, HttpContext http, WorldDbContext db)
@@ -65,6 +65,7 @@ public static class BuildingEndpoints
         {
             Name = dto.Name,
             Description = dto.Description,
+            Notes = dto.Notes,
             LocationId = dto.LocationId,
             IsPrebuilt = dto.IsPrebuilt
         };
@@ -80,14 +81,14 @@ public static class BuildingEndpoints
         }
 
         return TypedResults.Created($"/api/buildings/{b.Id}",
-            new BuildingDetailDto(b.Id, b.Name, b.Description, b.ImagePath, b.LocationId, b.IsPrebuilt));
+            new BuildingDetailDto(b.Id, b.Name, b.Description, b.Notes, b.ImagePath, b.LocationId, b.IsPrebuilt));
     }
 
     private static async Task<Results<NoContent, NotFound>> Update(int id, UpdateBuildingDto dto, WorldDbContext db)
     {
         var b = await db.Buildings.FindAsync(id);
         if (b is null) return TypedResults.NotFound();
-        b.Name = dto.Name; b.Description = dto.Description; b.LocationId = dto.LocationId; b.IsPrebuilt = dto.IsPrebuilt;
+        b.Name = dto.Name; b.Description = dto.Description; b.Notes = dto.Notes; b.LocationId = dto.LocationId; b.IsPrebuilt = dto.IsPrebuilt;
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -8,7 +8,7 @@ namespace OvcinaHra.Api.Endpoints;
 
 public static class ImageEndpoints
 {
-    private static readonly HashSet<string> ValidEntityTypes = ["locations", "items", "monsters", "secretstashes", "npcs"];
+    private static readonly HashSet<string> ValidEntityTypes = ["locations", "items", "monsters", "secretstashes", "npcs", "buildings"];
     private static readonly HashSet<string> AllowedContentTypes = ["image/jpeg", "image/png", "image/webp"];
     private const long MaxFileSize = 5 * 1024 * 1024; // 5 MB
 
@@ -129,6 +129,10 @@ public static class ImageEndpoints
                 var npc = await db.Npcs.FindAsync(entityId);
                 if (npc is not null) npc.ImagePath = blobKey;
                 break;
+            case "buildings":
+                var building = await db.Buildings.FindAsync(entityId);
+                if (building is not null) building.ImagePath = blobKey;
+                break;
         }
 
         await db.SaveChangesAsync();
@@ -154,6 +158,9 @@ public static class ImageEndpoints
             "npcs" => await db.Npcs.Where(n => n.Id == entityId)
                 .Select(n => new ValueTuple<string?, string?>(n.ImagePath, null))
                 .FirstOrDefaultAsync(),
+            "buildings" => await db.Buildings.Where(b => b.Id == entityId)
+                .Select(b => new ValueTuple<string?, string?>(b.ImagePath, null))
+                .FirstOrDefaultAsync(),
             _ => (null, null)
         };
     }
@@ -167,6 +174,7 @@ public static class ImageEndpoints
             "monsters" => await db.Monsters.AnyAsync(m => m.Id == entityId),
             "secretstashes" => await db.SecretStashes.AnyAsync(s => s.Id == entityId),
             "npcs" => await db.Npcs.AnyAsync(n => n.Id == entityId),
+            "buildings" => await db.Buildings.AnyAsync(b => b.Id == entityId),
             _ => false
         };
     }

--- a/src/OvcinaHra.Api/Migrations/20260422040350_AddBuildingNotes.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422040350_AddBuildingNotes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422040350_AddBuildingNotes")]
+    partial class AddBuildingNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -725,40 +728,6 @@ namespace OvcinaHra.Api.Migrations
                     b.ToTable("GameSkillBuildingRequirements");
                 });
 
-            modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.GameSpell", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("AvailabilityNotes")
-                        .HasMaxLength(1000)
-                        .HasColumnType("character varying(1000)");
-
-                    b.Property<int>("GameId")
-                        .HasColumnType("integer");
-
-                    b.Property<bool>("IsFindable")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("Price")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SpellId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("SpellId");
-
-                    b.HasIndex("GameId", "SpellId")
-                        .IsUnique();
-
-                    b.ToTable("GameSpells");
-                });
-
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.GameTimeSlot", b =>
                 {
                     b.Property<int>("Id")
@@ -1397,75 +1366,6 @@ namespace OvcinaHra.Api.Migrations
                     b.ToTable("SkillBuildingRequirements");
                 });
 
-            modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.Spell", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("Description")
-                        .HasMaxLength(4000)
-                        .HasColumnType("character varying(4000)");
-
-                    b.Property<string>("Effect")
-                        .IsRequired()
-                        .HasMaxLength(4000)
-                        .HasColumnType("character varying(4000)");
-
-                    b.Property<string>("ImagePath")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
-
-                    b.Property<bool>("IsLearnable")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("IsReaction")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("IsScroll")
-                        .HasColumnType("boolean");
-
-                    b.Property<int>("Level")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("ManaCost")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("MinMageLevel")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int?>("Price")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("School")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<NpgsqlTsVector>("SearchVector")
-                        .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("tsvector")
-                        .HasComputedColumnSql("to_tsvector('simple', coalesce(\"Name\", '') || ' ' || coalesce(\"Effect\", '') || ' ' || coalesce(\"Description\", ''))", true);
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("Name")
-                        .IsUnique();
-
-                    b.HasIndex("SearchVector");
-
-                    NpgsqlIndexBuilderExtensions.HasMethod(b.HasIndex("SearchVector"), "GIN");
-
-                    b.ToTable("Spells");
-                });
-
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.Tag", b =>
                 {
                     b.Property<int>("Id")
@@ -1982,25 +1882,6 @@ namespace OvcinaHra.Api.Migrations
                     b.Navigation("Building");
 
                     b.Navigation("GameSkill");
-                });
-
-            modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.GameSpell", b =>
-                {
-                    b.HasOne("OvcinaHra.Shared.Domain.Entities.Game", "Game")
-                        .WithMany()
-                        .HasForeignKey("GameId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("OvcinaHra.Shared.Domain.Entities.Spell", "Spell")
-                        .WithMany("GameSpells")
-                        .HasForeignKey("SpellId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Game");
-
-                    b.Navigation("Spell");
                 });
 
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.GameTimeSlot", b =>
@@ -2534,11 +2415,6 @@ namespace OvcinaHra.Api.Migrations
                     b.Navigation("BuildingRequirements");
 
                     b.Navigation("GameSkills");
-                });
-
-            modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.Spell", b =>
-                {
-                    b.Navigation("GameSpells");
                 });
 
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.Tag", b =>

--- a/src/OvcinaHra.Api/Migrations/20260422040350_AddBuildingNotes.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422040350_AddBuildingNotes.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBuildingNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Notes",
+                table: "Buildings",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Notes",
+                table: "Buildings");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.9.3</Version>
+    <Version>0.9.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
@@ -60,24 +60,37 @@ else
     </OvcinaGrid>
 }
 
-<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="500px">
+<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="900px">
     <BodyContentTemplate Context="popupContext">
-        <DxFormLayout>
-            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
-                <DxTextBox @bind-Text="@name" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
-                <DxMemo @bind-Text="@description" Rows="3" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
-                <DxComboBox Data="@gameLocations" @bind-Value="@locationId"
-                            TextFieldName="Name" ValueFieldName="Id"
-                            NullText="Bez lokace" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="" ColSpanMd="12">
-                <DxCheckBox @bind-Checked="@isPrebuilt">Představěná organizátory</DxCheckBox>
-            </DxFormLayoutItem>
-        </DxFormLayout>
+        <div class="row g-3">
+            @if (editingId.HasValue)
+            {
+                <div class="col-md-5">
+                    <ImagePicker EntityType="buildings" EntityId="editingId.Value" Alt="Obrázek budovy" AspectRatio="3:2" />
+                </div>
+            }
+            <div class="@(editingId.HasValue ? "col-md-7" : "col-md-12")">
+                <DxFormLayout>
+                    <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                        <DxTextBox @bind-Text="@name" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
+                        <DxMemo @bind-Text="@description" Rows="3" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
+                        <DxMemo @bind-Text="@notes" Rows="3" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
+                        <DxComboBox Data="@gameLocations" @bind-Value="@locationId"
+                                    TextFieldName="Name" ValueFieldName="Id"
+                                    NullText="Bez lokace" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="" ColSpanMd="12">
+                        <DxCheckBox @bind-Checked="@isPrebuilt">Představěná organizátory</DxCheckBox>
+                    </DxFormLayoutItem>
+                </DxFormLayout>
+            </div>
+        </div>
         @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
         <div class="d-flex gap-2 mt-3">
             @if (editingId.HasValue) { <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true">Smazat</button> }
@@ -102,7 +115,7 @@ else
     [SupplyParameterFromQuery] public bool Catalog { get; set; }
 
     private List<BuildingListDto> buildings = []; private bool loading = true, isModalVisible, isDeleteVisible, isSaving, isPrebuilt;
-    private string modalTitle = "", name = ""; private string? error, description; private int? editingId;
+    private string modalTitle = "", name = ""; private string? error, description, notes; private int? editingId;
     private int? locationId;
     private List<LocationListDto> gameLocations = [];
     private HashSet<int> assignedBuildingIds = [];
@@ -148,7 +161,7 @@ else
     {
         error = null;
         gameLocations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gameId}");
-        if (b is null) { editingId = null; name = ""; description = null; locationId = null; isPrebuilt = false; modalTitle = "Nová budova"; }
+        if (b is null) { editingId = null; name = ""; description = null; notes = null; locationId = null; isPrebuilt = false; modalTitle = "Nová budova"; }
         else { editingId = b.Id; name = b.Name; locationId = b.LocationId; isPrebuilt = b.IsPrebuilt; modalTitle = $"Upravit: {b.Name}"; _ = LoadDetailAsync(b.Id); }
         isModalVisible = true;
         StateHasChanged();
@@ -157,7 +170,7 @@ else
     private async Task LoadDetailAsync(int id)
     {
         var d = await Api.GetAsync<BuildingDetailDto>($"/api/buildings/{id}");
-        if (d is not null) { description = d.Description; StateHasChanged(); }
+        if (d is not null) { description = d.Description; notes = d.Notes; StateHasChanged(); }
     }
 
     private async Task SaveAsync()
@@ -165,8 +178,8 @@ else
         error = null; isSaving = true;
         try
         {
-            if (editingId.HasValue) await Api.PutAsync($"/api/buildings/{editingId}", new UpdateBuildingDto(name, description, locationId, isPrebuilt));
-            else await Api.PostAsync<CreateBuildingDto, BuildingDetailDto>($"/api/buildings?gameId={gameId}", new CreateBuildingDto(name, description, locationId, isPrebuilt));
+            if (editingId.HasValue) await Api.PutAsync($"/api/buildings/{editingId}", new UpdateBuildingDto(name, description, notes, locationId, isPrebuilt));
+            else await Api.PostAsync<CreateBuildingDto, BuildingDetailDto>($"/api/buildings?gameId={gameId}", new CreateBuildingDto(name, description, notes, locationId, isPrebuilt));
             isModalVisible = false; await LoadAsync();
         }
         catch (Exception ex) { error = ex.Message; } finally { isSaving = false; }

--- a/src/OvcinaHra.Shared/Domain/Entities/Building.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Building.cs
@@ -5,6 +5,7 @@ public class Building
     public int Id { get; set; }
     public required string Name { get; set; }
     public string? Description { get; set; }
+    public string? Notes { get; set; }
     public string? ImagePath { get; set; }
     public int? LocationId { get; set; }
     public bool IsPrebuilt { get; set; }

--- a/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
@@ -3,15 +3,17 @@ namespace OvcinaHra.Shared.Dtos;
 public record BuildingListDto(int Id, string Name, int? LocationId, string? LocationName, bool IsPrebuilt);
 
 public record BuildingDetailDto(
-    int Id, string Name, string? Description, string? ImagePath,
+    int Id, string Name, string? Description, string? Notes, string? ImagePath,
     int? LocationId, bool IsPrebuilt);
 
 public record CreateBuildingDto(
     string Name,
-    string? Description = null, int? LocationId = null, bool IsPrebuilt = false);
+    string? Description = null, string? Notes = null,
+    int? LocationId = null, bool IsPrebuilt = false);
 
 public record UpdateBuildingDto(
-    string Name, string? Description, int? LocationId, bool IsPrebuilt);
+    string Name, string? Description, string? Notes,
+    int? LocationId, bool IsPrebuilt);
 
 // Game assignment
 public record GameBuildingDto(int GameId, int BuildingId);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/BuildingEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/BuildingEndpointTests.cs
@@ -161,9 +161,11 @@ public class BuildingEndpointTests(PostgresFixture postgres) : IntegrationTestBa
     {
         var createResp = await Client.PostAsJsonAsync("/api/buildings",
             new CreateBuildingDto("Chata", Notes: "původní poznámka"));
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
         var created = await createResp.Content.ReadFromJsonAsync<BuildingDetailDto>();
+        Assert.NotNull(created);
 
-        var updateDto = new UpdateBuildingDto(created!.Name, created.Description, "nová poznámka pro orgy", created.LocationId, created.IsPrebuilt);
+        var updateDto = new UpdateBuildingDto(created.Name, created.Description, "nová poznámka pro orgy", created.LocationId, created.IsPrebuilt);
         var updateResp = await Client.PutAsJsonAsync($"/api/buildings/{created.Id}", updateDto);
         Assert.Equal(HttpStatusCode.NoContent, updateResp.StatusCode);
 

--- a/tests/OvcinaHra.Api.Tests/Endpoints/BuildingEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/BuildingEndpointTests.cs
@@ -128,7 +128,7 @@ public class BuildingEndpointTests(PostgresFixture postgres) : IntegrationTestBa
             new CreateBuildingDto("Stará věž"));
         var created = await createResponse.Content.ReadFromJsonAsync<BuildingDetailDto>();
 
-        var updateDto = new UpdateBuildingDto("Nová věž", "Opravená a posílená věž", null, true);
+        var updateDto = new UpdateBuildingDto("Nová věž", "Opravená a posílená věž", null, null, true);
         var response = await Client.PutAsJsonAsync($"/api/buildings/{created!.Id}", updateDto);
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
@@ -137,6 +137,38 @@ public class BuildingEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         Assert.Equal("Nová věž", updated!.Name);
         Assert.Equal("Opravená a posílená věž", updated.Description);
         Assert.True(updated.IsPrebuilt);
+    }
+
+    // ── Notes round-trip ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_WithNotes_PersistsAndReturnsThem()
+    {
+        var dto = new CreateBuildingDto("Strážní věž", Notes: "Dveře se zasekávají — org má náhradní kliku.");
+        var response = await Client.PostAsJsonAsync("/api/buildings", dto);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var created = await response.Content.ReadFromJsonAsync<BuildingDetailDto>();
+        Assert.NotNull(created);
+        Assert.Equal("Dveře se zasekávají — org má náhradní kliku.", created.Notes);
+
+        var fetched = await Client.GetFromJsonAsync<BuildingDetailDto>($"/api/buildings/{created.Id}");
+        Assert.Equal("Dveře se zasekávají — org má náhradní kliku.", fetched!.Notes);
+    }
+
+    [Fact]
+    public async Task Update_ChangesNotes_PersistsNewValue()
+    {
+        var createResp = await Client.PostAsJsonAsync("/api/buildings",
+            new CreateBuildingDto("Chata", Notes: "původní poznámka"));
+        var created = await createResp.Content.ReadFromJsonAsync<BuildingDetailDto>();
+
+        var updateDto = new UpdateBuildingDto(created!.Name, created.Description, "nová poznámka pro orgy", created.LocationId, created.IsPrebuilt);
+        var updateResp = await Client.PutAsJsonAsync($"/api/buildings/{created.Id}", updateDto);
+        Assert.Equal(HttpStatusCode.NoContent, updateResp.StatusCode);
+
+        var updated = await Client.GetFromJsonAsync<BuildingDetailDto>($"/api/buildings/{created.Id}");
+        Assert.Equal("nová poznámka pro orgy", updated!.Notes);
     }
 
     // ── Delete ──────────────────────────────────────────────────────────────

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
@@ -58,6 +58,28 @@ public class ImageEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
     }
 
     [Fact]
+    public async Task Upload_ForBuilding_ReturnsOkAndPersistsBlobKey()
+    {
+        var createResp = await Client.PostAsJsonAsync("/api/buildings", new CreateBuildingDto("Foto budova"));
+        var building = await createResp.Content.ReadFromJsonAsync<BuildingDetailDto>();
+
+        using var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(ValidPng);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        content.Add(fileContent, "file", "photo.png");
+
+        var response = await Client.PostAsync($"/api/images/buildings/{building!.Id}", content);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ImageUploadResult>();
+        Assert.NotNull(result);
+        Assert.StartsWith($"buildings/{building.Id}/", result.BlobKey);
+
+        var refreshed = await Client.GetFromJsonAsync<BuildingDetailDto>($"/api/buildings/{building.Id}");
+        Assert.Equal(result.BlobKey, refreshed!.ImagePath);
+    }
+
+    [Fact]
     public async Task Upload_InvalidContentType_ReturnsBadRequest()
     {
         // Arrange — create a location

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
@@ -61,14 +61,16 @@ public class ImageEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
     public async Task Upload_ForBuilding_ReturnsOkAndPersistsBlobKey()
     {
         var createResp = await Client.PostAsJsonAsync("/api/buildings", new CreateBuildingDto("Foto budova"));
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
         var building = await createResp.Content.ReadFromJsonAsync<BuildingDetailDto>();
+        Assert.NotNull(building);
 
         using var content = new MultipartFormDataContent();
         var fileContent = new ByteArrayContent(ValidPng);
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
         content.Add(fileContent, "file", "photo.png");
 
-        var response = await Client.PostAsync($"/api/images/buildings/{building!.Id}", content);
+        var response = await Client.PostAsync($"/api/images/buildings/{building.Id}", content);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var result = await response.Content.ReadFromJsonAsync<ImageUploadResult>();
@@ -76,7 +78,8 @@ public class ImageEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
         Assert.StartsWith($"buildings/{building.Id}/", result.BlobKey);
 
         var refreshed = await Client.GetFromJsonAsync<BuildingDetailDto>($"/api/buildings/{building.Id}");
-        Assert.Equal(result.BlobKey, refreshed!.ImagePath);
+        Assert.NotNull(refreshed);
+        Assert.Equal(result.BlobKey, refreshed.ImagePath);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- `Building` entity gets a general-purpose `Notes` (Poznámky) column, max 1000 chars — distinct from any per-field reward notes.
- The `ImagePicker` component now works for buildings: `buildings` is registered in the image endpoint whitelist and all three entity switches (update, get, exists).
- The building detail popup grows to a two-column layout when editing — image on the left, form on the right — matching the NPC list pattern. New entities stay single-column until saved.
- EF migration `AddBuildingNotes` adds the single column, nothing else.

## Test plan
- [x] 244 API integration tests pass (incl. 2 new `Notes` round-trips + 1 new image-upload-for-buildings)
- [x] Build clean, 0 warnings
- [ ] Local smoke: open a building, paste a photo, add a note, save, reload — image + note persist
- [ ] Deploy: `AddBuildingNotes` migration applies cleanly to prod DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)