### PR TITLE
feat(personal-quest-wizard): guided create flow with inline reward creators [v0.10.1]

### DIFF
--- a/docs/plans/2026-04-23-personal-quest-wizard-design.md
+++ b/docs/plans/2026-04-23-personal-quest-wizard-design.md
@@ -1,0 +1,129 @@
+# Quest Maker Wizard — design (Phase 2)
+
+**Date:** 2026-04-23
+**Status:** Approved — ready for implementation planning
+**Depends on:** Phase 1 shipped in PR #57 (v0.10.0) — spell rewards + catalog XP.
+**Branch:** `feat/personal-quest-wizard`
+
+## Problem
+
+Content managers creating a PersonalQuest currently have to leave the game-quests view whenever a reward's catalog entry is missing: jump to `/items`, create it, maybe also add it to the game, jump back, find their half-filled form, try to remember where they were. Flow breaks every time.
+
+Phase 1 added the missing reward types and XP model but kept the same popup. Creating a quest still means:
+- Open popup → fill fields → save
+- "Need a new item reward" → close popup → navigate to `/items` → create → navigate to game → link item to game → back to personal quests → reopen popup → try to remember form state → add reward
+
+Phase 2 collapses that into one sitting.
+
+## Scope of this design
+
+A **Quest Maker Wizard** — a guided create-quest flow launched from the game-quests view that handles everything in a single popup, including inline creation of missing rewards. Phase 2 does **not** replace the existing catalog popup; both coexist.
+
+## Decisions made with user
+
+| Q | Answer |
+|---|---|
+| Wizard mode | Create-only. Existing popup keeps handling edits + quick catalog creates. |
+| Shell | Big `DxPopup` (Width=900px, `AllowResize=true`, scrollable body). No new route. |
+| Form shape | **Smart form** — all fields visible in sections. No stepper, no draft save. |
+| Inline creators | All 3 reward types (Skill, Item, Spell). Each is a small nested `DxPopup`. Reuses existing `Create*Dto` + existing POST endpoints. |
+| Inline-creator side-effect | On save: catalog entity created AND auto-linked to the current game (`GameItem` / `GameSkill` / `GameSpell`) with defaults — user doesn't have to add it to the game separately. |
+| Launch button | `PersonalQuestList.razor` game-view toolbar, label **"Vytvořit quest pro hru"**, icon `bi-magic`, next to the existing "Nový" button. Only rendered when a game is selected. |
+| Save flow | Sequential API calls with one progress indicator. On error: stop, surface message, leave partial state. User can retry or clean up via the existing popup. |
+| Post-save | Close wizard, return to game-quests list, new row visible. |
+| Field coverage | Full superset of the existing popup: Name, Difficulty, XpCost, 4 class flags, Description, QuestCardText, RewardCardText, RewardNote, Notes + all 3 reward types + per-game config (XpCost override, PerKingdomLimit). |
+| Draft save | Not in scope. Closing the wizard mid-flow discards the in-memory state. |
+| Version bump | 0.10.0 → 0.10.1 (UI-only additive, no schema change). Final value confirmed at implementation time. |
+
+## Architecture
+
+### Components to create
+
+1. **`QuestWizard.razor`** — the main component. Hosts the outer `DxPopup`, the smart form split into 4 sections, and owns the wizard view-model. Renders the 3 inline-creator sub-popups as children and handles the sequential save flow.
+2. **`SkillInlineCreator.razor`** — small nested `DxPopup`; form mirrors `/skills` create popup; POST to `/api/skills` + `/api/skills/game-skill`. Emits `EventCallback<SkillDto>` on save.
+3. **`ItemInlineCreator.razor`** — analogous for items. POST to `/api/items` + `/api/items/game-item`.
+4. **`SpellInlineCreator.razor`** — analogous for spells. POST to `/api/spells` + `/api/spells/game-spell`. Hides `IsLearnable` from the reward-creator preset (force-sets `false`) because non-learnable is required for quest rewards.
+
+All four live under `src/OvcinaHra.Client/Pages/PersonalQuests/` (co-located with `PersonalQuestList.razor`).
+
+### Form sections (single scrollable body)
+
+Order, top to bottom:
+
+1. **Základ** — Name (required), Difficulty, XpCost spinner.
+2. **Pravidla** — 4 class flags (Warrior/Archer/Mage/Thief checkboxes), Description text.
+3. **Texty** — QuestCardText (multi-line), RewardCardText (multi-line), RewardNote (short), Notes (multi-line).
+4. **Odměny** — three sub-sections: Dovednosti / Předměty / Kouzla. Each has a combobox of existing catalog entries (filtered per reward type; spells filtered to `IsLearnable = false`) + a "Vytvořit novou…" button that opens the appropriate inline creator. Added rewards appear as badges with an `×` remove button and (for items/scrolls) a quantity spinner.
+5. **Per-hra** — XpCost override (nullable, `NullText="výchozí: {catalog}"`), PerKingdomLimit spinner.
+
+### View-model shape
+
+One `WizardModel` class holding all the fields above plus three in-memory reward lists (not persisted until save):
+```csharp
+public sealed class WizardModel
+{
+    public string Name { get; set; } = "";
+    public TreasureQuestDifficulty Difficulty { get; set; } = TreasureQuestDifficulty.Early;
+    public int XpCost { get; set; }
+    // class flags, texts, per-game fields...
+    public List<SkillReward> Skills { get; } = new();
+    public List<ItemReward> Items { get; } = new();
+    public List<SpellReward> Spells { get; } = new();
+    public int? GameXpOverride { get; set; }
+    public int? PerKingdomLimit { get; set; }
+}
+```
+
+The reward sub-types store both the referenced entity ID and a display name for badge rendering before the quest even exists.
+
+### Save flow
+
+Triggered by the single "Uložit a přidat do hry" button. Progress indicator (step label + small spinner) above the button. Sequence:
+
+1. `POST /api/personal-quests` with the catalog fields + XpCost → returns `{ id }`.
+2. For each reward in `model.Skills`/`Items`/`Spells`:
+   - `POST /api/personal-quests/{questId}/{type}-rewards` with the reward DTO.
+3. `POST /api/personal-quests/game-link` with `{ gameId, questId, XpCost: model.GameXpOverride, PerKingdomLimit: model.PerKingdomLimit }`.
+4. Close wizard, parent page reloads quest list, new row visible.
+
+Inline creators handle their own linking at the moment the user saves them, NOT at wizard save time — so by the time the wizard saves the quest, every reward entity already exists in the catalog AND is linked to the game. Wizard save only has to wire rewards to the quest and create the game-link.
+
+### Error handling
+
+Each save step has a `try/catch`. On exception:
+- Progress indicator shows the failing step.
+- Error message (Czech, from the server response body when available) shown in a red alert above the save button.
+- Wizard stays open. User can retry (state intact) or close (partial state persists — they can finish via the existing popup).
+
+No atomic "wizard save" endpoint. Each step is idempotent on retry except the initial POST; duplicates are caught by existing uniqueness constraints (e.g., `409 Conflict` on duplicate spell-reward).
+
+### Launch gating
+
+The "Vytvořit quest pro hru" button is rendered only when `GameContext.SelectedGameId is not null` AND the user is on the game view (not catalog). Matches the existing per-game card's visibility logic.
+
+## What's NOT in Phase 2
+
+- **Editing existing quests via wizard** — stays in the popup.
+- **Draft save / resume** — close = discard.
+- **Batch create** — save closes the wizard.
+- **New atomic server endpoint** — the client orchestrates, server endpoints stay as-is.
+- **Preview / "Review" step** — smart form is already visible-all-at-once.
+- **Templates / duplicate-from-existing** — separate feature.
+
+## Risks & mitigations
+
+- **Partial save on failure:** Not full ACID, but acceptable. Content-manager-only app. If quest is created but reward fails, the user can finish via the existing popup OR cleanup via the existing Delete row. The alternative (new atomic endpoint) would add server complexity disproportionate to the rare failure path.
+- **Inline creator desync with main wizard form:** Inline creator closes and returns the new entity; wizard auto-selects it as a reward. If the user cancels inline creator, no change. Simple callback-based contract.
+- **Scope creep on validation:** Keep client-side validation minimal — required fields (Name) and numeric bounds (XpCost >= 0). Server is authoritative. Rely on the server's 400s (added in Phase 1's fixup) to catch negative values.
+
+## Version & deployment
+
+- Client version bump **0.10.0 → 0.10.1** in the implementation PR.
+- Pure additive UI. No migrations, no server endpoints. Auto-deploys on merge.
+
+## File footprint estimate
+
+- 4 new razor components (~200–400 lines each, varies)
+- No new C# files in Shared or Api — reuses everything Phase 1 shipped
+- Minor edit to `PersonalQuestList.razor` for the launch button + wizard mounting
+- Maybe 1–2 integration tests exercising the full create-quest flow end-to-end (optional — current coverage is probably enough; defer decision to implementation plan)

--- a/docs/plans/2026-04-23-personal-quest-wizard-implementation.md
+++ b/docs/plans/2026-04-23-personal-quest-wizard-implementation.md
@@ -1,0 +1,340 @@
+# Quest Maker Wizard — Implementation Plan (Phase 2)
+
+> **For Claude:** Use superpowers:subagent-driven-development to execute.
+
+**Design:** `docs/plans/2026-04-23-personal-quest-wizard-design.md` (required reading)
+
+**Goal:** Ship a create-quest wizard launched from the game-quests view, with inline creators for the 3 reward types that also auto-link the new catalog entity to the current game.
+
+**Architecture:** Pure client-side. One big `DxPopup` with a smart form in `QuestWizard.razor`, three small nested `DxPopup` inline creators (Skill/Item/Spell), sequential client-side save flow calling existing Phase 1 endpoints. Zero new server code, zero migrations.
+
+**Tech stack:** Blazor WASM + DevExpress Blazor 25.2.5. `ApiClient` wrapper. `GameContextService` for active-game id.
+
+**Branch:** `feat/personal-quest-wizard` (design doc already committed).
+
+**Project conventions:**
+- Every commit subject ends `[v0.10.1]`.
+- UI strings Czech with diacritics. Identifiers English.
+- `dotnet build` must be green at every task boundary.
+- No new API endpoints. No migrations. No schema changes.
+- Reuse existing `CreateSkillDto` / `CreateItemDto` / `CreateSpellDto` / `CreateGameSkillDto` / `CreateGameItemDto` / `CreateGameSpellDto` — do not invent new DTOs.
+- `Api.PostAsync<TRequest, TResponse>(path, body)` + `Api.DeleteAsync(path)` patterns established in `PersonalQuestList.razor`.
+- Destructive UI actions need `DxPopup` confirmations; reward badges follow the existing "no-confirm" pattern (match Items).
+
+**Working directory:** `C:\Users\TomášPajonk\source\repos\timurlain\ovcinahra`.
+
+---
+
+## Task 1 — Inline creator trio (Skill, Item, Spell)
+
+All three follow an identical pattern. One implementer dispatch. One commit.
+
+**Files to create:**
+- `src/OvcinaHra.Client/Pages/PersonalQuests/SkillInlineCreator.razor`
+- `src/OvcinaHra.Client/Pages/PersonalQuests/ItemInlineCreator.razor`
+- `src/OvcinaHra.Client/Pages/PersonalQuests/SpellInlineCreator.razor`
+
+**Each component shape:**
+
+```razor
+@* SkillInlineCreator.razor — template *@
+@inject ApiClient Api
+@using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Domain.Enums
+
+<DxPopup @bind-Visible="@Visible" HeaderText="Nová dovednost" Width="640px">
+    <BodyContentTemplate Context="ctx">
+        <DxFormLayout>
+            @* fields — mirror the Skills.razor create popup — minimum required
+               for a reward-grade entity: Name, Category, optional Effect, optional
+               ClassRestriction (conditional on Category=Class) *@
+        </DxFormLayout>
+        @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" @onclick="Cancel" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">
+                @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit a přidat
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter] public int GameId { get; set; }
+    [Parameter] public EventCallback<SkillDto> Created { get; set; }
+
+    // local model fields + isSaving + error
+
+    private async Task SaveAsync()
+    {
+        error = null; isSaving = true;
+        try
+        {
+            var created = await Api.PostAsync<CreateSkillRequest, SkillDto>(
+                "/api/skills", new CreateSkillRequest(/* fields */));
+
+            // Auto-link to current game per design decision Q1/B
+            await Api.PostAsync<CreateGameSkillDto, object?>(
+                "/api/skills/game-skill",
+                new CreateGameSkillDto(GameId, created.Id /* + defaults if applicable */));
+
+            await Created.InvokeAsync(created);
+            await VisibleChanged.InvokeAsync(false);
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task Cancel() => await VisibleChanged.InvokeAsync(false);
+}
+```
+
+**Per-entity specifics:**
+
+- **Skill**: fields Name, Category (`DxComboBox` with `SkillCategory` values), ClassRestriction (conditional on `Category == Class`), Effect, RequirementNotes. Use `CreateSkillRequest` and endpoints already used by `Skills.razor`. Link via `/api/skills/game-skill` (match payload shape used in `SkillService` or existing code — inspect before implementing).
+- **Item**: fields Name, ItemType (combo), Description, Price (nullable), IsSold checkbox auto-toggles with Price, StockCount. Use `CreateItemDto`. Link via `/api/items/game-item` with `CreateGameItemDto(gameId, itemId)` defaults.
+- **Spell**: fields Name, Level, ManaCost, School (combo), IsScroll, IsReaction, MinMageLevel, Price (nullable), Effect, Description. **`IsLearnable` is not exposed — force `false` server-side** (set `IsLearnable = false` in the DTO before POST; since non-learnable is required for quest rewards per Phase 1). Link via `/api/spells/game-spell`.
+
+**Verification:** `dotnet build` clean.
+
+**Commit:**
+```bash
+git add src/OvcinaHra.Client/Pages/PersonalQuests/SkillInlineCreator.razor \
+        src/OvcinaHra.Client/Pages/PersonalQuests/ItemInlineCreator.razor \
+        src/OvcinaHra.Client/Pages/PersonalQuests/SpellInlineCreator.razor
+git commit -m "feat(quest-wizard): inline creators for skill/item/spell rewards [v0.10.1]"
+```
+
+**Before starting this task, read:**
+- `src/OvcinaHra.Client/Pages/Skills/Skills.razor` — see the current Create-skill popup to know exactly which fields matter
+- `src/OvcinaHra.Client/Pages/Items/ItemList.razor` — see Create-item popup
+- `src/OvcinaHra.Client/Pages/Spells/SpellList.razor` — see Create-spell popup
+- `src/OvcinaHra.Client/Services/SkillService.cs` / `src/OvcinaHra.Client/Services/PersonalQuestService.cs` — see if there are wrapper methods to reuse rather than raw `Api.PostAsync`
+
+---
+
+## Task 2 — `QuestWizard.razor` component
+
+The meat of the wizard. One implementer dispatch. One commit.
+
+**Files to create:**
+- `src/OvcinaHra.Client/Pages/PersonalQuests/QuestWizard.razor`
+
+**Public parameters:**
+```csharp
+[Parameter] public bool Visible { get; set; }
+[Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+[Parameter] public int GameId { get; set; }
+[Parameter] public int CatalogXpFallback { get; set; }  // display-only for the per-game hint
+[Parameter] public EventCallback Saved { get; set; }   // parent reloads list
+```
+
+**Shell:**
+```razor
+<DxPopup @bind-Visible="@Visible" HeaderText="Vytvořit nový personal quest"
+         Width="900px" AllowResize="true" HeaderCssClass="oh-wizard-header">
+    <BodyContentTemplate Context="ctx">
+        <!-- 4 form sections, see design doc "Form sections" -->
+        <!-- Rewards section renders the 3 reward-type sub-blocks, each with
+             Existing-entry combobox + "Vytvořit novou…" button that toggles
+             an inline creator -->
+        <!-- Save flow UI: progress indicator + error alert + "Uložit a přidat
+             do hry" button + "Zrušit" -->
+    </BodyContentTemplate>
+</DxPopup>
+
+<SkillInlineCreator @bind-Visible="@skillCreatorVisible" GameId="@GameId"
+                    Created="@OnSkillCreated" />
+<ItemInlineCreator  @bind-Visible="@itemCreatorVisible"  GameId="@GameId"
+                    Created="@OnItemCreated" />
+<SpellInlineCreator @bind-Visible="@spellCreatorVisible" GameId="@GameId"
+                    Created="@OnSpellCreated" />
+```
+
+**View-model sketch:**
+```csharp
+private WizardModel model = new();
+
+private bool skillCreatorVisible, itemCreatorVisible, spellCreatorVisible;
+private List<SkillDto> allSkills = [];
+private List<ItemListDto> allItems = [];
+private List<SpellListDto> allSpells = [];  // filtered to IsLearnable=false
+private int? pickedSkillId, pickedItemId, pickedSpellId;
+private int pickedItemQty = 1, pickedSpellQty = 1;
+
+private string progressLabel = "";
+private bool isSaving;
+private string? error;
+
+protected override async Task OnParametersSetAsync()
+{
+    if (Visible && allSkills.Count == 0)
+    {
+        allSkills = await Api.GetListAsync<SkillDto>("/api/skills");
+        allItems  = await Api.GetListAsync<ItemListDto>("/api/items");
+        var spells = await Api.GetListAsync<SpellListDto>("/api/spells");
+        allSpells = spells.Where(s => !s.IsLearnable).ToList();
+    }
+}
+
+private sealed class WizardModel
+{
+    public string Name { get; set; } = "";
+    public TreasureQuestDifficulty Difficulty { get; set; } = TreasureQuestDifficulty.Early;
+    public int XpCost { get; set; }
+    public bool AllowWarrior { get; set; }
+    public bool AllowArcher { get; set; }
+    public bool AllowMage { get; set; }
+    public bool AllowThief { get; set; }
+    public string? Description { get; set; }
+    public string? QuestCardText { get; set; }
+    public string? RewardCardText { get; set; }
+    public string? RewardNote { get; set; }
+    public string? Notes { get; set; }
+    public List<int> SkillRewardIds { get; } = new();
+    public List<(int ItemId, int Qty)> ItemRewards { get; } = new();
+    public List<(int SpellId, int Qty)> SpellRewards { get; } = new();
+    public int? GameXpOverride { get; set; }
+    public int? PerKingdomLimit { get; set; }
+}
+```
+
+**Save sequence:**
+```csharp
+private async Task SaveAsync()
+{
+    if (string.IsNullOrWhiteSpace(model.Name)) { error = "Název je povinný."; return; }
+    if (model.XpCost < 0) { error = "XP cena nesmí být záporná."; return; }
+
+    error = null; isSaving = true;
+    try
+    {
+        progressLabel = "Vytvářím quest…";
+        var detail = await Api.PostAsync<CreatePersonalQuestDto, PersonalQuestDetailDto>(
+            "/api/personal-quests",
+            new CreatePersonalQuestDto(
+                model.Name, model.Difficulty, model.Description,
+                model.AllowWarrior, model.AllowArcher, model.AllowMage, model.AllowThief,
+                model.QuestCardText, model.RewardCardText, model.RewardNote, model.Notes,
+                model.XpCost));
+
+        progressLabel = "Přidávám odměny…";
+        foreach (var id in model.SkillRewardIds)
+            await Api.PostAsync<AddSkillRewardDto, object?>(
+                $"/api/personal-quests/{detail.Id}/skill-rewards", new AddSkillRewardDto(id));
+        foreach (var (itemId, qty) in model.ItemRewards)
+            await Api.PostAsync<AddItemRewardDto, object?>(
+                $"/api/personal-quests/{detail.Id}/item-rewards", new AddItemRewardDto(itemId, qty));
+        foreach (var (spellId, qty) in model.SpellRewards)
+            await Api.PostAsync<AddSpellRewardDto, object?>(
+                $"/api/personal-quests/{detail.Id}/spell-rewards", new AddSpellRewardDto(spellId, qty));
+
+        progressLabel = "Přidávám do hry…";
+        await Api.PostAsync<CreateGamePersonalQuestDto, object?>(
+            "/api/personal-quests/game-link",
+            new CreateGamePersonalQuestDto(GameId, detail.Id, model.GameXpOverride, model.PerKingdomLimit));
+
+        progressLabel = "Hotovo";
+        await Saved.InvokeAsync();
+        await VisibleChanged.InvokeAsync(false);
+        ResetModel();
+    }
+    catch (Exception ex) { error = $"{progressLabel} — {ex.Message}"; }
+    finally { isSaving = false; }
+}
+
+private void OnSkillCreated(SkillDto s)
+{
+    allSkills.Add(s);
+    if (!model.SkillRewardIds.Contains(s.Id)) model.SkillRewardIds.Add(s.Id);
+    skillCreatorVisible = false;
+}
+// similar for Item, Spell
+```
+
+**Reward-section UI (one per type):**
+- combobox of existing (filtered to non-learnable for spells, exclude already-added)
+- "Přidat" button that pushes to `model.SkillRewardIds` / `ItemRewards` / `SpellRewards`
+- "Vytvořit novou" button that flips the inline-creator `visible` flag
+- badges below for already-added rewards with `×` remove button
+- for Item + scroll-Spell: quantity spinner next to combobox
+
+Match the styling of the rewards section in `PersonalQuestList.razor` (Phase 1) so the two popups feel consistent.
+
+**Verification:** `dotnet build` clean. No integration tests — UI only.
+
+**Commit:**
+```bash
+git add src/OvcinaHra.Client/Pages/PersonalQuests/QuestWizard.razor
+git commit -m "feat(quest-wizard): QuestWizard component with smart form + sequential save [v0.10.1]"
+```
+
+---
+
+## Task 3 — Launch button + mount + version bump
+
+One implementer dispatch. One commit.
+
+**Files:**
+- Modify: `src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor` — in the game-view toolbar next to the existing "+ Nový" button, add:
+
+  ```razor
+  @if (!Catalog && GameContext.SelectedGameId is int wizardGameId)
+  {
+      <button class="btn btn-outline-primary ms-2" @onclick="() => wizardVisible = true">
+          <i class="bi bi-magic me-1"></i>Vytvořit quest pro hru
+      </button>
+  }
+  ```
+
+  Then mount the wizard component anywhere in the page (outside the existing popup):
+
+  ```razor
+  @if (GameContext.SelectedGameId is int wizardMountGameId)
+  {
+      <QuestWizard @bind-Visible="@wizardVisible"
+                   GameId="@wizardMountGameId"
+                   CatalogXpFallback="0"
+                   Saved="@LoadAsync" />
+  }
+  ```
+
+  Add to `@code`:
+  ```csharp
+  private bool wizardVisible;
+  ```
+
+  `LoadAsync` already exists (it's the method that refreshes the grid). Hook it to `Saved`.
+
+- Modify: `src/OvcinaHra.Client/OvcinaHra.Client.csproj:10` — bump `0.10.0` to `0.10.1`.
+
+**Verification:** Full `dotnet build` green. `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --nologo` still 260 passing (no test changes here, but confirm no regression).
+
+**Commit:**
+```bash
+git add src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor \
+        src/OvcinaHra.Client/OvcinaHra.Client.csproj
+git commit -m "feat(quest-wizard): launch button + version bump to 0.10.1 [v0.10.1]"
+```
+
+---
+
+## Post-tasks
+
+1. Push: `git push -u origin feat/personal-quest-wizard`
+2. Open PR via `gh pr create` — title `feat(personal-quest-wizard): guided create flow with inline reward creators [v0.10.1]`
+3. Wait for CI (`build`, `build-and-test` required by branch protection).
+4. If Copilot leaves review comments: fix each one with a fixup commit, push, re-wait for CI.
+5. Squash-merge, delete branch.
+6. Watch the auto-deploy: main → CD pipeline → Azure Container App. Verify `/api/version` returns `0.10.1` once deploy completes.
+
+## Out of scope (explicit)
+
+- Editing existing quests via wizard — stays in the popup.
+- Draft save / resume.
+- Batch create.
+- New server endpoints.
+- Integration tests for the UI (covered by Phase 1's API tests + manual smoke after deploy).

--- a/docs/plans/2026-04-23-personal-quest-wizard-implementation.md
+++ b/docs/plans/2026-04-23-personal-quest-wizard-implementation.md
@@ -21,7 +21,7 @@
 - `Api.PostAsync<TRequest, TResponse>(path, body)` + `Api.DeleteAsync(path)` patterns established in `PersonalQuestList.razor`.
 - Destructive UI actions need `DxPopup` confirmations; reward badges follow the existing "no-confirm" pattern (match Items).
 
-**Working directory:** `C:\Users\TomášPajonk\source\repos\timurlain\ovcinahra`.
+**Working directory:** Repository root (`.`).
 
 ---
 

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.10.0</Version>
+    <Version>0.10.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/ItemInlineCreator.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/ItemInlineCreator.razor
@@ -1,0 +1,159 @@
+@* ItemInlineCreator.razor — inline popup for creating a brand-new Item template
+   and auto-linking it into the currently selected game. Emits the created
+   ItemListDto via the `Created` callback so the parent wizard can auto-select
+   it as a quest reward. *@
+
+@inject ApiClient Api
+
+<DxPopup @bind-Visible="@Visible" HeaderText="Nový předmět" Width="640px">
+    <BodyContentTemplate Context="ctx">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                <DxTextBox @bind-Text="@name" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Typ" ColSpanMd="12">
+                <DxComboBox Data="@itemTypeValues" @bind-Value="@itemType"
+                            TextFieldName="Display" ValueFieldName="Value" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Popis / efekt" ColSpanMd="12">
+                <DxMemo @bind-Text="@effect" Rows="3" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Cena (groše)" ColSpanMd="12">
+                <DxSpinEdit Value="@price"
+                            ValueExpression="@(() => price)"
+                            ValueChanged="@((int? v) => { price = v; isSold = v.HasValue; })"
+                            MinValue="0"
+                            NullText="(žádná)"
+                            ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+
+        @if (error is not null)
+        {
+            <div class="alert alert-danger mt-2">@error</div>
+        }
+
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" @onclick="Cancel" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">
+                @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit a přidat
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter] public int GameId { get; set; }
+    [Parameter] public EventCallback<ItemListDto> Created { get; set; }
+
+    private string name = "";
+    private ItemType itemType = ItemType.Miscellaneous;
+    private string? effect;
+    private int? price;
+    private bool isSold;
+
+    private bool isSaving;
+    private string? error;
+
+    private static readonly List<EnumItem<ItemType>> itemTypeValues =
+        Enum.GetValues<ItemType>()
+            .Select(v => new EnumItem<ItemType>(v, v.GetDisplayName()))
+            .ToList();
+
+    private record EnumItem<T>(T Value, string Display);
+
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        var wasVisible = Visible;
+        await base.SetParametersAsync(parameters);
+        if (!wasVisible && Visible)
+        {
+            name = "";
+            itemType = ItemType.Miscellaneous;
+            effect = null;
+            price = null;
+            isSold = false;
+            error = null;
+            isSaving = false;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            error = "Název je povinný.";
+            return;
+        }
+
+        error = null;
+        isSaving = true;
+        try
+        {
+            // 1) Create the catalog item. CreateItemDto uses optional params for
+            //    everything after Name + ItemType, so we only set what we expose.
+            var created = await Api.PostAsync<CreateItemDto, ItemDetailDto>(
+                "/api/items",
+                new CreateItemDto(
+                    Name: name,
+                    ItemType: itemType,
+                    Effect: effect));
+
+            if (created is null)
+            {
+                error = "Server nevrátil vytvořený předmět.";
+                return;
+            }
+
+            // 2) Auto-link to the current game with minimal defaults — price only if
+            //    the user entered one (then IsSold auto-tracks). StockCount left null,
+            //    IsFindable defaults to false.
+            await Api.PostAsync<CreateGameItemDto, object?>(
+                "/api/items/game-item",
+                new CreateGameItemDto(
+                    GameId: GameId,
+                    ItemId: created.Id,
+                    Price: price,
+                    StockCount: null,
+                    IsSold: isSold,
+                    SaleCondition: null,
+                    IsFindable: false));
+
+            // Convert ItemDetailDto -> ItemListDto so the parent wizard sees the same
+            // shape it already uses for its existing-item picker.
+            var listDto = new ItemListDto(
+                Id: created.Id,
+                Name: created.Name,
+                ItemType: created.ItemType,
+                Effect: created.Effect,
+                PhysicalForm: created.PhysicalForm,
+                IsCraftable: created.IsCraftable,
+                ReqWarrior: created.ReqWarrior,
+                ReqArcher: created.ReqArcher,
+                ReqMage: created.ReqMage,
+                ReqThief: created.ReqThief,
+                IsUnique: created.IsUnique,
+                IsLimited: created.IsLimited,
+                ImagePath: created.ImagePath);
+
+            await Created.InvokeAsync(listDto);
+            await VisibleChanged.InvokeAsync(false);
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+
+    private async Task Cancel() => await VisibleChanged.InvokeAsync(false);
+}

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
@@ -17,6 +17,12 @@
                     @onclick='() => Nav.NavigateTo("/personal-quests?catalog=true")'>Katalog</button>
         </div>
         <button class="btn btn-primary" @onclick="() => OpenModal((PersonalQuestListDto?)null)">+ Nový osobní quest</button>
+        @if (!Catalog && GameContext.SelectedGameId is int wizardGameId)
+        {
+            <button class="btn btn-outline-primary ms-2" @onclick="() => wizardVisible = true">
+                <i class="bi bi-magic me-1"></i>Vytvořit quest pro hru
+            </button>
+        }
     </div>
 </div>
 
@@ -400,6 +406,13 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+@if (GameContext.SelectedGameId is int wizardMountGameId)
+{
+    <QuestWizard @bind-Visible="@wizardVisible"
+                 GameId="@wizardMountGameId"
+                 Saved="@LoadAsync" />
+}
+
 @code {
     [SupplyParameterFromQuery]
     public bool Catalog { get; set; }
@@ -408,6 +421,7 @@ else
     private List<GamePersonalQuestListDto> gameItems = [];
     private HashSet<int> assignedItemIds = [];
     private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
+    private bool wizardVisible;
 
     // Lookup lists for combo boxes
     private List<SkillDto> allSkills = [];

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/PersonalQuestList.razor
@@ -17,7 +17,7 @@
                     @onclick='() => Nav.NavigateTo("/personal-quests?catalog=true")'>Katalog</button>
         </div>
         <button class="btn btn-primary" @onclick="() => OpenModal((PersonalQuestListDto?)null)">+ Nový osobní quest</button>
-        @if (!Catalog && GameContext.SelectedGameId is int wizardGameId)
+        @if (!Catalog && GameContext.SelectedGameId.HasValue)
         {
             <button class="btn btn-outline-primary ms-2" @onclick="() => wizardVisible = true">
                 <i class="bi bi-magic me-1"></i>Vytvořit quest pro hru

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/QuestWizard.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/QuestWizard.razor
@@ -263,6 +263,7 @@
 
     private WizardModel model = new();
     private bool loaded;
+    private bool wasVisible;
 
     // Catalog reference lists.
     private List<SkillDto> allSkills = new();
@@ -304,6 +305,27 @@
     // Scroll detection for optional quantity spinner.
     private bool SelectedSpellIsScroll =>
         newSpellId is int id && allSpells.FirstOrDefault(s => s.Id == id)?.IsScroll == true;
+
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        await base.SetParametersAsync(parameters);
+        if (Visible && !wasVisible)
+        {
+            // Closed → open transition. Reset form state so a reopened wizard is pristine.
+            model = new();
+            newSkillId = null;
+            newItemId = null;
+            newSpellId = null;
+            newItemQuantity = 1;
+            newSpellQuantity = 1;
+            error = null;
+            progressLabel = "";
+            skillCreatorVisible = false;
+            itemCreatorVisible = false;
+            spellCreatorVisible = false;
+        }
+        wasVisible = Visible;
+    }
 
     protected override async Task OnParametersSetAsync()
     {
@@ -454,7 +476,7 @@
             progressLabel = "Hotovo.";
             await Saved.InvokeAsync();
             await VisibleChanged.InvokeAsync(false);
-            model = new();  // reset for next open
+            // Form reset now centralized in SetParametersAsync on closed → open transition.
         }
         catch (Exception ex)
         {

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/QuestWizard.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/QuestWizard.razor
@@ -1,0 +1,489 @@
+@* QuestWizard.razor — "Create a new personal quest" smart wizard popup.
+
+   Wraps Phase 1's multi-call reward wiring into a single form + sequential-save
+   flow, with inline creation of Skills/Items/Spells directly from the combobox
+   row. Reuses Phase 1 DTOs (CreatePersonalQuestDto, AddSkillRewardDto,
+   AddItemRewardDto, AddSpellRewardDto, CreateGamePersonalQuestDto). No new DTOs
+   introduced in OvcinaHra.Shared.
+
+   Spell quantity spinner is only shown for scrolls (IsScroll == true), matching
+   the Phase 1 rewards UI in PersonalQuestList.razor. *@
+
+@inject ApiClient Api
+
+<DxPopup @bind-Visible="@Visible" HeaderText="Vytvořit nový personal quest"
+         Width="900px" AllowResize="true">
+    <BodyContentTemplate Context="ctx">
+        <DxFormLayout>
+
+            @* --- 1) Základ --- *@
+            <DxFormLayoutGroup Caption="Základ" ColSpanMd="12">
+                <DxFormLayoutItem Caption="Název *" ColSpanMd="12">
+                    <DxTextBox @bind-Text="@model.Name" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Obtížnost" ColSpanMd="6">
+                    <DxComboBox Data="@difficultyValues" @bind-Value="@model.Difficulty"
+                                TextFieldName="Display" ValueFieldName="Value" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="XP cena" ColSpanMd="6">
+                    <DxSpinEdit @bind-Value="@model.XpCost" MinValue="0" MaxValue="999" />
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+
+            @* --- 2) Pravidla --- *@
+            <DxFormLayoutGroup Caption="Pravidla" ColSpanMd="12">
+                <DxFormLayoutItem Caption="Povolání" ColSpanMd="12">
+                    <div class="d-flex gap-3 flex-wrap">
+                        <DxCheckBox @bind-Checked="@model.AllowWarrior">Válečník</DxCheckBox>
+                        <DxCheckBox @bind-Checked="@model.AllowArcher">Lučištník</DxCheckBox>
+                        <DxCheckBox @bind-Checked="@model.AllowMage">Mág</DxCheckBox>
+                        <DxCheckBox @bind-Checked="@model.AllowThief">Zloděj</DxCheckBox>
+                    </div>
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Popis (interní)" ColSpanMd="12">
+                    <DxMemo @bind-Text="@model.Description" Rows="3" />
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+
+            @* --- 3) Texty --- *@
+            <DxFormLayoutGroup Caption="Texty" ColSpanMd="12">
+                <DxFormLayoutItem Caption="Text karty questu" ColSpanMd="12">
+                    <DxMemo @bind-Text="@model.QuestCardText" Rows="4" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Text karty odměny" ColSpanMd="12">
+                    <DxMemo @bind-Text="@model.RewardCardText" Rows="4" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Poznámka k odměně" ColSpanMd="12">
+                    <DxTextBox @bind-Text="@model.RewardNote" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Poznámky (interní)" ColSpanMd="12">
+                    <DxMemo @bind-Text="@model.Notes" Rows="3" />
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+
+            @* --- 4) Odměny --- *@
+            <DxFormLayoutGroup Caption="Odměny" ColSpanMd="12">
+                <DxFormLayoutItem ColSpanMd="12">
+                    <div class="p-2 border rounded" style="background: var(--oh-surface, #fafafa);">
+
+                        @* Skill rewards *@
+                        <div class="mb-3">
+                            <strong class="small">Dovednosti:</strong>
+                            @if (model.SkillRewardIds.Any())
+                            {
+                                <div class="mt-1 mb-2">
+                                    @foreach (var sid in model.SkillRewardIds.ToList())
+                                    {
+                                        var s = allSkills.FirstOrDefault(x => x.Id == sid);
+                                        <span class="badge bg-secondary me-1">
+                                            @(s?.Name ?? $"#{sid}")
+                                            <button class="btn btn-sm btn-link text-white p-0 ms-1"
+                                                    @onclick="() => model.SkillRewardIds.Remove(sid)">
+                                                <i class="bi bi-x"></i>
+                                            </button>
+                                        </span>
+                                    }
+                                </div>
+                            }
+                            else
+                            {
+                                <span class="text-muted small ms-2">Žádné dovednosti.</span>
+                            }
+                            <div class="d-flex gap-2 align-items-end mt-1">
+                                <div style="flex:1">
+                                    <DxComboBox Data="@SkillsNotYetAdded" @bind-Value="@newSkillId"
+                                                TextFieldName="Name" ValueFieldName="Id"
+                                                NullText="(přidat dovednost)"
+                                                SearchMode="ListSearchMode.AutoSearch" />
+                                </div>
+                                <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                                        disabled="@(newSkillId is null)"
+                                        @onclick="AddSkillRewardLocal">
+                                    <i class="bi bi-plus me-1"></i>Přidat
+                                </button>
+                                <button class="btn btn-sm btn-outline-secondary" style="height:34px"
+                                        @onclick="() => skillCreatorVisible = true">
+                                    <i class="bi bi-plus-circle me-1"></i>Vytvořit novou…
+                                </button>
+                            </div>
+                        </div>
+
+                        @* Item rewards *@
+                        <div class="mb-3">
+                            <strong class="small">Předměty:</strong>
+                            @if (model.ItemRewards.Any())
+                            {
+                                <div class="mt-1 mb-2">
+                                    @foreach (var (iid, qty) in model.ItemRewards.ToList())
+                                    {
+                                        var it = allItems.FirstOrDefault(x => x.Id == iid);
+                                        <span class="badge bg-secondary me-1">
+                                            @(it?.Name ?? $"#{iid}") ×@qty
+                                            <button class="btn btn-sm btn-link text-white p-0 ms-1"
+                                                    @onclick="() => RemoveItemLocal(iid)">
+                                                <i class="bi bi-x"></i>
+                                            </button>
+                                        </span>
+                                    }
+                                </div>
+                            }
+                            else
+                            {
+                                <span class="text-muted small ms-2">Žádné předměty.</span>
+                            }
+                            <div class="d-flex gap-2 align-items-end mt-1">
+                                <div style="flex:1">
+                                    <DxComboBox Data="@ItemsNotYetAdded" @bind-Value="@newItemId"
+                                                TextFieldName="Name" ValueFieldName="Id"
+                                                NullText="(přidat předmět)"
+                                                SearchMode="ListSearchMode.AutoSearch" />
+                                </div>
+                                <div style="width:70px">
+                                    <DxSpinEdit @bind-Value="@newItemQuantity" MinValue="1" />
+                                </div>
+                                <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                                        disabled="@(newItemId is null)"
+                                        @onclick="AddItemRewardLocal">
+                                    <i class="bi bi-plus me-1"></i>Přidat
+                                </button>
+                                <button class="btn btn-sm btn-outline-secondary" style="height:34px"
+                                        @onclick="() => itemCreatorVisible = true">
+                                    <i class="bi bi-plus-circle me-1"></i>Vytvořit nový…
+                                </button>
+                            </div>
+                        </div>
+
+                        @* Spell rewards *@
+                        <div class="mb-1">
+                            <strong class="small">Kouzla:</strong>
+                            @if (model.SpellRewards.Any())
+                            {
+                                <div class="mt-1 mb-2">
+                                    @foreach (var (sid, qty) in model.SpellRewards.ToList())
+                                    {
+                                        var sp = allSpells.FirstOrDefault(x => x.Id == sid);
+                                        <span class="badge bg-secondary me-1">
+                                            @(sp?.Name ?? $"#{sid}")@(qty > 1 ? $" ×{qty}" : "")
+                                            <button class="btn btn-sm btn-link text-white p-0 ms-1"
+                                                    @onclick="() => RemoveSpellLocal(sid)">
+                                                <i class="bi bi-x"></i>
+                                            </button>
+                                        </span>
+                                    }
+                                </div>
+                            }
+                            else
+                            {
+                                <span class="text-muted small ms-2">Žádná kouzla.</span>
+                            }
+                            <div class="d-flex gap-2 align-items-end mt-1">
+                                <div style="flex:1">
+                                    <DxComboBox Data="@SpellsNotYetAdded" @bind-Value="@newSpellId"
+                                                TextFieldName="Name" ValueFieldName="Id"
+                                                NullText="(přidat kouzlo)"
+                                                SearchMode="ListSearchMode.AutoSearch" />
+                                </div>
+                                @if (SelectedSpellIsScroll)
+                                {
+                                    <div style="width:70px">
+                                        <DxSpinEdit @bind-Value="@newSpellQuantity" MinValue="1" />
+                                    </div>
+                                }
+                                <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                                        disabled="@(newSpellId is null)"
+                                        @onclick="AddSpellRewardLocal">
+                                    <i class="bi bi-plus me-1"></i>Přidat
+                                </button>
+                                <button class="btn btn-sm btn-outline-secondary" style="height:34px"
+                                        @onclick="() => spellCreatorVisible = true">
+                                    <i class="bi bi-plus-circle me-1"></i>Vytvořit nové…
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+
+            @* --- 5) Nastavení pro hru --- *@
+            <DxFormLayoutGroup Caption="Nastavení pro hru" ColSpanMd="12">
+                <DxFormLayoutItem Caption="XP override (pro tuto hru)" ColSpanMd="6">
+                    <DxSpinEdit Value="@model.GameXpOverride"
+                                ValueExpression="@(() => model.GameXpOverride)"
+                                ValueChanged="@((int? v) => model.GameXpOverride = v)"
+                                MinValue="0" MaxValue="999"
+                                NullText="@($"výchozí: {model.XpCost}")"
+                                ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Limit na království" ColSpanMd="6">
+                    <DxSpinEdit Value="@model.PerKingdomLimit"
+                                ValueExpression="@(() => model.PerKingdomLimit)"
+                                ValueChanged="@((int? v) => model.PerKingdomLimit = v)"
+                                MinValue="0" MaxValue="99"
+                                NullText="(bez omezení)"
+                                ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+        </DxFormLayout>
+
+        @if (error is not null)
+        {
+            <div class="alert alert-danger mt-2">@error</div>
+        }
+
+        @if (isSaving && !string.IsNullOrEmpty(progressLabel))
+        {
+            <div class="alert alert-info mt-2 d-flex align-items-center gap-2">
+                <span class="spinner-border spinner-border-sm"></span>
+                <span>@progressLabel</span>
+            </div>
+        }
+
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" @onclick="Cancel" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">
+                @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Uložit a přidat do hry
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<SkillInlineCreator @bind-Visible="@skillCreatorVisible" GameId="@GameId"
+                    Created="@OnSkillCreated" />
+<ItemInlineCreator  @bind-Visible="@itemCreatorVisible"  GameId="@GameId"
+                    Created="@OnItemCreated" />
+<SpellInlineCreator @bind-Visible="@spellCreatorVisible" GameId="@GameId"
+                    Created="@OnSpellCreated" />
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter] public int GameId { get; set; }
+    [Parameter] public EventCallback Saved { get; set; }
+
+    private WizardModel model = new();
+    private bool loaded;
+
+    // Catalog reference lists.
+    private List<SkillDto> allSkills = new();
+    private List<ItemListDto> allItems = new();
+    private List<SpellListDto> allSpells = new();
+
+    // Picker transient values.
+    private int? newSkillId;
+    private int? newItemId;
+    private int newItemQuantity = 1;
+    private int? newSpellId;
+    private int newSpellQuantity = 1;
+
+    // Inline creator popup flags.
+    private bool skillCreatorVisible;
+    private bool itemCreatorVisible;
+    private bool spellCreatorVisible;
+
+    // Save flow state.
+    private string? error;
+    private string progressLabel = "";
+    private bool isSaving;
+
+    private static readonly List<EnumItem<TreasureQuestDifficulty>> difficultyValues =
+        Enum.GetValues<TreasureQuestDifficulty>()
+            .Select(v => new EnumItem<TreasureQuestDifficulty>(v, v.GetDisplayName()))
+            .ToList();
+
+    private record EnumItem<T>(T Value, string Display);
+
+    // Derived pickers (exclude already-added).
+    private IEnumerable<SkillDto> SkillsNotYetAdded =>
+        allSkills.Where(s => !model.SkillRewardIds.Contains(s.Id));
+    private IEnumerable<ItemListDto> ItemsNotYetAdded =>
+        allItems.Where(i => !model.ItemRewards.Any(r => r.ItemId == i.Id));
+    private IEnumerable<SpellListDto> SpellsNotYetAdded =>
+        allSpells.Where(sp => !model.SpellRewards.Any(r => r.SpellId == sp.Id));
+
+    // Scroll detection for optional quantity spinner.
+    private bool SelectedSpellIsScroll =>
+        newSpellId is int id && allSpells.FirstOrDefault(s => s.Id == id)?.IsScroll == true;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Visible && !loaded)
+        {
+            allSkills = await Api.GetListAsync<SkillDto>("/api/skills");
+            allItems = await Api.GetListAsync<ItemListDto>("/api/items");
+            var spells = await Api.GetListAsync<SpellListDto>("/api/spells");
+            // Phase 1 spell-reward endpoint rejects IsLearnable=true spells with 400.
+            allSpells = spells.Where(s => !s.IsLearnable).ToList();
+            loaded = true;
+        }
+    }
+
+    private void AddSkillRewardLocal()
+    {
+        if (newSkillId is int id && !model.SkillRewardIds.Contains(id))
+        {
+            model.SkillRewardIds.Add(id);
+        }
+        newSkillId = null;
+    }
+
+    private void AddItemRewardLocal()
+    {
+        if (newItemId is int id && !model.ItemRewards.Any(r => r.ItemId == id))
+        {
+            model.ItemRewards.Add((id, Math.Max(1, newItemQuantity)));
+        }
+        newItemId = null;
+        newItemQuantity = 1;
+    }
+
+    private void AddSpellRewardLocal()
+    {
+        if (newSpellId is int id && !model.SpellRewards.Any(r => r.SpellId == id))
+        {
+            var qty = SelectedSpellIsScroll ? Math.Max(1, newSpellQuantity) : 1;
+            model.SpellRewards.Add((id, qty));
+        }
+        newSpellId = null;
+        newSpellQuantity = 1;
+    }
+
+    private void RemoveItemLocal(int itemId)
+    {
+        var existing = model.ItemRewards.FirstOrDefault(r => r.ItemId == itemId);
+        if (existing != default) model.ItemRewards.Remove(existing);
+    }
+
+    private void RemoveSpellLocal(int spellId)
+    {
+        var existing = model.SpellRewards.FirstOrDefault(r => r.SpellId == spellId);
+        if (existing != default) model.SpellRewards.Remove(existing);
+    }
+
+    private void OnSkillCreated(SkillDto s)
+    {
+        if (!allSkills.Any(x => x.Id == s.Id)) allSkills.Add(s);
+        if (!model.SkillRewardIds.Contains(s.Id)) model.SkillRewardIds.Add(s.Id);
+        skillCreatorVisible = false;
+    }
+
+    private void OnItemCreated(ItemListDto i)
+    {
+        if (!allItems.Any(x => x.Id == i.Id)) allItems.Add(i);
+        if (!model.ItemRewards.Any(r => r.ItemId == i.Id))
+            model.ItemRewards.Add((i.Id, 1));
+        itemCreatorVisible = false;
+    }
+
+    private void OnSpellCreated(SpellListDto s)
+    {
+        if (!allSpells.Any(x => x.Id == s.Id)) allSpells.Add(s);
+        if (!model.SpellRewards.Any(r => r.SpellId == s.Id))
+            model.SpellRewards.Add((s.Id, 1));
+        spellCreatorVisible = false;
+    }
+
+    private async Task Cancel()
+    {
+        await VisibleChanged.InvokeAsync(false);
+    }
+
+    private async Task SaveAsync()
+    {
+        if (string.IsNullOrWhiteSpace(model.Name)) { error = "Název je povinný."; return; }
+        if (model.XpCost < 0) { error = "XP cena nesmí být záporná."; return; }
+
+        error = null;
+        isSaving = true;
+        try
+        {
+            progressLabel = "Vytvářím quest…";
+            var detail = await Api.PostAsync<CreatePersonalQuestDto, PersonalQuestDetailDto>(
+                "/api/personal-quests",
+                new CreatePersonalQuestDto(
+                    Name: model.Name,
+                    Difficulty: model.Difficulty,
+                    Description: model.Description,
+                    AllowWarrior: model.AllowWarrior,
+                    AllowArcher: model.AllowArcher,
+                    AllowMage: model.AllowMage,
+                    AllowThief: model.AllowThief,
+                    QuestCardText: model.QuestCardText,
+                    RewardCardText: model.RewardCardText,
+                    RewardNote: model.RewardNote,
+                    Notes: model.Notes,
+                    XpCost: model.XpCost));
+
+            if (detail is null)
+            {
+                error = "Server nevrátil vytvořený quest.";
+                return;
+            }
+
+            progressLabel = "Přidávám odměny…";
+            foreach (var id in model.SkillRewardIds)
+            {
+                await Api.PostAsync<AddSkillRewardDto, object?>(
+                    $"/api/personal-quests/{detail.Id}/skill-rewards",
+                    new AddSkillRewardDto(id));
+            }
+
+            foreach (var (itemId, qty) in model.ItemRewards)
+            {
+                await Api.PostAsync<AddItemRewardDto, object?>(
+                    $"/api/personal-quests/{detail.Id}/item-rewards",
+                    new AddItemRewardDto(itemId, qty));
+            }
+
+            foreach (var (spellId, qty) in model.SpellRewards)
+            {
+                await Api.PostAsync<AddSpellRewardDto, object?>(
+                    $"/api/personal-quests/{detail.Id}/spell-rewards",
+                    new AddSpellRewardDto(spellId, qty));
+            }
+
+            progressLabel = "Přidávám do hry…";
+            await Api.PostAsync<CreateGamePersonalQuestDto, object?>(
+                "/api/personal-quests/game-link",
+                new CreateGamePersonalQuestDto(
+                    GameId: GameId,
+                    PersonalQuestId: detail.Id,
+                    XpCost: model.GameXpOverride,
+                    PerKingdomLimit: model.PerKingdomLimit));
+
+            progressLabel = "Hotovo.";
+            await Saved.InvokeAsync();
+            await VisibleChanged.InvokeAsync(false);
+            model = new();  // reset for next open
+        }
+        catch (Exception ex)
+        {
+            error = $"{progressLabel} Chyba: {ex.Message}";
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+
+    private sealed class WizardModel
+    {
+        public string Name { get; set; } = "";
+        public TreasureQuestDifficulty Difficulty { get; set; } = TreasureQuestDifficulty.Early;
+        public int XpCost { get; set; }
+        public bool AllowWarrior { get; set; }
+        public bool AllowArcher { get; set; }
+        public bool AllowMage { get; set; }
+        public bool AllowThief { get; set; }
+        public string? Description { get; set; }
+        public string? QuestCardText { get; set; }
+        public string? RewardCardText { get; set; }
+        public string? RewardNote { get; set; }
+        public string? Notes { get; set; }
+        public List<int> SkillRewardIds { get; } = new();
+        public List<(int ItemId, int Qty)> ItemRewards { get; } = new();
+        public List<(int SpellId, int Qty)> SpellRewards { get; } = new();
+        public int? GameXpOverride { get; set; }
+        public int? PerKingdomLimit { get; set; }
+    }
+}

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/SkillInlineCreator.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/SkillInlineCreator.razor
@@ -1,0 +1,144 @@
+@* SkillInlineCreator.razor — inline popup for creating a brand-new Skill template
+   and auto-linking it into the currently selected game. Emits the created
+   SkillDto via the `Created` callback so the parent wizard can auto-select it
+   as a quest reward without forcing the user to navigate away. *@
+
+@inject SkillService SkillSvc
+
+<DxPopup @bind-Visible="@Visible" HeaderText="Nová dovednost" Width="640px">
+    <BodyContentTemplate Context="ctx">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                <DxTextBox @bind-Text="@name" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Kategorie" ColSpanMd="12">
+                <DxComboBox Data="@skillCategoryValues" @bind-Value="@category"
+                            TextFieldName="Display" ValueFieldName="Value" />
+            </DxFormLayoutItem>
+
+            @if (category == SkillCategory.Class)
+            {
+                <DxFormLayoutItem Caption="Povolání" ColSpanMd="12">
+                    <DxComboBox Data="@playerClassValues" @bind-Value="@classRestriction"
+                                TextFieldName="Display" ValueFieldName="Value" />
+                </DxFormLayoutItem>
+            }
+
+            <DxFormLayoutItem Caption="Efekt" ColSpanMd="12">
+                <DxMemo @bind-Text="@effect" Rows="3" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+
+        @if (error is not null)
+        {
+            <div class="alert alert-danger mt-2">@error</div>
+        }
+
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" @onclick="Cancel" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">
+                @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit a přidat
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter] public int GameId { get; set; }
+    [Parameter] public EventCallback<SkillDto> Created { get; set; }
+
+    private string name = "";
+    private SkillCategory category = SkillCategory.Adventure;
+    private PlayerClass classRestriction = PlayerClass.Warrior;
+    private string? effect;
+
+    private bool isSaving;
+    private string? error;
+
+    private static readonly List<EnumItem<SkillCategory>> skillCategoryValues =
+        Enum.GetValues<SkillCategory>()
+            .Select(v => new EnumItem<SkillCategory>(v, v.GetDisplayName()))
+            .ToList();
+
+    private static readonly List<EnumItem<PlayerClass>> playerClassValues =
+        Enum.GetValues<PlayerClass>()
+            .Select(v => new EnumItem<PlayerClass>(v, v.GetDisplayName()))
+            .ToList();
+
+    private record EnumItem<T>(T Value, string Display);
+
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        var wasVisible = Visible;
+        await base.SetParametersAsync(parameters);
+        if (!wasVisible && Visible)
+        {
+            // Reset fields each time the popup is opened.
+            name = "";
+            category = SkillCategory.Adventure;
+            classRestriction = PlayerClass.Warrior;
+            effect = null;
+            error = null;
+            isSaving = false;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            error = "Název je povinný.";
+            return;
+        }
+
+        error = null;
+        isSaving = true;
+        try
+        {
+            var cr = category == SkillCategory.Class ? (PlayerClass?)classRestriction : null;
+
+            // 1) Create the catalog template.
+            var createdTemplate = await SkillSvc.CreateAsync(
+                new CreateSkillRequest(
+                    Name: name,
+                    ClassRestriction: cr,
+                    Effect: effect,
+                    RequirementNotes: null,
+                    RequiredBuildingIds: Array.Empty<int>(),
+                    Category: category));
+
+            // 2) Auto-link to the current game as a per-game copy of the template.
+            //    Skills don't have a lightweight game-link DTO — the only path is the
+            //    full template-copy endpoint POST /api/games/{gameId}/skills. We mirror
+            //    the template's fields 1:1, XpCost=0, no level requirement.
+            await SkillSvc.CreateGameSkillAsync(GameId,
+                new CreateGameSkillRequest(
+                    TemplateSkillId: createdTemplate.Id,
+                    Name: createdTemplate.Name,
+                    Category: createdTemplate.Category,
+                    ClassRestriction: createdTemplate.ClassRestriction,
+                    Effect: createdTemplate.Effect,
+                    RequirementNotes: createdTemplate.RequirementNotes,
+                    BuildingRequirementIds: Array.Empty<int>(),
+                    XpCost: 0,
+                    LevelRequirement: null));
+
+            await Created.InvokeAsync(createdTemplate);
+            await VisibleChanged.InvokeAsync(false);
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+
+    private async Task Cancel() => await VisibleChanged.InvokeAsync(false);
+}

--- a/src/OvcinaHra.Client/Pages/PersonalQuests/SpellInlineCreator.razor
+++ b/src/OvcinaHra.Client/Pages/PersonalQuests/SpellInlineCreator.razor
@@ -1,0 +1,192 @@
+@* SpellInlineCreator.razor — inline popup for creating a brand-new Spell template
+   and auto-linking it into the currently selected game. Emits the created
+   SpellListDto via the `Created` callback so the parent wizard can auto-select
+   it as a quest reward.
+
+   Note: IsLearnable is intentionally NOT exposed. Phase 1's personal-quest spell-
+   reward endpoint rejects learnable spells (400), so every spell created via
+   this wizard-inline path is forced to IsLearnable = false. *@
+
+@inject ApiClient Api
+
+<DxPopup @bind-Visible="@Visible" HeaderText="Nové kouzlo" Width="640px">
+    <BodyContentTemplate Context="ctx">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                <DxTextBox @bind-Text="@name" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Typ (škola)" ColSpanMd="12">
+                <DxComboBox Data="@schoolValues" @bind-Value="@school"
+                            TextFieldName="Display" ValueFieldName="Value" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Úroveň" ColSpanMd="4">
+                <DxSpinEdit @bind-Value="@level" MinValue="0" MaxValue="5" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Mana" ColSpanMd="4">
+                <DxSpinEdit @bind-Value="@manaCost" MinValue="0" MaxValue="5" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Min. úroveň mága" ColSpanMd="4">
+                <DxSpinEdit @bind-Value="@minMageLevel" MinValue="0" MaxValue="5" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Svitek" ColSpanMd="6">
+                <DxCheckBox @bind-Checked="@isScroll" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Reakce" ColSpanMd="6">
+                <DxCheckBox @bind-Checked="@isReaction" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Cena (groše)" ColSpanMd="12">
+                <DxSpinEdit @bind-Value="@price" MinValue="0" MaxValue="9999"
+                            NullText="(žádná)"
+                            ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+            </DxFormLayoutItem>
+
+            <DxFormLayoutItem Caption="Efekt (text karty)" ColSpanMd="12">
+                <DxMemo @bind-Text="@effect" Rows="3" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+
+        @if (error is not null)
+        {
+            <div class="alert alert-danger mt-2">@error</div>
+        }
+
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" @onclick="Cancel" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">
+                @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit a přidat
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter] public int GameId { get; set; }
+    [Parameter] public EventCallback<SpellListDto> Created { get; set; }
+
+    private string name = "";
+    private int level;
+    private int manaCost;
+    private int minMageLevel;
+    private SpellSchool school = SpellSchool.Fire;
+    private bool isScroll;
+    private bool isReaction;
+    private int? price;
+    private string effect = "";
+
+    private bool isSaving;
+    private string? error;
+
+    private static readonly List<EnumItem<SpellSchool>> schoolValues =
+        Enum.GetValues<SpellSchool>()
+            .Select(v => new EnumItem<SpellSchool>(v, v.GetDisplayName()))
+            .ToList();
+
+    private record EnumItem<T>(T Value, string Display);
+
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        var wasVisible = Visible;
+        await base.SetParametersAsync(parameters);
+        if (!wasVisible && Visible)
+        {
+            name = "";
+            level = 0;
+            manaCost = 0;
+            minMageLevel = 0;
+            school = SpellSchool.Fire;
+            isScroll = false;
+            isReaction = false;
+            price = null;
+            effect = "";
+            error = null;
+            isSaving = false;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            error = "Název je povinný.";
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(effect))
+        {
+            error = "Efekt je povinný — je to text karty.";
+            return;
+        }
+
+        error = null;
+        isSaving = true;
+        try
+        {
+            // 1) Create catalog spell. IsLearnable is forced to false because the
+            //    Phase 1 personal-quest spell-reward endpoint rejects learnable
+            //    spells with 400 (they're not scroll/reward material by definition).
+            var created = await Api.PostAsync<CreateSpellDto, SpellDetailDto>(
+                "/api/spells",
+                new CreateSpellDto(
+                    Name: name,
+                    Level: level,
+                    ManaCost: manaCost,
+                    School: school,
+                    IsScroll: isScroll,
+                    IsReaction: isReaction,
+                    IsLearnable: false,
+                    MinMageLevel: minMageLevel,
+                    Price: price,
+                    Effect: effect,
+                    Description: null));
+
+            if (created is null)
+            {
+                error = "Server nevrátil vytvořené kouzlo.";
+                return;
+            }
+
+            // 2) Auto-link to the current game with defaults (no per-game price
+            //    override, not findable, no availability notes).
+            await Api.PostAsync<CreateGameSpellDto, object?>(
+                "/api/spells/game-spell",
+                new CreateGameSpellDto(
+                    GameId: GameId,
+                    SpellId: created.Id));
+
+            // Convert to the SpellListDto shape the parent wizard already uses for
+            // its existing-spell picker.
+            var listDto = new SpellListDto(
+                Id: created.Id,
+                Name: created.Name,
+                Level: created.Level,
+                School: created.School,
+                IsScroll: created.IsScroll,
+                IsReaction: created.IsReaction,
+                IsLearnable: created.IsLearnable,
+                ManaCost: created.ManaCost,
+                MinMageLevel: created.MinMageLevel,
+                Price: created.Price,
+                Effect: created.Effect,
+                Description: created.Description);
+
+            await Created.InvokeAsync(listDto);
+            await VisibleChanged.InvokeAsync(false);
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+
+    private async Task Cancel() => await VisibleChanged.InvokeAsync(false);
+}


### PR DESCRIPTION
## Summary

Phase 2 of the PersonalQuest work — the Quest Maker Wizard. Design: `docs/plans/2026-04-23-personal-quest-wizard-design.md`.

Launched from the game-view "Osobní questy" page via **"Vytvořit quest pro hru"**. One smart-form popup covers every field the old popup has + all three reward types + per-game config + inline creators for missing rewards.

## What's new

- **QuestWizard.razor** — big `DxPopup` (900px, resizable) with 5 sections: Základ, Pravidla, Texty, Odměny, Nastavení pro hru
- **Inline creators** — three small nested `DxPopup` components (`SkillInlineCreator`, `ItemInlineCreator`, `SpellInlineCreator`). When the user creates a new skill/item/spell mid-wizard, the entity is saved to the catalog AND auto-linked to the current game — no flow breaks
- **Sequential save flow** with progress indicator: create quest → add each reward → link to game. Errors leave partial state (user can retry or clean up via the existing popup)

## What's NOT in this PR

- No edit mode in the wizard (existing popup keeps handling edits)
- No draft save / resume
- No batch create
- No new server endpoints or migrations — pure client-side, reuses everything Phase 1 shipped
- No integration tests for the wizard UI (covered by Phase 1's 260 API tests + manual smoke)

## Server impact

None. Zero changes under `OvcinaHra.Shared`, `OvcinaHra.Api`, or `tests/`. All 260 API tests still green.

## Version

0.10.0 → **0.10.1** (UI-only additive).

## Test plan

- [ ] Game view: "Vytvořit quest pro hru" button appears; clicking opens the wizard
- [ ] Catalog view: button is hidden
- [ ] No active game: button is hidden
- [ ] Fill out basics + class flags + XP + rewards + per-game config → save → wizard closes, new row appears in the grid
- [ ] Inline creator (any of the 3 types) → entity appears in catalog AND in the current game AND auto-selected as the reward
- [ ] Try to save with empty Name → validation error appears, nothing persists
- [ ] Try to save with negative XP → validation error, nothing persists
- [ ] Sequential save: provoke an error mid-flow (e.g., duplicate quest name) → error message surfaces with the step name, wizard stays open
- [ ] Close wizard mid-edit → state discarded (confirmed intentional, no draft save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)