### PR TITLE
fix(treasures): difficulty labels Start / Rozvoj hry / Střed hry / Závěr hry [v0.9.7]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.9.6</Version>
+    <Version>0.9.7</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -68,9 +68,9 @@ else
                             </h6>
                             <div class="d-flex gap-1 flex-wrap mb-1">
                                 <span class="badge bg-info text-dark" title="Start">S:@loc.StartCount</span>
-                                <span class="badge bg-info text-dark" title="Raná hra">R:@loc.EarlyCount</span>
+                                <span class="badge bg-info text-dark" title="Rozvoj hry">R:@loc.EarlyCount</span>
                                 <span class="badge bg-warning text-dark" title="Střed hry">M:@loc.MidgameCount</span>
-                                <span class="badge bg-danger" title="Závěr">L:@loc.LategameCount</span>
+                                <span class="badge bg-danger" title="Závěr hry">L:@loc.LategameCount</span>
                             </div>
                             <div class="d-flex justify-content-between">
                                 <small class="text-muted">Celkem: @loc.TotalItems</small>

--- a/src/OvcinaHra.Shared/Domain/Enums/TreasureQuestDifficulty.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/TreasureQuestDifficulty.cs
@@ -6,15 +6,15 @@ namespace OvcinaHra.Shared.Domain.Enums;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TreasureQuestDifficulty
 {
-    [Display(Name = "Začátek")]
+    [Display(Name = "Start")]
     Start,
 
-    [Display(Name = "Začátek hry")]
+    [Display(Name = "Rozvoj hry")]
     Early,
 
     [Display(Name = "Střed hry")]
     Midgame,
 
-    [Display(Name = "Konec hry")]
+    [Display(Name = "Závěr hry")]
     Lategame
 }


### PR DESCRIPTION
## Summary
- `TreasureQuestDifficulty` Display-name rename: Start / Rozvoj hry / Střed hry / Závěr hry.
- TreasurePlanning location-card tooltips updated to match (Raná hra → Rozvoj hry, Závěr → Závěr hry).

## Test plan
- [ ] Treasure-quest dropdown shows the 4 new labels
- [ ] Location-card tooltips in Treasure planning read the new names