### PR TITLE
feat(buildings): enrich catalog grid with Popis + Poznámky [v0.9.6]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
@@ -31,7 +31,9 @@ public static class BuildingEndpoints
         var buildings = await db.Buildings
             .Include(b => b.Location)
             .OrderBy(b => b.Name)
-            .Select(b => new BuildingListDto(b.Id, b.Name, b.LocationId, b.Location != null ? b.Location.Name : null, b.IsPrebuilt))
+            .Select(b => new BuildingListDto(
+                b.Id, b.Name, b.Description, b.Notes,
+                b.LocationId, b.Location != null ? b.Location.Name : null, b.IsPrebuilt))
             .ToListAsync();
         return TypedResults.Ok(buildings);
     }
@@ -45,6 +47,8 @@ public static class BuildingEndpoints
             .Select(gb => new BuildingListDto(
                 gb.Building.Id,
                 gb.Building.Name,
+                gb.Building.Description,
+                gb.Building.Notes,
                 gb.Building.LocationId,
                 gb.Building.Location != null ? gb.Building.Location.Name : null,
                 gb.Building.IsPrebuilt))

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.9.5</Version>
+    <Version>0.9.6</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
@@ -29,7 +29,7 @@ else if (!Catalog && buildings.Count == 0)
 }
 else
 {
-    <OvcinaGrid Data="@buildings" KeyFieldName="Id" LayoutKey="grid-layout-buildings"
+    <OvcinaGrid Data="@buildings" KeyFieldName="Id" LayoutKey="grid-layout-buildings-v2"
                 RowClick="@(e => OpenModal((BuildingListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
@@ -37,6 +37,8 @@ else
             <DxGridDataColumn FieldName="IsPrebuilt" Caption="Představěná" Width="120px">
                 <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
             </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Description" Caption="Popis" Width="260px" Visible="false" />
+            <DxGridDataColumn FieldName="Notes" Caption="Poznámky" Width="260px" Visible="false" />
 @if (Catalog)
             {
                 <DxGridDataColumn Caption="" Width="120px" TextAlignment="GridTextAlignment.Center">
@@ -162,15 +164,9 @@ else
         error = null;
         gameLocations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gameId}");
         if (b is null) { editingId = null; name = ""; description = null; notes = null; locationId = null; isPrebuilt = false; modalTitle = "Nová budova"; }
-        else { editingId = b.Id; name = b.Name; locationId = b.LocationId; isPrebuilt = b.IsPrebuilt; modalTitle = $"Upravit: {b.Name}"; _ = LoadDetailAsync(b.Id); }
+        else { editingId = b.Id; name = b.Name; description = b.Description; notes = b.Notes; locationId = b.LocationId; isPrebuilt = b.IsPrebuilt; modalTitle = $"Upravit: {b.Name}"; }
         isModalVisible = true;
         StateHasChanged();
-    }
-
-    private async Task LoadDetailAsync(int id)
-    {
-        var d = await Api.GetAsync<BuildingDetailDto>($"/api/buildings/{id}");
-        if (d is not null) { description = d.Description; notes = d.Notes; StateHasChanged(); }
     }
 
     private async Task SaveAsync()

--- a/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
@@ -1,6 +1,8 @@
 namespace OvcinaHra.Shared.Dtos;
 
-public record BuildingListDto(int Id, string Name, int? LocationId, string? LocationName, bool IsPrebuilt);
+public record BuildingListDto(
+    int Id, string Name, string? Description, string? Notes,
+    int? LocationId, string? LocationName, bool IsPrebuilt);
 
 public record BuildingDetailDto(
     int Id, string Name, string? Description, string? Notes, string? ImagePath,

--- a/tests/OvcinaHra.Api.Tests/Endpoints/BuildingEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/BuildingEndpointTests.cs
@@ -173,6 +173,21 @@ public class BuildingEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         Assert.Equal("nová poznámka pro orgy", updated!.Notes);
     }
 
+    [Fact]
+    public async Task GetAll_EnrichedListDto_IncludesDescriptionAndNotes()
+    {
+        var createResp = await Client.PostAsJsonAsync("/api/buildings",
+            new CreateBuildingDto("Kovárna", Description: "Místní kovárna", Notes: "Kovář má rád medovinu."));
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+        var created = await createResp.Content.ReadFromJsonAsync<BuildingDetailDto>();
+        Assert.NotNull(created);
+
+        var list = await Client.GetFromJsonAsync<List<BuildingListDto>>("/api/buildings");
+        var listed = Assert.Single(list!, b => b.Id == created.Id);
+        Assert.Equal("Místní kovárna", listed.Description);
+        Assert.Equal("Kovář má rád medovinu.", listed.Notes);
+    }
+
     // ── Delete ──────────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
Mirror of the creature grid enrichment ([v0.9.5](https://github.com/timurlain/OvcinaHra/pull/52)) for buildings.

- `BuildingListDto` now carries `Description` + `Notes` alongside the existing columns.
- Grid gets two hidden columns (Popis, Poznámky) — revealed via the column chooser.
- `LayoutKey` bumped to `grid-layout-buildings-v2` so stale saved filters don't replay against the new schema.
- `OpenModal` prefills Description + Notes from the list DTO synchronously; the async `LoadDetailAsync` helper is removed.

## Test plan
- [x] 17 Building integration tests pass, incl. new enriched-list-DTO assertion
- [x] Build clean, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)