### PR TITLE
feat(monsters): Poznámky + enriched catalog grid [v0.9.5]

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/MonsterConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/MonsterConfiguration.cs
@@ -12,6 +12,7 @@ public class MonsterConfiguration : IEntityTypeConfiguration<Monster>
         builder.Property(e => e.Name).IsRequired().HasMaxLength(200);
         builder.HasIndex(e => e.Name).IsUnique();
         builder.Property(e => e.MonsterType).HasConversion<string>().HasMaxLength(30);
+        builder.Property(e => e.Notes).HasMaxLength(1000);
 
         builder.OwnsOne(e => e.Stats, s =>
         {

--- a/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
@@ -9,6 +9,8 @@ namespace OvcinaHra.Api.Endpoints;
 
 public static class MonsterEndpoints
 {
+    private const int MaxNotesLength = 1000;
+
     public static RouteGroupBuilder MapMonsterEndpoints(this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/monsters").WithTags("Monsters");
@@ -45,7 +47,7 @@ public static class MonsterEndpoints
                 m.Stats.Attack, m.Stats.Defense, m.Stats.Health,
                 m.RewardXp, m.RewardMoney,
                 m.Abilities, m.AiBehavior, m.RewardNotes, m.Notes,
-                m.MonsterTags.Select(mt => mt.Tag.Name).ToList()))
+                m.MonsterTags.OrderBy(mt => mt.Tag.Name).Select(mt => mt.Tag.Name).ToList()))
             .ToListAsync();
         return TypedResults.Ok(monsters);
     }
@@ -64,8 +66,11 @@ public static class MonsterEndpoints
             m.RewardXp, m.RewardMoney, m.RewardNotes, m.Notes, m.ImagePath, tags));
     }
 
-    private static async Task<Created<MonsterDetailDto>> Create(CreateMonsterDto dto, WorldDbContext db)
+    private static async Task<Results<Created<MonsterDetailDto>, BadRequest<string>>> Create(CreateMonsterDto dto, WorldDbContext db)
     {
+        if (dto.Notes?.Length > MaxNotesLength)
+            return TypedResults.BadRequest($"Notes cannot exceed {MaxNotesLength} characters.");
+
         var m = new Monster
         {
             Name = dto.Name,
@@ -88,8 +93,11 @@ public static class MonsterEndpoints
                 m.RewardXp, m.RewardMoney, m.RewardNotes, m.Notes, m.ImagePath, []));
     }
 
-    private static async Task<Results<NoContent, NotFound>> Update(int id, UpdateMonsterDto dto, WorldDbContext db)
+    private static async Task<Results<NoContent, NotFound, BadRequest<string>>> Update(int id, UpdateMonsterDto dto, WorldDbContext db)
     {
+        if (dto.Notes?.Length > MaxNotesLength)
+            return TypedResults.BadRequest($"Notes cannot exceed {MaxNotesLength} characters.");
+
         var m = await db.Monsters.FindAsync(id);
         if (m is null) return TypedResults.NotFound();
 

--- a/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
@@ -42,7 +42,10 @@ public static class MonsterEndpoints
             .OrderBy(m => m.Name)
             .Select(m => new MonsterListDto(
                 m.Id, m.Name, m.MonsterType, m.Category,
-                m.Stats.Attack, m.Stats.Defense, m.Stats.Health))
+                m.Stats.Attack, m.Stats.Defense, m.Stats.Health,
+                m.RewardXp, m.RewardMoney,
+                m.Abilities, m.AiBehavior, m.RewardNotes, m.Notes,
+                m.MonsterTags.Select(mt => mt.Tag.Name).ToList()))
             .ToListAsync();
         return TypedResults.Ok(monsters);
     }
@@ -58,7 +61,7 @@ public static class MonsterEndpoints
         return TypedResults.Ok(new MonsterDetailDto(
             m.Id, m.Name, m.Category, m.MonsterType, m.Abilities, m.AiBehavior,
             m.Stats.Attack, m.Stats.Defense, m.Stats.Health,
-            m.RewardXp, m.RewardMoney, m.RewardNotes, m.ImagePath, tags));
+            m.RewardXp, m.RewardMoney, m.RewardNotes, m.Notes, m.ImagePath, tags));
     }
 
     private static async Task<Created<MonsterDetailDto>> Create(CreateMonsterDto dto, WorldDbContext db)
@@ -73,7 +76,8 @@ public static class MonsterEndpoints
             AiBehavior = dto.AiBehavior,
             RewardXp = dto.RewardXp,
             RewardMoney = dto.RewardMoney,
-            RewardNotes = dto.RewardNotes
+            RewardNotes = dto.RewardNotes,
+            Notes = dto.Notes
         };
         db.Monsters.Add(m);
         await db.SaveChangesAsync();
@@ -81,7 +85,7 @@ public static class MonsterEndpoints
         return TypedResults.Created($"/api/monsters/{m.Id}",
             new MonsterDetailDto(m.Id, m.Name, m.Category, m.MonsterType, m.Abilities, m.AiBehavior,
                 m.Stats.Attack, m.Stats.Defense, m.Stats.Health,
-                m.RewardXp, m.RewardMoney, m.RewardNotes, m.ImagePath, []));
+                m.RewardXp, m.RewardMoney, m.RewardNotes, m.Notes, m.ImagePath, []));
     }
 
     private static async Task<Results<NoContent, NotFound>> Update(int id, UpdateMonsterDto dto, WorldDbContext db)
@@ -98,6 +102,7 @@ public static class MonsterEndpoints
         m.RewardXp = dto.RewardXp;
         m.RewardMoney = dto.RewardMoney;
         m.RewardNotes = dto.RewardNotes;
+        m.Notes = dto.Notes;
 
         await db.SaveChangesAsync();
         return TypedResults.NoContent();

--- a/src/OvcinaHra.Api/Migrations/20260422090759_AddMonsterNotes.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422090759_AddMonsterNotes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422090759_AddMonsterNotes")]
+    partial class AddMonsterNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -81,10 +84,6 @@ namespace OvcinaHra.Api.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
-
-                    b.Property<string>("Notes")
-                        .HasMaxLength(1000)
-                        .HasColumnType("character varying(1000)");
 
                     b.HasKey("Id");
 
@@ -723,40 +722,6 @@ namespace OvcinaHra.Api.Migrations
                     b.HasIndex("BuildingId");
 
                     b.ToTable("GameSkillBuildingRequirements");
-                });
-
-            modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.GameSpell", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("AvailabilityNotes")
-                        .HasMaxLength(1000)
-                        .HasColumnType("character varying(1000)");
-
-                    b.Property<int>("GameId")
-                        .HasColumnType("integer");
-
-                    b.Property<bool>("IsFindable")
-                        .HasColumnType("boolean");
-
-                    b.Property<int?>("Price")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("SpellId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("SpellId");
-
-                    b.HasIndex("GameId", "SpellId")
-                        .IsUnique();
-
-                    b.ToTable("GameSpells");
                 });
 
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.GameTimeSlot", b =>
@@ -1401,75 +1366,6 @@ namespace OvcinaHra.Api.Migrations
                     b.ToTable("SkillBuildingRequirements");
                 });
 
-            modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.Spell", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("Description")
-                        .HasMaxLength(4000)
-                        .HasColumnType("character varying(4000)");
-
-                    b.Property<string>("Effect")
-                        .IsRequired()
-                        .HasMaxLength(4000)
-                        .HasColumnType("character varying(4000)");
-
-                    b.Property<string>("ImagePath")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
-
-                    b.Property<bool>("IsLearnable")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("IsReaction")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("IsScroll")
-                        .HasColumnType("boolean");
-
-                    b.Property<int>("Level")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("ManaCost")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("MinMageLevel")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int?>("Price")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("School")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<NpgsqlTsVector>("SearchVector")
-                        .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("tsvector")
-                        .HasComputedColumnSql("to_tsvector('simple', coalesce(\"Name\", '') || ' ' || coalesce(\"Effect\", '') || ' ' || coalesce(\"Description\", ''))", true);
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("Name")
-                        .IsUnique();
-
-                    b.HasIndex("SearchVector");
-
-                    NpgsqlIndexBuilderExtensions.HasMethod(b.HasIndex("SearchVector"), "GIN");
-
-                    b.ToTable("Spells");
-                });
-
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.Tag", b =>
                 {
                     b.Property<int>("Id")
@@ -1986,25 +1882,6 @@ namespace OvcinaHra.Api.Migrations
                     b.Navigation("Building");
 
                     b.Navigation("GameSkill");
-                });
-
-            modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.GameSpell", b =>
-                {
-                    b.HasOne("OvcinaHra.Shared.Domain.Entities.Game", "Game")
-                        .WithMany()
-                        .HasForeignKey("GameId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("OvcinaHra.Shared.Domain.Entities.Spell", "Spell")
-                        .WithMany("GameSpells")
-                        .HasForeignKey("SpellId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Game");
-
-                    b.Navigation("Spell");
                 });
 
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.GameTimeSlot", b =>
@@ -2538,11 +2415,6 @@ namespace OvcinaHra.Api.Migrations
                     b.Navigation("BuildingRequirements");
 
                     b.Navigation("GameSkills");
-                });
-
-            modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.Spell", b =>
-                {
-                    b.Navigation("GameSpells");
                 });
 
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.Tag", b =>

--- a/src/OvcinaHra.Api/Migrations/20260422090759_AddMonsterNotes.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422090759_AddMonsterNotes.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMonsterNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Notes",
+                table: "Monsters",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Notes",
+                table: "Monsters");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.9.4</Version>
+    <Version>0.9.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
@@ -31,7 +31,7 @@ else if (!Catalog && monsters.Count == 0)
 }
 else
 {
-    <OvcinaGrid Data="@monsters" KeyFieldName="Id" LayoutKey="grid-layout-monsters"
+    <OvcinaGrid Data="@monsters" KeyFieldName="Id" LayoutKey="grid-layout-monsters-v2"
                 RowClick="@(e => OpenModal((MonsterListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
@@ -40,6 +40,13 @@ else
             <DxGridDataColumn FieldName="Attack" Caption="Útok" Width="80px" />
             <DxGridDataColumn FieldName="Defense" Caption="Obrana" Width="80px" />
             <DxGridDataColumn FieldName="Health" Caption="Životy" Width="80px" />
+            <DxGridDataColumn FieldName="RewardXp" Caption="XP" Width="80px" />
+            <DxGridDataColumn FieldName="RewardMoney" Caption="Groše" Width="90px" />
+            <DxGridDataColumn FieldName="TagsDisplay" Caption="Tagy" Width="180px" />
+            <DxGridDataColumn FieldName="Abilities" Caption="Schopnosti" Width="240px" Visible="false" />
+            <DxGridDataColumn FieldName="AiBehavior" Caption="AI chování" Width="240px" Visible="false" />
+            <DxGridDataColumn FieldName="RewardNotes" Caption="Odměna pozn." Width="200px" Visible="false" />
+            <DxGridDataColumn FieldName="Notes" Caption="Poznámky" Width="240px" Visible="false" />
             @if (Catalog)
             {
                 <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false">
@@ -93,6 +100,9 @@ else
             </DxFormLayoutItem>
             <DxFormLayoutItem Caption="AI chování" ColSpanMd="12">
                 <DxMemo @bind-Text="@aiBehavior" Rows="2" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
+                <DxMemo @bind-Text="@notes" Rows="3" />
             </DxFormLayoutItem>
             <DxFormLayoutGroup Caption="Odměny" ColSpanMd="12">
                 <DxFormLayoutItem Caption="XP" ColSpanMd="4">
@@ -184,7 +194,7 @@ else
     private List<MonsterListDto> monsters = [];
     private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
     private string modalTitle = "", name = "";
-    private string? error, abilities, aiBehavior, rewardNotes;
+    private string? error, abilities, aiBehavior, rewardNotes, notes;
     private int? editingId;
     private MonsterType monsterType = MonsterType.Beast;
     private int category = 1, attack = 1, defense = 1, health = 5;
@@ -278,7 +288,7 @@ else
         {
             editingId = null; name = ""; monsterType = MonsterType.Beast; category = 1;
             attack = 1; defense = 1; health = 5; abilities = null; aiBehavior = null;
-            rewardXp = 0; rewardMoney = 0; rewardNotes = null;
+            rewardXp = 0; rewardMoney = 0; rewardNotes = null; notes = null;
             modalTitle = "Nová příšera";
         }
         else
@@ -294,7 +304,7 @@ else
     private async Task LoadDetailAsync(int id)
     {
         var d = await Api.GetAsync<MonsterDetailDto>($"/api/monsters/{id}");
-        if (d is not null) { abilities = d.Abilities; aiBehavior = d.AiBehavior; rewardXp = d.RewardXp ?? 0; rewardMoney = d.RewardMoney ?? 0; rewardNotes = d.RewardNotes; }
+        if (d is not null) { abilities = d.Abilities; aiBehavior = d.AiBehavior; rewardXp = d.RewardXp ?? 0; rewardMoney = d.RewardMoney ?? 0; rewardNotes = d.RewardNotes; notes = d.Notes; }
         await LoadLootAsync(id);
         StateHasChanged();
     }
@@ -339,9 +349,9 @@ else
             int? xp = rewardXp > 0 ? rewardXp : null;
             int? money = rewardMoney > 0 ? rewardMoney : null;
             if (editingId.HasValue)
-                await Api.PutAsync($"/api/monsters/{editingId}", new UpdateMonsterDto(name, category, monsterType, attack, defense, health, abilities, aiBehavior, xp, money, rewardNotes));
+                await Api.PutAsync($"/api/monsters/{editingId}", new UpdateMonsterDto(name, category, monsterType, attack, defense, health, abilities, aiBehavior, xp, money, rewardNotes, notes));
             else
-                await Api.PostAsync<CreateMonsterDto, MonsterDetailDto>("/api/monsters", new CreateMonsterDto(name, category, monsterType, attack, defense, health, abilities, aiBehavior, xp, money, rewardNotes));
+                await Api.PostAsync<CreateMonsterDto, MonsterDetailDto>("/api/monsters", new CreateMonsterDto(name, category, monsterType, attack, defense, health, abilities, aiBehavior, xp, money, rewardNotes, notes));
             isModalVisible = false; await LoadAsync();
         }
         catch (Exception ex) { error = ex.Message; }

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
@@ -295,6 +295,9 @@ else
         {
             editingId = m.Id; name = m.Name; monsterType = m.MonsterType; category = m.Category;
             attack = m.Attack; defense = m.Defense; health = m.Health;
+            abilities = m.Abilities; aiBehavior = m.AiBehavior;
+            rewardXp = m.RewardXp ?? 0; rewardMoney = m.RewardMoney ?? 0;
+            rewardNotes = m.RewardNotes; notes = m.Notes;
             modalTitle = $"Upravit: {m.Name}";
             _ = LoadDetailAsync(m.Id);
         }

--- a/src/OvcinaHra.Shared/Domain/Entities/Monster.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Monster.cs
@@ -15,6 +15,7 @@ public class Monster
     public int? RewardXp { get; set; }
     public int? RewardMoney { get; set; }
     public string? RewardNotes { get; set; }
+    public string? Notes { get; set; }
     public string? ImagePath { get; set; }
 
     public ICollection<MonsterTagLink> MonsterTags { get; set; } = [];

--- a/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
@@ -15,7 +15,7 @@ public record MonsterListDto(
     public string MonsterTypeDisplay => MonsterType.GetDisplayName();
 
     [JsonIgnore]
-    public string TagsDisplay => string.Join(", ", TagNames ?? []);
+    public string TagsDisplay => string.Join(", ", TagNames);
 }
 
 public record MonsterDetailDto(

--- a/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
@@ -4,10 +4,18 @@ using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Shared.Dtos;
 
-public record MonsterListDto(int Id, string Name, MonsterType MonsterType, int Category, int Attack, int Defense, int Health)
+public record MonsterListDto(
+    int Id, string Name, MonsterType MonsterType, int Category,
+    int Attack, int Defense, int Health,
+    int? RewardXp, int? RewardMoney,
+    string? Abilities, string? AiBehavior, string? RewardNotes, string? Notes,
+    List<string> TagNames)
 {
     [JsonIgnore]
     public string MonsterTypeDisplay => MonsterType.GetDisplayName();
+
+    [JsonIgnore]
+    public string TagsDisplay => string.Join(", ", TagNames ?? []);
 }
 
 public record MonsterDetailDto(
@@ -23,6 +31,7 @@ public record MonsterDetailDto(
     int? RewardXp,
     int? RewardMoney,
     string? RewardNotes,
+    string? Notes,
     string? ImagePath,
     List<TagDto> Tags);
 
@@ -37,7 +46,8 @@ public record CreateMonsterDto(
     string? AiBehavior = null,
     int? RewardXp = null,
     int? RewardMoney = null,
-    string? RewardNotes = null);
+    string? RewardNotes = null,
+    string? Notes = null);
 
 public record UpdateMonsterDto(
     string Name,
@@ -50,7 +60,8 @@ public record UpdateMonsterDto(
     string? AiBehavior,
     int? RewardXp,
     int? RewardMoney,
-    string? RewardNotes);
+    string? RewardNotes,
+    string? Notes = null);
 
 // Per-game monster assignment
 public record GameMonsterDto(int GameId, int MonsterId, string MonsterName);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MonsterEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MonsterEndpointTests.cs
@@ -85,7 +85,8 @@ public class MonsterEndpointTests(PostgresFixture postgres) : IntegrationTestBas
         Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
 
         var created = await createResp.Content.ReadFromJsonAsync<MonsterDetailDto>();
-        Assert.Equal("Reaguje na světlo.", created!.Notes);
+        Assert.NotNull(created);
+        Assert.Equal("Reaguje na světlo.", created.Notes);
 
         var list = await Client.GetFromJsonAsync<List<MonsterListDto>>("/api/monsters");
         var listed = Assert.Single(list!, m => m.Id == created.Id);
@@ -98,9 +99,11 @@ public class MonsterEndpointTests(PostgresFixture postgres) : IntegrationTestBas
     {
         var createResp = await Client.PostAsJsonAsync("/api/monsters",
             new CreateMonsterDto("Goblin", 1, MonsterType.Goblin, 2, 1, 4, Notes: "původní"));
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
         var created = await createResp.Content.ReadFromJsonAsync<MonsterDetailDto>();
+        Assert.NotNull(created);
 
-        var updateDto = new UpdateMonsterDto(created!.Name, created.Category, created.MonsterType,
+        var updateDto = new UpdateMonsterDto(created.Name, created.Category, created.MonsterType,
             created.Attack, created.Defense, created.Health,
             created.Abilities, created.AiBehavior, created.RewardXp, created.RewardMoney, created.RewardNotes,
             Notes: "nová poznámka");
@@ -112,18 +115,33 @@ public class MonsterEndpointTests(PostgresFixture postgres) : IntegrationTestBas
     }
 
     [Fact]
+    public async Task Create_NotesOverLimit_ReturnsBadRequest()
+    {
+        var tooLong = new string('a', 1001);
+        var resp = await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto("Dlouhonotář", 1, MonsterType.Beast, 1, 1, 1, Notes: tooLong));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
     public async Task GetAll_EnrichedListDto_IncludesRewardsAbilitiesAndTags()
     {
         var createResp = await Client.PostAsJsonAsync("/api/monsters",
             new CreateMonsterDto("Arcimág", 5, MonsterType.Legend, 7, 5, 25,
                 Abilities: "Kouzlí", AiBehavior: "útočí z dálky",
                 RewardXp: 120, RewardMoney: 30, RewardNotes: "odměna"));
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
         var created = await createResp.Content.ReadFromJsonAsync<MonsterDetailDto>();
+        Assert.NotNull(created);
 
         var tagResp = await Client.PostAsJsonAsync("/api/tags",
             new CreateTagDto("elitní", TagKind.Monster));
+        Assert.Equal(HttpStatusCode.Created, tagResp.StatusCode);
         var tag = await tagResp.Content.ReadFromJsonAsync<TagDto>();
-        await Client.PostAsync($"/api/monsters/{created!.Id}/tags/{tag!.Id}", null);
+        Assert.NotNull(tag);
+
+        var assignResp = await Client.PostAsync($"/api/monsters/{created.Id}/tags/{tag.Id}", null);
+        Assert.Equal(HttpStatusCode.Created, assignResp.StatusCode);
 
         var list = await Client.GetFromJsonAsync<List<MonsterListDto>>("/api/monsters");
         var listed = Assert.Single(list!, m => m.Id == created.Id);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MonsterEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MonsterEndpointTests.cs
@@ -78,6 +78,64 @@ public class MonsterEndpointTests(PostgresFixture postgres) : IntegrationTestBas
     }
 
     [Fact]
+    public async Task Create_WithNotes_PersistsAndReturnsThem()
+    {
+        var dto = new CreateMonsterDto("Trolík", 2, MonsterType.Beast, 4, 3, 12, Notes: "Reaguje na světlo.");
+        var createResp = await Client.PostAsJsonAsync("/api/monsters", dto);
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+
+        var created = await createResp.Content.ReadFromJsonAsync<MonsterDetailDto>();
+        Assert.Equal("Reaguje na světlo.", created!.Notes);
+
+        var list = await Client.GetFromJsonAsync<List<MonsterListDto>>("/api/monsters");
+        var listed = Assert.Single(list!, m => m.Id == created.Id);
+        Assert.Equal("Reaguje na světlo.", listed.Notes);
+        Assert.Empty(listed.TagNames);
+    }
+
+    [Fact]
+    public async Task Update_ChangesNotes_PersistsNewValue()
+    {
+        var createResp = await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto("Goblin", 1, MonsterType.Goblin, 2, 1, 4, Notes: "původní"));
+        var created = await createResp.Content.ReadFromJsonAsync<MonsterDetailDto>();
+
+        var updateDto = new UpdateMonsterDto(created!.Name, created.Category, created.MonsterType,
+            created.Attack, created.Defense, created.Health,
+            created.Abilities, created.AiBehavior, created.RewardXp, created.RewardMoney, created.RewardNotes,
+            Notes: "nová poznámka");
+        var updateResp = await Client.PutAsJsonAsync($"/api/monsters/{created.Id}", updateDto);
+        Assert.Equal(HttpStatusCode.NoContent, updateResp.StatusCode);
+
+        var fetched = await Client.GetFromJsonAsync<MonsterDetailDto>($"/api/monsters/{created.Id}");
+        Assert.Equal("nová poznámka", fetched!.Notes);
+    }
+
+    [Fact]
+    public async Task GetAll_EnrichedListDto_IncludesRewardsAbilitiesAndTags()
+    {
+        var createResp = await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto("Arcimág", 5, MonsterType.Legend, 7, 5, 25,
+                Abilities: "Kouzlí", AiBehavior: "útočí z dálky",
+                RewardXp: 120, RewardMoney: 30, RewardNotes: "odměna"));
+        var created = await createResp.Content.ReadFromJsonAsync<MonsterDetailDto>();
+
+        var tagResp = await Client.PostAsJsonAsync("/api/tags",
+            new CreateTagDto("elitní", TagKind.Monster));
+        var tag = await tagResp.Content.ReadFromJsonAsync<TagDto>();
+        await Client.PostAsync($"/api/monsters/{created!.Id}/tags/{tag!.Id}", null);
+
+        var list = await Client.GetFromJsonAsync<List<MonsterListDto>>("/api/monsters");
+        var listed = Assert.Single(list!, m => m.Id == created.Id);
+        Assert.Equal(120, listed.RewardXp);
+        Assert.Equal(30, listed.RewardMoney);
+        Assert.Equal("Kouzlí", listed.Abilities);
+        Assert.Equal("útočí z dálky", listed.AiBehavior);
+        Assert.Equal("odměna", listed.RewardNotes);
+        Assert.Contains("elitní", listed.TagNames);
+    }
+
+    [Fact]
     public async Task Delete_ExistingMonster_ReturnsNoContent()
     {
         var createResponse = await Client.PostAsJsonAsync("/api/monsters",


### PR DESCRIPTION
## Summary
- Monster entity gains a general-purpose **Notes** column (nullable, max 1000 chars), kept distinct from the existing `RewardNotes` field which is still scoped to rewards only.
- `MonsterListDto` now carries most of the detail fields — `Abilities`, `AiBehavior`, `RewardXp`, `RewardMoney`, `RewardNotes`, `Notes`, and a joined `TagsDisplay` derived from tag names. The catalog grid shows rewards + tags by default; long-text columns (Schopnosti, AI chování, Odměna pozn., Poznámky) are hidden behind the column chooser. Excel-style: organizer reveals what they need.
- `LayoutKey` bumped to `grid-layout-monsters-v2` so stale localStorage filters don't replay against the new schema.
- Popup form gets a `Poznámky` memo above the Odměny group.
- EF migration: `AddMonsterNotes` (single column).

## Test plan
- [x] 244 API integration tests pass, incl. 3 new ones: Notes round-trip on Create/Update + enriched list DTO assertions (rewards, abilities, tag names).
- [x] Build clean, 0 warnings.
- [ ] Local smoke: open catalog, reveal hidden columns via right-click, verify tags show joined; add Poznámky to a creature, save, reload, still there.
- [ ] Deploy: `AddMonsterNotes` migration applies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)