### PR TITLE
feat(personal-quest): spell rewards + catalog XP (phase 1) [v0.10.0]

### DIFF
--- a/docs/plans/2026-04-22-personal-quest-spell-rewards-and-catalog-xp-design.md
+++ b/docs/plans/2026-04-22-personal-quest-spell-rewards-and-catalog-xp-design.md
@@ -1,0 +1,191 @@
+# PersonalQuest — Spell rewards + catalog-level XP (design)
+
+**Date:** 2026-04-22
+**Status:** Approved — ready for implementation planning
+**Branch:** `feat/personal-quest-spell-rewards-and-catalog-xp`
+
+## Problem
+
+Three related gaps in the current PersonalQuest domain:
+
+1. **Spells are not a valid reward type.** Rewards today are Skills (many) and Items (many, with quantity). Game designers need to award spells — especially scrolls.
+2. **XP is invisible from catalog view.** `XpCost` lives only on `GamePersonalQuest`. The catalog popup never shows it, so a user editing a quest template has no idea what XP cost the quest is supposed to have. The per-game card also only renders under three AND-ed conditions, so the XP input can be missed entirely.
+3. **Quest-creation flow breaks** when missing dependencies (no item/skill/spell exists yet). This is Phase 2 (wizard); tracked separately and NOT part of this design.
+
+## Scope of this design
+
+Phase 1 — targeted patches to the existing `PersonalQuestList.razor` popup. No new page, no wizard. Addresses gaps #1 and #2 only.
+
+## Decisions made with user
+
+| Q | Answer |
+|---|---|
+| Wizard scope | Parallel flow (not a replacement) — Phase 2, separate |
+| XP model | **Catalog default + per-game override**: `PersonalQuest.XpCost` (required), `GamePersonalQuest.XpCost` optional (nullable = use catalog) |
+| Spell reward quantity | **Applies only when `IsScroll=true`**. Entity carries `Quantity`; UI hides spinner for non-scrolls and persists `1` |
+| Validation | **UI + API**. Combobox filters to non-learnable client-side; API returns 400 if `spell.IsLearnable == true` |
+| Version bump | 0.9.7 → **0.10.0** (minor, new reward type is a domain-level addition) |
+
+## Domain model changes
+
+### New entity: `PersonalQuestSpellReward`
+
+```csharp
+public class PersonalQuestSpellReward
+{
+    public int PersonalQuestId { get; set; }
+    public PersonalQuest PersonalQuest { get; set; } = null!;
+
+    public int SpellId { get; set; }
+    public Spell Spell { get; set; } = null!;
+
+    public int Quantity { get; set; } = 1;
+}
+```
+
+**Configuration (`PersonalQuestSpellRewardConfiguration`):**
+- Composite PK: `(PersonalQuestId, SpellId)`
+- FK to `PersonalQuest`: cascade on delete (matches SkillReward / ItemReward pattern)
+- FK to `Spell`: restrict on delete (a spell referenced as a reward cannot be deleted from the catalog without unlinking first — matches item FK behaviour)
+- `Quantity`: default 1, min constraint left to API (no DB-level CHECK needed; dev-grade app)
+
+### Modified entity: `PersonalQuest`
+
+Add `public int XpCost { get; set; }` — default 0. Base XP cost for the quest.
+
+Add navigation: `public ICollection<PersonalQuestSpellReward> SpellRewards { get; set; } = new List<PersonalQuestSpellReward>();`
+
+### Modified entity: `GamePersonalQuest`
+
+Change `XpCost` from `int` to `int?`. Semantic:
+- `null` → use `PersonalQuest.XpCost` (catalog default)
+- non-null → per-game override
+
+### DbContext
+
+Add `DbSet<PersonalQuestSpellReward> PersonalQuestSpellRewards`.
+
+## DTO changes
+
+### New
+
+```csharp
+public record AddSpellRewardDto(int SpellId, int Quantity = 1);
+
+public record PersonalQuestSpellRewardSummary(int SpellId, string SpellName, bool IsScroll, int Quantity);
+```
+
+### Modified
+
+`PersonalQuestListDto`:
+- Add `int XpCost` (the catalog value)
+- Add `IReadOnlyList<PersonalQuestSpellRewardSummary> SpellRewards`
+- Update computed `RewardSummary` (server-side) to include spell rewards: e.g. `"+ Svitek Ohnivého šípu ×3"`
+
+`PersonalQuestDetailDto`: mirror the above additions.
+
+`CreatePersonalQuestDto`, `UpdatePersonalQuestDto`: add `int XpCost`.
+
+`GamePersonalQuestListDto`:
+- `XpCost` becomes `int?`
+- Add computed `int EffectiveXpCost => XpCost ?? PersonalQuest.XpCost` (server-side)
+
+`CreateGamePersonalQuestDto`, `UpdateGamePersonalQuestDto`: `XpCost` → `int?`.
+
+## API surface
+
+Added under `/api/personal-quests`:
+
+| Verb | Path | Behaviour |
+|---|---|---|
+| POST | `/{id}/spell-rewards` | Body: `AddSpellRewardDto`. **Returns 400** if `spell.IsLearnable == true`. Returns 404 if spell or quest missing. Returns 201 on success. |
+| DELETE | `/{id}/spell-rewards/{spellId}` | Returns 204. 404 if the reward link doesn't exist. |
+
+Existing endpoints (Create/Update PersonalQuest, game-link CRUD) gain `XpCost` in their DTO payloads — no new endpoint needed.
+
+## UI changes (`PersonalQuestList.razor`)
+
+### 1. XP in the main form
+
+Add an always-visible `DxSpinEdit` for `XpCost` in the quest form (bound to `model.XpCost`). Label: **"XP cena"**. Placed next to Difficulty for visibility.
+
+### 2. Per-game card XP override
+
+The existing spinner in the per-game card becomes nullable:
+- `@bind-Value="@gpqXpCost"` (nullable int)
+- `NullText="@($"výchozí: {model.XpCost}")"` — shows the catalog default when no override
+- Visual hint below: when `gpqXpCost is null`, render small text `"(bez přepisu — použije se hodnota {model.XpCost})"`
+
+### 3. New Spell rewards section
+
+Mirror the Items section exactly. Located under the existing Skills and Items reward blocks. Renders only when `editingId.HasValue`.
+
+```
+<h6>Kouzla</h6>
+{badges for existing PersonalQuestSpellReward rows}
+<DxComboBox
+  Data="@SpellsNotYetAdded"                    (*)
+  @bind-Value="@newSpellId"
+  TextFieldName="Name" ValueFieldName="Id"
+  NullText="(přidat kouzlo)"
+  SearchMode="ListSearchMode.AutoSearch" />
+
+@if (newSpellIsScroll) {
+  <DxSpinEdit @bind-Value="@newSpellQuantity" MinValue="1" />
+}
+<button>Přidat</button>
+```
+
+`SpellsNotYetAdded` filters:
+- catalog spells with `IsLearnable == false`
+- excludes spells already in `detailSpellRewards`
+
+`newSpellIsScroll` is derived from the currently selected spell. When false, `newSpellQuantity` is forced to 1 and the spinner is hidden.
+
+Badge display: `{SpellName} ×{Quantity}` if `Quantity > 1`, else just `{SpellName}`.
+
+### 4. Game grid
+
+Add `EffectiveXpCost` column (caption "XP cena"). Keep existing `XpCost` column available but hidden-by-default as "XP (jen override)" for users who want to see only overrides.
+
+**`LayoutKey` bump required** — column semantics changed.
+
+## Migration strategy
+
+Name: `AddPersonalQuestSpellRewardsAndCatalogXp`
+
+Operations:
+1. `AddColumn XpCost (int, default 0, NOT NULL)` on `PersonalQuests`
+2. `AlterColumn XpCost (int NULL)` on `GamePersonalQuests` — existing values preserved as explicit overrides
+3. `CreateTable PersonalQuestSpellRewards` with composite PK, FKs, Quantity column
+
+All additive or nullability-relaxing — safe under a running app. Runs automatically via `db.Database.MigrateAsync()` at startup (established pattern).
+
+**Data caveat:** Existing catalog quests get `XpCost = 0` on migration. Existing per-game links preserve their current value as an explicit override. After deploy, user walks through catalog quests once to set proper catalog defaults — lightweight (a handful of rows).
+
+## Testing (integration, Testcontainers PostgreSQL)
+
+New API tests in `PersonalQuestEndpointTests`:
+- `SpellReward_LearnableSpell_Returns400`
+- `SpellReward_NonLearnable_Returns201`
+- `SpellReward_Scroll_QuantityGreaterThanOne_Persisted`
+- `SpellReward_NonScroll_QuantityForcedToOne` — API-level: if UI sends Quantity>1 for non-scroll, we accept but this behaviour is documented (UI prevents it)
+- `Delete_SpellReward_Returns204`
+- `CreateQuest_WithXpCost_Persisted`
+- `GamePersonalQuest_XpCostNull_EffectiveFallsBackToCatalog`
+- `GamePersonalQuest_XpCostSet_EffectiveEqualsOverride`
+
+Existing tests that create `GamePersonalQuest` with explicit `XpCost`: update DTOs to `int?`, most assertions unchanged.
+
+## Version & deploy
+
+- `OvcinaHra.Client.csproj`: 0.9.7 → **0.10.0**
+- Auto-deploys on merge to `main` — migration runs at Api startup
+- No manual data backfill required; user handles catalog XP defaults via UI after deploy
+
+## Out of scope (explicit)
+
+- **Quest Maker Wizard** — Phase 2, separate design
+- Spell reward image/icon rendering in reward badges — use plain text for now
+- Per-kingdom spell-reward limits — use the existing `PerKingdomLimit` on `GamePersonalQuest` if that becomes relevant
+- Default XP per Difficulty (auto-suggest) — can be layered later

--- a/docs/plans/2026-04-22-personal-quest-spell-rewards-and-catalog-xp-implementation.md
+++ b/docs/plans/2026-04-22-personal-quest-spell-rewards-and-catalog-xp-implementation.md
@@ -1,0 +1,994 @@
+# PersonalQuest — Spell Rewards + Catalog-Level XP Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Design:** `docs/plans/2026-04-22-personal-quest-spell-rewards-and-catalog-xp-design.md` (required reading — reference its sections where cited)
+
+**Goal:** Add Spell as a third PersonalQuest reward type (many-to-many, non-learnable only, scrolls allow Quantity>1) and migrate XP from per-game-only to catalog-default-with-per-game-override.
+
+**Architecture:** Purely additive domain extension. New `PersonalQuestSpellReward` join table mirrors `PersonalQuestItemReward`. `PersonalQuest.XpCost` becomes the intrinsic catalog value; `GamePersonalQuest.XpCost` goes nullable as an optional override. UI stays in the existing `PersonalQuestList.razor` popup (wizard is out of scope — Phase 2).
+
+**Tech Stack:** .NET 10, ASP.NET Core Minimal API, EF Core 10 + Npgsql, Blazor WASM + DevExpress Blazor 25.2.5, xUnit + Testcontainers PostgreSQL.
+
+**Branch:** `feat/personal-quest-spell-rewards-and-catalog-xp` (design doc already committed as `02ce111`).
+
+**Project conventions to remember during execution:**
+- TDD every time: write the failing test, run it red, write the minimal code, run it green, commit. Don't skip the red step.
+- Every commit subject includes `[v0.10.0]` suffix. Version bump to `0.10.0` is a dedicated task at the end; intermediate commits still tag the target version.
+- Run `dotnet test` from the repo root — must be green before advancing to the next task.
+- UI strings in Czech with diacritics. Routes, identifiers, class names, commit subjects in English.
+- DevExpress DxGrid always via the `OvcinaGrid` wrapper. When the grid column schema changes, bump the `LayoutKey` suffix — otherwise users' cached localStorage filters replay against the new schema (see MEMORY: "OvcinaGrid LayoutKey bump").
+- No destructive-action confirmations required for reward-badge remove buttons (existing Items section uses plain click — match that pattern; see MEMORY: "Destructive action confirm" — reward badges are explicitly NOT in scope for confirm popups).
+- EF Core migrations auto-apply on API startup via `db.Database.MigrateAsync()`. No manual migrate step at deploy.
+- Server-generated migrations live in `src/OvcinaHra.Api/Migrations/`. Generate with `dotnet ef migrations add <Name> --project src/OvcinaHra.Api --startup-project src/OvcinaHra.Api --output-dir Migrations`.
+- Configurations auto-register via `ApplyConfigurationsFromAssembly` in `WorldDbContext.OnModelCreating`. Adding a config file is enough — no manual registration line.
+
+**Working directory for all commands:** `C:\Users\TomášPajonk\source\repos\timurlain\ovcinahra`.
+
+---
+
+## Task 1 — Add `XpCost` to catalog `PersonalQuest` entity
+
+**Covers design section:** "Domain model changes → Modified entity: PersonalQuest".
+
+**Files:**
+- Modify: `src/OvcinaHra.Shared/Domain/Entities/PersonalQuest.cs:21` (add the new property after `ImagePath`)
+- Modify: `src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs` (add `XpCost` to `PersonalQuestListDto`, `PersonalQuestDetailDto`, `CreatePersonalQuestDto`, `UpdatePersonalQuestDto`)
+- Modify: `src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs` (map `XpCost` in Create, Update, Get-by-id, List, List-by-game projections)
+- Test: `tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs` (add `CreateQuest_WithXpCost_Persisted`)
+
+### Step 1: Write the failing test
+
+Append this test to `PersonalQuestEndpointTests.cs`:
+
+```csharp
+[Fact]
+public async Task CreateQuest_WithXpCost_Persisted()
+{
+    var create = new CreatePersonalQuestDto(
+        Name: "Test XP Quest",
+        Difficulty: TreasureQuestDifficulty.Early,
+        Description: null,
+        AllowWarrior: true, AllowArcher: false, AllowMage: false, AllowThief: false,
+        QuestCardText: null, RewardCardText: null, RewardNote: null, Notes: null,
+        XpCost: 12);
+
+    var resp = await Client.PostAsJsonAsync("/api/personal-quests", create);
+    Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+    var body = await resp.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+    Assert.NotNull(body);
+    Assert.Equal(12, body.XpCost);
+}
+```
+
+### Step 2: Run the test — it MUST fail
+
+```
+dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter FullyQualifiedName~CreateQuest_WithXpCost_Persisted
+```
+Expected: compile error ("`CreatePersonalQuestDto` does not contain a definition for `XpCost`" and "`PersonalQuestDetailDto` does not contain a definition for `XpCost`"). That's the red.
+
+### Step 3: Minimal implementation
+
+Add to `PersonalQuest.cs` immediately below `public string? ImagePath`:
+
+```csharp
+    public int XpCost { get; set; }
+```
+
+In `PersonalQuestDtos.cs`, add `int XpCost` as the last positional parameter on the four records:
+- `PersonalQuestListDto`
+- `PersonalQuestDetailDto`
+- `CreatePersonalQuestDto`
+- `UpdatePersonalQuestDto`
+
+In `PersonalQuestEndpoints.cs`:
+- In the `Create` handler body, include `XpCost = dto.XpCost` on the new entity
+- In the `Update` handler body, include `entity.XpCost = dto.XpCost`
+- In the projection used by the list handler (`GetAll`) and `GetById`, add `XpCost = q.XpCost`
+- In the by-game projection, include `XpCost = gl.PersonalQuest.XpCost` (the catalog value — this is not the override; the override comes in Task 2 via `EffectiveXpCost`)
+
+### Step 4: Run the test — MUST pass, AND the existing 22 tests must stay green
+
+```
+dotnet test
+```
+Expected: 23 passing, 0 failing.
+
+### Step 5: Commit
+
+```bash
+git add src/OvcinaHra.Shared/Domain/Entities/PersonalQuest.cs \
+        src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs \
+        src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs \
+        tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+git commit -m "feat(personal-quest): add XpCost to catalog entity + DTOs [v0.10.0]"
+```
+
+> **Migration note deferred:** we don't generate the EF migration until Task 3 so that all schema changes end up in a single migration file `AddPersonalQuestSpellRewardsAndCatalogXp`. The test database is brought up by the existing test fixture via `EnsureCreated` / applied migrations — in this repo the fixture applies pending migrations on startup, so the new column will not exist for the test run yet. **If the test fails at runtime with "column XpCost does not exist"**, jump to Task 3 first (generate migration) and come back. Recheck in the test fixture (`tests/OvcinaHra.Api.Tests/Fixtures/PostgresFixture.cs`) whether it uses `MigrateAsync` or `EnsureCreatedAsync`. If the latter, the column is created from the current model and this caveat is moot.
+
+---
+
+## Task 2 — Make `GamePersonalQuest.XpCost` nullable with `EffectiveXpCost`
+
+**Covers design section:** "Domain model changes → Modified entity: GamePersonalQuest" + "DTO changes".
+
+**Files:**
+- Modify: `src/OvcinaHra.Shared/Domain/Entities/GamePersonalQuest.cs:7` (XpCost `int` → `int?`)
+- Modify: `src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs` (GamePersonalQuestListDto.XpCost → `int?`; add `int EffectiveXpCost`; CreateGamePersonalQuestDto.XpCost → `int?`; UpdateGamePersonalQuestDto.XpCost → `int?`)
+- Modify: `src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs` (by-game projection computes `EffectiveXpCost = gl.XpCost ?? gl.PersonalQuest.XpCost`; Create/UpdateGameLink map nullable XpCost)
+- Modify: `src/OvcinaHra.Api/Data/Configurations/GamePersonalQuestConfiguration.cs` (if it has `.IsRequired()` on XpCost, remove it or set `.IsRequired(false)`)
+- Test: `tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs` (update 5 existing tests that reference XpCost; add 2 new tests)
+
+### Step 1: Write the 2 failing tests
+
+Append:
+
+```csharp
+[Fact]
+public async Task GamePersonalQuest_XpCostNull_EffectiveFallsBackToCatalog()
+{
+    // Arrange: create a game, create a quest with catalog XpCost=42, link with override=null
+    var game = await CreateGameAsync();
+    var quest = await CreatePersonalQuestAsync(xpCost: 42);
+
+    var link = await Client.PostAsJsonAsync("/api/personal-quests/game-link",
+        new CreateGamePersonalQuestDto(GameId: game.Id, PersonalQuestId: quest.Id,
+                                       XpCost: null, PerKingdomLimit: null));
+    Assert.Equal(HttpStatusCode.Created, link.StatusCode);
+
+    // Act
+    var list = await Client.GetFromJsonAsync<List<GamePersonalQuestListDto>>(
+        $"/api/personal-quests/by-game/{game.Id}");
+    Assert.NotNull(list);
+    var row = Assert.Single(list);
+
+    // Assert
+    Assert.Null(row.XpCost);
+    Assert.Equal(42, row.EffectiveXpCost);
+}
+
+[Fact]
+public async Task GamePersonalQuest_XpCostSet_EffectiveEqualsOverride()
+{
+    var game = await CreateGameAsync();
+    var quest = await CreatePersonalQuestAsync(xpCost: 42);
+
+    await Client.PostAsJsonAsync("/api/personal-quests/game-link",
+        new CreateGamePersonalQuestDto(game.Id, quest.Id, XpCost: 7, PerKingdomLimit: null));
+
+    var list = await Client.GetFromJsonAsync<List<GamePersonalQuestListDto>>(
+        $"/api/personal-quests/by-game/{game.Id}");
+    var row = Assert.Single(list!);
+
+    Assert.Equal(7, row.XpCost);
+    Assert.Equal(7, row.EffectiveXpCost);
+}
+```
+
+If `CreatePersonalQuestAsync` and `CreateGameAsync` helpers don't already exist in the test file, add them as small private helpers (POST to `/api/personal-quests` or `/api/games` and return the deserialized detail DTO). Check if similar helpers already exist before duplicating — there are 22 existing tests, patterns are established.
+
+### Step 2: Run — the 2 new tests fail (compile error on `EffectiveXpCost`; nullable type mismatch on `XpCost`)
+
+```
+dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter FullyQualifiedName~GamePersonalQuest_XpCost
+```
+
+### Step 3: Minimal implementation
+
+1. `GamePersonalQuest.cs` line 7: `public int XpCost { get; set; }` → `public int? XpCost { get; set; }`
+
+2. `GamePersonalQuestConfiguration.cs`: if there's a `.Property(x => x.XpCost).IsRequired()`, change to `.IsRequired(false)` or remove. If nothing was specified, EF defaults to nullable for `int?`.
+
+3. `PersonalQuestDtos.cs`:
+   - `GamePersonalQuestListDto.XpCost`: `int` → `int?`
+   - Add new positional parameter `int EffectiveXpCost` to `GamePersonalQuestListDto`
+   - `CreateGamePersonalQuestDto.XpCost`: `int = 0` → `int? = null`
+   - `UpdateGamePersonalQuestDto.XpCost`: `int` → `int?`
+
+4. `PersonalQuestEndpoints.cs`:
+   - In the by-game list projection (around line 200–214 per survey), add `EffectiveXpCost = gl.XpCost ?? gl.PersonalQuest.XpCost` and forward the nullable `XpCost` through
+   - `CreateGameLink` handler: accept nullable XpCost — no code change needed if you just pass `dto.XpCost` through
+   - `UpdateGameLink` handler: same — the `int? = ?` flows through
+
+5. Update the 5 existing tests that hit XpCost (from survey: lines 154, 184, 256, 337, 389):
+   - Where a test posts `XpCost: 15` (int), it still works — int is implicitly convertible to `int?`
+   - Where a test asserts `Assert.Equal(15, row.XpCost)` with `row.XpCost` now `int?`, change to `Assert.Equal(15, row.XpCost)` — xUnit will promote, no change needed usually. If there's a type inference error, use `Assert.Equal<int?>(15, row.XpCost)` or assert `row.EffectiveXpCost` instead where semantically appropriate.
+   - `UpdateGameLink_TunesXpCost` (line 389): the test updates XpCost 10 → 25. Still valid with nullable. If it asserts a non-null value, that stays correct.
+
+### Step 4: Run — all tests pass
+
+```
+dotnet test
+```
+Expected: 25 passing, 0 failing.
+
+### Step 5: Commit
+
+```bash
+git add src/OvcinaHra.Shared/Domain/Entities/GamePersonalQuest.cs \
+        src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs \
+        src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs \
+        src/OvcinaHra.Api/Data/Configurations/GamePersonalQuestConfiguration.cs \
+        tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+git commit -m "feat(personal-quest): nullable game-level XpCost + EffectiveXpCost fallback [v0.10.0]"
+```
+
+---
+
+## Task 3 — Add `PersonalQuestSpellReward` entity + EF migration
+
+**Covers design section:** "Domain model changes → New entity: PersonalQuestSpellReward" + "Migration strategy".
+
+**Files:**
+- Create: `src/OvcinaHra.Shared/Domain/Entities/PersonalQuestSpellReward.cs`
+- Create: `src/OvcinaHra.Api/Data/Configurations/PersonalQuestSpellRewardConfiguration.cs`
+- Modify: `src/OvcinaHra.Shared/Domain/Entities/PersonalQuest.cs` (add `SpellRewards` navigation)
+- Modify: `src/OvcinaHra.Api/Data/WorldDbContext.cs:54` (add `DbSet<PersonalQuestSpellReward>` right after `PersonalQuestItemRewards`)
+- Generate: `src/OvcinaHra.Api/Migrations/<timestamp>_AddPersonalQuestSpellRewardsAndCatalogXp.cs`
+
+### Step 1: Create the entity
+
+`src/OvcinaHra.Shared/Domain/Entities/PersonalQuestSpellReward.cs`:
+
+```csharp
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class PersonalQuestSpellReward
+{
+    public int PersonalQuestId { get; set; }
+    public int SpellId { get; set; }
+    public int Quantity { get; set; } = 1;
+
+    public PersonalQuest PersonalQuest { get; set; } = null!;
+    public Spell Spell { get; set; } = null!;
+}
+```
+
+### Step 2: Create the configuration (mirrors `PersonalQuestItemRewardConfiguration`)
+
+`src/OvcinaHra.Api/Data/Configurations/PersonalQuestSpellRewardConfiguration.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class PersonalQuestSpellRewardConfiguration : IEntityTypeConfiguration<PersonalQuestSpellReward>
+{
+    public void Configure(EntityTypeBuilder<PersonalQuestSpellReward> b)
+    {
+        b.HasKey(e => new { e.PersonalQuestId, e.SpellId });
+        b.Property(e => e.Quantity).HasDefaultValue(1);
+        b.ToTable(t => t.HasCheckConstraint("CK_PQSpellReward_Qty_Positive", "\"Quantity\" >= 1"));
+        b.HasOne(e => e.PersonalQuest).WithMany(q => q.SpellRewards)
+            .HasForeignKey(e => e.PersonalQuestId).OnDelete(DeleteBehavior.Cascade);
+        b.HasOne(e => e.Spell).WithMany()
+            .HasForeignKey(e => e.SpellId).OnDelete(DeleteBehavior.Restrict);
+    }
+}
+```
+
+### Step 3: Add the navigation on `PersonalQuest`
+
+In `PersonalQuest.cs`, after `ItemRewards` collection:
+
+```csharp
+    public ICollection<PersonalQuestSpellReward> SpellRewards { get; set; } = [];
+```
+
+### Step 4: Register DbSet in `WorldDbContext.cs:54`
+
+Add right after `PersonalQuestItemRewards`:
+
+```csharp
+public DbSet<PersonalQuestSpellReward> PersonalQuestSpellRewards => Set<PersonalQuestSpellReward>();
+```
+
+### Step 5: Generate the migration
+
+```bash
+dotnet ef migrations add AddPersonalQuestSpellRewardsAndCatalogXp \
+  --project src/OvcinaHra.Api \
+  --startup-project src/OvcinaHra.Api \
+  --output-dir Migrations
+```
+
+Inspect the generated `_AddPersonalQuestSpellRewardsAndCatalogXp.cs`. Verify it contains:
+- `AddColumn<int>(name: "XpCost", table: "PersonalQuests", ... defaultValue: 0)`
+- `AlterColumn<int>(name: "XpCost", table: "GamePersonalQuests", ... nullable: true)`  _(or however EF names the table — check actual migration output)_
+- `CreateTable(name: "PersonalQuestSpellRewards", ...)` with composite PK, FK to PersonalQuests (cascade), FK to Spells (restrict), Quantity default 1, CHECK constraint on Quantity
+
+If any of these are missing, something in Tasks 1/2/3 wasn't saved. Don't hand-edit the migration unless you understand the fix — go back and correct the entity/config.
+
+### Step 6: Build + run all tests (migrations run on fixture startup)
+
+```
+dotnet build
+dotnet test
+```
+Expected: green (25 passing from Task 2).
+
+### Step 7: Commit
+
+```bash
+git add src/OvcinaHra.Shared/Domain/Entities/PersonalQuestSpellReward.cs \
+        src/OvcinaHra.Shared/Domain/Entities/PersonalQuest.cs \
+        src/OvcinaHra.Api/Data/Configurations/PersonalQuestSpellRewardConfiguration.cs \
+        src/OvcinaHra.Api/Data/WorldDbContext.cs \
+        src/OvcinaHra.Api/Migrations/
+git commit -m "feat(personal-quest): PersonalQuestSpellReward entity + migration [v0.10.0]"
+```
+
+---
+
+## Task 4 — `POST /api/personal-quests/{id}/spell-rewards` — 201 on non-learnable spell
+
+**Covers design section:** "API surface → POST /{id}/spell-rewards (201 branch)" + "DTO changes → AddSpellRewardDto".
+
+**Files:**
+- Modify: `src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs` (add `AddSpellRewardDto`, `PersonalQuestSpellRewardSummary`)
+- Modify: `src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs` (add `MapPost("/{id:int}/spell-rewards", ...)` handler near the existing item/skill reward endpoints — around line 28–31 per survey)
+- Test: `tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs`
+
+### Step 1: Write the failing test
+
+```csharp
+[Fact]
+public async Task SpellReward_NonLearnable_Returns201()
+{
+    var quest = await CreatePersonalQuestAsync();
+    var spell = await CreateSpellAsync(name: "Test scroll",
+                                       isScroll: true, isLearnable: false, minMageLevel: 0);
+
+    var resp = await Client.PostAsJsonAsync(
+        $"/api/personal-quests/{quest.Id}/spell-rewards",
+        new AddSpellRewardDto(spell.Id, Quantity: 1));
+
+    Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+    var detail = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+        $"/api/personal-quests/{quest.Id}");
+    Assert.NotNull(detail);
+    Assert.Single(detail.SpellRewards);
+    Assert.Equal(spell.Id, detail.SpellRewards[0].SpellId);
+    Assert.Equal(1, detail.SpellRewards[0].Quantity);
+}
+```
+
+Add a `CreateSpellAsync` helper if not present — it POSTs to `/api/spells` using `CreateSpellDto`.
+
+### Step 2: Run — FAIL (compile error on `AddSpellRewardDto`, `SpellRewards` on detail DTO)
+
+### Step 3: Implement
+
+In `PersonalQuestDtos.cs`, add:
+
+```csharp
+public record AddSpellRewardDto(int SpellId, int Quantity = 1);
+
+public record PersonalQuestSpellRewardSummary(int SpellId, string SpellName, bool IsScroll, int Quantity);
+```
+
+Extend `PersonalQuestDetailDto` with:
+```csharp
+IReadOnlyList<PersonalQuestSpellRewardSummary> SpellRewards
+```
+
+Update `PersonalQuestEndpoints.cs`:
+- In the `GetById` / detail projection, include:
+  ```csharp
+  SpellRewards = q.SpellRewards
+      .Select(sr => new PersonalQuestSpellRewardSummary(sr.SpellId, sr.Spell.Name, sr.Spell.IsScroll, sr.Quantity))
+      .ToList()
+  ```
+- Add a new endpoint mapper next to `AddItemReward`:
+  ```csharp
+  pq.MapPost("/{id:int}/spell-rewards", AddSpellReward);
+  ```
+- Implement the handler (happy path only for this task — validation comes in Task 5):
+  ```csharp
+  static async Task<IResult> AddSpellReward(int id, AddSpellRewardDto dto, WorldDbContext db)
+  {
+      if (!await db.PersonalQuests.AnyAsync(q => q.Id == id))
+          return TypedResults.NotFound($"Quest #{id} neexistuje.");
+
+      var spell = await db.Spells.FindAsync(dto.SpellId);
+      if (spell is null)
+          return TypedResults.NotFound($"Kouzlo #{dto.SpellId} neexistuje.");
+
+      var link = new PersonalQuestSpellReward
+      {
+          PersonalQuestId = id,
+          SpellId = dto.SpellId,
+          Quantity = dto.Quantity
+      };
+      db.PersonalQuestSpellRewards.Add(link);
+      await db.SaveChangesAsync();
+
+      return TypedResults.Created($"/api/personal-quests/{id}/spell-rewards/{dto.SpellId}");
+  }
+  ```
+
+### Step 4: Run — test passes
+
+```
+dotnet test
+```
+
+### Step 5: Commit
+
+```bash
+git add src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs \
+        src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs \
+        tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+git commit -m "feat(personal-quest): POST spell-rewards endpoint (non-learnable path) [v0.10.0]"
+```
+
+---
+
+## Task 5 — `POST /spell-rewards` returns 400 for learnable spell
+
+**Covers design section:** "API surface — 400 when `spell.IsLearnable == true`".
+
+**Files:**
+- Modify: `src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs` (validation branch in `AddSpellReward`)
+- Test: `tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs`
+
+### Step 1: Write the failing test
+
+```csharp
+[Fact]
+public async Task SpellReward_LearnableSpell_Returns400()
+{
+    var quest = await CreatePersonalQuestAsync();
+    var spell = await CreateSpellAsync(name: "Učenlivé kouzlo",
+                                       isScroll: false, isLearnable: true, minMageLevel: 1);
+
+    var resp = await Client.PostAsJsonAsync(
+        $"/api/personal-quests/{quest.Id}/spell-rewards",
+        new AddSpellRewardDto(spell.Id));
+
+    Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    var detail = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+        $"/api/personal-quests/{quest.Id}");
+    Assert.Empty(detail!.SpellRewards);
+}
+```
+
+### Step 2: Run — FAIL (currently the endpoint returns 201 because no validation)
+
+### Step 3: Implement
+
+In `AddSpellReward`, between the spell-not-found check and the insert:
+
+```csharp
+if (spell.IsLearnable)
+    return TypedResults.BadRequest($"Kouzlo #{dto.SpellId} je naučitelné — nelze ho použít jako odměnu personal questu.");
+```
+
+### Step 4: Run — green
+
+### Step 5: Commit
+
+```bash
+git add src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs \
+        tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+git commit -m "feat(personal-quest): reject learnable-spell reward with 400 [v0.10.0]"
+```
+
+---
+
+## Task 6 — Quantity > 1 persists for scroll rewards
+
+**Covers design section:** "Spell reward quantity" (UI hides, API accepts).
+
+**Files:**
+- Test: `tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs` (new test only — likely no production code change, this is a verification)
+
+### Step 1: Write the test
+
+```csharp
+[Fact]
+public async Task SpellReward_Scroll_QuantityGreaterThanOne_Persisted()
+{
+    var quest = await CreatePersonalQuestAsync();
+    var scroll = await CreateSpellAsync("Svitek ohnivého šípu",
+                                        isScroll: true, isLearnable: false, minMageLevel: 0);
+
+    var resp = await Client.PostAsJsonAsync(
+        $"/api/personal-quests/{quest.Id}/spell-rewards",
+        new AddSpellRewardDto(scroll.Id, Quantity: 3));
+    Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+    var detail = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+        $"/api/personal-quests/{quest.Id}");
+    var reward = Assert.Single(detail!.SpellRewards);
+    Assert.Equal(3, reward.Quantity);
+    Assert.True(reward.IsScroll);
+}
+```
+
+### Step 2: Run
+
+Expected: PASS without code changes (endpoint from Task 4 already persists Quantity; Task 5 doesn't touch it). If it fails, fix the projection to include `IsScroll` from `sr.Spell.IsScroll`.
+
+### Step 3: Commit
+
+```bash
+git add tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+git commit -m "test(personal-quest): verify scroll-reward quantity persists [v0.10.0]"
+```
+
+---
+
+## Task 7 — `DELETE /api/personal-quests/{id}/spell-rewards/{spellId}` returns 204
+
+**Covers design section:** "API surface → DELETE /{id}/spell-rewards/{spellId}".
+
+**Files:**
+- Modify: `src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs`
+- Test: `tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs`
+
+### Step 1: Write the failing test
+
+```csharp
+[Fact]
+public async Task Delete_SpellReward_Returns204()
+{
+    var quest = await CreatePersonalQuestAsync();
+    var spell = await CreateSpellAsync("Svitek bleskového úderu",
+                                        isScroll: true, isLearnable: false, minMageLevel: 0);
+
+    await Client.PostAsJsonAsync($"/api/personal-quests/{quest.Id}/spell-rewards",
+        new AddSpellRewardDto(spell.Id));
+
+    var del = await Client.DeleteAsync(
+        $"/api/personal-quests/{quest.Id}/spell-rewards/{spell.Id}");
+    Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+
+    var detail = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+        $"/api/personal-quests/{quest.Id}");
+    Assert.Empty(detail!.SpellRewards);
+}
+```
+
+### Step 2: Run — FAIL (404, endpoint missing)
+
+### Step 3: Implement
+
+Add mapper near the delete-item-reward line:
+
+```csharp
+pq.MapDelete("/{id:int}/spell-rewards/{spellId:int}", RemoveSpellReward);
+```
+
+Handler:
+
+```csharp
+static async Task<IResult> RemoveSpellReward(int id, int spellId, WorldDbContext db)
+{
+    var link = await db.PersonalQuestSpellRewards
+        .FirstOrDefaultAsync(x => x.PersonalQuestId == id && x.SpellId == spellId);
+    if (link is null) return TypedResults.NotFound();
+
+    db.PersonalQuestSpellRewards.Remove(link);
+    await db.SaveChangesAsync();
+    return TypedResults.NoContent();
+}
+```
+
+### Step 4: Run — green
+
+### Step 5: Commit
+
+```bash
+git add src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs \
+        tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+git commit -m "feat(personal-quest): DELETE spell-reward endpoint [v0.10.0]"
+```
+
+---
+
+## Task 8 — Expose `SpellRewards` on list DTOs and roll into `RewardSummary`
+
+**Covers design section:** "DTO changes → PersonalQuestListDto / DetailDto additions" + "RewardSummary server-side".
+
+**Files:**
+- Modify: `src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs` (add `SpellRewards` to `PersonalQuestListDto`)
+- Modify: `src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs` (list + by-game projections include SpellRewards; `BuildRewardSummary` appends spell rewards)
+- Test: extend `GetByGame_MultipleLinked_ReturnsWithRewardSummary` or add a focused assertion
+
+### Step 1: Focused test addition
+
+Append a minimal assertion to the existing `GetByGame_MultipleLinked_ReturnsWithRewardSummary` test, OR add a new test:
+
+```csharp
+[Fact]
+public async Task GetByGame_QuestWithSpellReward_IncludesSpellInRewardSummary()
+{
+    var game = await CreateGameAsync();
+    var quest = await CreatePersonalQuestAsync(xpCost: 5);
+    var scroll = await CreateSpellAsync("Svitek léčení",
+                                         isScroll: true, isLearnable: false, minMageLevel: 0);
+    await Client.PostAsJsonAsync($"/api/personal-quests/{quest.Id}/spell-rewards",
+        new AddSpellRewardDto(scroll.Id, Quantity: 2));
+    await Client.PostAsJsonAsync("/api/personal-quests/game-link",
+        new CreateGamePersonalQuestDto(game.Id, quest.Id, XpCost: null, PerKingdomLimit: null));
+
+    var list = await Client.GetFromJsonAsync<List<GamePersonalQuestListDto>>(
+        $"/api/personal-quests/by-game/{game.Id}");
+    var row = Assert.Single(list!);
+    Assert.NotNull(row.RewardSummary);
+    Assert.Contains("Svitek léčení", row.RewardSummary);
+    Assert.Contains("×2", row.RewardSummary);
+}
+```
+
+### Step 2: Run — likely FAIL (summary doesn't include spells yet)
+
+### Step 3: Implement
+
+Add `SpellRewards` (list of `PersonalQuestSpellRewardSummary`) to `PersonalQuestListDto`.
+
+In both list projections (catalog list and by-game list), include spell rewards:
+```csharp
+SpellRewards = q.SpellRewards
+    .Select(sr => new PersonalQuestSpellRewardSummary(sr.SpellId, sr.Spell.Name, sr.Spell.IsScroll, sr.Quantity))
+    .ToList()
+```
+
+Update `BuildRewardSummary(q)` around line 200–214 to append spell names. Pattern (adapt to the actual existing code):
+```csharp
+parts.AddRange(q.SpellRewards.Select(sr =>
+    sr.Quantity > 1 ? $"{sr.Spell.Name} ×{sr.Quantity}" : sr.Spell.Name));
+```
+
+### Step 4: Run — green
+
+### Step 5: Commit
+
+```bash
+git add src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs \
+        src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs \
+        tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+git commit -m "feat(personal-quest): expose spell rewards on list + in RewardSummary [v0.10.0]"
+```
+
+---
+
+## Task 9 — Client: XP spinner in the main quest form
+
+**Covers design section:** "UI changes → 1. XP in the main form".
+
+**Files:**
+- Modify: `src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor` (around line 153 — the Difficulty `DxFormLayoutItem`; and the code-behind `@code` block to bind `XpCost`)
+
+### Step 1: Add UI markup
+
+Locate the `DxFormLayoutItem` for Difficulty at line 153. Insert a new item immediately after it:
+
+```razor
+<DxFormLayoutItem Caption="XP cena" ColSpanMd="6">
+    <DxSpinEdit @bind-Value="@model.XpCost" MinValue="0" MaxValue="999" />
+</DxFormLayoutItem>
+```
+
+Consider setting Difficulty's `ColSpanMd="6"` so the two sit side-by-side on one row. If Difficulty already occupies `ColSpanMd="12"`, shrink it.
+
+### Step 2: Update `@code` model class
+
+Wherever the page defines its edit model (there's likely an `EditModel` class or set of private fields), add:
+- `public int XpCost { get; set; }` on the model
+- When loading a quest into the model (open-popup handler), map `detail.XpCost` in
+- When saving (PUT/POST), include `XpCost = model.XpCost` in the DTO payload
+
+### Step 3: Verify build and runtime
+
+```
+dotnet build
+```
+
+Manual runtime check (no automated UI test):
+1. `./devStart.bat` or `dotnet run --project src/OvcinaHra.Client`
+2. Open `/personal-quests`, edit a quest, confirm the XP spinner shows and persists
+
+### Step 4: Commit
+
+```bash
+git add src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+git commit -m "feat(personal-quest): XP spinner in main quest form [v0.10.0]"
+```
+
+---
+
+## Task 10 — Client: per-game XP spinner becomes nullable with fallback hint
+
+**Covers design section:** "UI changes → 2. Per-game card XP override".
+
+**Files:**
+- Modify: `src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor` (lines 276–315 — per-game config card; the code-behind field `gpqXpCost`)
+
+### Step 1: Code-behind change
+
+Change the field declaration from `private int gpqXpCost;` to `private int? gpqXpCost;`.
+
+When loading the GamePersonalQuest linked row, map `row.XpCost` (now `int?`) directly to `gpqXpCost`.
+
+When saving (PUT), pass `gpqXpCost` directly as the nullable value.
+
+### Step 2: Update the two `DxSpinEdit` occurrences (lines ~288, ~303)
+
+Replace with:
+
+```razor
+<DxSpinEdit @bind-Value="@gpqXpCost" MinValue="0"
+            NullText="@($"výchozí: {model.XpCost}")"
+            ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+```
+
+Below the spinner, add the hint-when-null:
+
+```razor
+@if (gpqXpCost is null)
+{
+    <div class="form-text small">
+        Bez přepisu — pro tuto hru platí výchozí @model.XpCost XP z katalogu.
+    </div>
+}
+```
+
+### Step 3: Build + runtime check
+
+```
+dotnet build
+```
+
+### Step 4: Commit
+
+```bash
+git add src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+git commit -m "feat(personal-quest): per-game XP override with catalog-fallback hint [v0.10.0]"
+```
+
+---
+
+## Task 11 — Client: Spell rewards section in the popup
+
+**Covers design section:** "UI changes → 3. New Spell rewards section".
+
+This is the largest UI task. Mirrors the Items reward section (starts line 236 per survey).
+
+**Files:**
+- Modify: `src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor`
+
+### Step 1: Code-behind additions
+
+Add to the `@code` block:
+
+```csharp
+private List<PersonalQuestSpellRewardSummary> detailSpellRewards = [];
+private List<SpellListDto> allSpells = []; // catalog of non-learnable spells
+private int? newSpellId;
+private int newSpellQuantity = 1;
+
+private SpellListDto? SelectedAddableSpell =>
+    allSpells.FirstOrDefault(s => s.Id == newSpellId);
+
+private bool SelectedSpellIsScroll => SelectedAddableSpell?.IsScroll == true;
+
+private IEnumerable<SpellListDto> SpellsNotYetAdded =>
+    allSpells.Where(s =>
+        !s.IsLearnable &&
+        !detailSpellRewards.Any(r => r.SpellId == s.Id));
+```
+
+In the page initialisation (OnInitializedAsync or whatever loader sets up catalog reference lists), load:
+
+```csharp
+allSpells = await Api.GetListAsync<SpellListDto>("/api/spells");
+```
+
+When opening the popup for an existing quest, populate `detailSpellRewards` from `detail.SpellRewards`.
+
+Add handlers:
+
+```csharp
+private async Task AddSpellRewardAsync()
+{
+    if (newSpellId is null) return;
+    var qty = SelectedSpellIsScroll ? newSpellQuantity : 1;
+    try
+    {
+        await Api.PostAsync<AddSpellRewardDto, object?>(
+            $"/api/personal-quests/{editingId}/spell-rewards",
+            new AddSpellRewardDto(newSpellId.Value, qty));
+        // reload quest detail so detailSpellRewards refreshes
+        var updated = await Api.GetAsync<PersonalQuestDetailDto>(
+            $"/api/personal-quests/{editingId}");
+        if (updated is not null) detailSpellRewards = updated.SpellRewards.ToList();
+        newSpellId = null;
+        newSpellQuantity = 1;
+    }
+    catch (Exception ex) { error = ex.Message; }
+}
+
+private async Task RemoveSpellRewardAsync(int spellId)
+{
+    try
+    {
+        var ok = await Api.DeleteAsync(
+            $"/api/personal-quests/{editingId}/spell-rewards/{spellId}");
+        if (ok) detailSpellRewards = detailSpellRewards
+            .Where(r => r.SpellId != spellId).ToList();
+    }
+    catch (Exception ex) { error = ex.Message; }
+}
+```
+
+### Step 2: Mark-up — new section
+
+Insert right after the Items reward block (mirrors the Items section in structure):
+
+```razor
+@* --- Spell rewards (catalog-level, mirrors Items section) --- *@
+<div class="mt-2">
+    <strong class="small">Kouzla:</strong>
+    @if (detailSpellRewards.Any())
+    {
+        <div class="mt-1">
+            @foreach (var sr in detailSpellRewards)
+            {
+                <span class="badge bg-secondary me-1">
+                    @sr.SpellName@(sr.Quantity > 1 ? $" ×{sr.Quantity}" : "")
+                    <button class="btn btn-sm btn-link text-white p-0 ms-1"
+                            @onclick="() => RemoveSpellRewardAsync(sr.SpellId)">
+                        <i class="bi bi-x"></i>
+                    </button>
+                </span>
+            }
+        </div>
+    }
+    else
+    {
+        <span class="text-muted small ms-2">Žádná kouzla.</span>
+    }
+    <div class="d-flex gap-2 align-items-end mt-1">
+        <div style="flex:1">
+            <DxComboBox Data="@SpellsNotYetAdded" @bind-Value="@newSpellId"
+                        TextFieldName="Name" ValueFieldName="Id"
+                        NullText="(přidat kouzlo)" SearchMode="ListSearchMode.AutoSearch" />
+        </div>
+        @if (SelectedSpellIsScroll)
+        {
+            <div style="width:70px">
+                <DxSpinEdit @bind-Value="@newSpellQuantity" MinValue="1" />
+            </div>
+        }
+        <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                disabled="@(newSpellId is null)"
+                @onclick="AddSpellRewardAsync">
+            <i class="bi bi-plus me-1"></i>Přidat
+        </button>
+    </div>
+</div>
+```
+
+### Step 3: Build + runtime check
+
+```
+dotnet build
+```
+
+Manual flow:
+1. Open quest popup → Kouzla section appears with empty state
+2. Combobox offers only `IsLearnable=false` spells
+3. Select a scroll → quantity spinner appears → pick 3 → Přidat → badge "Name ×3" appears
+4. Select a non-scroll non-learnable spell → no quantity spinner → Přidat → badge "Name" (no quantity)
+5. Click × on badge → spell reward is removed
+
+### Step 4: Commit
+
+```bash
+git add src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+git commit -m "feat(personal-quest): spell rewards section in detail popup [v0.10.0]"
+```
+
+---
+
+## Task 12 — Client: `EffectiveXpCost` column + `LayoutKey` bump
+
+**Covers design section:** "UI changes → 4. Game grid".
+
+**Files:**
+- Modify: `src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor` (line 95 LayoutKey; add column to the game-view grid Columns block)
+
+### Step 1: Bump the LayoutKey
+
+Line 95:
+```razor
+LayoutKey="grid-layout-personal-quests-game"
+```
+→
+```razor
+LayoutKey="grid-layout-personal-quests-game-v2"
+```
+
+### Step 2: Add the EffectiveXpCost column
+
+Find the existing `<DxGridDataColumn FieldName="XpCost" ...>` in the game-view grid's `Columns` block and:
+- Rename its `FieldName` to `EffectiveXpCost` and keep caption `"XP cena"` (this is now the effective value shown by default)
+- Add a second column for the raw override value, hidden-by-default:
+
+```razor
+<DxGridDataColumn FieldName="EffectiveXpCost" Caption="XP cena" Width="110px" />
+<DxGridDataColumn FieldName="XpCost" Caption="XP (přepis)" Width="120px" Visible="false" />
+```
+
+### Step 3: Build
+
+```
+dotnet build
+```
+
+### Step 4: Commit
+
+```bash
+git add src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+git commit -m "feat(personal-quest): EffectiveXpCost grid column + LayoutKey v2 [v0.10.0]"
+```
+
+---
+
+## Task 13 — Bump client version to `0.10.0`
+
+**Covers design section:** "Version & deploy".
+
+**Files:**
+- Modify: `src/OvcinaHra.Client/OvcinaHra.Client.csproj:10`
+
+### Step 1: Edit
+
+```xml
+<Version>0.10.0</Version>
+```
+
+### Step 2: Build + run all tests one final time
+
+```
+dotnet build
+dotnet test
+```
+
+### Step 3: Commit
+
+```bash
+git add src/OvcinaHra.Client/OvcinaHra.Client.csproj
+git commit -m "chore: bump client version to 0.10.0 [v0.10.0]"
+```
+
+---
+
+## Post-tasks: PR & merge
+
+1. Push the branch: `git push -u origin feat/personal-quest-spell-rewards-and-catalog-xp`
+2. Open PR targeting `main`:
+   ```bash
+   gh pr create --base main --head feat/personal-quest-spell-rewards-and-catalog-xp \
+     --title "feat(personal-quest): spell rewards + catalog XP [v0.10.0]" \
+     --body "<summary referencing the design doc>"
+   ```
+3. Wait for CI (`build` + `build-and-test` must pass — branch protection enforces this).
+4. Handle any Copilot review comments with fixup commits.
+5. Squash-merge, delete branch.
+
+## Things to avoid (captured from prior session learnings)
+
+- **Don't hand-edit the generated migration file unless you fully understand it.** If a field is missing, go back to the entity/config and regenerate the migration by deleting the generated file and re-running `dotnet ef migrations add`.
+- **Don't use `AllowFilter` on `DxGridDataColumn`** — not valid in DevExpress Blazor 25.2.5; compiles fine, crashes at render (see MEMORY: "DevExpress attr errors at runtime").
+- **Don't skip the `LayoutKey` bump** in Task 12 — users' cached localStorage filters will replay against the new schema and confuse everyone.
+- **Don't commit without the `[v0.10.0]` tag** — project convention, enforced nowhere in CI but caught at review.
+- **Don't add destructive-confirm popups to reward badges** — the Items section doesn't have one and we want spells to match.

--- a/src/OvcinaHra.Api/Data/Configurations/GamePersonalQuestConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/GamePersonalQuestConfiguration.cs
@@ -16,7 +16,8 @@ public class GamePersonalQuestConfiguration : IEntityTypeConfiguration<GamePerso
         b.HasIndex(e => e.GameId);
         b.ToTable(t =>
         {
-            t.HasCheckConstraint("CK_GamePersonalQuest_XpCost_NonNegative", "\"XpCost\" >= 0");
+            t.HasCheckConstraint("CK_GamePersonalQuest_XpCost_NonNegative",
+                "\"XpCost\" IS NULL OR \"XpCost\" >= 0");
             t.HasCheckConstraint("CK_GamePersonalQuest_PKL_Positive",
                 "\"PerKingdomLimit\" IS NULL OR \"PerKingdomLimit\" >= 1");
         });

--- a/src/OvcinaHra.Api/Data/Configurations/PersonalQuestConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/PersonalQuestConfiguration.cs
@@ -13,5 +13,8 @@ public class PersonalQuestConfiguration : IEntityTypeConfiguration<PersonalQuest
         b.HasIndex(e => e.Name).IsUnique();
         b.Property(e => e.Description).HasMaxLength(500);
         b.Property(e => e.Difficulty).HasConversion<string>().HasMaxLength(20);
+        b.ToTable(t => t.HasCheckConstraint(
+            "CK_PersonalQuest_XpCost_NonNegative",
+            "\"XpCost\" >= 0"));
     }
 }

--- a/src/OvcinaHra.Api/Data/Configurations/PersonalQuestSpellRewardConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/PersonalQuestSpellRewardConfiguration.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class PersonalQuestSpellRewardConfiguration : IEntityTypeConfiguration<PersonalQuestSpellReward>
+{
+    public void Configure(EntityTypeBuilder<PersonalQuestSpellReward> b)
+    {
+        b.HasKey(e => new { e.PersonalQuestId, e.SpellId });
+        b.Property(e => e.Quantity).HasDefaultValue(1);
+        b.ToTable(t => t.HasCheckConstraint("CK_PQSpellReward_Qty_Positive", "\"Quantity\" >= 1"));
+        b.HasOne(e => e.PersonalQuest).WithMany(q => q.SpellRewards)
+            .HasForeignKey(e => e.PersonalQuestId).OnDelete(DeleteBehavior.Cascade);
+        b.HasOne(e => e.Spell).WithMany()
+            .HasForeignKey(e => e.SpellId).OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -52,6 +52,7 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<PersonalQuest> PersonalQuests => Set<PersonalQuest>();
     public DbSet<PersonalQuestSkillReward> PersonalQuestSkillRewards => Set<PersonalQuestSkillReward>();
     public DbSet<PersonalQuestItemReward> PersonalQuestItemRewards => Set<PersonalQuestItemReward>();
+    public DbSet<PersonalQuestSpellReward> PersonalQuestSpellRewards => Set<PersonalQuestSpellReward>();
     public DbSet<GamePersonalQuest> GamePersonalQuests => Set<GamePersonalQuest>();
     public DbSet<CharacterPersonalQuest> CharacterPersonalQuests => Set<CharacterPersonalQuest>();
 

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -29,6 +29,8 @@ public static class PersonalQuestEndpoints
         group.MapDelete("/{id:int}/skill-rewards/{skillId:int}", RemoveSkillReward);
         group.MapPost("/{id:int}/item-rewards", AddItemReward);
         group.MapDelete("/{id:int}/item-rewards/{itemId:int}", RemoveItemReward);
+        group.MapPost("/{id:int}/spell-rewards", AddSpellReward);
+        group.MapDelete("/{id:int}/spell-rewards/{spellId:int}", RemoveSpellReward);
 
         return group;
     }
@@ -51,6 +53,7 @@ public static class PersonalQuestEndpoints
             .AsNoTracking()
             .Include(pq => pq.SkillRewards).ThenInclude(sr => sr.Skill)
             .Include(pq => pq.ItemRewards).ThenInclude(ir => ir.Item)
+            .Include(pq => pq.SpellRewards).ThenInclude(sr => sr.Spell)
             .FirstOrDefaultAsync(pq => pq.Id == id);
         if (q is null) return TypedResults.NotFound();
 
@@ -118,6 +121,7 @@ public static class PersonalQuestEndpoints
         q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
         q.SkillRewards.Select(sr => new SkillRewardDto(sr.SkillId, sr.Skill?.Name ?? string.Empty)).ToList(),
         q.ItemRewards.Select(ir => new ItemRewardDto(ir.ItemId, ir.Item?.Name ?? string.Empty, ir.Quantity)).ToList(),
+        q.SpellRewards.Select(sr => new PersonalQuestSpellRewardSummary(sr.SpellId, sr.Spell?.Name ?? string.Empty, sr.Spell?.IsScroll ?? false, sr.Quantity)).ToList(),
         q.XpCost);
 
     private static PersonalQuestListDto ToListDto(PersonalQuest q) => new(
@@ -276,6 +280,41 @@ public static class PersonalQuestEndpoints
         if (ir is null) return TypedResults.NotFound();
 
         db.PersonalQuestItemRewards.Remove(ir);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<IResult> AddSpellReward(int id, AddSpellRewardDto dto, WorldDbContext db)
+    {
+        if (!await db.PersonalQuests.AnyAsync(q => q.Id == id))
+            return TypedResults.NotFound($"Quest #{id} neexistuje.");
+
+        var spell = await db.Spells.FindAsync(dto.SpellId);
+        if (spell is null)
+            return TypedResults.NotFound($"Kouzlo #{dto.SpellId} neexistuje.");
+
+        if (spell.IsLearnable)
+            return TypedResults.BadRequest($"Kouzlo #{dto.SpellId} je naučitelné — nelze ho použít jako odměnu personal questu.");
+
+        var link = new PersonalQuestSpellReward
+        {
+            PersonalQuestId = id,
+            SpellId = dto.SpellId,
+            Quantity = dto.Quantity
+        };
+        db.PersonalQuestSpellRewards.Add(link);
+        await db.SaveChangesAsync();
+
+        return TypedResults.Created($"/api/personal-quests/{id}/spell-rewards/{dto.SpellId}");
+    }
+
+    private static async Task<IResult> RemoveSpellReward(int id, int spellId, WorldDbContext db)
+    {
+        var link = await db.PersonalQuestSpellRewards
+            .FirstOrDefaultAsync(x => x.PersonalQuestId == id && x.SpellId == spellId);
+        if (link is null) return TypedResults.NotFound();
+
+        db.PersonalQuestSpellRewards.Remove(link);
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -71,7 +71,8 @@ public static class PersonalQuestEndpoints
             QuestCardText = dto.QuestCardText,
             RewardCardText = dto.RewardCardText,
             RewardNote = dto.RewardNote,
-            Notes = dto.Notes
+            Notes = dto.Notes,
+            XpCost = dto.XpCost
         };
         db.PersonalQuests.Add(q);
         await db.SaveChangesAsync();
@@ -95,6 +96,7 @@ public static class PersonalQuestEndpoints
         q.RewardCardText = dto.RewardCardText;
         q.RewardNote = dto.RewardNote;
         q.Notes = dto.Notes;
+        q.XpCost = dto.XpCost;
 
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
@@ -115,7 +117,8 @@ public static class PersonalQuestEndpoints
         q.AllowWarrior, q.AllowArcher, q.AllowMage, q.AllowThief,
         q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
         q.SkillRewards.Select(sr => new SkillRewardDto(sr.SkillId, sr.Skill?.Name ?? string.Empty)).ToList(),
-        q.ItemRewards.Select(ir => new ItemRewardDto(ir.ItemId, ir.Item?.Name ?? string.Empty, ir.Quantity)).ToList());
+        q.ItemRewards.Select(ir => new ItemRewardDto(ir.ItemId, ir.Item?.Name ?? string.Empty, ir.Quantity)).ToList(),
+        q.XpCost);
 
     private static PersonalQuestListDto ToListDto(PersonalQuest q) => new(
         q.Id, q.Name, q.Description, q.Difficulty,
@@ -123,7 +126,8 @@ public static class PersonalQuestEndpoints
         q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
         q.SkillRewards.Select(sr => sr.SkillId).ToList(),
         q.ItemRewards.Select(ir => new PersonalQuestItemRewardSummary(ir.ItemId, ir.Item.Name, ir.Quantity)).ToList(),
-        BuildRewardSummary(q));
+        BuildRewardSummary(q),
+        q.XpCost);
 
     // ---------- Per-game link endpoints ----------
 

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -41,6 +41,7 @@ public static class PersonalQuestEndpoints
             .AsNoTracking()
             .Include(q => q.SkillRewards).ThenInclude(sr => sr.Skill)
             .Include(q => q.ItemRewards).ThenInclude(r => r.Item)
+            .Include(q => q.SpellRewards).ThenInclude(sr => sr.Spell)
             .OrderBy(q => q.Name)
             .ToListAsync();
 
@@ -130,6 +131,7 @@ public static class PersonalQuestEndpoints
         q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
         q.SkillRewards.Select(sr => sr.SkillId).ToList(),
         q.ItemRewards.Select(ir => new PersonalQuestItemRewardSummary(ir.ItemId, ir.Item.Name, ir.Quantity)).ToList(),
+        q.SpellRewards.Select(sr => new PersonalQuestSpellRewardSummary(sr.SpellId, sr.Spell.Name, sr.Spell.IsScroll, sr.Quantity)).ToList(),
         BuildRewardSummary(q),
         q.XpCost);
 
@@ -142,6 +144,7 @@ public static class PersonalQuestEndpoints
             .Where(g => g.GameId == gameId)
             .Include(g => g.PersonalQuest).ThenInclude(q => q.SkillRewards).ThenInclude(sr => sr.Skill)
             .Include(g => g.PersonalQuest).ThenInclude(q => q.ItemRewards).ThenInclude(ir => ir.Item)
+            .Include(g => g.PersonalQuest).ThenInclude(q => q.SpellRewards).ThenInclude(sr => sr.Spell)
             .OrderBy(g => g.PersonalQuest.Name)
             .ToListAsync();
 
@@ -202,7 +205,8 @@ public static class PersonalQuestEndpoints
             q.AllowWarrior, q.AllowArcher, q.AllowMage, q.AllowThief,
             q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
             g.GameId, g.XpCost, g.XpCost ?? q.XpCost, g.PerKingdomLimit,
-            BuildRewardSummary(q));
+            BuildRewardSummary(q),
+            q.SpellRewards.Select(sr => new PersonalQuestSpellRewardSummary(sr.SpellId, sr.Spell.Name, sr.Spell.IsScroll, sr.Quantity)).ToList());
     }
 
     private static string? BuildRewardSummary(PersonalQuest q)
@@ -217,6 +221,12 @@ public static class PersonalQuestEndpoints
         {
             parts.Add(string.Join(", ",
                 q.ItemRewards.OrderBy(i => i.Item.Name).Select(i => $"{i.Item.Name} ×{i.Quantity}")));
+        }
+        if (q.SpellRewards.Count > 0)
+        {
+            parts.Add(string.Join(", ",
+                q.SpellRewards.OrderBy(s => s.Spell.Name)
+                    .Select(s => s.Quantity > 1 ? $"{s.Spell.Name} ×{s.Quantity}" : s.Spell.Name)));
         }
         return parts.Count > 0 ? string.Join(" │ ", parts) : null;
     }

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -197,7 +197,7 @@ public static class PersonalQuestEndpoints
             q.Id, q.Name, q.Description, q.Difficulty,
             q.AllowWarrior, q.AllowArcher, q.AllowMage, q.AllowThief,
             q.QuestCardText, q.RewardCardText, q.RewardNote, q.Notes, q.ImagePath,
-            g.GameId, g.XpCost, g.PerKingdomLimit,
+            g.GameId, g.XpCost, g.XpCost ?? q.XpCost, g.PerKingdomLimit,
             BuildRewardSummary(q));
     }
 

--- a/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/PersonalQuestEndpoints.cs
@@ -61,8 +61,11 @@ public static class PersonalQuestEndpoints
         return TypedResults.Ok(ToDetailDto(q));
     }
 
-    private static async Task<Created<PersonalQuestDetailDto>> Create(CreatePersonalQuestDto dto, WorldDbContext db)
+    private static async Task<Results<Created<PersonalQuestDetailDto>, BadRequest<string>>> Create(CreatePersonalQuestDto dto, WorldDbContext db)
     {
+        if (dto.XpCost < 0)
+            return TypedResults.BadRequest("XP cena nesmí být záporná.");
+
         var q = new PersonalQuest
         {
             Name = dto.Name,
@@ -84,8 +87,11 @@ public static class PersonalQuestEndpoints
         return TypedResults.Created($"/api/personal-quests/{q.Id}", ToDetailDto(q));
     }
 
-    private static async Task<Results<NoContent, NotFound>> Update(int id, UpdatePersonalQuestDto dto, WorldDbContext db)
+    private static async Task<Results<NoContent, NotFound, BadRequest<string>>> Update(int id, UpdatePersonalQuestDto dto, WorldDbContext db)
     {
+        if (dto.XpCost < 0)
+            return TypedResults.BadRequest("XP cena nesmí být záporná.");
+
         var q = await db.PersonalQuests.FindAsync(id);
         if (q is null) return TypedResults.NotFound();
 
@@ -305,6 +311,11 @@ public static class PersonalQuestEndpoints
 
         if (spell.IsLearnable)
             return TypedResults.BadRequest($"Kouzlo #{dto.SpellId} je naučitelné — nelze ho použít jako odměnu personal questu.");
+
+        var exists = await db.PersonalQuestSpellRewards
+            .AnyAsync(x => x.PersonalQuestId == id && x.SpellId == dto.SpellId);
+        if (exists)
+            return TypedResults.Conflict($"Kouzlo #{dto.SpellId} už je přiřazeno jako odměna tohoto questu.");
 
         var link = new PersonalQuestSpellReward
         {

--- a/src/OvcinaHra.Api/Migrations/20260422190826_AddPersonalQuestCatalogXpCost.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422190826_AddPersonalQuestCatalogXpCost.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422190826_AddPersonalQuestCatalogXpCost")]
+    partial class AddPersonalQuestCatalogXpCost
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260422190826_AddPersonalQuestCatalogXpCost.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422190826_AddPersonalQuestCatalogXpCost.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPersonalQuestCatalogXpCost : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "XpCost",
+                table: "PersonalQuests",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "XpCost",
+                table: "PersonalQuests");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Migrations/20260422192840_NullableGamePersonalQuestXpCost.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422192840_NullableGamePersonalQuestXpCost.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422192840_NullableGamePersonalQuestXpCost")]
+    partial class NullableGamePersonalQuestXpCost
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260422192840_NullableGamePersonalQuestXpCost.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422192840_NullableGamePersonalQuestXpCost.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class NullableGamePersonalQuestXpCost : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_GamePersonalQuest_XpCost_NonNegative",
+                table: "GamePersonalQuests");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "XpCost",
+                table: "GamePersonalQuests",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_GamePersonalQuest_XpCost_NonNegative",
+                table: "GamePersonalQuests",
+                sql: "\"XpCost\" IS NULL OR \"XpCost\" >= 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_GamePersonalQuest_XpCost_NonNegative",
+                table: "GamePersonalQuests");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "XpCost",
+                table: "GamePersonalQuests",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_GamePersonalQuest_XpCost_NonNegative",
+                table: "GamePersonalQuests",
+                sql: "\"XpCost\" >= 0");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Migrations/20260422194419_AddPersonalQuestSpellRewardsTable.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422194419_AddPersonalQuestSpellRewardsTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422194419_AddPersonalQuestSpellRewardsTable")]
+    partial class AddPersonalQuestSpellRewardsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260422194419_AddPersonalQuestSpellRewardsTable.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422194419_AddPersonalQuestSpellRewardsTable.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPersonalQuestSpellRewardsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PersonalQuestSpellRewards",
+                columns: table => new
+                {
+                    PersonalQuestId = table.Column<int>(type: "integer", nullable: false),
+                    SpellId = table.Column<int>(type: "integer", nullable: false),
+                    Quantity = table.Column<int>(type: "integer", nullable: false, defaultValue: 1)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PersonalQuestSpellRewards", x => new { x.PersonalQuestId, x.SpellId });
+                    table.CheckConstraint("CK_PQSpellReward_Qty_Positive", "\"Quantity\" >= 1");
+                    table.ForeignKey(
+                        name: "FK_PersonalQuestSpellRewards_PersonalQuests_PersonalQuestId",
+                        column: x => x.PersonalQuestId,
+                        principalTable: "PersonalQuests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PersonalQuestSpellRewards_Spells_SpellId",
+                        column: x => x.SpellId,
+                        principalTable: "Spells",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersonalQuestSpellRewards_SpellId",
+                table: "PersonalQuestSpellRewards",
+                column: "SpellId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PersonalQuestSpellRewards");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Migrations/20260422211917_AddPersonalQuestXpCostNonNegativeCheck.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422211917_AddPersonalQuestXpCostNonNegativeCheck.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422211917_AddPersonalQuestXpCostNonNegativeCheck")]
+    partial class AddPersonalQuestXpCostNonNegativeCheck
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260422211917_AddPersonalQuestXpCostNonNegativeCheck.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422211917_AddPersonalQuestXpCostNonNegativeCheck.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPersonalQuestXpCostNonNegativeCheck : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_PersonalQuest_XpCost_NonNegative",
+                table: "PersonalQuests",
+                sql: "\"XpCost\" >= 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_PersonalQuest_XpCost_NonNegative",
+                table: "PersonalQuests");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.9.8</Version>
+    <Version>0.10.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
@@ -92,7 +92,7 @@ else if (Catalog)
 }
 else
 {
-    <OvcinaGrid Data="@gameItems" KeyFieldName="Id" LayoutKey="grid-layout-personal-quests-game"
+    <OvcinaGrid Data="@gameItems" KeyFieldName="Id" LayoutKey="grid-layout-personal-quests-game-v2"
                 RowClick="@(e => OpenModal((GamePersonalQuestListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="" Caption="" Width="40px" AllowSort="false" AllowGroup="false" FixedPosition="GridColumnFixedPosition.Left">
@@ -130,7 +130,8 @@ else
             <DxGridDataColumn FieldName="HasImage" Caption="Obrázek" Width="100px" Visible="false">
                 <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="XpCost" Caption="XP cena" Width="100px" />
+            <DxGridDataColumn FieldName="EffectiveXpCost" Caption="XP cena" Width="110px" />
+            <DxGridDataColumn FieldName="XpCost" Caption="XP (přepis)" Width="120px" Visible="false" />
             <DxGridDataColumn FieldName="PerKingdomLimit" Caption="Limit / království" Width="150px" />
         </Columns>
     </OvcinaGrid>
@@ -153,6 +154,9 @@ else
             <DxFormLayoutItem Caption="Obtížnost" ColSpanMd="6">
                 <DxComboBox Data="@difficultyValues" @bind-Value="@difficulty"
                             TextFieldName="Display" ValueFieldName="Value" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="XP cena" ColSpanMd="6">
+                <DxSpinEdit @bind-Value="@xpCost" MinValue="0" MaxValue="999" />
             </DxFormLayoutItem>
             <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
                 <DxTextBox @bind-Text="@description" />
@@ -269,6 +273,48 @@ else
                         </button>
                     </div>
                 </div>
+
+                @* --- Spell rewards (catalog-level, mirrors Items section) --- *@
+                <div class="mt-2">
+                    <strong class="small">Kouzla:</strong>
+                    @if (detailSpellRewards.Any())
+                    {
+                        <div class="mt-1">
+                            @foreach (var sr in detailSpellRewards)
+                            {
+                                <span class="badge bg-secondary me-1">
+                                    @sr.SpellName@(sr.Quantity > 1 ? $" ×{sr.Quantity}" : "")
+                                    <button class="btn btn-sm btn-link text-white p-0 ms-1"
+                                            @onclick="() => RemoveSpellRewardAsync(sr.SpellId)">
+                                        <i class="bi bi-x"></i>
+                                    </button>
+                                </span>
+                            }
+                        </div>
+                    }
+                    else
+                    {
+                        <span class="text-muted small ms-2">Žádná kouzla.</span>
+                    }
+                    <div class="d-flex gap-2 align-items-end mt-1">
+                        <div style="flex:1">
+                            <DxComboBox Data="@SpellsNotYetAdded" @bind-Value="@newSpellId"
+                                        TextFieldName="Name" ValueFieldName="Id"
+                                        NullText="(přidat kouzlo)" SearchMode="ListSearchMode.AutoSearch" />
+                        </div>
+                        @if (SelectedSpellIsScroll)
+                        {
+                            <div style="width:70px">
+                                <DxSpinEdit @bind-Value="@newSpellQuantity" MinValue="1" />
+                            </div>
+                        }
+                        <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                                disabled="@(newSpellId is null)"
+                                @onclick="AddSpellRewardAsync">
+                            <i class="bi bi-plus me-1"></i>Přidat
+                        </button>
+                    </div>
+                </div>
             </div>
         }
 
@@ -286,12 +332,20 @@ else
                     <p class="text-muted small mb-2">Quest není přiřazen k této hře.</p>
                     <DxFormLayout>
                         <DxFormLayoutItem Caption="XP cena" ColSpanMd="6">
-                            <DxSpinEdit @bind-Value="@gpqXpCost" MinValue="0" />
+                            <DxSpinEdit @bind-Value="@gpqXpCost" MinValue="0"
+                                        NullText="@($"výchozí: {xpCost}")"
+                                        ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
                         </DxFormLayoutItem>
                         <DxFormLayoutItem Caption="Limit na království" ColSpanMd="6">
                             <DxSpinEdit @bind-Value="@gpqPerKingdomLimit" MinValue="1" NullText="(neomezeno)" />
                         </DxFormLayoutItem>
                     </DxFormLayout>
+                    @if (gpqXpCost is null)
+                    {
+                        <div class="form-text small">
+                            Bez přepisu — pro tuto hru platí výchozí @xpCost XP z katalogu.
+                        </div>
+                    }
                     <button class="btn btn-outline-primary btn-sm mt-2" @onclick="AddGamePersonalQuestAsync">
                         <i class="bi bi-plus-circle me-1"></i>Přidat do hry
                     </button>
@@ -300,12 +354,20 @@ else
                 {
                     <DxFormLayout>
                         <DxFormLayoutItem Caption="XP cena" ColSpanMd="6">
-                            <DxSpinEdit @bind-Value="@gpqXpCost" MinValue="0" />
+                            <DxSpinEdit @bind-Value="@gpqXpCost" MinValue="0"
+                                        NullText="@($"výchozí: {xpCost}")"
+                                        ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
                         </DxFormLayoutItem>
                         <DxFormLayoutItem Caption="Limit na království" ColSpanMd="6">
                             <DxSpinEdit @bind-Value="@gpqPerKingdomLimit" MinValue="1" NullText="(neomezeno)" />
                         </DxFormLayoutItem>
                     </DxFormLayout>
+                    @if (gpqXpCost is null)
+                    {
+                        <div class="form-text small">
+                            Bez přepisu — pro tuto hru platí výchozí @xpCost XP z katalogu.
+                        </div>
+                    }
                     <div class="d-flex gap-2 mt-2">
                         <button class="btn btn-sm btn-primary" @onclick="SaveGamePersonalQuestAsync" disabled="@isSaving">Uložit nastavení</button>
                         <button class="btn btn-sm btn-outline-danger" @onclick="RemoveGamePersonalQuestAsync" disabled="@isSaving">Odebrat z hry</button>
@@ -350,6 +412,7 @@ else
     // Lookup lists for combo boxes
     private List<SkillDto> allSkills = [];
     private List<ItemListDto> allItems = [];
+    private List<SpellListDto> allSpells = [];
 
     // Context menu (game view only)
     private DxContextMenu? contextMenu;
@@ -361,18 +424,22 @@ else
     private string? error, description, questCardText, rewardCardText, rewardNote, notes;
     private int? editingId;
     private TreasureQuestDifficulty difficulty = TreasureQuestDifficulty.Start;
+    private int xpCost;
     private bool allowWarrior, allowArcher, allowMage, allowThief;
 
     // Reward pickers
     private List<SkillRewardDto> detailSkillRewards = [];
     private List<ItemRewardDto> detailItemRewards = [];
+    private List<PersonalQuestSpellRewardSummary> detailSpellRewards = [];
     private int? newSkillId;
     private int? newItemId;
     private int newItemQuantity = 1;
+    private int? newSpellId;
+    private int newSpellQuantity = 1;
 
     // Per-game config
     private bool gpqLoading, gpqExists;
-    private int gpqXpCost;
+    private int? gpqXpCost;
     private int? gpqPerKingdomLimit;
 
     private static readonly List<EnumItem<TreasureQuestDifficulty>> difficultyValues =
@@ -387,6 +454,16 @@ else
     private List<ItemListDto> ItemsNotYetAdded =>
         allItems.Where(i => !detailItemRewards.Any(ir => ir.ItemId == i.Id)).ToList();
 
+    private SpellListDto? SelectedAddableSpell =>
+        allSpells.FirstOrDefault(s => s.Id == newSpellId);
+
+    private bool SelectedSpellIsScroll => SelectedAddableSpell?.IsScroll == true;
+
+    private IEnumerable<SpellListDto> SpellsNotYetAdded =>
+        allSpells.Where(s =>
+            !s.IsLearnable &&
+            !detailSpellRewards.Any(r => r.SpellId == s.Id));
+
     private bool _previousCatalog;
 
     protected override async Task OnInitializedAsync()
@@ -397,6 +474,7 @@ else
         await LoadAsync();
         allItems = await Api.GetListAsync<ItemListDto>("/api/items");
         allSkills = (await SkillSvc.GetAllAsync()).ToList();
+        allSpells = await Api.GetListAsync<SpellListDto>("/api/spells");
     }
 
     protected override async Task OnParametersSetAsync()
@@ -477,15 +555,19 @@ else
         name = "";
         description = null;
         difficulty = TreasureQuestDifficulty.Start;
+        xpCost = 0;
         allowWarrior = allowArcher = allowMage = allowThief = false;
         questCardText = rewardCardText = rewardNote = notes = null;
         detailSkillRewards = [];
         detailItemRewards = [];
+        detailSpellRewards = [];
         newSkillId = null;
         newItemId = null;
         newItemQuantity = 1;
+        newSpellId = null;
+        newSpellQuantity = 1;
         gpqExists = false;
-        gpqXpCost = 0;
+        gpqXpCost = null;
         gpqPerKingdomLimit = null;
     }
 
@@ -496,6 +578,7 @@ else
         {
             description = d.Description;
             difficulty = d.Difficulty;
+            xpCost = d.XpCost;
             allowWarrior = d.AllowWarrior;
             allowArcher = d.AllowArcher;
             allowMage = d.AllowMage;
@@ -506,6 +589,7 @@ else
             notes = d.Notes;
             detailSkillRewards = d.SkillRewards.ToList();
             detailItemRewards = d.ItemRewards.ToList();
+            detailSpellRewards = d.SpellRewards.ToList();
         }
         await LoadGamePersonalQuestAsync(id);
         StateHasChanged();
@@ -528,7 +612,7 @@ else
         }
         else
         {
-            gpqXpCost = 0;
+            gpqXpCost = null;
             gpqPerKingdomLimit = null;
         }
         gpqLoading = false;
@@ -610,6 +694,38 @@ else
         catch (Exception ex) { error = ex.Message; }
     }
 
+    private async Task AddSpellRewardAsync()
+    {
+        if (editingId is null || newSpellId is null) return;
+        var qty = SelectedSpellIsScroll ? newSpellQuantity : 1;
+        try
+        {
+            await Api.PostAsync<AddSpellRewardDto, object?>(
+                $"/api/personal-quests/{editingId.Value}/spell-rewards",
+                new AddSpellRewardDto(newSpellId.Value, qty));
+            var updated = await Api.GetAsync<PersonalQuestDetailDto>(
+                $"/api/personal-quests/{editingId.Value}");
+            if (updated is not null) detailSpellRewards = updated.SpellRewards.ToList();
+            newSpellId = null;
+            newSpellQuantity = 1;
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task RemoveSpellRewardAsync(int spellId)
+    {
+        if (editingId is null) return;
+        try
+        {
+            var ok = await Api.DeleteAsync(
+                $"/api/personal-quests/{editingId.Value}/spell-rewards/{spellId}");
+            if (ok)
+                detailSpellRewards = detailSpellRewards
+                    .Where(r => r.SpellId != spellId).ToList();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
     private async Task AddGamePersonalQuestAsync()
     {
         if (editingId is null || GameContext.SelectedGameId is null) return;
@@ -678,14 +794,14 @@ else
                 await PqSvc.UpdateAsync(editingId.Value,
                     new UpdatePersonalQuestDto(name, difficulty, description,
                         allowWarrior, allowArcher, allowMage, allowThief,
-                        questCardText, rewardCardText, rewardNote, notes));
+                        questCardText, rewardCardText, rewardNote, notes, xpCost));
             }
             else
             {
                 var created = await PqSvc.CreateAsync(
                     new CreatePersonalQuestDto(name, difficulty, description,
                         allowWarrior, allowArcher, allowMage, allowThief,
-                        questCardText, rewardCardText, rewardNote, notes));
+                        questCardText, rewardCardText, rewardNote, notes, xpCost));
                 if (!Catalog && GameContext.SelectedGameId is int gid && created is not null)
                     await PqSvc.CreateGameLinkAsync(gid, created.Id);
             }

--- a/src/OvcinaHra.Client/Services/PersonalQuestService.cs
+++ b/src/OvcinaHra.Client/Services/PersonalQuestService.cs
@@ -38,12 +38,12 @@ public class PersonalQuestService
     public Task<List<GamePersonalQuestListDto>> GetByGameAsync(int gameId)
         => _api.GetListAsync<GamePersonalQuestListDto>($"/api/personal-quests/by-game/{gameId}");
 
-    public Task<GamePersonalQuestDto?> CreateGameLinkAsync(int gameId, int pqId, int xpCost = 0, int? perKingdomLimit = null)
+    public Task<GamePersonalQuestDto?> CreateGameLinkAsync(int gameId, int pqId, int? xpCost = null, int? perKingdomLimit = null)
         => _api.PostAsync<CreateGamePersonalQuestDto, GamePersonalQuestDto>(
             "/api/personal-quests/game-link",
             new CreateGamePersonalQuestDto(gameId, pqId, xpCost, perKingdomLimit));
 
-    public Task UpdateGameLinkAsync(int gameId, int pqId, int xpCost, int? perKingdomLimit)
+    public Task UpdateGameLinkAsync(int gameId, int pqId, int? xpCost, int? perKingdomLimit)
         => _api.PutAsync(
             $"/api/personal-quests/game-link/{gameId}/{pqId}",
             new UpdateGamePersonalQuestDto(xpCost, perKingdomLimit));

--- a/src/OvcinaHra.Shared/Domain/Entities/GamePersonalQuest.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GamePersonalQuest.cs
@@ -4,7 +4,7 @@ public class GamePersonalQuest
 {
     public int GameId { get; set; }
     public int PersonalQuestId { get; set; }
-    public int XpCost { get; set; }
+    public int? XpCost { get; set; }
     public int? PerKingdomLimit { get; set; }
 
     public Game Game { get; set; } = null!;

--- a/src/OvcinaHra.Shared/Domain/Entities/PersonalQuest.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/PersonalQuest.cs
@@ -19,6 +19,7 @@ public class PersonalQuest
     public string? RewardNote { get; set; }
     public string? Notes { get; set; }
     public string? ImagePath { get; set; }
+    public int XpCost { get; set; }
 
     public ICollection<PersonalQuestSkillReward> SkillRewards { get; set; } = [];
     public ICollection<PersonalQuestItemReward> ItemRewards { get; set; } = [];

--- a/src/OvcinaHra.Shared/Domain/Entities/PersonalQuest.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/PersonalQuest.cs
@@ -23,6 +23,7 @@ public class PersonalQuest
 
     public ICollection<PersonalQuestSkillReward> SkillRewards { get; set; } = [];
     public ICollection<PersonalQuestItemReward> ItemRewards { get; set; } = [];
+    public ICollection<PersonalQuestSpellReward> SpellRewards { get; set; } = [];
     public ICollection<GamePersonalQuest> GameLinks { get; set; } = [];
     public ICollection<CharacterPersonalQuest> CharacterAssignments { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/PersonalQuestSpellReward.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/PersonalQuestSpellReward.cs
@@ -1,0 +1,11 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class PersonalQuestSpellReward
+{
+    public int PersonalQuestId { get; set; }
+    public int SpellId { get; set; }
+    public int Quantity { get; set; } = 1;
+
+    public PersonalQuest PersonalQuest { get; set; } = null!;
+    public Spell Spell { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
@@ -20,7 +20,8 @@ public record PersonalQuestListDto(
     string? ImagePath,
     IReadOnlyList<int> SkillRewardIds,
     IReadOnlyList<PersonalQuestItemRewardSummary> ItemRewards,
-    string? RewardSummary = null)
+    string? RewardSummary = null,
+    int XpCost = 0)
 {
     [JsonIgnore]
     public string DifficultyDisplay => Difficulty.GetDisplayName();
@@ -62,7 +63,8 @@ public record PersonalQuestDetailDto(
     string? Notes,
     string? ImagePath,
     List<SkillRewardDto> SkillRewards,
-    List<ItemRewardDto> ItemRewards);
+    List<ItemRewardDto> ItemRewards,
+    int XpCost = 0);
 
 public record SkillRewardDto(int SkillId, string SkillName);
 public record ItemRewardDto(int ItemId, string ItemName, int Quantity);
@@ -78,7 +80,8 @@ public record CreatePersonalQuestDto(
     string? QuestCardText = null,
     string? RewardCardText = null,
     string? RewardNote = null,
-    string? Notes = null);
+    string? Notes = null,
+    int XpCost = 0);
 
 public record UpdatePersonalQuestDto(
     string Name,
@@ -91,7 +94,8 @@ public record UpdatePersonalQuestDto(
     string? QuestCardText,
     string? RewardCardText,
     string? RewardNote,
-    string? Notes);
+    string? Notes,
+    int XpCost = 0);
 
 public record GamePersonalQuestListDto(
     int Id,            // PersonalQuest.Id, matches the ListDto for popup reuse

--- a/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
@@ -112,7 +112,8 @@ public record GamePersonalQuestListDto(
     string? Notes,
     string? ImagePath,
     int GameId,
-    int XpCost,
+    int? XpCost,
+    int EffectiveXpCost,
     int? PerKingdomLimit,
     string? RewardSummary)
 {
@@ -142,13 +143,13 @@ public record GamePersonalQuestListDto(
 public record GamePersonalQuestDto(
     int GameId,
     int PersonalQuestId,
-    int XpCost,
+    int? XpCost,
     int? PerKingdomLimit);
 
 public record CreateGamePersonalQuestDto(int GameId, int PersonalQuestId,
-    int XpCost = 0, int? PerKingdomLimit = null);
+    int? XpCost = null, int? PerKingdomLimit = null);
 
-public record UpdateGamePersonalQuestDto(int XpCost, int? PerKingdomLimit);
+public record UpdateGamePersonalQuestDto(int? XpCost, int? PerKingdomLimit);
 
 public record AddSkillRewardDto(int SkillId);
 public record AddItemRewardDto(int ItemId, int Quantity = 1);

--- a/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
@@ -20,6 +20,7 @@ public record PersonalQuestListDto(
     string? ImagePath,
     IReadOnlyList<int> SkillRewardIds,
     IReadOnlyList<PersonalQuestItemRewardSummary> ItemRewards,
+    IReadOnlyList<PersonalQuestSpellRewardSummary> SpellRewards,
     string? RewardSummary = null,
     int XpCost = 0)
 {
@@ -118,7 +119,8 @@ public record GamePersonalQuestListDto(
     int? XpCost,
     int EffectiveXpCost,
     int? PerKingdomLimit,
-    string? RewardSummary)
+    string? RewardSummary,
+    IReadOnlyList<PersonalQuestSpellRewardSummary> SpellRewards)
 {
     [JsonIgnore]
     public string DifficultyDisplay => Difficulty.GetDisplayName();

--- a/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/PersonalQuestDtos.cs
@@ -48,6 +48,8 @@ public record PersonalQuestListDto(
 
 public record PersonalQuestItemRewardSummary(int ItemId, string ItemName, int Quantity);
 
+public record PersonalQuestSpellRewardSummary(int SpellId, string SpellName, bool IsScroll, int Quantity);
+
 public record PersonalQuestDetailDto(
     int Id,
     string Name,
@@ -64,6 +66,7 @@ public record PersonalQuestDetailDto(
     string? ImagePath,
     List<SkillRewardDto> SkillRewards,
     List<ItemRewardDto> ItemRewards,
+    IReadOnlyList<PersonalQuestSpellRewardSummary> SpellRewards,
     int XpCost = 0);
 
 public record SkillRewardDto(int SkillId, string SkillName);
@@ -153,3 +156,4 @@ public record UpdateGamePersonalQuestDto(int? XpCost, int? PerKingdomLimit);
 
 public record AddSkillRewardDto(int SkillId);
 public record AddItemRewardDto(int ItemId, int Quantity = 1);
+public record AddSpellRewardDto(int SpellId, int Quantity = 1);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -658,4 +658,57 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
         Assert.NotNull(body);
         Assert.Equal(12, body.XpCost);
     }
+
+    [Fact]
+    public async Task GamePersonalQuest_XpCostNull_EffectiveFallsBackToCatalog()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Hra fallback", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(
+                Name: "Fallback úkol",
+                Difficulty: TreasureQuestDifficulty.Early,
+                XpCost: 42));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        var link = await Client.PostAsJsonAsync("/api/personal-quests/game-link",
+            new CreateGamePersonalQuestDto(GameId: game!.Id, PersonalQuestId: quest!.Id,
+                                           XpCost: null, PerKingdomLimit: null));
+        Assert.Equal(HttpStatusCode.Created, link.StatusCode);
+
+        var list = await Client.GetFromJsonAsync<List<GamePersonalQuestListDto>>(
+            $"/api/personal-quests/by-game/{game.Id}");
+        Assert.NotNull(list);
+        var row = Assert.Single(list);
+
+        Assert.Null(row.XpCost);
+        Assert.Equal(42, row.EffectiveXpCost);
+    }
+
+    [Fact]
+    public async Task GamePersonalQuest_XpCostSet_EffectiveEqualsOverride()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Hra override", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var questResponse = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(
+                Name: "Override úkol",
+                Difficulty: TreasureQuestDifficulty.Early,
+                XpCost: 42));
+        var quest = await questResponse.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+
+        await Client.PostAsJsonAsync("/api/personal-quests/game-link",
+            new CreateGamePersonalQuestDto(game!.Id, quest!.Id, XpCost: 7, PerKingdomLimit: null));
+
+        var list = await Client.GetFromJsonAsync<List<GamePersonalQuestListDto>>(
+            $"/api/personal-quests/by-game/{game.Id}");
+        var row = Assert.Single(list!);
+
+        Assert.Equal(7, row.XpCost);
+        Assert.Equal(7, row.EffectiveXpCost);
+    }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -792,18 +792,55 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
         Assert.Empty(detail!.SpellRewards);
     }
 
+    [Fact]
+    public async Task GetByGame_QuestWithSpellReward_IncludesSpellInRewardSummary()
+    {
+        var game = await CreateGameAsync();
+        var quest = await CreatePersonalQuestAsync(xpCost: 5);
+        var scroll = await CreateSpellAsync(name: "Svitek léčení (test-summary)",
+                                            isScroll: true, isLearnable: false);
+        await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest.Id}/spell-rewards",
+            new AddSpellRewardDto(scroll.Id, Quantity: 2));
+        await Client.PostAsJsonAsync("/api/personal-quests/game-link",
+            new CreateGamePersonalQuestDto(game.Id, quest.Id, XpCost: null, PerKingdomLimit: null));
+
+        var list = await Client.GetFromJsonAsync<List<GamePersonalQuestListDto>>(
+            $"/api/personal-quests/by-game/{game.Id}");
+        var row = Assert.Single(list!);
+        Assert.NotNull(row.RewardSummary);
+        Assert.Contains("Svitek léčení (test-summary)", row.RewardSummary);
+        Assert.Contains("×2", row.RewardSummary);
+        // Confirm SpellRewards arrays are populated on the list DTO too
+        Assert.Single(row.SpellRewards);
+        Assert.Equal(scroll.Id, row.SpellRewards[0].SpellId);
+        Assert.Equal(2, row.SpellRewards[0].Quantity);
+        Assert.True(row.SpellRewards[0].IsScroll);
+    }
+
     // ---------- helpers ----------
 
     private async Task<PersonalQuestDetailDto> CreatePersonalQuestAsync(
-        string name = "Test quest")
+        string name = "Test quest",
+        int xpCost = 0)
     {
         var resp = await Client.PostAsJsonAsync("/api/personal-quests",
             new CreatePersonalQuestDto(
                 Name: name,
-                Difficulty: TreasureQuestDifficulty.Early));
+                Difficulty: TreasureQuestDifficulty.Early,
+                XpCost: xpCost));
         resp.EnsureSuccessStatusCode();
         var quest = await resp.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
         return quest!;
+    }
+
+    private async Task<GameDetailDto> CreateGameAsync(string name = "Test Hra")
+    {
+        var resp = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto(name, 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        resp.EnsureSuccessStatusCode();
+        var game = await resp.Content.ReadFromJsonAsync<GameDetailDto>();
+        return game!;
     }
 
     private async Task<Spell> CreateSpellAsync(

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -639,4 +639,23 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
             $"/api/personal-quests/{quest.Id}");
         Assert.Empty(reloaded!.ItemRewards);
     }
+
+    [Fact]
+    public async Task CreateQuest_WithXpCost_Persisted()
+    {
+        var create = new CreatePersonalQuestDto(
+            Name: "Test XP Quest",
+            Difficulty: TreasureQuestDifficulty.Early,
+            Description: null,
+            AllowWarrior: true, AllowArcher: false, AllowMage: false, AllowThief: false,
+            QuestCardText: null, RewardCardText: null, RewardNote: null, Notes: null,
+            XpCost: 12);
+
+        var resp = await Client.PostAsJsonAsync("/api/personal-quests", create);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+        var body = await resp.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+        Assert.NotNull(body);
+        Assert.Equal(12, body.XpCost);
+    }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -818,6 +818,57 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
         Assert.True(row.SpellRewards[0].IsScroll);
     }
 
+    [Fact]
+    public async Task CreateQuest_NegativeXpCost_Returns400()
+    {
+        var dto = new CreatePersonalQuestDto(
+            Name: "Bad XP quest",
+            Difficulty: TreasureQuestDifficulty.Early,
+            Description: null,
+            AllowWarrior: true, AllowArcher: false, AllowMage: false, AllowThief: false,
+            QuestCardText: null, RewardCardText: null, RewardNote: null, Notes: null,
+            XpCost: -5);
+
+        var resp = await Client.PostAsJsonAsync("/api/personal-quests", dto);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateQuest_NegativeXpCost_Returns400()
+    {
+        var quest = await CreatePersonalQuestAsync(xpCost: 5);
+        var upd = new UpdatePersonalQuestDto(
+            Name: quest.Name,
+            Difficulty: quest.Difficulty,
+            Description: null,
+            AllowWarrior: false, AllowArcher: false, AllowMage: false, AllowThief: false,
+            QuestCardText: null, RewardCardText: null, RewardNote: null, Notes: null,
+            XpCost: -1);
+
+        var resp = await Client.PutAsJsonAsync($"/api/personal-quests/{quest.Id}", upd);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task SpellReward_Duplicate_Returns409()
+    {
+        var quest = await CreatePersonalQuestAsync();
+        var spell = await CreateSpellAsync(name: "Dvojitý svitek (test)",
+                                            isScroll: true, isLearnable: false);
+
+        var first = await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest.Id}/spell-rewards",
+            new AddSpellRewardDto(spell.Id));
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+
+        var second = await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest.Id}/spell-rewards",
+            new AddSpellRewardDto(spell.Id));
+        Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
+    }
+
     // ---------- helpers ----------
 
     private async Task<PersonalQuestDetailDto> CreatePersonalQuestAsync(

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -711,4 +711,119 @@ public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationT
         Assert.Equal(7, row.XpCost);
         Assert.Equal(7, row.EffectiveXpCost);
     }
+
+    // ======================================================================
+    // Batch D — Spell reward endpoints (Tasks 4–7)
+    // ======================================================================
+
+    [Fact]
+    public async Task SpellReward_NonLearnable_Returns201()
+    {
+        var quest = await CreatePersonalQuestAsync();
+        var spell = await CreateSpellAsync(name: "Svitek ohně (test)",
+                                           isScroll: true, isLearnable: false);
+
+        var resp = await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest.Id}/spell-rewards",
+            new AddSpellRewardDto(spell.Id, Quantity: 1));
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+        var detail = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+            $"/api/personal-quests/{quest.Id}");
+        Assert.NotNull(detail);
+        Assert.Single(detail.SpellRewards);
+        Assert.Equal(spell.Id, detail.SpellRewards[0].SpellId);
+        Assert.Equal(1, detail.SpellRewards[0].Quantity);
+    }
+
+    [Fact]
+    public async Task SpellReward_LearnableSpell_Returns400()
+    {
+        var quest = await CreatePersonalQuestAsync();
+        var spell = await CreateSpellAsync(name: "Učenlivé kouzlo (test)",
+                                           isScroll: false, isLearnable: true);
+
+        var resp = await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest.Id}/spell-rewards",
+            new AddSpellRewardDto(spell.Id));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var detail = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+            $"/api/personal-quests/{quest.Id}");
+        Assert.Empty(detail!.SpellRewards);
+    }
+
+    [Fact]
+    public async Task SpellReward_Scroll_QuantityGreaterThanOne_Persisted()
+    {
+        var quest = await CreatePersonalQuestAsync();
+        var scroll = await CreateSpellAsync(name: "Svitek léčení (test)",
+                                            isScroll: true, isLearnable: false);
+
+        var resp = await Client.PostAsJsonAsync(
+            $"/api/personal-quests/{quest.Id}/spell-rewards",
+            new AddSpellRewardDto(scroll.Id, Quantity: 3));
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+        var detail = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+            $"/api/personal-quests/{quest.Id}");
+        var reward = Assert.Single(detail!.SpellRewards);
+        Assert.Equal(3, reward.Quantity);
+        Assert.True(reward.IsScroll);
+    }
+
+    [Fact]
+    public async Task Delete_SpellReward_Returns204()
+    {
+        var quest = await CreatePersonalQuestAsync();
+        var spell = await CreateSpellAsync(name: "Svitek bleskového úderu (test)",
+                                            isScroll: true, isLearnable: false);
+
+        await Client.PostAsJsonAsync($"/api/personal-quests/{quest.Id}/spell-rewards",
+            new AddSpellRewardDto(spell.Id));
+
+        var del = await Client.DeleteAsync(
+            $"/api/personal-quests/{quest.Id}/spell-rewards/{spell.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+
+        var detail = await Client.GetFromJsonAsync<PersonalQuestDetailDto>(
+            $"/api/personal-quests/{quest.Id}");
+        Assert.Empty(detail!.SpellRewards);
+    }
+
+    // ---------- helpers ----------
+
+    private async Task<PersonalQuestDetailDto> CreatePersonalQuestAsync(
+        string name = "Test quest")
+    {
+        var resp = await Client.PostAsJsonAsync("/api/personal-quests",
+            new CreatePersonalQuestDto(
+                Name: name,
+                Difficulty: TreasureQuestDifficulty.Early));
+        resp.EnsureSuccessStatusCode();
+        var quest = await resp.Content.ReadFromJsonAsync<PersonalQuestDetailDto>();
+        return quest!;
+    }
+
+    private async Task<Spell> CreateSpellAsync(
+        string name,
+        bool isScroll,
+        bool isLearnable)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var spell = new Spell
+        {
+            Name = name,
+            Effect = "Testovací efekt",
+            IsScroll = isScroll,
+            IsLearnable = isLearnable,
+            Level = isScroll ? 0 : 1,
+            ManaCost = isScroll ? 0 : 1
+        };
+        db.Spells.Add(spell);
+        await db.SaveChangesAsync();
+        return spell;
+    }
 }


### PR DESCRIPTION
## Summary
Phase 1 of the PersonalQuest domain evolution — design doc `docs/plans/2026-04-22-personal-quest-spell-rewards-and-catalog-xp-design.md`.

**1. Spell is now a third reward type** alongside Skill and Item.
- `PersonalQuestSpellReward` join entity with `Quantity` (default 1)
- Only non-learnable spells allowed — API returns 400 on learnable, 409 on duplicate
- Scrolls (`IsScroll=true`) support Quantity>1; non-scrolls default to 1 (UI hides the spinner)
- UI: new Kouzla section in the quest popup with filtered combobox + conditional quantity spinner + badges with remove buttons

**2. XP is now a catalog-default with optional per-game override**
- `PersonalQuest.XpCost` — always visible in the main quest form, `CHECK >= 0`, API guards negatives on Create/Update
- `GamePersonalQuest.XpCost` becomes `int?` — null means "use catalog default"
- `EffectiveXpCost` computed server-side (`override ?? catalog`); surfaced in the by-game grid
- UI: per-game spinner shows `výchozí: {catalog}` when null + hint line below

**3. Version bump 0.9.7 → 0.10.0** (new reward type = minor bump)

Wizard from the design doc is Phase 2 — not in this PR.

## Migrations (additive, auto-applied at startup)
- `AddPersonalQuestCatalogXpCost` — adds `XpCost` column to PersonalQuests
- `NullableGamePersonalQuestXpCost` — relaxes GamePersonalQuest.XpCost to nullable + null-aware check
- `AddPersonalQuestSpellRewardsTable` — creates the join table with composite PK, FK cascade/restrict, quantity check
- `AddPersonalQuestXpCostNonNegativeCheck` — CHECK constraint for catalog XpCost

## Tests
260 passing, 0 failing. 8 new integration tests:
- `CreateQuest_WithXpCost_Persisted`
- `CreateQuest_NegativeXpCost_Returns400`
- `UpdateQuest_NegativeXpCost_Returns400`
- `GamePersonalQuest_XpCostNull_EffectiveFallsBackToCatalog`
- `GamePersonalQuest_XpCostSet_EffectiveEqualsOverride`
- `SpellReward_NonLearnable_Returns201`
- `SpellReward_LearnableSpell_Returns400`
- `SpellReward_Scroll_QuantityGreaterThanOne_Persisted`
- `SpellReward_Duplicate_Returns409`
- `Delete_SpellReward_Returns204`
- `GetByGame_QuestWithSpellReward_IncludesSpellInRewardSummary`

## Test plan
- [ ] Catalog: create/edit a PersonalQuest, set XP cena, save — value persists
- [ ] Try to save with a negative XP — UI spinner blocks; direct API call returns 400
- [ ] Add a skill reward, an item reward, a spell reward (non-learnable) — all three appear as badges
- [ ] Try to add a learnable spell as reward — combobox filters it out; direct API call returns 400
- [ ] Add a scroll as reward with Quantity 3 — badge shows "Name ×3"
- [ ] Add a non-scroll non-learnable spell — no quantity spinner; badge shows name only
- [ ] Game view: grid shows "XP cena" column with effective value (override or catalog)
- [ ] Game view: open quest detail — per-game XP spinner shows `výchozí: {catalog}` when no override is set; setting a value overrides; clearing it reverts to catalog
- [ ] Remove a spell reward — disappears from badges and DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)