### PR TITLE
Claude design refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -486,3 +486,6 @@ src/OvcinaHra.Client/wwwroot/appsettings.Development.json
 
 # Git worktrees (Claude Code / superpowers)
 .worktrees/
+
+# Claude Design handoff bundles (large, regenerable)
+docs/design/handoff/

--- a/docs/design/BUILDER-BRIEF-TEMPLATE.md
+++ b/docs/design/BUILDER-BRIEF-TEMPLATE.md
@@ -1,0 +1,166 @@
+# Builder Brief — Shared Template
+
+Every dialog in this design programme gets a designer brief (`docs/design/dialogs/<name>.md`) plus a per-dialog addendum at the bottom of that same file. This template is the shared boilerplate all builder runs inherit; the addendum only adds what is page-specific.
+
+Use this template verbatim as the top of any builder prompt. Do not rewrite it per dialog — reference it.
+
+---
+
+```
+ROLE
+You are a senior Blazor WebAssembly + DevExpress engineer working on
+OvčinaHra, an organizer-only world-building companion app for a Czech
+children's outdoor fantasy LARP (Tolkien's Rhovanion). The app is .NET 10,
+Blazor WASM, DevExpress Blazor 25.2.5, PostgreSQL + EF Core, MapLibre,
+Azure Blob Storage. Repo root: C:/Users/TomášPajonk/source/repos/timurlain/ovcinahra.
+
+INPUT
+  · Approved HTML mockup: docs/design/dialogs/<name>.mockup.html
+    (either exported from Claude Design via "Export as standalone HTML",
+     or arriving through "Handoff to Claude Code → Send to local coding
+     agent" — in which case the HTML + metadata land in this session's
+     working tree under .handoff/ and you should copy the HTML into
+     docs/design/dialogs/<name>.mockup.html before starting).
+  · Designer brief (intent, fields, states): docs/design/dialogs/<name>.md
+  · Per-dialog builder addendum is the tail section of the same .md file.
+  · Ovčina design system setup: docs/design/CLAUDE-DESIGN-SETUP.md
+    — the design system lives at the Claude Design org level and is the
+    source of truth for the tokens that appear in the mockup.
+
+YOUR JOB
+Port the approved mockup to production Blazor using DevExpress components
+and the existing theme file. Do NOT re-imagine the design; the mockup is
+the contract. If the mockup and addendum disagree, STOP and ask.
+
+HARD CONSTRAINTS — non-negotiable
+  1. Use DevExpress components where one fits: DxPopup, DxFormLayout,
+     DxFormLayoutItem, DxGrid, DxGridDataColumn, DxComboBox, DxTextBox,
+     DxMemo, DxSpinEdit, DxCheckBox, DxDateEdit, DxFlyout. Do NOT hand-roll
+     markup when a DevExpress component already exists for the job.
+  2. All colors, fonts, radii, shadows via the --oh-* CSS custom properties
+     in src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css. NO inline hex
+     in Razor. NO new tokens without first adding them to the :root block
+     of that file with a brief comment.
+  3. Component-specific overrides belong in ovcinahra-theme.css as DevExpress
+     class selectors (.dxbl-popup, .dxbl-grid, .dxbl-text-edit, etc.).
+     Prefer adding to the existing file over creating a new CSS file.
+  4. Czech labels verbatim from the mockup. Diacritics (č ř š ž ů ě á í é)
+     must render correctly. Do NOT re-translate, do NOT "fix" wording.
+  5. Preserve the existing data layer: ApiClient injection, GameContext,
+     @bind-Text / @bind-Value patterns, existing DTOs. New DTO shapes are
+     allowed only if the addendum explicitly requests them.
+  6. Destructive actions (Smazat, Odebrat, Vyřadit, …) route through a
+     DxPopup confirmation — never wire a delete button straight to the
+     handler. See MEMORY rule §D.
+  7. If the addendum introduces new DxGrid columns or changes existing
+     ones, bump the grid's LayoutKey string (see MEMORY rule §L) so stale
+     localStorage filters do not replay against the new schema.
+  8. Every new DxGridDataColumn attribute must be verified to exist on the
+     current DevExpress version (25.2.5) — see MEMORY rule §A. If in doubt,
+     run the app and open DevTools console before claiming done.
+  9. ImagePicker is the canonical image slot. Always pass AspectRatio as
+     "W:H" and Width as a concrete px value. Do NOT replicate its
+     upload/delete logic in the page.
+
+DATA-MODEL PREREQUISITES
+If the addendum lists schema changes (new enum, new lookup table, new FK):
+  a. Add migration first (EF Core, idempotent, reviewable).
+  b. Add entity / configuration / DTO / endpoint / service.
+  c. Only then wire the UI. A UI that binds to a non-existent field must
+     never be committed.
+
+COPY & NAMING
+  · Always Hrdina / Hrdinové in player-facing Czech UI; never hráč/postava
+    (MEMORY rule §H).
+  · "Představěná" (IsPrebuilt label) is intentional — do not rename
+    (MEMORY rule §P).
+  · Kingdom names and hex values are canon (MEMORY rule §K). Do not adjust
+    saturation, do not swap between kingdoms.
+
+COMMITS & DEPLOY
+  · Commit messages must include [vX.Y.Z] version tag (MEMORY rule §V1).
+  · Bump package version before every deploy (patch/minor/major)
+    (MEMORY rule §V2).
+  · Never mutate files under publish/wwwroot after `dotnet publish` —
+    breaks service-worker SRI (MEMORY rule §S). Use
+    appsettings.{Env}.json overrides instead.
+
+VERIFICATION BEFORE CLAIMING DONE
+  · `dotnet build` clean, zero new warnings.
+  · App starts, dialog opens, every state shown in the mockup is reachable
+    in the live app.
+  · DevTools console: no DevExpress attribute errors, no 404s on assets,
+    no unhandled promise rejections.
+  · Czech diacritics render in headers, chips, grid cells, tooltips.
+  · Touch targets ≥ 44 px at 768–1024 px breakpoint.
+  · Drozd appears only where the mockup places him — audit frequency.
+  · Backend prereqs (migration, endpoint, DTO) actually applied and tested
+    with `dotnet run` before UI port is considered complete.
+
+OUT OF SCOPE
+  · Do not touch other pages or unrelated code paths.
+  · Do not refactor shared components (OvcinaGrid, ImagePicker, MapView,
+    GameSelector) except as the addendum explicitly requests.
+  · Do not change the meaning of existing --oh-* tokens — only add new
+    ones with fresh names.
+
+WHEN YOU GET STUCK
+  · If the mockup is ambiguous, propose two options with a one-line
+    tradeoff each and ask, do not guess.
+  · If a DevExpress component cannot express something in the mockup
+    without excessive override CSS, flag it — the design may need to
+    adjust, not the code.
+```
+
+---
+
+## Referenced MEMORY rules (abbreviations used above)
+
+| Ref | MEMORY entry | One-line |
+|-----|--------------|---------|
+| §A  | feedback_ovcinahra_devexpress_runtime_attrs | Unknown DxGrid attrs compile but throw at render |
+| §D  | feedback_ovcinahra_destructive_confirm | Delete/remove must go through DxPopup confirm |
+| §H  | feedback_ovcinahra_hrdina_copy | Hrdina/Hrdinové, never hráč/postava |
+| §K  | feedback_ovcina_kingdom_seal_palette | Canon kingdom hex, no re-saturation |
+| §L  | feedback_ovcinagrid_layoutkey_bump | Bump LayoutKey when grid columns change |
+| §P  | feedback_ovcinahra_predstavena_term | Představěná is intentional wording |
+| §S  | feedback_ovcinahra_pwa_sri_no_postpublish_mutation | No post-publish file mutation |
+| §V1 | feedback_ovcinahra_version_in_commits | Commits include [vX.Y.Z] |
+| §V2 | feedback_ovcinahra_version_in_deploys | Bump version before every deploy |
+
+Full MEMORY lives at: `C:/Users/TomášPajonk/.claude/projects/C--Users-Tom--Pajonk-source-repos-azra/memory/MEMORY.md`.
+
+---
+
+## Per-dialog addendum — what each dialog's .md adds at the bottom
+
+```
+## Builder addendum — <DialogName>
+
+TARGET FILES
+  · Razor:     src/OvcinaHra.Client/Pages/<area>/<page>.razor
+  · Isolated CSS (if any): <page>.razor.css
+  · Theme additions: src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+  · Shared component changes: <list, or "none">
+
+DATA-MODEL PREREQS
+  · <migration file, entity, DTO, endpoint, service — or "none">
+
+FIELD BINDINGS (mockup → Razor)
+  · <field label>  →  <CSharp prop>  via  <Dx component, @bind-X="…">
+  · …
+
+IMAGE SLOTS
+  · <slot name>: AspectRatio="W:H" Width="Npx" EntityType="…" Field="…"
+
+GRID COLUMN CHANGES (if any)
+  · Add/remove/rename: <list>
+  · New LayoutKey: "<bumped-string>"
+
+VALIDATION
+  · <required fields>
+  · <server-side checks>
+
+NOTES TO THE BUILDER (optional)
+  · <one-line hints, known gotchas, deprecations>
+```

--- a/docs/design/CLAUDE-DESIGN-SETUP.md
+++ b/docs/design/CLAUDE-DESIGN-SETUP.md
@@ -1,0 +1,146 @@
+# Claude Design — OvčinaHra Design-System Setup
+
+**One-time onboarding.** Every dialog brief written afterwards inherits this — tokens, fonts, kingdom canon, Drozd all come from here, not from the prompt.
+
+**Prerequisites**
+
+- Claude Pro / Max / Team / Enterprise account (Claude Design is not on the free tier)
+- Access to this repo: `C:/Users/TomášPajonk/source/repos/timurlain/ovcinahra`
+
+---
+
+## Step 1 — Open Claude Design and create the OvčinaHra org
+
+1. Go to https://claude.ai/design
+2. Project picker (bottom-left) → click current org → **Create new organization** (or reuse an existing one dedicated to Ovčina work)
+3. Name it `Ovčina` (shared with future sister-app work for registrace.ovcina.cz)
+4. Complete the onboarding flow — it will ask you to upload source material in the next step.
+
+## Step 2 — Upload source material
+
+Upload in this order (most signal first). The docs warn linking whole monorepos can lag — link subdirectories.
+
+### 2a. Codebase
+
+Link or upload these subpaths only (not the whole repo):
+
+- `src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css` — **the `--oh-*` token file, critical**
+- `src/OvcinaHra.Client/wwwroot/css/app.css`
+- `src/OvcinaHra.Client/Components/` — existing shared components (`ImagePicker`, `OvcinaGrid`, `MapView`, `GameSelector`, `LocationEditPopup`)
+- `src/OvcinaHra.Client/Layout/` — navbar and page shell
+
+### 2b. Screenshots of the current app
+
+Capture from https://hra.ovcina.cz and upload:
+
+- Home page
+- Any one list page (e.g., Characters)
+- The current edit popup on that list page
+- The Map page (crown jewel — signals the aesthetic)
+
+These teach Claude what we have; the design system job is to improve, not invent from zero.
+
+### 2c. Hand-drawn game art (the heart of the aesthetic)
+
+Pull from Ovčina OneDrive (read-only):
+
+- `games/.../MagicalDeckLokaceJsouCajk/assets/` — parchment card art
+- `games/2026 05 01 Balinova pozvánka/ifp6ekov8kpg1.jpeg` — Rhovanion parchment map
+- `sources/documents/05 Ovcina/Podzim/domy_ovcina.jpg` — hand-drawn kingdom buildings
+- Any existing Drozd sketch (if we have one) — otherwise Claude will propose one, we refine
+
+### 2d. Kingdom canon (paste into the onboarding chat)
+
+```
+Four kingdoms — canonical hex, never swap, never re-saturate:
+  Esgaroth       #242F3D   Lake-town humans, slate blue
+  Aradhryand     #243525   Mirkwood elves, deep green
+  Azanulinbar    #8C2423   Erebor dwarves, bordeaux
+  Nový Arnor     #504B25   Northern rangers, muted gold
+
+Race enum (render as chips):
+  Člověk · Trpaslík · Elf · Hobit · Dúnadan
+
+Every dialog may have a Kingdom badge (48×48) next to the entity name.
+```
+
+### 2e. Drozd — the mascot
+
+```
+Drozd (thrush of Erebor) is our mascot.
+Hand-drawn ink-on-parchment style, quiet, helpful, never chatty.
+Appears ONLY in empty / loading / error / first-run states — never on populated screens.
+
+Canonical sizes:
+  120×120   dialog empty-state illustration
+   48×48   compact inline (beside error toast, beside an empty grid row)
+   24×24   header corner mark (edit-dialog titles, page headers)
+
+Czech micro-copy library:
+  empty    "Zatím tu nic není."                "Zatím tu nikdo nepřebývá."
+  loading  "Drozd listuje kronikou…"           "Posel je na cestě…"
+  error    "Něco se pokazilo. Zkuste to znovu." "Drozd ztratil stránku."
+  first    "Tady začne kronika."
+```
+
+### 2f. LocationKind marker colors (canon, distinct from kingdom palette)
+
+Locations on the map and in the Locations grid use their own marker palette, tied to `LocationKind`. These are NOT kingdom colors and must not be swapped for them.
+
+```
+LocationKind marker colors (canon):
+  Town        #2c3e50   dark slate       — Město
+  Village     #27ae60   fresh green      — Vesnice
+  Magical     #8e44ad   violet           — Kouzelné
+  Hobbit      #f39c12   amber            — Hobit
+  Wilderness  #16a085   teal             — Pustina
+
+Usage:
+  · 10 px dot in the Locations grid (leftmost cue)
+  · circular map pin on /map and /locations/{id} › Mapa tab
+  · small chip in the LocationKind combobox, prefixed to the label
+```
+
+## Step 3 — Review the generated design system
+
+After Claude generates the UI kit, verify each item. Anything wrong, tell Claude in the onboarding chat to fix it before saving.
+
+- [ ] Primary color is forest green `#2D5016` (not default Material blue, not Blazing Berry purple)
+- [ ] Surface is parchment cream `#FFF8F0`; alt surface `#F5EDE3`
+- [ ] Card border accent is burnt orange `#B26223`
+- [ ] Headings use Merriweather; body Inter; monospace JetBrains Mono
+- [ ] Czech diacritics (č ř š ž ů ě á í é) render cleanly at every size
+- [ ] Drozd is registered as a mascot / state-illustration asset with the four state variants
+- [ ] Kingdom lookups stored as a component/pattern with canonical hex, so new dialogs can reference "Kingdom badge" by name
+- [ ] Destructive-action button style exists as a ghost-bordeaux variant (outline `#8C2423`, transparent fill, hover fills bordeaux)
+- [ ] A modal / dialog pattern exists matching DxPopup shape: forest-green header with cream text, parchment body, burnt-orange 1 px border, large corner radius, softer top-corner radii only
+
+## Step 4 — Known limitations to work around
+
+From Anthropic's docs:
+
+- **Inline comments occasionally disappear before Claude reads them.** Workaround: paste the comment text into the chat instead.
+- **Large codebases cause lag.** Link subdirectories only, never the repo root.
+- **"Chat upstream error":** start a new chat tab inside the same project; the design system persists.
+- **Compact layout save errors:** switch to full view before saving.
+
+## Step 5 — After setup, every dialog brief becomes tiny
+
+Once the design system is in place, dialog briefs drop the tokens/fonts/Drozd/kingdom block. They carry only:
+
+- One-line context (what page / what task)
+- Field list (label, type, span)
+- Image slots with aspect ratios
+- States to render (create, populated, error, …)
+- Data-model prereqs
+- Any page-specific copy
+
+See `docs/design/dialogs/character-list.md` for the canonical short-form brief.
+
+---
+
+## Handoff path: Claude Design → Claude Code
+
+When a mockup is approved in Claude Design, the native export `Export → Handoff to Claude Code → Send to local coding agent` drops the approved HTML plus metadata into a fresh Claude Code session here. That session picks up the builder brief (`docs/design/BUILDER-BRIEF-TEMPLATE.md` + the per-dialog addendum) and ports the mockup to DevExpress Blazor.
+
+Alternative: `Export as standalone HTML` → save at `docs/design/dialogs/<name>.mockup.html` → tell Claude Code in this repo *"<name> mockup approved"*.

--- a/docs/design/dialogs/character-list.md
+++ b/docs/design/dialogs/character-list.md
@@ -1,0 +1,169 @@
+# Design Brief — CharacterList edit dialog
+
+**Status:** v2 (Claude-Design-native) · 2026-04-22
+**Target surface:** Claude Design (claude.ai/design) — Ovčina org, design system already set up per `docs/design/CLAUDE-DESIGN-SETUP.md`
+**Implementation target:** `src/OvcinaHra.Client/Pages/Characters/CharacterList.razor` + `ovcinahra-theme.css`
+
+## Why this dialog matters
+
+Characters are the face of the game. Organizers maintain a roster of 50–200 hrdinové (player characters + NPCs). Currently the dialog is a plain 600 px DxPopup with a flat form and no portrait — it reads like a CRUD panel, not a ranger's character sheet.
+
+## Current pain
+
+- **No portrait slot** — biggest miss; `ImagePicker` component already exists, ready to wire
+- Race is free text — no structure, no consistency across the roster
+- Kingdom doesn't exist as a concept yet (to be introduced)
+- Rodič combobox lists the character itself and shows no portrait preview
+- Poznámky memo is only 3 rows — cramped for a LARP with 30 years of lore
+- Smazat button sits orphaned far-left in the footer
+- Empty state uses a generic Bootstrap people-icon, not Drozd
+- Header is plain text with no visual anchor
+
+## Data-model prerequisites (apply before UI port)
+
+1. **Race enum** on `Character.Race`: `Human`, `Dwarf`, `Elf`, `Hobbit`, `Dunedain` (Czech labels: Člověk, Trpaslík, Elf, Hobit, Dúnadan)
+2. **Kingdom lookup table:** `Kingdom { Id, Name, HexColor, BadgeImageUrl, Description }`. Seed with the four canon kingdoms.
+3. `Character.KingdomId` FK, nullable.
+4. DTO updates: `CharacterListDto`, `CharacterDetailDto`, `CreateCharacterDto`, `UpdateCharacterDto` gain `Race` + `KingdomId`.
+5. Migration + endpoint pass-through.
+
+## Prompt for Claude Design
+
+Paste this into a new Claude Design project within the Ovčina org (design system is inherited automatically — no palette/fonts/Drozd/kingdoms boilerplate needed).
+
+---
+
+```
+Design the edit dialog for a Character in OvčinaHra (organizer tool,
+desktop-first with 10" tablet as secondary). This is the detail view
+opened from the Characters list — both for creating a new character
+and editing an existing one.
+
+FIELDS (Czech labels, render verbatim)
+
+  Identity section (top)
+    Název postavy          text, required
+    Rasa                   chip-picker: Člověk · Trpaslík · Elf · Hobit · Dúnadan
+    Království (Kingdom)   lookup dropdown; each option renders the
+                           kingdom badge (48×48) + name + hex swatch;
+                           "(žádné)" is allowed
+    Hráčská postava        toggle Ano/Ne (shows/hides the Player panel)
+
+  Portrait (right side of Identity)
+    Single image slot, aspect ratio 4:5, display ~240×300
+    Drag-drop or click to upload · empty state shows a small thrush-and-
+    feather outline with caption "Nahrát portrét"
+    Hover on filled image → burnt-orange × in top-right to remove
+
+  Player panel (visible only when Hráčská = Ano)
+    Jméno hráče            text
+    Příjmení hráče         text
+    ID v registraci        number; if set, show a compact pill-link
+                           "Otevřít v registraci" (external-arrow icon)
+                           aligned to the right edge of the row
+
+  Lineage section
+    Rodič (Parent)         combobox of other characters — EXCLUDE self;
+                           each option renders a 24×30 portrait thumb +
+                           name + small race chip
+    Rok narození           number input; to its right, a computed age
+                           read-out in muted walnut text
+
+  Notes section
+    Poznámky               multi-line memo, min 6 rows, resizable;
+                           placeholder: "Deník kronikáře — příběh postavy,
+                           vztahy, zvyky, poznámky z her…"
+
+FOOTER (right-aligned except Smazat)
+  Smazat        ghost-bordeaux (outline only), far-left, visible only
+                when editing an existing character
+  Zrušit        secondary
+  Uložit        primary; disabled until Název is filled
+
+HEADER
+  Edit mode:    tiny 24×24 thrush icon before the title "Upravit: {name}"
+  Create mode:  tiny 24×24 quill-plus icon before "Nová postava"
+  Right side:   close × only
+
+STATES TO RENDER (stack vertically on faint parchment page bg)
+
+  1. Create (empty form, portrait empty, Hráčská off, Smazat hidden,
+     Uložit disabled)
+  2. Edit populated — example data:
+       Název: "Radovan Větrný"
+       Rasa: Dúnadan
+       Království: Nový Arnor
+       Hráčská: Ano, Jméno: "Tomáš", Příjmení: "Novák",
+         ID v registraci: 1247
+       Rodič: "Finarfin Větrný" with 24×30 thumb
+       Rok narození: 1985 → age read-out "41 let"
+       Poznámky: two short paragraphs of sample ranger lore in Czech
+  3. Validation error — Název missing, red bordeaux helper text under
+     the field, Uložit disabled; no intrusive alert banner
+
+BEHIND THE DIALOG
+Show a sliver of the Characters list grid (behind a soft backdrop):
+  columns [portrait 32×40] · Název · Kingdom badge 24×24 · Rasa chip ·
+  Hráč · Hráčská
+
+AUDIENCE
+Game organizers, ages 30–60, working at a desk to prepare an event
+(primary) or on a 10" tablet in the forest during the event (secondary).
+Czech-native, no English labels anywhere in the UI.
+
+DROZD FREQUENCY
+Drozd must NOT appear in the populated edit state.
+He may appear as a 48×48 perch in the validation-error state,
+muted, with caption "Něco chybí."
+```
+
+---
+
+## Builder addendum — CharacterList
+
+TARGET FILES
+- Razor: `src/OvcinaHra.Client/Pages/Characters/CharacterList.razor`
+- Theme additions: `src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css` (only if Claude Design introduces new tokens — add to `:root`)
+- New component (optional): `src/OvcinaHra.Client/Components/KingdomPicker.razor` (DxComboBox wrapper that renders badge + name)
+- Shared component changes: none
+
+DATA-MODEL PREREQS
+- Migration: `AddRaceEnumAndKingdomLookup`
+  - Add `Race` enum column on `Characters` (defaults to null)
+  - Create `Kingdoms` table with `Id`, `Name`, `HexColor`, `BadgeImageUrl`, `Description`
+  - Add `KingdomId` FK nullable on `Characters`
+  - Seed four canonical kingdoms (Esgaroth, Aradhryand, Azanulinbar, Nový Arnor)
+- Entity: `OvcinaHra.Shared/Domain/Entities/Kingdom.cs`
+- Configuration: `OvcinaHra.Api/Data/Configurations/KingdomConfiguration.cs`
+- Endpoint: `GET /api/kingdoms` returning `KingdomDto[]`
+- DTO updates: `CharacterListDto`, `CharacterDetailDto`, `CreateCharacterDto`, `UpdateCharacterDto` gain `Race` (enum) + `KingdomId` (int?)
+
+FIELD BINDINGS (mockup → Razor)
+- Název postavy → `name` via `DxTextBox @bind-Text="@name"`
+- Rasa → `race` (enum) via chip picker component (new) or `DxComboBox` with enum data
+- Království → `kingdomId` via `KingdomPicker` bound to `/api/kingdoms`
+- Hráčská postava → `isPlayedCharacter` via `DxCheckBox`
+- Jméno / Příjmení hráče → `playerFirstName` / `playerLastName` via `DxTextBox`
+- ID v registraci → `externalPersonId` via `DxSpinEdit` (conditional render)
+- Rodič → `parentCharacterId` via `DxComboBox` (filter out `editingId` from data source)
+- Rok narození → `birthYear` via `DxSpinEdit`
+- Poznámky → `notes` via `DxMemo Rows="6"`
+- Portrait → `ImagePicker` with `EntityType="character"`, `EntityId="@editingId"`, `AspectRatio="4:5"`, `Width="240px"`
+
+IMAGE SLOTS
+- Character portrait: `AspectRatio="4:5"`, `Width="240px"`, `EntityType="character"`, no `Field` (uses default image slot)
+- Kingdom badge: served from `KingdomDto.BadgeImageUrl`, rendered at 48×48 in the picker option and 24×24 in grid column
+
+GRID COLUMN CHANGES
+- Add: `Portrait` (32×40 thumb at start), `Kingdom` (badge 24×24 + name), `Rasa` (chip)
+- Keep: `Název`, `Hráč`, `Hráčská`, `ID v registraci`
+- Bump `LayoutKey`: `"grid-layout-characters"` → `"grid-layout-characters-v2"`
+
+VALIDATION
+- `Název postavy` required, non-empty after trim
+- If `Hráčská = true` and `ExternalPersonId` is set, must match an existing registrace person (server-side only)
+- `BirthYear` must be ≥ 1900 and ≤ current year + 1
+
+NOTES TO THE BUILDER
+- `ImagePicker` can only bind when `EntityId > 0`. In Create mode, render a placeholder ("Portrét bude možné nahrát po uložení") and enable the slot after the first Save.
+- Inherit all verification-loop and MEMORY rules from `docs/design/BUILDER-BRIEF-TEMPLATE.md` — do not re-state them here.

--- a/docs/design/dialogs/location-detail.md
+++ b/docs/design/dialogs/location-detail.md
@@ -1,0 +1,257 @@
+# Design Brief — Location detail page `/locations/{id}`
+
+**Status:** v1 · 2026-04-23
+**Target surface:** Claude Design (Ovčina org)
+**Implementation target:** new `src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor` (fresh page, NOT a popup) + reuse/extend `.location-card-*` CSS
+
+## Why a dedicated page
+
+The current `LocationEditPopup` is 900 × 700 with 4 tabs. Organizers prepping an event spend minutes on a single location (reading lore, tweaking GamePotential, placing stashes). A popup forces tunnel-vision; a page gives them room and a shareable URL.
+
+## Reference — current Upravit tab
+
+The existing form (screenshot shared 2026-04-23) already renders Název · Typ · Oblast · GPS (with an "upravit na mapě" link) · Obrázek · Foto umístění · Info pro CP (NPC) · Co nachystat na lokaci · Rodič · Smazat/Zrušit/Uložit footer. Keep those labels verbatim. The redesign's job is to refine grouping (Identita · Vizuál · Obsah · Organizační sections), normalize the image aspect ratios (main 1:1, placement 4:3), and — per the designer's choice — decide where the mini-map lives.
+
+## User decisions already locked
+
+| Decision | Value |
+|---|---|
+| Parchment card | Refine existing `.location-card-*`, don't rebuild |
+| Main image AR | **1:1** |
+| Placement photo AR | **4:3** landscape |
+| Variants | **Nested expansion** in the grid; on this page, shown as a variant-tree sidebar |
+| Stashes | **MTG card size (5:7 portrait)**, 3-column tiles, name + treasure quests, NO descriptions |
+| Mini-map | **Separate tab** |
+
+## Page layout overview
+
+Header (breadcrumb) → Title strip (Name, Region·Kind badge, action row) → **Tab strip** → Tab content below.
+
+Tab strip (left-to-right): **Karta** · **Upravit** · **Lore** · **Skrýše** · *(optional)* **Mapa**
+
+### Where does the mini-map live?
+
+**Designer's call.** Two equally valid options — pick the one that reads cleaner in the mockup:
+
+- **Option 1:** Dedicated **Mapa** tab (as originally briefed).
+- **Option 2:** Inline mini-map panel on the **Upravit** tab, sitting beside the GPS row. The existing page already surfaces "upravit na mapě" next to coordinates — promote that hint into a small MapLibre preview (240×180 or similar), clickable to open `/map?focus={id}`. This keeps editing flow in one place and frees the tab strip.
+
+The two options should not both appear. Pick one, label it clearly in the mockup, and drop the other section from the rendered output.
+
+## Prompt for Claude Design
+
+Paste into a new project in the **Ovčina** org (design system inherited).
+
+```
+Design the location detail page for OvčinaHra at URL /locations/{id}. This
+is where organizers do deep editing on a single location between events.
+
+AUDIENCE & DEVICE
+Organizers, 30–60, desktop first (1440 wide nominal) with 10" tablet as
+secondary. Czech only. Tabs are touch-targetable (≥ 44 px).
+
+PAGE SKELETON
+
+  Breadcrumb:  Lokace / {Name of current location}
+  Title strip:
+    [← zpět]  Lokace (h1, Merriweather)
+    Subline:  Region · LocationKind chip · Parent link (if variant)
+    Right-side actions: [Uložit] primary · [Zrušit] secondary · overflow
+      menu (bi-three-dots-vertical): Smazat (ghost-bordeaux), Nastavit
+      GPS, Přiřadit quest
+
+  Tab strip (sticky below title):
+    Karta · Upravit · Lore · Skrýše · [optional Mapa]
+    Karta is default on page load.
+
+  PLACEMENT OF THE MINI-MAP — DESIGNER'S CHOICE
+  Two options — choose one and commit to it in the mockup:
+
+    (A) A fifth tab "Mapa" containing the embedded MapLibre preview (as
+        detailed in TAB 5 below).
+    (B) An inline map panel embedded inside the Upravit tab, placed to the
+        right of the GPS coordinate row (240–320 px square MapLibre preview
+        with a single pin, "Otevřít v plné mapě" link beneath it). In this
+        variant, DO NOT add a Mapa tab at all and skip TAB 5.
+
+  The current app already surfaces "upravit na mapě" next to GPS — (B) is
+  the natural promotion of that hint. Only render one option in the final
+  mockup so the implementation path is unambiguous.
+
+============================================================
+TAB 1 — Karta (parchment card, read-mostly)
+============================================================
+
+Refined version of the existing .location-card treatment. Layout:
+
+  Header row (right-aligned, serif):
+    Name (Merriweather 900 2.4rem)
+    "Region — Kind" italic muted line
+
+  Body (CSS grid, 2 cols on ≥1024 px):
+    Left col (42%): Description paragraph in Georgia serif,
+      1.05rem, line-height 1.65, justified, hyphens auto.
+    Right col (58%):
+      - Main image at 1:1 (the container is flex-58%, image fills width,
+        displayed as a SQUARE via aspect-ratio:1/1, object-fit:cover).
+      - Below it, a small caption strip: "Znak lokace" (optional tag chips)
+
+  Details block (below body, full width):
+    numeric id badge (#42, JetBrains Mono, burnt-orange border chip)
+    paragraph text (Details field)
+
+  GamePotential strip:
+    parchment-alt background, burnt-orange 3 px left border (ribbon),
+    label "Herní potenciál:" bold, content inline.
+
+  Variants footer (if any):
+    "Varianty (3):" — horizontal list of chip-like links
+
+DO NOT include any edit affordances on this tab. Read-only.
+
+============================================================
+TAB 2 — Upravit (edit form)
+============================================================
+
+DxFormLayout in two columns on desktop. Field order:
+
+  Section: "Identita"
+    Název (DxTextBox, required, full width)
+    Druh (DxComboBox - LocationKind, with marker-dot prefix in each option)
+    Oblast (DxTextBox, free-text autocomplete from existing regions)
+    Rodič (DxComboBox of parents; EXCLUDE self + its descendants)
+
+  Section: "Vizuál"
+    Hlavní obrázek — ImagePicker EntityType="locations" field=default,
+      AspectRatio="1:1", Width="280px"
+    Fotka umístění — ImagePicker EntityType="locations" field="placement",
+      AspectRatio="4:3", Width="360px"
+
+  Section: "Obsah" (full width)
+    Popis (DxMemo, Rows=4, NullText="Čtenářský popis lokace…")
+    Detaily (DxMemo, Rows=5, NullText="Pravidlové poznámky, vazby…")
+    Herní potenciál (DxMemo, Rows=3, NullText="Co lokace nabízí hrám…")
+
+  Section: "Organizační"
+    Přípravné poznámky (DxMemo, Rows=3)
+    NPC info (DxMemo, Rows=3)
+    Prompt (DxTextBox, italic hint: "volitelné — generátor scén")
+
+  Footer: Uložit (primary) + Zrušit (secondary) fixed at page bottom
+    during scroll; Smazat (ghost-bordeaux) far-left, only when editing
+    existing record; Save is disabled until Název is non-empty.
+
+============================================================
+TAB 3 — Lore
+============================================================
+
+Two-pane read+edit for long-form world content.
+  Left pane (60%): preview — Georgia serif, 1.1rem, line-height 1.7,
+    muted parchment bg, hand-lettered feel.
+  Right pane (40%): DxMemo 18 rows, writes to Location.Notes (or similar
+    lore field — reuse existing field).
+Toggle "Vzhled pergamenu" (preview) vs "Editor" on narrower screens.
+
+============================================================
+TAB 4 — Skrýše (reworked)
+============================================================
+
+Header: "Skrýše v této lokaci (N)" + button "+ Přidat skrýši" (opens
+SecretStash picker).
+
+Main grid of MTG-sized tiles.
+Tile aspect ratio: 5:7 portrait (2.5 in × 3.5 in — the physical MTG card
+size, ratio 0.714). Use "5:7" verbatim for ImagePicker. Display size
+160 × 224 px on desktop (exactly 5:7), 120 × 168 px on tablet.
+
+  3 columns desktop ≥ 1024 px
+  2 columns tablet 768–1024 px
+  1 column mobile < 768 px
+  Row gap 24 px, column gap 20 px.
+
+Each tile (composition, top to bottom):
+  · Image area at 5:7 (ImagePicker read-only here — upload happens on the
+    SecretStash page).
+  · Stash name (Merriweather 700 1rem, forest green, 2-line ellipsis).
+  · Hairline separator (1 px, burnt-orange 30% alpha).
+  · TreasureQuest list: bullet of title + a small "Poklad" pill
+    (muted amber bg #F9A825 20% + amber-dark border); 5 max, "+ N more"
+    footer.
+  · NO stash description text.
+  · On hover: subtle lift (translateY -2 px) + sage-mist tint.
+  · On click: navigates to /secret-stashes/{id}
+
+Empty state: Drozd perch (48×48) + "Žádné skrýše zatím nejsou přiřazené."
+
+============================================================
+TAB 5 — Mapa (ONLY IF YOU PICKED OPTION A ABOVE)
+============================================================
+
+A 720 × 420 embedded MapLibre tile (same style as the main /map page)
+centered on this location's GPS coordinates with the single pin placed
+and colored by LocationKind marker color. No edit. Below the map:
+
+  · "GPS: 50.0832°, 14.4336°" (JetBrains Mono)
+  · [Otevřít v plné mapě →] (primary button, links to /map?focus={id})
+  · If no GPS set: parchment empty state with Drozd perch + copy
+    "Lokace ještě nemá GPS. Nastav ji přes Upravit › Organizační.".
+
+If you picked Option B (inline map on Upravit), drop this tab entirely —
+no placeholder, no stub. Just end the tab strip at Skrýše.
+
+============================================================
+STATES TO RENDER (stack vertically for the mockup)
+============================================================
+
+  1. Tab=Karta — location "Esgaroth" populated with a 4-para description,
+     1:1 image of a village sketch, details id #08, GamePotential strip,
+     no variants.
+  2. Tab=Upravit — same location, form fields populated, image picker
+     slots show current images.
+  3. Tab=Skrýše — 5 stashes shown as 3-col MTG tiles (row 1: 3 tiles,
+     row 2: 2 tiles), one tile has overflow "+ 3 more".
+  4. Tab=Mapa — mini-map with single pin; below it GPS + "Otevřít v plné
+     mapě" button.
+  5. Tab=Karta empty state (location with no description/images yet) —
+     Drozd slot in the right column asking "Napiš první popis této lokace."
+
+ANTI-PATTERNS
+  · No kingdom colors on LocationKind chips (kinds have their own palette).
+  · No Drozd on populated Karta / Upravit / Skrýše / Mapa tabs.
+  · No 16:9 cinematic main image — we locked 1:1.
+  · No stash descriptions anywhere.
+```
+
+---
+
+## Builder addendum — LocationDetail page
+
+TARGET FILES
+- New page: `src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor` (route `/locations/{id:int}`)
+- Existing popup `src/OvcinaHra.Client/Components/LocationEditPopup.razor` → repurpose Karta tab as the quick-peek popup (per `location-list.md`); the remaining tabs (Upravit, Lore, Skrýše, Mapa) move to the new page.
+- New component: `src/OvcinaHra.Client/Components/LocationStashTile.razor` (shared with grid's rework)
+- Theme: extend `.location-card-*` (already in `ovcinahra-theme.css`) for the 1:1 image constraint; append `.oh-loc-detail-*` scoped block for tab-specific styling
+
+DATA BINDINGS
+- Page loads `GET /api/locations/{id}?gameId={contextGameId}` on route change
+- Karta uses existing `LocationListDto` fields — no new DTO needed
+- Skrýše tab uses `LocationListDto.Stashes[]` already present
+- Mini-map tab calls `map-interop.js` with `LocationListDto.Coordinates` (GpsCoordinates value object already projects to the DTO via existing serialization)
+- Edit form saves via existing `PUT /api/locations/{id}` endpoint — no new endpoint needed
+
+NAVIGATION FLOW
+- Grid quick-peek popup → "Otevřít detail →" → `NavigationManager.NavigateTo($"/locations/{id}")`
+- Mini-map tab → "Otevřít v plné mapě" → `NavigationManager.NavigateTo($"/map?focus={id}")`
+- Parent/variant links stay in-app (NavigationManager, no full reload)
+
+OUT OF SCOPE
+- GPS placement (keep existing GpsDialog flow, exposed via overflow menu)
+- Stash editing (still lives on /secret-stashes)
+- Map pin layer changes (MapPage owns that)
+
+NOTES
+- This page uses tabs heavily — use `DxTabs`; each tab's content should NOT pre-render (lazy render) to keep first paint cheap.
+- Mini-map tab uses MapLibre; ensure `map-interop.js` supports single-pin read-only mode.
+- Tile image URLs: GET `/api/images/secretstashes/{stash.Id}` returns `ImageUrl`; the LocationStashTile component fetches once per tile with `OnParametersSetAsync` + local cache.
+- MEMORY §D: Smazat always goes through DxPopup confirm.
+- MEMORY §L: this page uses no DxGrid, so no LayoutKey concerns.

--- a/docs/design/dialogs/location-list.md
+++ b/docs/design/dialogs/location-list.md
@@ -1,0 +1,209 @@
+# Design Brief — Locations grid + quick-peek popup
+
+**Status:** v1 · 2026-04-23
+**Target surface:** Claude Design (claude.ai/design) — Ovčina org, design system already set up (`docs/design/CLAUDE-DESIGN-SETUP.md`)
+**Implementation target:** `src/OvcinaHra.Client/Pages/Locations/LocationList.razor` + grid CSS additions to `ovcinahra-theme.css`
+
+## Why this matters
+
+Locations are the most-touched catalog in the app. Every organizer opens this grid multiple times per session during event prep. The current grid is functional but noisy — inline stash cards bleed flavor text, the context menu is discoverable only via three-dots, and variants are a wall of links rather than a hierarchy.
+
+## Current state (summary)
+
+- Dual-mode: **by-game** (default at `/locations`) vs **catalog** (`/locations?catalog=true`)
+- Columns today: context menu · Name · Kind · Region · Parent/Variants · GamePotential · SetupNotes · *(by-game only)* Stashes inline
+- Row click → `LocationEditPopup` (4-tab popup)
+- Context-menu actions: GPS · Link · Map · Delete
+
+## Scope of this brief
+
+Grid **plus the quick-peek popup** that opens on row click. Full detail lives at `/locations/{id}` — a separate brief (`location-detail.md`).
+
+## User decisions already locked
+
+| Decision | Value |
+|---|---|
+| Detail split | Hybrid — grid popup is quick peek, full detail is a page |
+| Parchment card treatment | Refine existing `.location-card-*` |
+| Dual-mode grid | Keep both. Inline stash column stays (user can hide it) |
+| Image aspect — main | **1:1** |
+| Image aspect — placement | **4:3** landscape |
+| Grid thumbnail | **Colored dot only** (kind-based marker color) — no thumbnail image |
+| Stash tile inside grid cell | **MTG card size** (5:7 portrait) |
+| Stash tile content | Image · Name · Treasure Quests listed below · **no descriptions** |
+| Stash tile layout | **3 columns** on desktop, 2 tablet, 1 mobile |
+| Variants | **Nested expansion** — click parent row expands to show variants inline |
+
+## Data prereqs (already in entity, no new schema)
+
+- `LocationKind` enum markers: `Town #2c3e50 · Village #27ae60 · Magical #8e44ad · Hobbit #f39c12 · Wilderness #16a085` (canonical, NOT kingdom colors)
+- `Location.ParentLocationId` → parent/variant tree
+- `LocationListDto.Stashes[].TreasureQuests[]` — what we render in the MTG-card tiles
+- `SecretStash.ImagePath` — already supported by ImageEndpoints ("secretstashes" entity type)
+
+## Prompt for Claude Design
+
+Paste into a new project inside the **Ovčina** org. Design system (forest green, parchment, kingdoms, Drozd) is inherited automatically — no token boilerplate.
+
+```
+Design the Locations grid for OvčinaHra — the organizer-facing catalog and
+per-game view of every location in the LARP world. This is the single most-
+touched screen in the app.
+
+AUDIENCE & DEVICE
+Game organizers, 30–60, desktop first (1280–1600 wide) with 10" tablet as
+secondary. Czech only, diacritics must render (č ř š ž ů ě).
+
+DUAL MODE (URL query ?catalog=true toggles)
+
+  Mode A — "by-game" (default, shown when an active game is selected)
+    Toolbar: Hledat · Filtr kinds · Filtr region · Pouze s questy · Pouze s poklady
+    Columns (left→right): context-menu dot · colored-dot marker · Název ·
+      Druh (kind chip) · Oblast (region text) · Rodič/Varianty · Skrýše (rich) ·
+      Questy (count badge) · GamePotential (muted) · SetupNotes (muted)
+
+  Mode B — "catalog" (global, all locations, may not be in current game)
+    Same columns except Skrýše is replaced by a single "Přiřadit ke hře" toggle
+    per row (Ano/Ne badge + quick-assign button on hover)
+
+MARKER DOT (leftmost visual cue, 10 px)
+Use LocationKind marker colors — canonical, distinct from kingdom colors:
+  Town        #2c3e50   dark slate
+  Village     #27ae60   fresh green
+  Magical     #8e44ad   violet
+  Hobbit      #f39c12   amber
+  Wilderness  #16a085   teal
+Render as a plain colored circle; tooltip on hover with the kind's Czech
+display name (Město / Vesnice / Kouzelné / Hobit / Pustina).
+
+VARIANTS HIERARCHY
+Parent rows show a disclosure chevron (▶) when `Variants.length > 0`. Click
+expands in place: variant rows appear indented 24 px under the parent, same
+columns, slightly dimmed. Parent row shows a "3 varianty" caption next to
+its Name. Map pins only ever show parents — hint this in the expanded state
+with a small `bi-geo-alt` icon next to the parent only.
+
+STASH COLUMN (by-game mode) — THE REWORK
+When a location has stashes, render them inside the Skrýše cell as a
+3-column mini-gallery of Magic-The-Gathering-sized tiles.
+
+Tile aspect ratio: 5:7 portrait (exactly 2.5 in × 3.5 in, the physical MTG
+card size — ratio 0.714). Use "5:7" verbatim when wiring ImagePicker.
+Display size in the grid: 70 × 98 px on desktop, 60 × 84 px on tablet.
+Never crop or skew — the tile IS the card. Layout:
+
+  [ tile | tile | tile ]
+  [ tile ]
+  …
+
+Each tile contains:
+  · stash image at 5:7 (ImagePicker / ImageUrlsDto.ImageUrl for "secretstashes")
+  · stash name (2-line max, ellipsis; Merriweather 0.8125rem, forest green)
+  · a thin hairline separator
+  · bulleted list of that stash's TreasureQuests (title + small "Poklad" pill
+    with muted amber bg); 3 max, "+ N více" if overflow
+  · NO stash description text
+Tiles use parchment-cream bg, burnt-orange 1px top border (the "ribbon"),
+subtle green-tinted shadow, 6 px corner radius.
+On hover: gentle lift + light sage-mist tint.
+On tablet: 2 tiles per row. On mobile: 1 tile per row.
+
+CONTEXT MENU (replaces current three-dots)
+Move to row-hover: a subtle icon group that appears on the right edge of
+the hovered row. Icons:
+  · bi-geo-alt-fill   → "Nastavit GPS"
+  · bi-link-45deg     → "Přiřadit quest"
+  · bi-map-fill       → "Otevřít na mapě"
+  · bi-trash-fill     → "Smazat"  (ghost-bordeaux)
+Each icon 28×28, spaced 6 px, muted when row not hovered.
+
+TOOLBAR (sticky above grid)
+  [ Hledat… ]  [ Druh ▼ ]  [ Oblast ▼ ]  [ toggle: jen s poklady ]
+  [ toggle: jen s questy ]                         [ + Nová lokace ]
+
+EMPTY STATE
+Use Drozd in the 120×120 state-illustration slot, copy:
+  title: "Zatím tu není žádná lokace."
+  cta:   "+ Nová lokace"
+
+QUICK-PEEK POPUP (row click)
+A 720×540 DxPopup showing ONLY the parchment card (read view). Content:
+  · location-card header: Name (right-aligned Merriweather 2.2rem),
+    Region · Druh (italic, muted)
+  · 2-column body:
+      left (42%): Description paragraph, Georgia serif, hyphens auto
+      right (58%): main image at 1:1 (so the image slot is a SQUARE
+      inside the 58% flex column — image is sized to fit the width of
+      the column while maintaining 1:1, then centered)
+  · Details block below with the numeric id badge (#42 in JetBrains Mono)
+  · GamePotential callout (parchment-alt strip)
+  · Variant links row (← parent, or → each variant)
+  · Footer buttons: [Otevřít detail →] (primary, navigates to /locations/{id})
+                    [Zavřít] (secondary)
+
+STATES TO RENDER (stack vertically on faint parchment page bg)
+
+  1. Grid by-game mode — 6 rows: one parent with 2 expanded variants, two
+     with inline stash tiles (varying counts: 1, 3, 5-so-overflow), rest
+     plain. Context icons visible on one hovered row.
+  2. Grid catalog mode — 6 rows with per-row "Přiřazeno ke hře" Ano/Ne
+     toggle and a hover-state "+ Přiřadit" button on the Ne rows.
+  3. Empty state with Drozd.
+  4. Quick-peek popup — example location "Esgarothský přístav", Town kind,
+     Lake-people region, 4 paragraph Czech description, image, details,
+     herní potenciál strip, one variant link.
+
+DEVEXPRESS MAPPING (for the builder brief downstream)
+  · DxGrid with DxGridDataColumn; OvcinaGrid (shared wrapper) keeps
+    LayoutKey; bump to "grid-layout-locations-v3" on ship.
+  · DxPopup for quick peek. DxFlyout (no popup) may be used for the hover
+    icon group to avoid re-layout.
+  · Stash tiles are a custom Razor component — ImagePicker for upload on
+    the SecretStash side, but here we just render <img src="{url}">.
+  · Marker dot is a 10 px span with background from a C# switch on
+    LocationKind.
+
+COPY DISCIPLINE
+  · Everywhere: Czech verbatim above. Never Hrdina/Hrdinové here — this is
+    the organizer's world-building view, entities are "lokace".
+  · Don't romanticize: no "whispering woods", no marketing copy. Muted.
+
+ANTI-PATTERNS
+  · NO image thumbnails in the grid rows (colored dot only).
+  · NO stash description text in the tiles.
+  · NO kingdom colors on location markers (kinds have their own canon).
+  · NO Drozd on populated screens (empty-state only here).
+```
+
+---
+
+## Builder addendum — LocationList grid + quick-peek popup
+
+TARGET FILES
+- Razor: `src/OvcinaHra.Client/Pages/Locations/LocationList.razor`
+- New component: `src/OvcinaHra.Client/Components/LocationStashTile.razor` (the MTG-card tile)
+- Theme additions: `src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css` (append `.oh-loc-*` scoped block)
+
+GRID COLUMN CHANGES
+- Add: marker dot column (40 px, first), variant disclosure chevron (on Name cell)
+- Rework: Stashes column — now renders `LocationStashTile` in 3-col CSS grid
+- Bump `LayoutKey` → `"grid-layout-locations-v3"` (MEMORY §L)
+- Context menu → replace DxContextMenu with DxFlyout triggered on row hover icon group
+
+DATA BINDINGS
+- Marker color: static C# dictionary `LocationKindMarkerColors` (Town #2c3e50 etc.) — NEW constants class in `OvcinaHra.Shared/Domain/Constants`
+- Stash tile image: GET `/api/images/secretstashes/{stash.Id}` → `ImageUrl`; cached per-tile
+
+QUICK-PEEK POPUP
+- 720×540 DxPopup
+- Reuse existing `.location-card-*` CSS (already in theme, already good) but normalize image aspect-ratio via `aspect-ratio: 1/1` on the image container
+- Footer "Otevřít detail →" calls `NavigationManager.NavigateTo($"/locations/{id}")`
+
+OUT OF SCOPE
+- Full edit form (lives on `/locations/{id}` page — see `location-detail.md`)
+- GPS placement flow (unchanged — keep the existing GpsDialog component)
+- Map pin styling (unchanged — MapPage uses its own marker system)
+
+NOTES
+- `LocationKindMarkerColors` is a new constants class — expose from Shared so both MapPage and LocationList can reference one source of truth. Consider also emitting CSS custom properties (`--oh-loc-town` etc.) if Claude Design suggests it.
+- Respect MEMORY §D — all destructive icons route through DxPopup confirm.

--- a/src/OvcinaHra.Api/Data/Configurations/CharacterConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/CharacterConfiguration.cs
@@ -12,6 +12,7 @@ public class CharacterConfiguration : IEntityTypeConfiguration<Character>
         builder.Property(e => e.Name).IsRequired().HasMaxLength(200);
         builder.Property(e => e.PlayerFirstName).HasMaxLength(100);
         builder.Property(e => e.PlayerLastName).HasMaxLength(100);
+        builder.Property(e => e.Race).HasConversion<string>().HasMaxLength(20);
         builder.HasIndex(e => e.ExternalPersonId).IsUnique().HasFilter("\"ExternalPersonId\" IS NOT NULL");
         builder.HasOne(e => e.ParentCharacter).WithMany(e => e.Children).HasForeignKey(e => e.ParentCharacterId);
         builder.HasQueryFilter(e => !e.IsDeleted);
@@ -25,6 +26,7 @@ public class CharacterAssignmentConfiguration : IEntityTypeConfiguration<Charact
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Class).HasConversion<string>().HasMaxLength(20);
         builder.HasOne(e => e.Character).WithMany(c => c.Assignments).HasForeignKey(e => e.CharacterId);
+        builder.HasOne(e => e.Kingdom).WithMany(k => k.Assignments).HasForeignKey(e => e.KingdomId).OnDelete(DeleteBehavior.SetNull);
         builder.HasIndex(e => e.GameId);
         builder.HasIndex(e => e.ExternalPersonId);
         builder.HasIndex(e => e.CharacterId);

--- a/src/OvcinaHra.Api/Data/Configurations/KingdomConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/KingdomConfiguration.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class KingdomConfiguration : IEntityTypeConfiguration<Kingdom>
+{
+    public void Configure(EntityTypeBuilder<Kingdom> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Name).IsRequired().HasMaxLength(100);
+        builder.Property(e => e.HexColor).HasMaxLength(7);
+        builder.Property(e => e.BadgeImageUrl).HasMaxLength(500);
+        builder.Property(e => e.Description).HasMaxLength(2000);
+        builder.HasIndex(e => e.Name).IsUnique();
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -42,6 +42,7 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<BattlefieldBonus> BattlefieldBonuses => Set<BattlefieldBonus>();
     public DbSet<LocalUser> LocalUsers => Set<LocalUser>();
     public DbSet<Character> Characters => Set<Character>();
+    public DbSet<Kingdom> Kingdoms => Set<Kingdom>();
     public DbSet<CharacterAssignment> CharacterAssignments => Set<CharacterAssignment>();
     public DbSet<CharacterEvent> CharacterEvents => Set<CharacterEvent>();
     public DbSet<GameEvent> GameEvents => Set<GameEvent>();

--- a/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
@@ -21,6 +21,7 @@ public static class CharacterEndpoints
         group.MapGet("/{id:int}/assignments", GetAssignments);
         group.MapPost("/{id:int}/assignments", CreateAssignment);
         group.MapPut("/assignments/{id:int}", UpdateAssignment);
+        group.MapPut("/{id:int}/assignment/kingdom", SetAssignmentKingdom);
         group.MapPost("/import/{gameId:int}", ImportFromRegistrace);
 
         return group;
@@ -31,24 +32,44 @@ public static class CharacterEndpoints
             ? null
             : $"{c.PlayerFirstName} {c.PlayerLastName}".Trim();
 
-    private static async Task<Ok<List<CharacterListDto>>> GetAll(WorldDbContext db, string? search = null)
+    private static async Task<Ok<List<CharacterListDto>>> GetAll(
+        WorldDbContext db, string? search = null, int? gameId = null)
     {
         var query = db.Characters.AsQueryable();
 
         if (!string.IsNullOrWhiteSpace(search))
             query = query.Where(c => c.Name.Contains(search));
 
-        var characters = await query
-            .OrderBy(c => c.Name)
-            .ToListAsync();
+        var characters = await query.OrderBy(c => c.Name).ToListAsync();
+
+        // Join active assignment's Kingdom for the given game (B1 behaviour).
+        Dictionary<int, (int KingdomId, string Name, string? HexColor)> kingdomByCharacter = new();
+        if (gameId is int gid && characters.Count > 0)
+        {
+            var charIds = characters.Select(c => c.Id).ToList();
+            var assignments = await db.CharacterAssignments
+                .Where(a => a.GameId == gid && a.IsActive && charIds.Contains(a.CharacterId) && a.KingdomId != null)
+                .Include(a => a.Kingdom)
+                .Select(a => new { a.CharacterId, a.KingdomId, a.Kingdom!.Name, a.Kingdom.HexColor })
+                .ToListAsync();
+
+            foreach (var a in assignments)
+                kingdomByCharacter[a.CharacterId] = (a.KingdomId!.Value, a.Name, a.HexColor);
+        }
 
         return TypedResults.Ok(characters
-            .Select(c => new CharacterListDto(
-                c.Id, c.Name, FullName(c), c.Race, c.IsPlayedCharacter, c.ExternalPersonId))
+            .Select(c =>
+            {
+                kingdomByCharacter.TryGetValue(c.Id, out var k);
+                return new CharacterListDto(
+                    c.Id, c.Name, FullName(c), c.Race, c.IsPlayedCharacter, c.ExternalPersonId,
+                    k.KingdomId == 0 ? null : k.KingdomId, k.Name, k.HexColor);
+            })
             .ToList());
     }
 
-    private static async Task<Results<Ok<CharacterDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
+    private static async Task<Results<Ok<CharacterDetailDto>, NotFound>> GetById(
+        int id, WorldDbContext db, int? gameId = null)
     {
         var c = await db.Characters
             .Include(c => c.ParentCharacter)
@@ -56,12 +77,33 @@ public static class CharacterEndpoints
 
         if (c is null) return TypedResults.NotFound();
 
+        int? kingdomId = null;
+        string? kingdomName = null;
+        string? kingdomHex = null;
+        int? activeAssignmentId = null;
+
+        if (gameId is int gid)
+        {
+            var assignment = await db.CharacterAssignments
+                .Include(a => a.Kingdom)
+                .FirstOrDefaultAsync(a => a.CharacterId == id && a.GameId == gid && a.IsActive);
+
+            if (assignment is not null)
+            {
+                activeAssignmentId = assignment.Id;
+                kingdomId = assignment.KingdomId;
+                kingdomName = assignment.Kingdom?.Name;
+                kingdomHex = assignment.Kingdom?.HexColor;
+            }
+        }
+
         return TypedResults.Ok(new CharacterDetailDto(
             c.Id, c.Name, c.PlayerFirstName, c.PlayerLastName,
             c.Race, c.BirthYear, c.Notes,
             c.IsPlayedCharacter, c.ExternalPersonId,
             c.ParentCharacterId, c.ParentCharacter?.Name,
-            c.CreatedAtUtc, c.UpdatedAtUtc));
+            c.CreatedAtUtc, c.UpdatedAtUtc,
+            kingdomId, kingdomName, kingdomHex, activeAssignmentId));
     }
 
     private static async Task<Created<CharacterDetailDto>> Create(CreateCharacterDto dto, WorldDbContext db)
@@ -138,18 +180,22 @@ public static class CharacterEndpoints
             ExternalPersonId = dto.ExternalPersonId,
             RegistraceCharacterId = dto.RegistraceCharacterId,
             Class = dto.Class,
-            Kingdom = dto.Kingdom,
+            KingdomId = dto.KingdomId,
             IsActive = true,
             StartedAtUtc = DateTime.UtcNow
         };
         db.CharacterAssignments.Add(assignment);
         await db.SaveChangesAsync();
 
+        if (assignment.KingdomId.HasValue)
+            await db.Entry(assignment).Reference(a => a.Kingdom).LoadAsync();
+
         return TypedResults.Created($"/api/characters/{id}/assignments",
             new CharacterAssignmentDto(
                 assignment.Id, assignment.CharacterId, character.Name,
                 assignment.GameId, assignment.ExternalPersonId, assignment.RegistraceCharacterId,
-                assignment.Class, assignment.Kingdom,
+                assignment.Class,
+                assignment.KingdomId, assignment.Kingdom?.Name, assignment.Kingdom?.HexColor,
                 assignment.IsActive, assignment.StartedAtUtc, assignment.EndedAtUtc));
     }
 
@@ -158,11 +204,13 @@ public static class CharacterEndpoints
         var assignments = await db.CharacterAssignments
             .Where(a => a.CharacterId == id)
             .Include(a => a.Character)
+            .Include(a => a.Kingdom)
             .OrderByDescending(a => a.StartedAtUtc)
             .Select(a => new CharacterAssignmentDto(
                 a.Id, a.CharacterId, a.Character.Name,
                 a.GameId, a.ExternalPersonId, a.RegistraceCharacterId,
-                a.Class, a.Kingdom,
+                a.Class,
+                a.KingdomId, a.Kingdom != null ? a.Kingdom.Name : null, a.Kingdom != null ? a.Kingdom.HexColor : null,
                 a.IsActive, a.StartedAtUtc, a.EndedAtUtc))
             .ToListAsync();
 
@@ -176,10 +224,31 @@ public static class CharacterEndpoints
         if (assignment is null) return TypedResults.NotFound();
 
         assignment.Class = dto.Class;
-        assignment.Kingdom = dto.Kingdom;
+        assignment.KingdomId = dto.KingdomId;
         assignment.IsActive = dto.IsActive;
         if (!dto.IsActive && assignment.EndedAtUtc is null)
             assignment.EndedAtUtc = DateTime.UtcNow;
+
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    // Upsert the kingdom on a character's active assignment for a given game.
+    // Used by the CharacterList edit dialog — kingdom belongs to per-game
+    // assignment, but the dialog exposes it alongside catalog fields for
+    // organizer convenience. Returns NotFound if the character has no active
+    // assignment for the given game (catalog-only characters cannot be given
+    // a kingdom without first being assigned to the game via import or
+    // CreateAssignment).
+    private static async Task<Results<NoContent, NotFound>> SetAssignmentKingdom(
+        int id, SetAssignmentKingdomDto dto, WorldDbContext db)
+    {
+        var assignment = await db.CharacterAssignments
+            .FirstOrDefaultAsync(a => a.CharacterId == id && a.GameId == dto.GameId && a.IsActive);
+
+        if (assignment is null) return TypedResults.NotFound();
+
+        assignment.KingdomId = dto.KingdomId;
 
         await db.SaveChangesAsync();
         return TypedResults.NoContent();

--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -8,7 +8,7 @@ namespace OvcinaHra.Api.Endpoints;
 
 public static class ImageEndpoints
 {
-    private static readonly HashSet<string> ValidEntityTypes = ["locations", "items", "monsters", "secretstashes", "npcs", "buildings"];
+    private static readonly HashSet<string> ValidEntityTypes = ["locations", "items", "monsters", "secretstashes", "npcs", "buildings", "characters", "kingdoms"];
     private static readonly HashSet<string> AllowedContentTypes = ["image/jpeg", "image/png", "image/webp"];
     private const long MaxFileSize = 5 * 1024 * 1024; // 5 MB
 
@@ -133,6 +133,14 @@ public static class ImageEndpoints
                 var building = await db.Buildings.FindAsync(entityId);
                 if (building is not null) building.ImagePath = blobKey;
                 break;
+            case "characters":
+                var character = await db.Characters.FindAsync(entityId);
+                if (character is not null) character.ImagePath = blobKey;
+                break;
+            case "kingdoms":
+                var kingdom = await db.Kingdoms.FindAsync(entityId);
+                if (kingdom is not null) kingdom.BadgeImageUrl = blobKey;
+                break;
         }
 
         await db.SaveChangesAsync();
@@ -161,6 +169,12 @@ public static class ImageEndpoints
             "buildings" => await db.Buildings.Where(b => b.Id == entityId)
                 .Select(b => new ValueTuple<string?, string?>(b.ImagePath, null))
                 .FirstOrDefaultAsync(),
+            "characters" => await db.Characters.Where(c => c.Id == entityId)
+                .Select(c => new ValueTuple<string?, string?>(c.ImagePath, null))
+                .FirstOrDefaultAsync(),
+            "kingdoms" => await db.Kingdoms.Where(k => k.Id == entityId)
+                .Select(k => new ValueTuple<string?, string?>(k.BadgeImageUrl, null))
+                .FirstOrDefaultAsync(),
             _ => (null, null)
         };
     }
@@ -175,6 +189,8 @@ public static class ImageEndpoints
             "secretstashes" => await db.SecretStashes.AnyAsync(s => s.Id == entityId),
             "npcs" => await db.Npcs.AnyAsync(n => n.Id == entityId),
             "buildings" => await db.Buildings.AnyAsync(b => b.Id == entityId),
+            "characters" => await db.Characters.AnyAsync(c => c.Id == entityId),
+            "kingdoms" => await db.Kingdoms.AnyAsync(k => k.Id == entityId),
             _ => false
         };
     }

--- a/src/OvcinaHra.Api/Endpoints/KingdomEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/KingdomEndpoints.cs
@@ -1,0 +1,113 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Endpoints;
+
+public static class KingdomEndpoints
+{
+    public static RouteGroupBuilder MapKingdomEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/kingdoms").WithTags("Kingdoms");
+
+        group.MapGet("/", GetAll);
+        group.MapPost("/", Create);
+        group.MapPut("/{id:int}", Update);
+        group.MapDelete("/{id:int}", Delete);
+
+        return group;
+    }
+
+    private static async Task<Ok<List<KingdomDto>>> GetAll(WorldDbContext db)
+    {
+        var kingdoms = await db.Kingdoms
+            .OrderBy(k => k.SortOrder)
+            .ThenBy(k => k.Name)
+            .Select(k => new KingdomDto(
+                k.Id, k.Name, k.HexColor, k.BadgeImageUrl, k.Description, k.SortOrder,
+                k.Assignments.Count))
+            .ToListAsync();
+
+        return TypedResults.Ok(kingdoms);
+    }
+
+    private static async Task<Results<Created<KingdomDto>, Conflict<string>, BadRequest<string>>> Create(
+        CreateKingdomDto dto, WorldDbContext db)
+    {
+        if (string.IsNullOrWhiteSpace(dto.Name))
+            return TypedResults.BadRequest("Název království je povinný.");
+
+        var exists = await db.Kingdoms.AnyAsync(k => k.Name == dto.Name);
+        if (exists)
+            return TypedResults.Conflict($"Království s názvem '{dto.Name}' už existuje.");
+
+        var k = new Kingdom
+        {
+            Name = dto.Name.Trim(),
+            HexColor = dto.HexColor,
+            BadgeImageUrl = dto.BadgeImageUrl,
+            Description = dto.Description,
+            SortOrder = dto.SortOrder
+        };
+        db.Kingdoms.Add(k);
+        await db.SaveChangesAsync();
+
+        return TypedResults.Created($"/api/kingdoms/{k.Id}",
+            new KingdomDto(k.Id, k.Name, k.HexColor, k.BadgeImageUrl, k.Description, k.SortOrder, 0));
+    }
+
+    // Name gating: if any CharacterAssignment references this kingdom, the Name
+    // cannot be changed (rename = canon change, must be done via code/migration).
+    // Other metadata (hex, badge, description, sort order) is freely editable.
+    private static async Task<Results<NoContent, NotFound, Conflict<string>, BadRequest<string>>> Update(
+        int id, UpdateKingdomDto dto, WorldDbContext db)
+    {
+        if (string.IsNullOrWhiteSpace(dto.Name))
+            return TypedResults.BadRequest("Název království je povinný.");
+
+        var k = await db.Kingdoms.FindAsync(id);
+        if (k is null) return TypedResults.NotFound();
+
+        if (!string.Equals(k.Name, dto.Name, StringComparison.Ordinal))
+        {
+            var inUse = await db.CharacterAssignments.AnyAsync(a => a.KingdomId == id);
+            if (inUse)
+                return TypedResults.Conflict(
+                    "Toto království je přiřazeno postavám — název nelze přejmenovat. Ostatní údaje můžete upravit.");
+
+            var nameClash = await db.Kingdoms.AnyAsync(x => x.Id != id && x.Name == dto.Name);
+            if (nameClash)
+                return TypedResults.Conflict($"Království s názvem '{dto.Name}' už existuje.");
+
+            k.Name = dto.Name.Trim();
+        }
+
+        k.HexColor = dto.HexColor;
+        k.BadgeImageUrl = dto.BadgeImageUrl;
+        k.Description = dto.Description;
+        k.SortOrder = dto.SortOrder;
+
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    // Blocked when any CharacterAssignment references the kingdom. Returning
+    // 409 keeps historic assignments intact.
+    private static async Task<Results<NoContent, NotFound, Conflict<string>>> Delete(
+        int id, WorldDbContext db)
+    {
+        var k = await db.Kingdoms.FindAsync(id);
+        if (k is null) return TypedResults.NotFound();
+
+        var inUse = await db.CharacterAssignments.AnyAsync(a => a.KingdomId == id);
+        if (inUse)
+            return TypedResults.Conflict(
+                "Toto království je přiřazeno postavám — nejde smazat. Nejprve odstraňte přiřazení.");
+
+        db.Kingdoms.Remove(k);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+}

--- a/src/OvcinaHra.Api/Endpoints/KingdomEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/KingdomEndpoints.cs
@@ -39,13 +39,15 @@ public static class KingdomEndpoints
         if (string.IsNullOrWhiteSpace(dto.Name))
             return TypedResults.BadRequest("Název království je povinný.");
 
-        var exists = await db.Kingdoms.AnyAsync(k => k.Name == dto.Name);
+        var normalizedName = dto.Name.Trim();
+
+        var exists = await db.Kingdoms.AnyAsync(k => k.Name == normalizedName);
         if (exists)
-            return TypedResults.Conflict($"Království s názvem '{dto.Name}' už existuje.");
+            return TypedResults.Conflict($"Království s názvem '{normalizedName}' už existuje.");
 
         var k = new Kingdom
         {
-            Name = dto.Name.Trim(),
+            Name = normalizedName,
             HexColor = dto.HexColor,
             BadgeImageUrl = dto.BadgeImageUrl,
             Description = dto.Description,
@@ -67,21 +69,23 @@ public static class KingdomEndpoints
         if (string.IsNullOrWhiteSpace(dto.Name))
             return TypedResults.BadRequest("Název království je povinný.");
 
+        var normalizedName = dto.Name.Trim();
+
         var k = await db.Kingdoms.FindAsync(id);
         if (k is null) return TypedResults.NotFound();
 
-        if (!string.Equals(k.Name, dto.Name, StringComparison.Ordinal))
+        if (!string.Equals(k.Name, normalizedName, StringComparison.Ordinal))
         {
             var inUse = await db.CharacterAssignments.AnyAsync(a => a.KingdomId == id);
             if (inUse)
                 return TypedResults.Conflict(
                     "Toto království je přiřazeno postavám — název nelze přejmenovat. Ostatní údaje můžete upravit.");
 
-            var nameClash = await db.Kingdoms.AnyAsync(x => x.Id != id && x.Name == dto.Name);
+            var nameClash = await db.Kingdoms.AnyAsync(x => x.Id != id && x.Name == normalizedName);
             if (nameClash)
-                return TypedResults.Conflict($"Království s názvem '{dto.Name}' už existuje.");
+                return TypedResults.Conflict($"Království s názvem '{normalizedName}' už existuje.");
 
-            k.Name = dto.Name.Trim();
+            k.Name = normalizedName;
         }
 
         k.HexColor = dto.HexColor;

--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -28,6 +28,7 @@ public static class ScanEndpoints
         var assignment = await db.CharacterAssignments
             .Include(a => a.Character)
             .Include(a => a.Events)
+            .Include(a => a.Kingdom)
             .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
 
         if (assignment is null) return TypedResults.NotFound();
@@ -72,7 +73,7 @@ public static class ScanEndpoints
             ch.Id, assignment.Id, personId,
             ch.Name, playerFullName,
             ch.Race, assignment.Class,
-            assignment.Kingdom, ch.BirthYear,
+            assignment.Kingdom?.Name, ch.BirthYear,
             currentLevel, totalXp, skills, recentEvents));
     }
 

--- a/src/OvcinaHra.Api/Migrations/20260422221753_AddRaceEnumAndKingdomLookup.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422221753_AddRaceEnumAndKingdomLookup.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422221753_AddRaceEnumAndKingdomLookup")]
+    partial class AddRaceEnumAndKingdomLookup
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -109,9 +112,6 @@ namespace OvcinaHra.Api.Migrations
 
                     b.Property<int?>("ExternalPersonId")
                         .HasColumnType("integer");
-
-                    b.Property<string>("ImagePath")
-                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("boolean");

--- a/src/OvcinaHra.Api/Migrations/20260422221753_AddRaceEnumAndKingdomLookup.cs
+++ b/src/OvcinaHra.Api/Migrations/20260422221753_AddRaceEnumAndKingdomLookup.cs
@@ -1,0 +1,164 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRaceEnumAndKingdomLookup : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1. Create Kingdoms lookup table.
+            migrationBuilder.CreateTable(
+                name: "Kingdoms",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    HexColor = table.Column<string>(type: "character varying(7)", maxLength: 7, nullable: true),
+                    BadgeImageUrl = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    Description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Kingdoms", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Kingdoms_Name",
+                table: "Kingdoms",
+                column: "Name",
+                unique: true);
+
+            // 2. Seed the four canonical kingdoms (hex matches the UI
+            //    --oh-kingdom-* tokens in app.css — do NOT re-saturate).
+            migrationBuilder.Sql(@"
+INSERT INTO ""Kingdoms"" (""Name"", ""HexColor"", ""SortOrder"") VALUES
+  ('Aradhryand',      '#2E7D32', 1),
+  ('Azanulinbar-Dum', '#C62828', 2),
+  ('Esgaroth',        '#1565C0', 3),
+  ('Nový Arnor',      '#F9A825', 4);
+");
+
+            // 3. Add nullable KingdomId on CharacterAssignments.
+            migrationBuilder.AddColumn<int>(
+                name: "KingdomId",
+                table: "CharacterAssignments",
+                type: "integer",
+                nullable: true);
+
+            // 4. Data migration: resolve existing free-text Kingdom strings
+            //    against the lookup table (case-insensitive) before dropping
+            //    the column. Unmatched values fall through as NULL.
+            migrationBuilder.Sql(@"
+UPDATE ""CharacterAssignments"" ca
+SET ""KingdomId"" = k.""Id""
+FROM ""Kingdoms"" k
+WHERE ca.""Kingdom"" IS NOT NULL
+  AND LOWER(k.""Name"") = LOWER(ca.""Kingdom"");
+");
+
+            // 5. Drop the old free-text column.
+            migrationBuilder.DropColumn(
+                name: "Kingdom",
+                table: "CharacterAssignments");
+
+            // 6. Migrate Character.Race: existing column is unbounded text with
+            //    free-text Czech values. Normalize known values to the new
+            //    Race enum names (English, stored as strings via HasConversion);
+            //    unknown values become NULL so the UI prompts to re-pick.
+            migrationBuilder.Sql(@"
+UPDATE ""Characters""
+SET ""Race"" = CASE LOWER(""Race"")
+    WHEN 'human'     THEN 'Human'
+    WHEN 'člověk'    THEN 'Human'
+    WHEN 'clovek'    THEN 'Human'
+    WHEN 'dwarf'     THEN 'Dwarf'
+    WHEN 'trpaslík'  THEN 'Dwarf'
+    WHEN 'trpaslik'  THEN 'Dwarf'
+    WHEN 'elf'       THEN 'Elf'
+    WHEN 'hobbit'    THEN 'Hobbit'
+    WHEN 'hobit'     THEN 'Hobbit'
+    WHEN 'dunedain'  THEN 'Dunedain'
+    WHEN 'dúnadan'   THEN 'Dunedain'
+    WHEN 'dunadan'   THEN 'Dunedain'
+    ELSE NULL
+END
+WHERE ""Race"" IS NOT NULL;
+");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Race",
+                table: "Characters",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            // 7. Wire the FK + index now that KingdomId is populated.
+            migrationBuilder.CreateIndex(
+                name: "IX_CharacterAssignments_KingdomId",
+                table: "CharacterAssignments",
+                column: "KingdomId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CharacterAssignments_Kingdoms_KingdomId",
+                table: "CharacterAssignments",
+                column: "KingdomId",
+                principalTable: "Kingdoms",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CharacterAssignments_Kingdoms_KingdomId",
+                table: "CharacterAssignments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CharacterAssignments_KingdomId",
+                table: "CharacterAssignments");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Race",
+                table: "Characters",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(20)",
+                oldMaxLength: 20,
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Kingdom",
+                table: "CharacterAssignments",
+                type: "text",
+                nullable: true);
+
+            // Reverse data migration: copy Kingdom.Name back to the free-text
+            // column so rollback preserves visible values.
+            migrationBuilder.Sql(@"
+UPDATE ""CharacterAssignments"" ca
+SET ""Kingdom"" = k.""Name""
+FROM ""Kingdoms"" k
+WHERE ca.""KingdomId"" = k.""Id"";
+");
+
+            migrationBuilder.DropColumn(
+                name: "KingdomId",
+                table: "CharacterAssignments");
+
+            migrationBuilder.DropTable(
+                name: "Kingdoms");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Migrations/20260423041624_AddCharacterImagePath.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260423041624_AddCharacterImagePath.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260423041624_AddCharacterImagePath")]
+    partial class AddCharacterImagePath
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260423041624_AddCharacterImagePath.cs
+++ b/src/OvcinaHra.Api/Migrations/20260423041624_AddCharacterImagePath.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCharacterImagePath : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ImagePath",
+                table: "Characters",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ImagePath",
+                table: "Characters");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -199,6 +199,7 @@ try
     app.MapItemEndpoints().RequireAuthorization();
     app.MapSecretStashEndpoints().RequireAuthorization();
     app.MapCharacterEndpoints().RequireAuthorization();
+    app.MapKingdomEndpoints().RequireAuthorization();
     app.MapMonsterEndpoints().RequireAuthorization();
     app.MapNpcEndpoints().RequireAuthorization();
     app.MapQuestEndpoints().RequireAuthorization();

--- a/src/OvcinaHra.Api/Services/RegistraceImportService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceImportService.cs
@@ -5,6 +5,7 @@ using OvcinaHra.Api.Data;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Api.Services;
 
@@ -30,6 +31,11 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
             return new ImportResultDto(0, 0, 0, [$"Failed to fetch from registrace: {ex.Message}"]);
         }
 
+        // Kingdom-name → id lookup, loaded once per import. Names from registrace
+        // are matched case-insensitively against the Kingdom lookup table.
+        var kingdomByName = await db.Kingdoms
+            .ToDictionaryAsync(k => k.Name, k => k.Id, StringComparer.OrdinalIgnoreCase);
+
         foreach (var record in records)
         {
             try
@@ -50,7 +56,7 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
                         Name = name,
                         PlayerFirstName = record.PersonFirstName,
                         PlayerLastName = record.PersonLastName,
-                        Race = record.Race,
+                        Race = RaceExtensions.TryParseRace(record.Race),
                         BirthYear = record.PersonBirthYear,
                         IsPlayedCharacter = true,
                         ExternalPersonId = record.PersonId,
@@ -66,7 +72,7 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
                     // Name is intentionally NOT updated — it's user-editable in our app
                     character.PlayerFirstName = record.PersonFirstName;
                     character.PlayerLastName = record.PersonLastName;
-                    character.Race = record.Race;
+                    character.Race = RaceExtensions.TryParseRace(record.Race);
                     character.BirthYear = record.PersonBirthYear;
                     character.UpdatedAtUtc = DateTime.UtcNow;
 
@@ -85,6 +91,13 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
                     Enum.TryParse<PlayerClass>(record.ClassOrType, ignoreCase: true, out var pc)
                         .WhenTrue(pc, ref playerClass);
 
+                int? kingdomId = null;
+                if (!string.IsNullOrWhiteSpace(record.KingdomName)
+                    && kingdomByName.TryGetValue(record.KingdomName, out var kid))
+                {
+                    kingdomId = kid;
+                }
+
                 if (assignment is null)
                 {
                     assignment = new CharacterAssignment
@@ -94,7 +107,7 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
                         ExternalPersonId = record.PersonId,
                         RegistraceCharacterId = record.CharacterId,
                         Class = playerClass,
-                        Kingdom = record.KingdomName,
+                        KingdomId = kingdomId,
                         IsActive = true,
                         StartedAtUtc = DateTime.UtcNow
                     };
@@ -105,7 +118,7 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
                 {
                     assignment.RegistraceCharacterId = record.CharacterId;
                     assignment.Class = playerClass;
-                    assignment.Kingdom = record.KingdomName;
+                    assignment.KingdomId = kingdomId;
                     updated++;
                 }
 

--- a/src/OvcinaHra.Client/Components/RaceChipPicker.razor
+++ b/src/OvcinaHra.Client/Components/RaceChipPicker.razor
@@ -1,0 +1,31 @@
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+<div class="oh-chips">
+    @foreach (var r in Enum.GetValues<Race>())
+    {
+        <button type="button"
+                class="oh-chip @(Value == r ? "sel" : string.Empty)"
+                @onclick="() => PickAsync(r)">
+            @r.GetDisplayName()
+        </button>
+    }
+    @if (AllowClear && Value is not null)
+    {
+        <button type="button" class="oh-chip oh-chip-clear" @onclick="() => PickAsync(null)" title="Vymazat">
+            <i class="bi bi-x"></i>
+        </button>
+    }
+</div>
+
+@code {
+    [Parameter] public Race? Value { get; set; }
+    [Parameter] public EventCallback<Race?> ValueChanged { get; set; }
+    [Parameter] public bool AllowClear { get; set; } = true;
+
+    private async Task PickAsync(Race? r)
+    {
+        Value = r;
+        await ValueChanged.InvokeAsync(r);
+    }
+}

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -155,6 +155,11 @@
                 <i class="bi bi-person-badge"></i><span class="nav-label">NPC</span>
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="kingdoms">
+                <i class="bi bi-flag"></i><span class="nav-label">Království</span>
+            </NavLink>
+        </div>
 
         <div class="oh-nav-section-label">Nástroje</div>
         <div class="nav-item px-3">

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.10.1</Version>
+    <Version>0.11.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
+++ b/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
@@ -2,6 +2,10 @@
 @attribute [Authorize]
 @inject ApiClient Api
 @inject GameContextService GameContext
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Extensions
+@using OvcinaHra.Client.Components
 
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">Postavy</h1>
@@ -34,20 +38,40 @@
 else if (characters.Count == 0)
 {
     <div class="text-center text-muted py-5">
-        <i class="bi bi-people fs-1 d-block mb-2"></i>
-        <p>Žádné postavy. Importujte z registrace nebo vytvořte novou.</p>
+        <i class="bi bi-feather fs-1 d-block mb-2"></i>
+        <p>Zatím tu nikdo nepřebývá.</p>
         <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová postava</button>
     </div>
 }
 else
 {
-    <OvcinaGrid Data="@characters" KeyFieldName="Id" LayoutKey="grid-layout-characters"
+    <OvcinaGrid Data="@characters" KeyFieldName="Id" LayoutKey="grid-layout-characters-v2"
                 RowClick="@(e => OpenModal((CharacterListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
+            <DxGridDataColumn FieldName="Race" Caption="Rasa" Width="120px">
+                <CellDisplayTemplate>
+                    @{ var r = (Race?)context.Value; }
+                    @if (r is not null)
+                    {
+                        <span class="oh-racechip">@r.Value.GetDisplayName()</span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="KingdomName" Caption="Království" Width="180px">
+                <CellDisplayTemplate>
+                    @{ var row = (CharacterListDto)context.DataItem; }
+                    @if (row.KingdomName is not null)
+                    {
+                        <div class="oh-kcell">
+                            <span class="oh-kbadge" style="background:@row.KingdomHexColor"></span>
+                            <span>@row.KingdomName</span>
+                        </div>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
             <DxGridDataColumn FieldName="PlayerFullName" Caption="Hráč" Width="180px" />
-            <DxGridDataColumn FieldName="Race" Caption="Rasa" Width="120px" />
-            <DxGridDataColumn FieldName="IsPlayedCharacter" Caption="Hráčská" Width="80px">
+            <DxGridDataColumn FieldName="IsPlayedCharacter" Caption="Hráčská" Width="90px">
                 <CellDisplayTemplate>@((bool)context.Value ? "Ano" : "Ne")</CellDisplayTemplate>
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="ExternalPersonId" Caption="ID v registraci" Width="140px" />
@@ -55,63 +79,181 @@ else
     </OvcinaGrid>
 }
 
-<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="600px">
+@* Edit / create dialog *@
+<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle"
+         CssClass="oh-char-dialog-popup" Width="960px">
     <BodyContentTemplate Context="popupContext">
-        <DxFormLayout>
-            <DxFormLayoutItem Caption="Název postavy" ColSpanMd="8">
-                <DxTextBox @bind-Text="@name" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Hráčská postava" ColSpanMd="4">
-                <DxCheckBox @bind-Checked="@isPlayedCharacter" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Jméno hráče" ColSpanMd="6">
-                <DxTextBox @bind-Text="@playerFirstName" NullText="(nezadáno)" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Příjmení hráče" ColSpanMd="6">
-                <DxTextBox @bind-Text="@playerLastName" NullText="(nezadáno)" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Rasa" ColSpanMd="6">
-                <DxTextBox @bind-Text="@race" NullText="(nezadáno)" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Rok narození" ColSpanMd="6">
-                <DxSpinEdit @bind-Value="@birthYear" />
-            </DxFormLayoutItem>
+        <div class="oh-char-dialog">
+
+            @* --- Identity section (fields + portrait) --- *@
+            <div class="oh-identity">
+                <div class="oh-identity-fields">
+                    <DxFormLayout CssClass="mb-0">
+                        <DxFormLayoutItem Caption="Název postavy" ColSpanMd="12">
+                            <DxTextBox @bind-Text="@name" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Rasa" ColSpanMd="12">
+                            <RaceChipPicker @bind-Value="@race" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Království (v aktuální hře)" ColSpanMd="12">
+                            @if (editingId.HasValue && activeAssignmentId.HasValue)
+                            {
+                                <DxComboBox TData="KingdomDto" TValue="int?"
+                                            Data="@kingdoms" @bind-Value="@kingdomId"
+                                            TextFieldName="Name" ValueFieldName="Id"
+                                            NullText="(žádné)" CssClass="oh-kcombo">
+                                    <ItemDisplayTemplate Context="kctx">
+                                        @{ var k = (KingdomDto)kctx.DataItem; }
+                                        <div class="oh-kcell">
+                                            <span class="oh-kbadge oh-kbadge-lg" style="background:@k.HexColor"></span>
+                                            <span>@k.Name</span>
+                                        </div>
+                                    </ItemDisplayTemplate>
+                                    <EditBoxDisplayTemplate Context="kbox">
+                                        @{ var k = kingdoms.FirstOrDefault(x => x.Id == kingdomId); }
+                                        @if (k is not null)
+                                        {
+                                            <div class="oh-kcell">
+                                                <span class="oh-kbadge" style="background:@k.HexColor"></span>
+                                                <span>@k.Name</span>
+                                            </div>
+                                        }
+                                        else
+                                        {
+                                            <span class="text-muted">(žádné)</span>
+                                        }
+                                    </EditBoxDisplayTemplate>
+                                </DxComboBox>
+                            }
+                            else
+                            {
+                                <div class="oh-kingdom-unavailable">
+                                    <i class="bi bi-info-circle me-1"></i>
+                                    @(editingId.HasValue
+                                        ? "Postava nemá přiřazení k aktuální hře — království nelze nastavit zde."
+                                        : "Království lze nastavit po uložení postavy a přiřazení ke hře.")
+                                </div>
+                            }
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Hráčská postava" ColSpanMd="12">
+                            <DxCheckBox @bind-Checked="@isPlayedCharacter" />
+                        </DxFormLayoutItem>
+                    </DxFormLayout>
+                </div>
+
+                <div class="oh-identity-portrait">
+                    @if (editingId.HasValue)
+                    {
+                        <ImagePicker EntityType="characters" EntityId="@editingId.Value"
+                                     AspectRatio="4:5" Width="240px" Alt="Portrét" />
+                    }
+                    else
+                    {
+                        <div class="oh-portrait-placeholder">
+                            <i class="bi bi-image fs-3 d-block mb-2"></i>
+                            <small>Portrét lze nahrát po uložení</small>
+                        </div>
+                    }
+                </div>
+            </div>
+
+            @* --- Player panel (only when Hráčská = Ano) --- *@
             @if (isPlayedCharacter)
             {
-                <DxFormLayoutItem Caption="ID v registraci" ColSpanMd="4">
-                    <DxSpinEdit @bind-Value="@externalPersonId" />
-                </DxFormLayoutItem>
+                <div class="oh-section-block">
+                    <div class="oh-section-label">Hráč</div>
+                    <DxFormLayout>
+                        <DxFormLayoutItem Caption="Jméno hráče" ColSpanMd="6">
+                            <DxTextBox @bind-Text="@playerFirstName" NullText="(nezadáno)" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Příjmení hráče" ColSpanMd="6">
+                            <DxTextBox @bind-Text="@playerLastName" NullText="(nezadáno)" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="ID v registraci" ColSpanMd="12">
+                            <div class="d-flex gap-2 align-items-center">
+                                <DxSpinEdit @bind-Value="@externalPersonId" CssClass="flex-grow-1" />
+                                @if (editingId.HasValue && externalPersonId.HasValue)
+                                {
+                                    <a href="https://registrace.ovcina.cz/person/@externalPersonId" target="_blank"
+                                       class="btn btn-sm btn-outline-secondary">
+                                        <i class="bi bi-box-arrow-up-right me-1"></i>Otevřít v registraci
+                                    </a>
+                                }
+                            </div>
+                        </DxFormLayoutItem>
+                    </DxFormLayout>
+                </div>
             }
-            <DxFormLayoutItem Caption="Rodič" ColSpanMd="12">
-                <DxComboBox Data="@allCharacters" @bind-Value="@parentCharacterId"
-                            TextFieldName="Name" ValueFieldName="Id"
-                            NullText="(žádný)" SearchMode="ListSearchMode.AutoSearch" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
-                <DxMemo @bind-Text="@notes" Rows="3" />
-            </DxFormLayoutItem>
-        </DxFormLayout>
 
-        @if (editingId.HasValue && externalPersonId.HasValue)
-        {
-            <div class="mt-2">
-                <a href="https://registrace.ovcina.cz/person/@externalPersonId" target="_blank" class="btn btn-sm btn-outline-secondary">
-                    <i class="bi bi-box-arrow-up-right me-1"></i> Registrace
-                </a>
+            @* --- Lineage section --- *@
+            <div class="oh-section-block">
+                <div class="oh-section-label">Rodokmen</div>
+                <DxFormLayout>
+                    <DxFormLayoutItem Caption="Rodič" ColSpanMd="12">
+                        <DxComboBox TData="CharacterListDto" TValue="int?"
+                                    Data="@ParentCandidates" @bind-Value="@parentCharacterId"
+                                    TextFieldName="Name" ValueFieldName="Id"
+                                    NullText="(žádný)" SearchMode="ListSearchMode.AutoSearch"
+                                    CssClass="oh-parent-combo">
+                            <ItemDisplayTemplate Context="pctx">
+                                @{ var p = (CharacterListDto)pctx.DataItem; }
+                                <div class="oh-parent-row">
+                                    <span class="oh-parent-thumb"></span>
+                                    <span>
+                                        <span class="oh-parent-name">@p.Name</span>
+                                        @if (p.Race is not null)
+                                        {
+                                            <span class="oh-racechip ms-1">@p.Race.Value.GetDisplayName()</span>
+                                        }
+                                    </span>
+                                </div>
+                            </ItemDisplayTemplate>
+                        </DxComboBox>
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Rok narození" ColSpanMd="12">
+                        <div class="d-flex gap-2 align-items-center">
+                            <DxSpinEdit @bind-Value="@birthYear" CssClass="flex-grow-1" />
+                            @if (birthYear.HasValue)
+                            {
+                                <span class="text-muted">@(DateTime.UtcNow.Year - birthYear.Value) let</span>
+                            }
+                        </div>
+                    </DxFormLayoutItem>
+                </DxFormLayout>
             </div>
-        }
 
-        @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
+            @* --- Notes section --- *@
+            <div class="oh-section-block">
+                <div class="oh-section-label">Poznámky</div>
+                <DxMemo @bind-Text="@notes" Rows="6"
+                        NullText="Deník kronikáře — příběh postavy, vztahy, zvyky, poznámky z her…" />
+            </div>
 
-        <div class="d-flex gap-2 mt-3">
-            @if (editingId.HasValue) { <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true" disabled="@isSaving">Smazat</button> }
-            <div style="flex: 1"></div>
-            <button class="btn btn-secondary" @onclick="() => isModalVisible = false" disabled="@isSaving">Zrušit</button>
-            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">Uložit</button>
+            @if (error is not null)
+            {
+                <div class="oh-drozd-val">
+                    <i class="bi bi-exclamation-circle oh-drozd-val-icon"></i>
+                    <div>
+                        <div class="oh-drozd-val-title">Něco se pokazilo</div>
+                        <div class="oh-drozd-val-msg">@error</div>
+                    </div>
+                </div>
+            }
+
+            <div class="oh-footer">
+                @if (editingId.HasValue)
+                {
+                    <button class="btn oh-btn-ghost-bordeaux" @onclick="() => isDeleteVisible = true" disabled="@isSaving">Smazat</button>
+                }
+                <div class="flex-grow-1"></div>
+                <button class="btn btn-secondary" @onclick="() => isModalVisible = false" disabled="@isSaving">Zrušit</button>
+                <button class="btn btn-primary" @onclick="SaveAsync" disabled="@(isSaving || string.IsNullOrWhiteSpace(name))">Uložit</button>
+            </div>
         </div>
     </BodyContentTemplate>
 </DxPopup>
 
+@* Delete confirmation — MEMORY §D *@
 <DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
     <BodyContentTemplate Context="popupContext">
         <p>Opravdu chcete smazat postavu <strong>@name</strong>?</p>
@@ -125,32 +267,55 @@ else
 @code {
     private List<CharacterListDto> characters = [];
     private List<CharacterListDto> allCharacters = [];
+    private List<KingdomDto> kingdoms = [];
     private bool loading = true, isModalVisible, isDeleteVisible, isSaving, isImporting;
     private string modalTitle = "", name = "";
-    private string? error, notes, race, playerFirstName, playerLastName;
+    private string? error, notes, playerFirstName, playerLastName;
+    private Race? race;
     private int? editingId;
     private int? externalPersonId;
     private int? parentCharacterId;
     private int? birthYear;
+    private int? kingdomId;
+    private int? originalKingdomId;
+    private int? activeAssignmentId;
     private bool isPlayedCharacter;
     private string searchText = "";
     private ImportResultDto? importResult;
+
+    private IEnumerable<CharacterListDto> ParentCandidates =>
+        allCharacters.Where(c => editingId is null || c.Id != editingId);
 
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
         await LoadAsync();
-        allCharacters = await Api.GetListAsync<CharacterListDto>("/api/characters");
+        await LoadParentSourceAsync();
+        kingdoms = await Api.GetListAsync<KingdomDto>("/api/kingdoms");
     }
 
     private async Task LoadAsync()
     {
         loading = true;
-        var url = string.IsNullOrWhiteSpace(searchText)
-            ? "/api/characters"
-            : $"/api/characters?search={Uri.EscapeDataString(searchText)}";
-        characters = await Api.GetListAsync<CharacterListDto>(url);
+        characters = await Api.GetListAsync<CharacterListDto>(BuildListUrl(searchText));
         loading = false;
+    }
+
+    private async Task LoadParentSourceAsync()
+    {
+        // Parent-of candidates: full roster (for the dropdown), same gameId so
+        // the per-game kingdom badge shows on option rows too.
+        allCharacters = await Api.GetListAsync<CharacterListDto>(BuildListUrl(null));
+    }
+
+    private string BuildListUrl(string? search)
+    {
+        var parts = new List<string>();
+        if (GameContext.SelectedGameId.HasValue)
+            parts.Add($"gameId={GameContext.SelectedGameId.Value}");
+        if (!string.IsNullOrWhiteSpace(search))
+            parts.Add($"search={Uri.EscapeDataString(search)}");
+        return parts.Count == 0 ? "/api/characters" : $"/api/characters?{string.Join('&', parts)}";
     }
 
     private void OpenModal(CharacterListDto? c)
@@ -161,6 +326,7 @@ else
             editingId = null; name = ""; isPlayedCharacter = false; externalPersonId = null;
             parentCharacterId = null; notes = null; race = null; birthYear = null;
             playerFirstName = null; playerLastName = null;
+            kingdomId = null; originalKingdomId = null; activeAssignmentId = null;
             modalTitle = "Nová postava";
         }
         else
@@ -169,6 +335,9 @@ else
             race = c.Race;
             isPlayedCharacter = c.IsPlayedCharacter;
             externalPersonId = c.ExternalPersonId;
+            kingdomId = c.KingdomId;
+            originalKingdomId = c.KingdomId;
+            activeAssignmentId = null; // resolved by LoadDetailAsync
             modalTitle = $"Upravit: {c.Name}";
             _ = LoadDetailAsync(c.Id);
         }
@@ -177,7 +346,10 @@ else
 
     private async Task LoadDetailAsync(int id)
     {
-        var d = await Api.GetAsync<CharacterDetailDto>($"/api/characters/{id}");
+        var url = GameContext.SelectedGameId.HasValue
+            ? $"/api/characters/{id}?gameId={GameContext.SelectedGameId.Value}"
+            : $"/api/characters/{id}";
+        var d = await Api.GetAsync<CharacterDetailDto>(url);
         if (d is not null)
         {
             notes = d.Notes;
@@ -186,6 +358,9 @@ else
             parentCharacterId = d.ParentCharacterId;
             playerFirstName = d.PlayerFirstName;
             playerLastName = d.PlayerLastName;
+            kingdomId = d.KingdomId;
+            originalKingdomId = d.KingdomId;
+            activeAssignmentId = d.ActiveAssignmentId;
         }
         StateHasChanged();
     }
@@ -196,14 +371,32 @@ else
         try
         {
             if (editingId.HasValue)
+            {
                 await Api.PutAsync($"/api/characters/{editingId}",
-                    new UpdateCharacterDto(name, playerFirstName, playerLastName, race, birthYear, notes, isPlayedCharacter, externalPersonId, parentCharacterId));
+                    new UpdateCharacterDto(name, playerFirstName, playerLastName, race,
+                        birthYear, notes, isPlayedCharacter, externalPersonId, parentCharacterId));
+            }
             else
+            {
                 await Api.PostAsync<CreateCharacterDto, CharacterDetailDto>("/api/characters",
-                    new CreateCharacterDto(name, playerFirstName, playerLastName, race, birthYear, notes, isPlayedCharacter, externalPersonId, parentCharacterId));
+                    new CreateCharacterDto(name, playerFirstName, playerLastName, race,
+                        birthYear, notes, isPlayedCharacter, externalPersonId, parentCharacterId));
+            }
+
+            // Per-game kingdom lives on the active CharacterAssignment, not on
+            // Character itself — push separately when the picker is enabled.
+            if (editingId.HasValue
+                && activeAssignmentId.HasValue
+                && GameContext.SelectedGameId.HasValue
+                && kingdomId != originalKingdomId)
+            {
+                await Api.PutAsync($"/api/characters/{editingId}/assignment/kingdom",
+                    new SetAssignmentKingdomDto(GameContext.SelectedGameId.Value, kingdomId));
+            }
+
             isModalVisible = false;
             await LoadAsync();
-            allCharacters = await Api.GetListAsync<CharacterListDto>("/api/characters");
+            await LoadParentSourceAsync();
         }
         catch (Exception ex) { error = ex.Message; }
         finally { isSaving = false; }
@@ -216,7 +409,7 @@ else
             await Api.DeleteAsync($"/api/characters/{editingId}");
             isDeleteVisible = false; isModalVisible = false;
             await LoadAsync();
-            allCharacters = await Api.GetListAsync<CharacterListDto>("/api/characters");
+            await LoadParentSourceAsync();
         }
         catch (Exception ex) { error = ex.Message; }
     }
@@ -230,7 +423,7 @@ else
             importResult = await Api.PostAsync<object, ImportResultDto>(
                 $"/api/characters/import/{GameContext.SelectedGameId}", new { });
             await LoadAsync();
-            allCharacters = await Api.GetListAsync<CharacterListDto>("/api/characters");
+            await LoadParentSourceAsync();
         }
         catch (Exception ex) { error = ex.Message; }
         finally { isImporting = false; }

--- a/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
+++ b/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
@@ -318,7 +318,7 @@ else
         return parts.Count == 0 ? "/api/characters" : $"/api/characters?{string.Join('&', parts)}";
     }
 
-    private void OpenModal(CharacterListDto? c)
+    private async Task OpenModal(CharacterListDto? c)
     {
         error = null;
         if (c is null)
@@ -328,20 +328,28 @@ else
             playerFirstName = null; playerLastName = null;
             kingdomId = null; originalKingdomId = null; activeAssignmentId = null;
             modalTitle = "Nová postava";
+            isModalVisible = true;
+            return;
         }
-        else
-        {
-            editingId = c.Id; name = c.Name;
-            race = c.Race;
-            isPlayedCharacter = c.IsPlayedCharacter;
-            externalPersonId = c.ExternalPersonId;
-            kingdomId = c.KingdomId;
-            originalKingdomId = c.KingdomId;
-            activeAssignmentId = null; // resolved by LoadDetailAsync
-            modalTitle = $"Upravit: {c.Name}";
-            _ = LoadDetailAsync(c.Id);
-        }
+
+        editingId = c.Id; name = c.Name;
+        race = c.Race;
+        isPlayedCharacter = c.IsPlayedCharacter;
+        externalPersonId = c.ExternalPersonId;
+        kingdomId = c.KingdomId;
+        originalKingdomId = c.KingdomId;
+        activeAssignmentId = null; // resolved by LoadDetailAsync
+        modalTitle = $"Upravit: {c.Name}";
         isModalVisible = true;
+
+        try
+        {
+            await LoadDetailAsync(c.Id);
+        }
+        catch (Exception ex)
+        {
+            error = $"Nepodařilo se načíst detail postavy: {ex.Message}";
+        }
     }
 
     private async Task LoadDetailAsync(int id)
@@ -404,9 +412,16 @@ else
 
     private async Task ConfirmDeleteAsync()
     {
+        error = null;
         try
         {
-            await Api.DeleteAsync($"/api/characters/{editingId}");
+            var deleted = await Api.DeleteAsync($"/api/characters/{editingId}");
+            if (!deleted)
+            {
+                error = "Smazání postavy selhalo.";
+                return;
+            }
+
             isDeleteVisible = false; isModalVisible = false;
             await LoadAsync();
             await LoadParentSourceAsync();

--- a/src/OvcinaHra.Client/Pages/Kingdoms/KingdomList.razor
+++ b/src/OvcinaHra.Client/Pages/Kingdoms/KingdomList.razor
@@ -1,0 +1,239 @@
+@page "/kingdoms"
+@attribute [Authorize]
+@inject ApiClient Api
+@using OvcinaHra.Shared.Dtos
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Království</h1>
+    <div class="d-flex gap-2">
+        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nové království</button>
+    </div>
+</div>
+
+<p class="text-muted mb-3" style="max-width: 60ch;">
+    Lookup tabulka s kanonickými královstvími světa. Přiřazení ke hrám se řídí per-game přes <em>CharacterAssignment</em>.
+    Království s přiřazenými postavami nelze přejmenovat ani smazat — taková změna patří do kódu a migrace.
+</p>
+
+@if (loading)
+{
+    <p>Načítám...</p>
+}
+else if (kingdoms.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-flag fs-1 d-block mb-2"></i>
+        <p>Zatím tu není žádné království.</p>
+        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nové království</button>
+    </div>
+}
+else
+{
+    <OvcinaGrid Data="@kingdoms" KeyFieldName="Id" LayoutKey="grid-layout-kingdoms"
+                RowClick="@(e => OpenModal((KingdomDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+        <Columns>
+            <DxGridDataColumn FieldName="HexColor" Caption="" Width="54px" AllowSort="false">
+                <CellDisplayTemplate>
+                    @{ var hex = (string?)context.Value; }
+                    @if (!string.IsNullOrWhiteSpace(hex))
+                    {
+                        <span class="oh-kbadge oh-kbadge-lg" style="background:@hex"></span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Name" Caption="Název" />
+            <DxGridDataColumn FieldName="HexColor" Caption="Hex" Width="110px">
+                <CellDisplayTemplate>
+                    <span class="oh-mono">@context.Value</span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="SortOrder" Caption="Pořadí" Width="90px" />
+            <DxGridDataColumn FieldName="AssignmentCount" Caption="Přiřazení" Width="110px">
+                <CellDisplayTemplate>
+                    @{ var n = (int)context.Value; }
+                    <span class="@(n > 0 ? "oh-racechip" : "text-muted")">@n</span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Description" Caption="Popis" />
+        </Columns>
+    </OvcinaGrid>
+}
+
+@* Edit / create dialog *@
+<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle"
+         CssClass="oh-char-dialog-popup" Width="640px">
+    <BodyContentTemplate Context="popupContext">
+        <div class="oh-char-dialog">
+            <DxFormLayout>
+                <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                    @if (isNameGated)
+                    {
+                        <div class="d-flex align-items-center gap-2">
+                            <DxTextBox @bind-Text="@name" Enabled="false" />
+                            <span class="text-muted" title="Toto království je přiřazeno postavám — název nelze přejmenovat zde.">
+                                <i class="bi bi-lock-fill"></i>
+                            </span>
+                        </div>
+                    }
+                    else
+                    {
+                        <DxTextBox @bind-Text="@name" />
+                    }
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Hex barva" ColSpanMd="8">
+                    <div class="d-flex align-items-center gap-2">
+                        <DxTextBox @bind-Text="@hexColor" NullText="#RRGGBB" />
+                        <span class="oh-kbadge oh-kbadge-lg" style="background:@(string.IsNullOrWhiteSpace(hexColor) ? "transparent" : hexColor)"></span>
+                    </div>
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Pořadí" ColSpanMd="4">
+                    <DxSpinEdit @bind-Value="@sortOrder" MinValue="0" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="URL znaku (badge)" ColSpanMd="12">
+                    <DxTextBox @bind-Text="@badgeImageUrl" NullText="https://…" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
+                    <DxMemo @bind-Text="@description" Rows="4" NullText="Stručná charakteristika království (volitelné)…" />
+                </DxFormLayoutItem>
+            </DxFormLayout>
+
+            @if (editingId.HasValue && assignmentCount > 0)
+            {
+                <div class="oh-section-block">
+                    <div class="oh-section-label">Přiřazení</div>
+                    <p class="mb-0">
+                        Toto království je přiřazeno <strong>@assignmentCount</strong>
+                        @(PluralForm(assignmentCount, "postavě", "postavám", "postavám")).
+                        Rename a smazání jsou proto zamčené.
+                    </p>
+                </div>
+            }
+
+            @if (error is not null)
+            {
+                <div class="oh-drozd-val">
+                    <i class="bi bi-exclamation-circle oh-drozd-val-icon"></i>
+                    <div>
+                        <div class="oh-drozd-val-title">Něco se pokazilo</div>
+                        <div class="oh-drozd-val-msg">@error</div>
+                    </div>
+                </div>
+            }
+
+            <div class="oh-footer">
+                @if (editingId.HasValue && assignmentCount == 0)
+                {
+                    <button class="btn oh-btn-ghost-bordeaux" @onclick="() => isDeleteVisible = true" disabled="@isSaving">Smazat</button>
+                }
+                <div class="flex-grow-1"></div>
+                <button class="btn btn-secondary" @onclick="() => isModalVisible = false" disabled="@isSaving">Zrušit</button>
+                <button class="btn btn-primary" @onclick="SaveAsync" disabled="@(isSaving || string.IsNullOrWhiteSpace(name))">Uložit</button>
+            </div>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@* Delete confirmation — MEMORY §D *@
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete smazat království <strong>@name</strong>?</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    private List<KingdomDto> kingdoms = [];
+    private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
+    private string modalTitle = "";
+    private string name = "";
+    private string? hexColor, badgeImageUrl, description;
+    private int sortOrder;
+    private int? editingId;
+    private int assignmentCount;
+    private string? error;
+
+    private bool isNameGated => editingId.HasValue && assignmentCount > 0;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        kingdoms = await Api.GetListAsync<KingdomDto>("/api/kingdoms");
+        loading = false;
+    }
+
+    private void OpenModal(KingdomDto? k)
+    {
+        error = null;
+        if (k is null)
+        {
+            editingId = null;
+            name = ""; hexColor = null; badgeImageUrl = null; description = null;
+            sortOrder = kingdoms.Count == 0 ? 1 : kingdoms.Max(x => x.SortOrder) + 1;
+            assignmentCount = 0;
+            modalTitle = "Nové království";
+        }
+        else
+        {
+            editingId = k.Id;
+            name = k.Name;
+            hexColor = k.HexColor;
+            badgeImageUrl = k.BadgeImageUrl;
+            description = k.Description;
+            sortOrder = k.SortOrder;
+            assignmentCount = k.AssignmentCount;
+            modalTitle = $"Upravit: {k.Name}";
+        }
+        isModalVisible = true;
+    }
+
+    private async Task SaveAsync()
+    {
+        error = null; isSaving = true;
+        try
+        {
+            if (editingId.HasValue)
+            {
+                await Api.PutAsync($"/api/kingdoms/{editingId}",
+                    new UpdateKingdomDto(name, hexColor, badgeImageUrl, description, sortOrder));
+            }
+            else
+            {
+                await Api.PostAsync<CreateKingdomDto, KingdomDto>("/api/kingdoms",
+                    new CreateKingdomDto(name, hexColor, badgeImageUrl, description, sortOrder));
+            }
+
+            isModalVisible = false;
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        try
+        {
+            await Api.DeleteAsync($"/api/kingdoms/{editingId}");
+            isDeleteVisible = false;
+            isModalVisible = false;
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; isDeleteVisible = false; }
+    }
+
+    // Czech plural helper for "postava" forms (1 → singular, 2-4 → paucal, 5+ → plural).
+    private static string PluralForm(int n, string one, string few, string many)
+    {
+        if (n == 1) return one;
+        if (n >= 2 && n <= 4) return few;
+        return many;
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Kingdoms/KingdomList.razor
+++ b/src/OvcinaHra.Client/Pages/Kingdoms/KingdomList.razor
@@ -219,9 +219,16 @@ else
 
     private async Task ConfirmDeleteAsync()
     {
+        error = null;
         try
         {
-            await Api.DeleteAsync($"/api/kingdoms/{editingId}");
+            var deleted = await Api.DeleteAsync($"/api/kingdoms/{editingId}");
+            if (!deleted)
+            {
+                error = "Smazání království selhalo.";
+                return;
+            }
+
             isDeleteVisible = false;
             isModalVisible = false;
             await LoadAsync();

--- a/src/OvcinaHra.Client/Pages/Scan/ScanPage.razor
+++ b/src/OvcinaHra.Client/Pages/Scan/ScanPage.razor
@@ -1,6 +1,7 @@
 @page "/p/{PersonId:int}"
 @attribute [Authorize]
 @inject ApiClient Api
+@using OvcinaHra.Shared.Extensions
 
 @if (loading)
 {
@@ -41,7 +42,7 @@ else if (character is not null)
                 }
                 @if (character.Race is not null)
                 {
-                    <span class="badge bg-info text-dark fs-6">@character.Race</span>
+                    <span class="badge bg-info text-dark fs-6">@character.Race.Value.GetDisplayName()</span>
                 }
             </div>
         </div>

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -490,3 +490,240 @@
 .location-card-body .location-card-text:only-child {
     flex: 1 1 100%;
 }
+
+/* ============================================================
+   Character edit dialog — Claude Design handoff, 2026-04-23
+   Scope: every selector here is prefixed .oh-* to avoid clashing
+   with Bootstrap/global classes. Lives in the CharacterList popup.
+   ============================================================ */
+
+/* --- Race chip picker ---------------------------------------- */
+.oh-chips {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.oh-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 13px;
+    border-radius: 99px;
+    background: var(--oh-surface);
+    border: 1px solid var(--oh-border);
+    font: 500 0.8125rem var(--oh-font-body);
+    color: var(--oh-text);
+    cursor: pointer;
+    transition: var(--oh-transition);
+    user-select: none;
+}
+
+.oh-chip:hover {
+    border-color: var(--oh-primary-light);
+    background: var(--oh-primary-surface);
+    color: var(--oh-primary);
+}
+
+.oh-chip.sel {
+    background: var(--oh-primary);
+    border-color: var(--oh-primary);
+    color: #fff;
+    box-shadow: 0 1px 3px rgba(45, 80, 22, 0.25);
+}
+
+.oh-chip-clear {
+    padding: 7px 10px;
+    color: var(--oh-text-secondary);
+}
+
+/* Small variant used in grid cells + parent combo option */
+.oh-racechip {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 99px;
+    background: var(--oh-primary-surface);
+    border: 1px solid rgba(74, 124, 52, 0.3);
+    color: var(--oh-primary);
+    font: 600 0.6875rem var(--oh-font-body);
+    white-space: nowrap;
+}
+
+/* --- Kingdom cell / badge (grid + combobox templates) -------- */
+.oh-kcell {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.oh-kbadge {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: inline-block;
+    border: 2px solid rgba(255, 255, 255, 0.6);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12);
+    flex-shrink: 0;
+}
+
+.oh-kbadge-lg {
+    width: 24px;
+    height: 24px;
+}
+
+/* --- Kingdom unavailable hint (no assignment in current game)  */
+.oh-kingdom-unavailable {
+    padding: 10px 12px;
+    background: var(--oh-surface-alt);
+    border: 1px dashed var(--oh-border);
+    border-radius: var(--oh-radius-sm);
+    color: var(--oh-text-secondary);
+    font-size: 0.8125rem;
+    line-height: 1.4;
+}
+
+/* --- Parent combobox item template --------------------------- */
+.oh-parent-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.oh-parent-thumb {
+    width: 24px;
+    height: 30px;
+    border-radius: 3px;
+    border: 1px solid var(--oh-border);
+    background: linear-gradient(145deg, #e8c89a 0%, #b88c5a 60%, #6b4a2a 100%);
+    flex-shrink: 0;
+}
+
+.oh-parent-name {
+    font-weight: 600;
+    color: var(--oh-text);
+}
+
+/* --- Character dialog wrapper + layout ----------------------- */
+.oh-char-dialog-popup .dxbl-popup-content {
+    max-width: 960px;
+}
+
+.oh-char-dialog {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* Identity section — two columns, portrait on the right */
+.oh-char-dialog .oh-identity {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 240px;
+    gap: 24px;
+    align-items: flex-start;
+}
+
+@media (max-width: 760px) {
+    .oh-char-dialog .oh-identity {
+        grid-template-columns: 1fr;
+    }
+    .oh-char-dialog .oh-identity-portrait {
+        justify-self: center;
+    }
+}
+
+.oh-char-dialog .oh-identity-portrait {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+.oh-portrait-placeholder {
+    width: 240px;
+    height: 300px;
+    border-radius: var(--oh-radius);
+    border: 2px dashed var(--oh-border);
+    background: var(--oh-surface-alt);
+    color: var(--oh-text-secondary);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 16px;
+    font-size: 0.8125rem;
+}
+
+/* Section blocks (Hráč, Rodokmen, Poznámky) */
+.oh-char-dialog .oh-section-block {
+    padding-top: 14px;
+    border-top: 1px solid var(--oh-border);
+}
+
+.oh-char-dialog .oh-section-label {
+    font-family: var(--oh-font-body);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--oh-text-secondary);
+    margin-bottom: 8px;
+}
+
+/* Footer row */
+.oh-char-dialog .oh-footer {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding-top: 14px;
+    border-top: 1px solid var(--oh-border);
+    margin-top: 6px;
+}
+
+/* Destructive ghost-bordeaux button (Smazat) */
+.oh-btn-ghost-bordeaux {
+    color: var(--oh-accent);
+    border: 1px solid rgba(178, 34, 34, 0.4);
+    background: transparent;
+    transition: var(--oh-transition);
+}
+
+.oh-btn-ghost-bordeaux:hover {
+    background: var(--oh-accent);
+    color: #fff;
+    border-color: var(--oh-accent);
+}
+
+/* --- Validation / Drozd error banner ------------------------- */
+.oh-drozd-val {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 10px 14px;
+    background: #FDECEC;
+    border: 1px solid rgba(198, 40, 40, 0.25);
+    border-left: 3px solid var(--oh-error);
+    border-radius: var(--oh-radius);
+}
+
+.oh-drozd-val-icon {
+    color: var(--oh-error);
+    font-size: 1.25rem;
+    line-height: 1.25;
+    flex-shrink: 0;
+}
+
+.oh-drozd-val-title {
+    font-family: var(--oh-font-heading);
+    font-style: italic;
+    color: var(--oh-error);
+    font-weight: 700;
+    font-size: 0.9375rem;
+}
+
+.oh-drozd-val-msg {
+    font-size: 0.8125rem;
+    color: var(--oh-text-secondary);
+    margin-top: 2px;
+}
+

--- a/src/OvcinaHra.Shared/Domain/Entities/Character.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Character.cs
@@ -1,3 +1,5 @@
+using OvcinaHra.Shared.Domain.Enums;
+
 namespace OvcinaHra.Shared.Domain.Entities;
 
 public class Character
@@ -6,12 +8,13 @@ public class Character
     public required string Name { get; set; }
     public string? PlayerFirstName { get; set; }
     public string? PlayerLastName { get; set; }
-    public string? Race { get; set; }
+    public Race? Race { get; set; }
     public int? BirthYear { get; set; }
     public string? Notes { get; set; }
     public bool IsPlayedCharacter { get; set; }
     public int? ExternalPersonId { get; set; }
     public int? ParentCharacterId { get; set; }
+    public string? ImagePath { get; set; }
     public bool IsDeleted { get; set; }
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;

--- a/src/OvcinaHra.Shared/Domain/Entities/CharacterAssignment.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/CharacterAssignment.cs
@@ -12,12 +12,13 @@ public class CharacterAssignment
 
     // Per-game snapshot
     public PlayerClass? Class { get; set; }
-    public string? Kingdom { get; set; }
+    public int? KingdomId { get; set; }
 
     public bool IsActive { get; set; } = true;
     public DateTime StartedAtUtc { get; set; } = DateTime.UtcNow;
     public DateTime? EndedAtUtc { get; set; }
 
     public Character Character { get; set; } = null!;
+    public Kingdom? Kingdom { get; set; }
     public ICollection<CharacterEvent> Events { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/Kingdom.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Kingdom.cs
@@ -1,0 +1,13 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class Kingdom
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public string? HexColor { get; set; }
+    public string? BadgeImageUrl { get; set; }
+    public string? Description { get; set; }
+    public int SortOrder { get; set; }
+
+    public ICollection<CharacterAssignment> Assignments { get; set; } = [];
+}

--- a/src/OvcinaHra.Shared/Domain/Enums/Race.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/Race.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Domain.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum Race
+{
+    [Display(Name = "Člověk")]
+    Human,
+
+    [Display(Name = "Trpaslík")]
+    Dwarf,
+
+    [Display(Name = "Elf")]
+    Elf,
+
+    [Display(Name = "Hobit")]
+    Hobbit,
+
+    [Display(Name = "Dúnadan")]
+    Dunedain
+}

--- a/src/OvcinaHra.Shared/Dtos/CharacterDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/CharacterDtos.cs
@@ -2,23 +2,30 @@ using OvcinaHra.Shared.Domain.Enums;
 
 namespace OvcinaHra.Shared.Dtos;
 
-// Character catalog (persistent identity)
+// Character catalog (persistent identity).
+// KingdomId / KingdomName / KingdomHexColor are optionally populated from the
+// character's active CharacterAssignment for a given gameId at read time — they
+// are NOT stored on the Character itself (a character can belong to different
+// kingdoms in different games).
 public record CharacterListDto(
-    int Id, string Name, string? PlayerFullName, string? Race,
-    bool IsPlayedCharacter, int? ExternalPersonId);
+    int Id, string Name, string? PlayerFullName, Race? Race,
+    bool IsPlayedCharacter, int? ExternalPersonId,
+    int? KingdomId = null, string? KingdomName = null, string? KingdomHexColor = null);
 
 public record CharacterDetailDto(
     int Id, string Name, string? PlayerFirstName, string? PlayerLastName,
-    string? Race, int? BirthYear, string? Notes,
+    Race? Race, int? BirthYear, string? Notes,
     bool IsPlayedCharacter, int? ExternalPersonId,
     int? ParentCharacterId, string? ParentCharacterName,
-    DateTime CreatedAtUtc, DateTime UpdatedAtUtc);
+    DateTime CreatedAtUtc, DateTime UpdatedAtUtc,
+    int? KingdomId = null, string? KingdomName = null, string? KingdomHexColor = null,
+    int? ActiveAssignmentId = null);
 
 public record CreateCharacterDto(
     string Name,
     string? PlayerFirstName = null,
     string? PlayerLastName = null,
-    string? Race = null,
+    Race? Race = null,
     int? BirthYear = null,
     string? Notes = null,
     bool IsPlayedCharacter = false,
@@ -29,30 +36,33 @@ public record UpdateCharacterDto(
     string Name,
     string? PlayerFirstName,
     string? PlayerLastName,
-    string? Race,
+    Race? Race,
     int? BirthYear,
     string? Notes,
     bool IsPlayedCharacter,
     int? ExternalPersonId,
     int? ParentCharacterId);
 
-// Per-game assignment (per-game snapshot)
+// Per-game assignment (per-game snapshot). Kingdom lives here, FK to Kingdoms.
 public record CharacterAssignmentDto(
     int Id, int CharacterId, string CharacterName,
     int GameId, int ExternalPersonId, int? RegistraceCharacterId,
-    PlayerClass? Class, string? Kingdom,
+    PlayerClass? Class, int? KingdomId, string? KingdomName, string? KingdomHexColor,
     bool IsActive, DateTime StartedAtUtc, DateTime? EndedAtUtc);
 
 public record CreateCharacterAssignmentDto(
     int GameId, int ExternalPersonId,
     PlayerClass? Class = null,
-    string? Kingdom = null,
+    int? KingdomId = null,
     int? RegistraceCharacterId = null);
 
 public record UpdateCharacterAssignmentDto(
     PlayerClass? Class,
-    string? Kingdom,
+    int? KingdomId,
     bool IsActive);
+
+// Dialog-driven upsert for the current game's kingdom on a character's assignment.
+public record SetAssignmentKingdomDto(int GameId, int? KingdomId);
 
 // Event log
 public record CharacterEventDto(
@@ -66,7 +76,7 @@ public record CreateCharacterEventDto(
 public record ScanCharacterDto(
     int CharacterId, int AssignmentId, int ExternalPersonId,
     string Name, string? PlayerFullName,
-    string? Race, PlayerClass? Class, string? Kingdom, int? BirthYear,
+    Race? Race, PlayerClass? Class, string? Kingdom, int? BirthYear,
     int CurrentLevel, int TotalXp,
     List<string> Skills, List<CharacterEventDto> RecentEvents);
 

--- a/src/OvcinaHra.Shared/Dtos/KingdomDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/KingdomDtos.cs
@@ -1,0 +1,24 @@
+namespace OvcinaHra.Shared.Dtos;
+
+public record KingdomDto(
+    int Id,
+    string Name,
+    string? HexColor,
+    string? BadgeImageUrl,
+    string? Description,
+    int SortOrder,
+    int AssignmentCount = 0);
+
+public record CreateKingdomDto(
+    string Name,
+    string? HexColor = null,
+    string? BadgeImageUrl = null,
+    string? Description = null,
+    int SortOrder = 0);
+
+public record UpdateKingdomDto(
+    string Name,
+    string? HexColor,
+    string? BadgeImageUrl,
+    string? Description,
+    int SortOrder);

--- a/src/OvcinaHra.Shared/Extensions/RaceExtensions.cs
+++ b/src/OvcinaHra.Shared/Extensions/RaceExtensions.cs
@@ -1,0 +1,23 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Extensions;
+
+public static class RaceExtensions
+{
+    public static Race? TryParseRace(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+
+        var normalized = value.Trim().ToLowerInvariant();
+
+        return normalized switch
+        {
+            "human" or "člověk" or "clovek" => Race.Human,
+            "dwarf" or "trpaslík" or "trpaslik" => Race.Dwarf,
+            "elf" => Race.Elf,
+            "hobbit" or "hobit" => Race.Hobbit,
+            "dunedain" or "dúnadan" or "dunadan" => Race.Dunedain,
+            _ => null
+        };
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
@@ -8,9 +8,15 @@ namespace OvcinaHra.Api.Tests.Endpoints;
 
 public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
 {
+    private async Task<int> GetKingdomIdAsync(string name)
+    {
+        var kingdoms = await Client.GetFromJsonAsync<List<KingdomDto>>("/api/kingdoms");
+        return kingdoms!.First(k => k.Name == name).Id;
+    }
+
     private async Task<(CharacterDetailDto character, CharacterAssignmentDto assignment)> SeedCharacterWithAssignment(
         int externalPersonId = 100, int gameId = 1,
-        string? race = "Dwarf", string? kingdom = "Erebor")
+        Race? race = Race.Dwarf, int? kingdomId = null)
     {
         var createResponse = await Client.PostAsJsonAsync("/api/characters",
             new CreateCharacterDto("Thorin", Race: race, IsPlayedCharacter: true, ExternalPersonId: externalPersonId));
@@ -19,7 +25,7 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
 
         var assignResponse = await Client.PostAsJsonAsync(
             $"/api/characters/{character!.Id}/assignments",
-            new CreateCharacterAssignmentDto(gameId, externalPersonId, null, kingdom));
+            new CreateCharacterAssignmentDto(gameId, externalPersonId, null, kingdomId));
         assignResponse.EnsureSuccessStatusCode();
         var assignment = await assignResponse.Content.ReadFromJsonAsync<CharacterAssignmentDto>();
 
@@ -29,7 +35,8 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
     [Fact]
     public async Task Scan_ActiveCharacter_ReturnsProfile()
     {
-        await SeedCharacterWithAssignment(externalPersonId: 100);
+        var dwarvesKingdomId = await GetKingdomIdAsync("Azanulinbar-Dum");
+        await SeedCharacterWithAssignment(externalPersonId: 100, kingdomId: dwarvesKingdomId);
 
         var response = await Client.GetAsync("/api/scan/100");
 
@@ -38,8 +45,8 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
         Assert.NotNull(profile);
         Assert.Equal("Thorin", profile.Name);
         Assert.Null(profile.PlayerFullName); // no player name set in seed
-        Assert.Equal("Dwarf", profile.Race);
-        Assert.Equal("Erebor", profile.Kingdom);
+        Assert.Equal(Race.Dwarf, profile.Race);
+        Assert.Equal("Azanulinbar-Dum", profile.Kingdom);
         Assert.Equal(0, profile.CurrentLevel);
         Assert.Equal(0, profile.TotalXp);
         Assert.Empty(profile.Skills);

--- a/tests/OvcinaHra.Api.Tests/Fixtures/IntegrationTestBase.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/IntegrationTestBase.cs
@@ -39,6 +39,16 @@ public abstract class IntegrationTestBase : IAsyncLifetime
         var truncateSql = string.Join("; ", tableNames.Select(t => $"TRUNCATE TABLE \"{t}\" CASCADE"));
         if (truncateSql.Length > 0)
             await db.Database.ExecuteSqlRawAsync(truncateSql);
+
+        // Re-seed the canonical Kingdom lookup rows the 20260422221753 migration
+        // inserts at apply-time (TRUNCATE CASCADE wipes them between test classes).
+        await db.Database.ExecuteSqlRawAsync("""
+            INSERT INTO "Kingdoms" ("Name", "HexColor", "SortOrder") VALUES
+              ('Aradhryand',      '#2E7D32', 1),
+              ('Azanulinbar-Dum', '#C62828', 2),
+              ('Esgaroth',        '#1565C0', 3),
+              ('Nový Arnor',      '#F9A825', 4)
+            """);
     }
 
     public async Task DisposeAsync()


### PR DESCRIPTION
## Summary
- Character edit dialog redesign + new Kingdoms catalog page (per-game Kingdom assignment)
- Race enum introduced with `RaceChipPicker` component; two EF migrations (`AddRaceEnumAndKingdomLookup`, `AddCharacterImagePath`)
- Design system setup + Claude Design handoff briefs under `docs/design/`
- Version bump to 0.11.0

## Test plan
- [ ] `dotnet test tests/OvcinaHra.Api.Tests` green
- [ ] Migrations apply cleanly on fresh DB
- [ ] `/characters` — edit dialog renders, Race chip picker works, image upload works
- [ ] `/kingdoms` — catalog CRUD works
- [ ] Per-game Kingdom assignment behaves as expected
- [ ] Regression check: QuestWizard + PersonalQuests flows still work