### PR TITLE
fix(spells): tidy edit popup layout & labels [v0.9.8]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.9.7</Version>
+    <Version>0.9.8</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Spells/SpellList.razor
+++ b/src/OvcinaHra.Client/Pages/Spells/SpellList.razor
@@ -40,10 +40,10 @@ else
 <DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="760px" MinHeight="640px">
     <BodyContentTemplate Context="popupContext">
         <DxFormLayout>
-            <DxFormLayoutItem Caption="Název" ColSpanMd="8">
+            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
                 <DxTextBox @bind-Text="@model.Name" />
             </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Typ (škola)" ColSpanMd="4">
+            <DxFormLayoutItem Caption="Typ (škola)" ColSpanMd="12">
                 <DxComboBox Data="@schoolValues" @bind-Value="@model.School"
                             TextFieldName="Display" ValueFieldName="Value" />
             </DxFormLayoutItem>
@@ -58,14 +58,16 @@ else
                 <DxSpinEdit @bind-Value="@model.MinMageLevel" MinValue="0" MaxValue="5" />
             </DxFormLayoutItem>
 
-            <DxFormLayoutItem Caption="Svitek (MAG-005)" ColSpanMd="4">
+            <DxFormLayoutItem Caption="Svitek" ColSpanMd="4">
                 <DxCheckBox @bind-Checked="@model.IsScroll" />
             </DxFormLayoutItem>
             <DxFormLayoutItem Caption="Reakce" ColSpanMd="4">
                 <DxCheckBox @bind-Checked="@model.IsReaction" />
             </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Naučitelné u budovy" ColSpanMd="4">
-                <DxCheckBox @bind-Checked="@model.IsLearnable" />
+            <DxFormLayoutItem Caption="Standartní" ColSpanMd="4">
+                <span title="Toto kouzlo se dá naučit ve městě dle standartních pravidel.">
+                    <DxCheckBox @bind-Checked="@model.IsLearnable" />
+                </span>
             </DxFormLayoutItem>
 
             <DxFormLayoutItem Caption="Cena naučení (groše)" ColSpanMd="12">


### PR DESCRIPTION
## Summary
Small polish to the Spell edit popup based on live feedback:

- **Název** and **Typ (škola)** each get their own full-width row. Previously Typ was squished into a 4-col slot next to Název and longer school names (e.g. \"Jedová škola\") were truncated to \"J.\".
- **Svitek (MAG-005)** → **Svitek**. The rule reference was clutter in the form.
- **Naučitelné u budovy** → **Standartní**, with a hover tooltip: *\"Toto kouzlo se dá naučit ve městě dle standartních pravidel.\"*

Pure UI polish, no schema/API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)