### PR TITLE
feat(locations): LocationDetail page, MTG stash tiles, inline mini-map [v0.11.0]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -489,3 +489,7 @@ src/OvcinaHra.Client/wwwroot/appsettings.Development.json
 
 # Claude Design handoff bundles (large, regenerable)
 docs/design/handoff/
+
+# Claude Design mockup exports (kept in Downloads, regenerable)
+*.mockup.html
+*.mockup.unbundled.html

--- a/src/OvcinaHra.Client/Components/LocationEditPopup.razor
+++ b/src/OvcinaHra.Client/Components/LocationEditPopup.razor
@@ -2,6 +2,7 @@
 @using OvcinaHra.Shared.Dtos
 @using OvcinaHra.Client.Pages.Locations
 @inject ApiClient Api
+@inject NavigationManager Nav
 
 <DxPopup AllowResize="true" @bind-Visible="@isVisible" HeaderText="@modalTitle" Width="900px" MinHeight="700px"
          CloseOnOutsideClick="false" ShowCloseButton="true">
@@ -78,6 +79,17 @@
                     </div>
                 }
             </div>
+
+            @* Quick-peek footer — jumps to the full /locations/{id} page *@
+            @if (editingId.HasValue)
+            {
+                <div class="d-flex justify-content-end gap-2 mt-3 pt-3" style="border-top:1px solid var(--oh-border);">
+                    <button class="btn btn-secondary" @onclick="() => isVisible = false">Zavřít</button>
+                    <button class="btn btn-primary" @onclick="OpenFullDetail">
+                        Otevřít detail <i class="bi bi-arrow-right-short"></i>
+                    </button>
+                </div>
+            }
         }
 
         @* ── Tab 1: Edit form ── *@
@@ -426,6 +438,15 @@
     }
 
     public void Close() => isVisible = false;
+
+    // Jumps to the full /locations/{id} page — organizers who open the popup
+    // from the grid can drop into deep-edit mode without losing their place.
+    private void OpenFullDetail()
+    {
+        if (!editingId.HasValue) return;
+        isVisible = false;
+        Nav.NavigateTo($"/locations/{editingId.Value}");
+    }
 
     private void OnParentChangeRequested(int? newParentId)
     {

--- a/src/OvcinaHra.Client/Components/LocationStashTile.razor
+++ b/src/OvcinaHra.Client/Components/LocationStashTile.razor
@@ -1,8 +1,7 @@
 @using OvcinaHra.Shared.Dtos
 @inject ApiClient Api
-@inject NavigationManager Nav
 
-<a class="oh-lc-tile" @onclick="Navigate" @onclick:preventDefault>
+<a class="oh-lc-tile" href="/secret-stashes/@Stash.Id">
     <div class="oh-lc-tile-img">
         @if (imageUrl is not null)
         {
@@ -41,13 +40,13 @@
     private List<LocationTreasureQuestDto> visibleQuests = [];
     private int overflowCount;
 
-    private static int _lastStashId;
+    private int? _loadedForStashId;
 
     protected override async Task OnParametersSetAsync()
     {
-        if (_lastStashId != Stash.Id)
+        if (_loadedForStashId != Stash.Id)
         {
-            _lastStashId = Stash.Id;
+            _loadedForStashId = Stash.Id;
             await LoadImageAsync();
         }
 
@@ -65,8 +64,6 @@
         }
         catch { imageUrl = null; }
     }
-
-    private void Navigate() => Nav.NavigateTo($"/secret-stashes/{Stash.Id}");
 
     // Czech plural for count: 1 → "další", 2-4 → "další", 5+ → "dalších"
     private static string PluralForm(int n, string one, string few, string many)

--- a/src/OvcinaHra.Client/Components/LocationStashTile.razor
+++ b/src/OvcinaHra.Client/Components/LocationStashTile.razor
@@ -1,0 +1,74 @@
+@using OvcinaHra.Shared.Dtos
+@inject ApiClient Api
+@inject NavigationManager Nav
+
+<a class="oh-lc-tile" @onclick="Navigate" @onclick:preventDefault>
+    <div class="oh-lc-tile-img">
+        @if (imageUrl is not null)
+        {
+            <img src="@imageUrl" alt="@Stash.Name" />
+        }
+        else
+        {
+            <div class="oh-lc-tile-img-empty">bez obrázku</div>
+        }
+        <span class="oh-lc-tile-mtgtag">5:7</span>
+    </div>
+    <div class="oh-lc-tile-body">
+        <div class="oh-lc-tile-name">@Stash.Name</div>
+        <div class="oh-lc-tile-sep"></div>
+        <ul class="oh-lc-tile-quests">
+            @foreach (var q in visibleQuests)
+            {
+                <li class="oh-lc-tile-quest">
+                    <span class="oh-lc-tile-quest-name">@q.Title</span>
+                    <span class="oh-lc-tile-quest-pill">Poklad</span>
+                </li>
+            }
+        </ul>
+        @if (overflowCount > 0)
+        {
+            <div class="oh-lc-tile-more">+ @overflowCount @PluralForm(overflowCount, "další", "další", "dalších")</div>
+        }
+    </div>
+</a>
+
+@code {
+    [Parameter, EditorRequired] public LocationStashDto Stash { get; set; } = null!;
+    [Parameter] public int MaxVisibleQuests { get; set; } = 5;
+
+    private string? imageUrl;
+    private List<LocationTreasureQuestDto> visibleQuests = [];
+    private int overflowCount;
+
+    private static int _lastStashId;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_lastStashId != Stash.Id)
+        {
+            _lastStashId = Stash.Id;
+            await LoadImageAsync();
+        }
+
+        var all = Stash.TreasureQuests ?? [];
+        visibleQuests = all.Take(MaxVisibleQuests).ToList();
+        overflowCount = Math.Max(0, all.Count - MaxVisibleQuests);
+    }
+
+    private async Task LoadImageAsync()
+    {
+        try
+        {
+            var urls = await Api.GetAsync<ImageUrlsDto>($"/api/images/secretstashes/{Stash.Id}");
+            imageUrl = urls?.ImageUrl;
+        }
+        catch { imageUrl = null; }
+    }
+
+    private void Navigate() => Nav.NavigateTo($"/secret-stashes/{Stash.Id}");
+
+    // Czech plural for count: 1 → "další", 2-4 → "další", 5+ → "dalších"
+    private static string PluralForm(int n, string one, string few, string many)
+        => n == 1 ? one : (n >= 2 && n <= 4 ? few : many);
+}

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -3,10 +3,14 @@
 @inject ApiClient Api
 @inject GameContextService GameContext
 @inject NavigationManager Nav
+@inject IJSRuntime JS
+@inject IConfiguration Config
+@implements IAsyncDisposable
 @using OvcinaHra.Shared.Domain.Enums
 @using OvcinaHra.Shared.Dtos
 @using OvcinaHra.Shared.Extensions
 @using OvcinaHra.Client.Components
+@using Microsoft.JSInterop
 
 @if (loading)
 {
@@ -373,9 +377,34 @@ else
 
     private static readonly LocationKind[] kindValues = Enum.GetValues<LocationKind>();
 
-    private bool HasGps =>
-        decimal.TryParse(latitudeStr?.Replace(',', '.'), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out _)
-        && decimal.TryParse(longitudeStr?.Replace(',', '.'), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out _);
+    // LocationKind marker colors — canonical, distinct from kingdom palette.
+    // Matches MapPage markerColors and Claude Design brief. Used for the
+    // inline mini-map pin color in Upravit.
+    private static readonly Dictionary<LocationKind, string> KindMarkerColors = new()
+    {
+        [LocationKind.Town] = "#2c3e50",
+        [LocationKind.Village] = "#27ae60",
+        [LocationKind.Magical] = "#8e44ad",
+        [LocationKind.Hobbit] = "#f39c12",
+        [LocationKind.Wilderness] = "#16a085"
+    };
+
+    private string MiniMapElementId => $"oh-lc-gps-map-{Id}";
+    private bool miniMapInited;
+    private decimal? lastMiniMapLat, lastMiniMapLon;
+
+    private bool HasGps => ParseGps(out _, out _);
+
+    private bool ParseGps(out decimal lat, out decimal lon)
+    {
+        lat = 0; lon = 0;
+        var inv = System.Globalization.CultureInfo.InvariantCulture;
+        var nf = System.Globalization.NumberStyles.Float;
+        if (string.IsNullOrWhiteSpace(latitudeStr) || string.IsNullOrWhiteSpace(longitudeStr))
+            return false;
+        return decimal.TryParse(latitudeStr.Replace(',', '.'), nf, inv, out lat)
+            && decimal.TryParse(longitudeStr.Replace(',', '.'), nf, inv, out lon);
+    }
 
     protected override async Task OnParametersSetAsync()
     {
@@ -502,4 +531,66 @@ else
         text.Split(new[] { "\r\n\r\n", "\n\n" }, StringSplitOptions.RemoveEmptyEntries)
             .Select(p => p.Trim())
             .Where(p => p.Length > 0);
+
+    // ---- Mini-map lifecycle --------------------------------------------
+    // Initializes a single-pin read-only MapLibre instance on the Upravit
+    // tab when GPS is set. Disposes when the user switches tabs away or
+    // clears GPS. Updates pin position when coordinates change.
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await ReconcileMiniMapAsync();
+    }
+
+    private async Task ReconcileMiniMapAsync()
+    {
+        decimal lat = 0, lon = 0;
+        var shouldShow = activeTab == "upravit" && loc is not null && ParseGps(out lat, out lon);
+
+        if (!shouldShow)
+        {
+            if (miniMapInited)
+            {
+                try { await JS.InvokeVoidAsync("ovcinaMiniMap.dispose", MiniMapElementId); } catch { }
+                miniMapInited = false;
+                lastMiniMapLat = null; lastMiniMapLon = null;
+            }
+            return;
+        }
+
+        var kindColor = KindMarkerColors.GetValueOrDefault(loc!.LocationKind, "#2D5016");
+        var apiKey = Config["Maps:MapyCzApiKey"] ?? "";
+
+        if (!miniMapInited)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("ovcinaMiniMap.init",
+                    MiniMapElementId, (double)lat, (double)lon, 12, kindColor, apiKey);
+                miniMapInited = true;
+                lastMiniMapLat = lat; lastMiniMapLon = lon;
+            }
+            catch { /* element may not be in DOM yet; retried on next render */ }
+            return;
+        }
+
+        if (lastMiniMapLat != lat || lastMiniMapLon != lon)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("ovcinaMiniMap.update",
+                    MiniMapElementId, (double)lat, (double)lon);
+                lastMiniMapLat = lat; lastMiniMapLon = lon;
+            }
+            catch { /* ignore transient errors */ }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (miniMapInited)
+        {
+            try { await JS.InvokeVoidAsync("ovcinaMiniMap.dispose", MiniMapElementId); } catch { }
+        }
+    }
 }

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -1,0 +1,505 @@
+@page "/locations/{Id:int}"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject GameContextService GameContext
+@inject NavigationManager Nav
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Extensions
+@using OvcinaHra.Client.Components
+
+@if (loading)
+{
+    <div class="oh-lc-page"><p>Načítám…</p></div>
+}
+else if (loc is null)
+{
+    <div class="oh-lc-page">
+        <p class="text-muted">Lokace nenalezena.</p>
+        <a class="btn btn-secondary" href="/locations">← zpět na seznam</a>
+    </div>
+}
+else
+{
+    <div class="oh-lc-page">
+
+        <div class="oh-lc-crumb">
+            <a href="/locations">Lokace</a> / <span>@loc.Name</span>
+        </div>
+
+        <div class="oh-lc-title-strip">
+            <a class="oh-lc-back" href="/locations"><i class="bi bi-arrow-left"></i> zpět</a>
+            <div>
+                <h1>@loc.Name</h1>
+                <div class="oh-lc-title-sub">
+                    @if (!string.IsNullOrWhiteSpace(loc.Region))
+                    {
+                        <span class="region">@loc.Region</span>
+                        <span>·</span>
+                    }
+                    <span>@loc.LocationKind.GetDisplayName()</span>
+                    @if (parent is not null)
+                    {
+                        <span>·</span>
+                        <a href="/locations/@parent.Id" class="oh-link"><i class="bi bi-arrow-up-short"></i> @parent.Name</a>
+                    }
+                </div>
+            </div>
+            <div class="oh-lc-title-actions">
+                @if (activeTab == "upravit")
+                {
+                    <button class="btn btn-secondary" @onclick='() => SwitchTab("karta")' disabled="@isSaving">Zrušit</button>
+                    <button class="btn btn-primary" @onclick="SaveAsync" disabled="@(isSaving || string.IsNullOrWhiteSpace(name))">Uložit</button>
+                }
+                else
+                {
+                    <button class="btn btn-secondary" @onclick='() => SwitchTab("upravit")'>
+                        <i class="bi bi-pencil me-1"></i> Upravit
+                    </button>
+                    <button class="btn oh-btn-ghost-bordeaux" @onclick="() => isDeleteVisible = true">
+                        <i class="bi bi-trash me-1"></i> Smazat
+                    </button>
+                }
+            </div>
+        </div>
+
+        <div class="oh-lc-tabs" role="tablist">
+            <button class="oh-lc-tab @(activeTab == "karta" ? "active" : "")" @onclick='() => SwitchTab("karta")'>
+                <i class="bi bi-card-text"></i> Karta
+            </button>
+            <button class="oh-lc-tab @(activeTab == "upravit" ? "active" : "")" @onclick='() => SwitchTab("upravit")'>
+                <i class="bi bi-pencil"></i> Upravit
+            </button>
+            <button class="oh-lc-tab @(activeTab == "lore" ? "active" : "")" @onclick='() => SwitchTab("lore")'>
+                <i class="bi bi-book"></i> Lore
+            </button>
+            <button class="oh-lc-tab @(activeTab == "skryse" ? "active" : "")" @onclick='() => SwitchTab("skryse")'>
+                <i class="bi bi-safe"></i> Skrýše
+                @if ((loc.Stashes?.Count ?? 0) > 0)
+                {
+                    <span class="oh-lc-count">@loc.Stashes!.Count</span>
+                }
+            </button>
+        </div>
+
+        @if (error is not null)
+        {
+            <div class="oh-drozd-val mb-3">
+                <i class="bi bi-exclamation-circle oh-drozd-val-icon"></i>
+                <div>
+                    <div class="oh-drozd-val-title">Něco se pokazilo</div>
+                    <div class="oh-drozd-val-msg">@error</div>
+                </div>
+            </div>
+        }
+
+        @* ── Tab: Karta (read parchment card) ── *@
+        @if (activeTab == "karta")
+        {
+            if (string.IsNullOrWhiteSpace(loc.Description) && mainImageUrl is null)
+            {
+                <div class="oh-lc-card">
+                    <h1 class="oh-lc-card-title">@loc.Name</h1>
+                    @if (!string.IsNullOrWhiteSpace(loc.Region))
+                    {
+                        <div class="oh-lc-card-region">@loc.Region — @loc.LocationKind.GetDisplayName()</div>
+                    }
+                    <div class="oh-lc-card-empty">
+                        <div class="oh-lc-empty-title">Tato lokace ještě čeká na popis</div>
+                        <div class="oh-lc-empty-copy">Napiš první popis a nahraj obrázek na záložce <strong>Upravit</strong>.</div>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="oh-lc-card">
+                    <h1 class="oh-lc-card-title">@loc.Name</h1>
+                    <div class="oh-lc-card-region">
+                        @if (!string.IsNullOrWhiteSpace(loc.Region)) { @loc.Region <text> — </text> }
+                        @loc.LocationKind.GetDisplayName()
+                    </div>
+                    <div class="oh-lc-card-body">
+                        <div class="oh-lc-card-text">
+                            @if (!string.IsNullOrWhiteSpace(loc.Description))
+                            {
+                                <p>@loc.Description</p>
+                            }
+                        </div>
+                        <div class="oh-lc-card-right">
+                            <div class="oh-lc-card-img">
+                                @if (mainImageUrl is not null)
+                                {
+                                    <img src="@mainImageUrl" alt="@loc.Name" />
+                                }
+                            </div>
+                            <div class="oh-lc-card-img-caption">
+                                <span>Znak lokace</span>
+                                <span>1:1</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    @if (!string.IsNullOrWhiteSpace(loc.Details))
+                    {
+                        <div class="oh-lc-card-details">
+                            <span class="oh-lc-card-id">@loc.Id.ToString("D2")</span>
+                            <p>@loc.Details</p>
+                        </div>
+                    }
+
+                    @if (!string.IsNullOrWhiteSpace(loc.GamePotential))
+                    {
+                        <div class="oh-lc-card-potential">
+                            <strong>Herní potenciál:</strong> @loc.GamePotential
+                        </div>
+                    }
+
+                    @if (variants.Count > 0)
+                    {
+                        <div class="oh-lc-card-variants">
+                            <span class="oh-lc-vlbl">Varianty (@variants.Count):</span>
+                            @foreach (var v in variants)
+                            {
+                                <a class="oh-lc-vchip" href="/locations/@v.Id">
+                                    <i class="bi bi-arrow-right-short"></i> @v.Name
+                                </a>
+                            }
+                        </div>
+                    }
+                </div>
+            }
+        }
+
+        @* ── Tab: Upravit (form with inline map panel) ── *@
+        @if (activeTab == "upravit")
+        {
+            <div class="oh-lc-sect">
+                <div class="oh-lc-sect-label"><i class="bi bi-card-heading"></i> Identita</div>
+                <DxFormLayout>
+                    <DxFormLayoutItem Caption="Název" ColSpanMd="8">
+                        <DxTextBox @bind-Text="@name" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Druh" ColSpanMd="4">
+                        <DxComboBox TData="LocationKind" TValue="LocationKind"
+                                    Data="@kindValues" @bind-Value="@locationKind"
+                                    NullText="-- vyber --" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Oblast" ColSpanMd="6">
+                        <DxTextBox @bind-Text="@region" NullText="(volitelné)" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Rodič" ColSpanMd="6">
+                        <DxComboBox TData="LocationListDto" TValue="int?"
+                                    Data="@parentCandidates" @bind-Value="@parentLocationId"
+                                    TextFieldName="Name" ValueFieldName="Id"
+                                    NullText="(žádný)" SearchMode="ListSearchMode.AutoSearch" />
+                    </DxFormLayoutItem>
+                </DxFormLayout>
+            </div>
+
+            <div class="oh-lc-sect">
+                <div class="oh-lc-sect-label"><i class="bi bi-geo-alt"></i> GPS</div>
+                <div class="oh-lc-gps-block">
+                    <div class="oh-lc-gps-row">
+                        <DxFormLayoutItem Caption="Latitude" ColSpanMd="12">
+                            <DxTextBox @bind-Text="@latitudeStr" NullText="např. 49,4543192" />
+                        </DxFormLayoutItem>
+                        <DxFormLayoutItem Caption="Longitude" ColSpanMd="12">
+                            <DxTextBox @bind-Text="@longitudeStr" NullText="např. 18,0203280" />
+                        </DxFormLayoutItem>
+                    </div>
+                    <div>
+                        @if (HasGps)
+                        {
+                            <div class="oh-lc-gps-map" id="oh-lc-gps-map-@Id"
+                                 title="Klik otevře plnou mapu"
+                                 @onclick="OpenFullMap"></div>
+                            <div class="oh-lc-gps-map-footer">
+                                <span class="oh-lc-gps-coords">@latitudeStr, @longitudeStr</span>
+                                <a href="/map?focus=@Id">otevřít v plné mapě →</a>
+                            </div>
+                        }
+                        else
+                        {
+                            <div class="oh-lc-gps-map-empty">
+                                <span><i class="bi bi-geo"></i> Nastav souřadnice vlevo, mini-mapa se objeví.</span>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+
+            <div class="oh-lc-sect">
+                <div class="oh-lc-sect-label"><i class="bi bi-image"></i> Vizuál</div>
+                <div class="oh-lc-visual-slots">
+                    <div>
+                        <small class="text-muted d-block mb-1">Hlavní obrázek (1:1)</small>
+                        <ImagePicker EntityType="locations" EntityId="@Id"
+                                     AspectRatio="1:1" Width="280px" Alt="Hlavní obrázek" />
+                    </div>
+                    <div>
+                        <small class="text-muted d-block mb-1">Fotka umístění (4:3)</small>
+                        <ImagePicker EntityType="locations" EntityId="@Id" Field="placement"
+                                     AspectRatio="4:3" Width="360px" Alt="Fotka umístění" />
+                    </div>
+                </div>
+            </div>
+
+            <div class="oh-lc-sect">
+                <div class="oh-lc-sect-label"><i class="bi bi-card-text"></i> Obsah</div>
+                <DxFormLayout>
+                    <DxFormLayoutItem Caption="Popis (pro kartu)" ColSpanMd="12">
+                        <DxMemo @bind-Text="@description" Rows="4" NullText="Čtenářský popis lokace…" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Detaily (pravidlové poznámky)" ColSpanMd="12">
+                        <DxMemo @bind-Text="@details" Rows="5" NullText="Pravidlové poznámky, vazby…" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Herní potenciál" ColSpanMd="12">
+                        <DxMemo @bind-Text="@gamePotential" Rows="3" NullText="Co lokace nabízí hrám…" />
+                    </DxFormLayoutItem>
+                </DxFormLayout>
+            </div>
+
+            <div class="oh-lc-sect">
+                <div class="oh-lc-sect-label"><i class="bi bi-clipboard"></i> Organizační</div>
+                <DxFormLayout>
+                    <DxFormLayoutItem Caption="Info pro CP (NPC)" ColSpanMd="12">
+                        <DxMemo @bind-Text="@npcInfo" Rows="3" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Co nachystat na lokaci" ColSpanMd="12">
+                        <DxMemo @bind-Text="@setupNotes" Rows="3" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Prompt (generátor)" ColSpanMd="12">
+                        <DxTextBox @bind-Text="@prompt" NullText="volitelné — generátor scén" />
+                    </DxFormLayoutItem>
+                </DxFormLayout>
+            </div>
+        }
+
+        @* ── Tab: Lore (preview vs editor) ── *@
+        @if (activeTab == "lore")
+        {
+            <div class="oh-lc-lore-cols">
+                <div class="oh-lc-lore-preview">
+                    @if (!string.IsNullOrWhiteSpace(loc.Description))
+                    {
+                        foreach (var para in SplitParagraphs(loc.Description))
+                        {
+                            <p>@para</p>
+                        }
+                    }
+                    else
+                    {
+                        <p class="text-muted"><em>Žádný popis — napiš první řádky příběhu lokace vpravo.</em></p>
+                    }
+                </div>
+                <div>
+                    <div class="oh-lc-lore-edit-head">
+                        <div class="oh-lc-sect-label" style="border:none;padding:0;margin:0"><i class="bi bi-pencil"></i> Editor</div>
+                    </div>
+                    <textarea class="oh-lc-lore-memo"
+                              placeholder="Napiš lore textů lokace — čtenářský, ne pravidlový…"
+                              @bind="loreText" @bind:event="oninput"></textarea>
+                    <div class="d-flex justify-content-end mt-2">
+                        <button class="btn btn-primary" @onclick="SaveLoreAsync" disabled="@isSaving">Uložit lore</button>
+                    </div>
+                </div>
+            </div>
+        }
+
+        @* ── Tab: Skrýše (MTG tiles) ── *@
+        @if (activeTab == "skryse")
+        {
+            <div class="oh-lc-stash-head">
+                <h3>
+                    <i class="bi bi-safe"></i>
+                    Skrýše v této lokaci
+                    <span class="oh-lc-stash-count">(@(loc.Stashes?.Count ?? 0))</span>
+                </h3>
+                <a class="btn btn-outline-secondary" href="/secret-stashes">
+                    <i class="bi bi-plus-lg me-1"></i> Spravovat skrýše
+                </a>
+            </div>
+
+            @if ((loc.Stashes?.Count ?? 0) == 0)
+            {
+                <div class="oh-lc-card-empty">
+                    <div class="oh-lc-empty-title">Žádné skrýše zatím nejsou přiřazené</div>
+                    <div class="oh-lc-empty-copy">Přiřaď skrýš k této lokaci přes stránku <strong>Tajné skrýše</strong>.</div>
+                </div>
+            }
+            else
+            {
+                <div class="oh-lc-stash-grid">
+                    @foreach (var stash in loc.Stashes!)
+                    {
+                        <LocationStashTile Stash="stash" />
+                    }
+                </div>
+            }
+        }
+    </div>
+}
+
+@* Delete confirmation popup — MEMORY §D *@
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="420px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete smazat lokaci <strong>@loc?.Name</strong>?</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public int Id { get; set; }
+
+    private LocationListDto? loc;
+    private LocationListDto? parent;
+    private List<LocationListDto> variants = [];
+    private List<LocationListDto> parentCandidates = [];
+    private string? mainImageUrl;
+
+    private string activeTab = "karta";
+    private bool loading = true, isSaving, isDeleteVisible;
+    private string? error;
+
+    // Form state (duplicate of loc for edit mode)
+    private string name = "";
+    private LocationKind locationKind;
+    private string? region, description, details, gamePotential, npcInfo, setupNotes, prompt, loreText;
+    private string latitudeStr = "", longitudeStr = "";
+    private int? parentLocationId;
+
+    private static readonly LocationKind[] kindValues = Enum.GetValues<LocationKind>();
+
+    private bool HasGps =>
+        decimal.TryParse(latitudeStr?.Replace(',', '.'), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out _)
+        && decimal.TryParse(longitudeStr?.Replace(',', '.'), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out _);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await GameContext.InitializeAsync();
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true; error = null;
+        try
+        {
+            loc = await Api.GetAsync<LocationListDto>($"/api/locations/{Id}");
+            if (loc is null) { loading = false; return; }
+
+            PopulateFormFromDto(loc);
+
+            // Parent + variants
+            var all = await Api.GetListAsync<LocationListDto>("/api/locations");
+            parentCandidates = all.Where(l => l.Id != Id).ToList();
+            parent = loc.ParentLocationId.HasValue
+                ? all.FirstOrDefault(l => l.Id == loc.ParentLocationId.Value)
+                : null;
+            variants = all.Where(l => l.ParentLocationId == Id).ToList();
+
+            // Main image (ImagePicker has its own fetch, but we also render img on Karta)
+            try
+            {
+                var urls = await Api.GetAsync<ImageUrlsDto>($"/api/images/locations/{Id}");
+                mainImageUrl = urls?.ImageUrl;
+            }
+            catch { mainImageUrl = null; }
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { loading = false; }
+    }
+
+    private void PopulateFormFromDto(LocationListDto d)
+    {
+        name = d.Name;
+        locationKind = d.LocationKind;
+        region = d.Region;
+        description = d.Description;
+        details = d.Details;
+        gamePotential = d.GamePotential;
+        npcInfo = d.NpcInfo;
+        setupNotes = d.SetupNotes;
+        prompt = null; // Prompt not on ListDto; future: fetch from dedicated detail endpoint
+        parentLocationId = d.ParentLocationId;
+        latitudeStr = d.Latitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "";
+        longitudeStr = d.Longitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "";
+        loreText = d.Description;
+    }
+
+    private void SwitchTab(string tab) => activeTab = tab;
+
+    private async Task SaveAsync()
+    {
+        if (string.IsNullOrWhiteSpace(name)) return;
+        error = null; isSaving = true;
+        try
+        {
+            await Api.PutAsync($"/api/locations/{Id}", BuildUpdateDto());
+            await LoadAsync();
+            activeTab = "karta";
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task SaveLoreAsync()
+    {
+        if (loc is null) return;
+        error = null; isSaving = true;
+        try
+        {
+            description = loreText;
+            await Api.PutAsync($"/api/locations/{Id}", BuildUpdateDto());
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private UpdateLocationDto BuildUpdateDto()
+    {
+        decimal? lat = null, lon = null;
+        if (decimal.TryParse(latitudeStr?.Replace(',', '.'), System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var la))
+            lat = la;
+        if (decimal.TryParse(longitudeStr?.Replace(',', '.'), System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var lo))
+            lon = lo;
+
+        return new UpdateLocationDto(
+            Name: name,
+            LocationKind: locationKind,
+            Latitude: lat,
+            Longitude: lon,
+            Description: description,
+            Details: details,
+            GamePotential: gamePotential,
+            Prompt: prompt,
+            Region: region,
+            NpcInfo: npcInfo,
+            SetupNotes: setupNotes,
+            ParentLocationId: parentLocationId);
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        try
+        {
+            await Api.DeleteAsync($"/api/locations/{Id}");
+            isDeleteVisible = false;
+            Nav.NavigateTo("/locations");
+        }
+        catch (Exception ex) { error = ex.Message; isDeleteVisible = false; }
+    }
+
+    private void OpenFullMap() => Nav.NavigateTo($"/map?focus={Id}");
+
+    private static IEnumerable<string> SplitParagraphs(string text) =>
+        text.Split(new[] { "\r\n\r\n", "\n\n" }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(p => p.Trim())
+            .Where(p => p.Length > 0);
+}

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -204,12 +204,14 @@ else
                 <div class="oh-lc-sect-label"><i class="bi bi-geo-alt"></i> GPS</div>
                 <div class="oh-lc-gps-block">
                     <div class="oh-lc-gps-row">
-                        <DxFormLayoutItem Caption="Latitude" ColSpanMd="12">
-                            <DxTextBox @bind-Text="@latitudeStr" NullText="např. 49,4543192" />
-                        </DxFormLayoutItem>
-                        <DxFormLayoutItem Caption="Longitude" ColSpanMd="12">
-                            <DxTextBox @bind-Text="@longitudeStr" NullText="např. 18,0203280" />
-                        </DxFormLayoutItem>
+                        <DxFormLayout>
+                            <DxFormLayoutItem Caption="Latitude" ColSpanMd="12">
+                                <DxTextBox @bind-Text="@latitudeStr" NullText="např. 49,4543192" />
+                            </DxFormLayoutItem>
+                            <DxFormLayoutItem Caption="Longitude" ColSpanMd="12">
+                                <DxTextBox @bind-Text="@longitudeStr" NullText="např. 18,0203280" />
+                            </DxFormLayoutItem>
+                        </DxFormLayout>
                     </div>
                     <div>
                         @if (HasGps)
@@ -392,6 +394,7 @@ else
     private string MiniMapElementId => $"oh-lc-gps-map-{Id}";
     private bool miniMapInited;
     private decimal? lastMiniMapLat, lastMiniMapLon;
+    private LocationKind? lastMiniMapKind;
 
     private bool HasGps => ParseGps(out _, out _);
 
@@ -417,16 +420,50 @@ else
         loading = true; error = null;
         try
         {
-            loc = await Api.GetAsync<LocationListDto>($"/api/locations/{Id}");
-            if (loc is null) { loading = false; return; }
+            var detail = await Api.GetAsync<LocationDetailDto>($"/api/locations/{Id}");
+            if (detail is null) { loc = null; loading = false; return; }
 
-            PopulateFormFromDto(loc);
+            // Game-scoped data (Stashes, Quests, LocationTreasureQuests) lives on
+            // /api/locations/by-game/{gameId}; /api/locations/{id} returns only
+            // the flat LocationDetailDto. Merge both into the LocationListDto
+            // shape the template expects.
+            IReadOnlyList<LocationStashDto> stashes = Array.Empty<LocationStashDto>();
+            IReadOnlyList<LocationQuestDto> quests = Array.Empty<LocationQuestDto>();
+            IReadOnlyList<LocationTreasureQuestDto> locationTreasureQuests =
+                Array.Empty<LocationTreasureQuestDto>();
+
+            if (GameContext.SelectedGameId.HasValue)
+            {
+                try
+                {
+                    var gameList = await Api.GetListAsync<LocationListDto>(
+                        $"/api/locations/by-game/{GameContext.SelectedGameId.Value}");
+                    var inGame = gameList.FirstOrDefault(l => l.Id == Id);
+                    if (inGame is not null)
+                    {
+                        stashes = inGame.Stashes;
+                        quests = inGame.Quests;
+                        locationTreasureQuests = inGame.LocationTreasureQuests;
+                    }
+                }
+                catch { /* non-fatal — detail view still usable without game context */ }
+            }
+
+            loc = new LocationListDto(
+                detail.Id, detail.Name, detail.LocationKind,
+                detail.Region, detail.Latitude, detail.Longitude,
+                detail.ParentLocationId,
+                detail.Description, detail.Details, detail.GamePotential,
+                detail.NpcInfo, detail.SetupNotes,
+                stashes, quests, locationTreasureQuests);
+
+            PopulateFormFromDto(detail);
 
             // Parent + variants
             var all = await Api.GetListAsync<LocationListDto>("/api/locations");
             parentCandidates = all.Where(l => l.Id != Id).ToList();
-            parent = loc.ParentLocationId.HasValue
-                ? all.FirstOrDefault(l => l.Id == loc.ParentLocationId.Value)
+            parent = detail.ParentLocationId.HasValue
+                ? all.FirstOrDefault(l => l.Id == detail.ParentLocationId.Value)
                 : null;
             variants = all.Where(l => l.ParentLocationId == Id).ToList();
 
@@ -442,7 +479,7 @@ else
         finally { loading = false; }
     }
 
-    private void PopulateFormFromDto(LocationListDto d)
+    private void PopulateFormFromDto(LocationDetailDto d)
     {
         name = d.Name;
         locationKind = d.LocationKind;
@@ -452,7 +489,7 @@ else
         gamePotential = d.GamePotential;
         npcInfo = d.NpcInfo;
         setupNotes = d.SetupNotes;
-        prompt = null; // Prompt not on ListDto; future: fetch from dedicated detail endpoint
+        prompt = d.Prompt;
         parentLocationId = d.ParentLocationId;
         latitudeStr = d.Latitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "";
         longitudeStr = d.Longitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "";
@@ -516,9 +553,16 @@ else
 
     private async Task ConfirmDeleteAsync()
     {
+        error = null;
         try
         {
-            await Api.DeleteAsync($"/api/locations/{Id}");
+            var deleted = await Api.DeleteAsync($"/api/locations/{Id}");
+            if (!deleted)
+            {
+                error = "Smazání lokace se nezdařilo.";
+                return;
+            }
+
             isDeleteVisible = false;
             Nav.NavigateTo("/locations");
         }
@@ -554,12 +598,24 @@ else
                 try { await JS.InvokeVoidAsync("ovcinaMiniMap.dispose", MiniMapElementId); } catch { }
                 miniMapInited = false;
                 lastMiniMapLat = null; lastMiniMapLon = null;
+                lastMiniMapKind = null;
             }
             return;
         }
 
-        var kindColor = KindMarkerColors.GetValueOrDefault(loc!.LocationKind, "#2D5016");
+        // Use the in-form locationKind (not loc.LocationKind) so the preview reflects
+        // the pending Druh change before the user saves.
+        var kindColor = KindMarkerColors.GetValueOrDefault(locationKind, "#2D5016");
         var apiKey = Config["Maps:MapyCzApiKey"] ?? "";
+
+        // If the kind changed while the map is live, dispose + reinit so the marker
+        // color updates (ovcinaMiniMap.update only repositions the pin).
+        if (miniMapInited && lastMiniMapKind != locationKind)
+        {
+            try { await JS.InvokeVoidAsync("ovcinaMiniMap.dispose", MiniMapElementId); } catch { }
+            miniMapInited = false;
+            lastMiniMapLat = null; lastMiniMapLon = null;
+        }
 
         if (!miniMapInited)
         {
@@ -569,6 +625,7 @@ else
                     MiniMapElementId, (double)lat, (double)lon, 12, kindColor, apiKey);
                 miniMapInited = true;
                 lastMiniMapLat = lat; lastMiniMapLon = lon;
+                lastMiniMapKind = locationKind;
             }
             catch { /* element may not be in DOM yet; retried on next render */ }
             return;

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -727,3 +727,537 @@
     margin-top: 2px;
 }
 
+/* ============================================================
+   Location detail page — Claude Design handoff, 2026-04-23
+   Route: /locations/{id:int}
+   Scope: every selector prefixed .oh-lc-* to avoid clashing with
+   the existing .location-card-* treatment or Bootstrap classes.
+   ============================================================ */
+
+/* --- Page shell + tab strip --- */
+.oh-lc-page {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 16px 40px 48px;
+    font-family: var(--oh-font-body);
+    color: var(--oh-text);
+}
+
+.oh-lc-crumb {
+    font-size: 0.8125rem;
+    color: var(--oh-text-secondary);
+    margin-bottom: 6px;
+}
+.oh-lc-crumb a { color: var(--oh-primary-light); text-decoration: none; }
+.oh-lc-crumb a:hover { color: var(--oh-primary); text-decoration: underline; }
+
+.oh-lc-title-strip {
+    display: flex;
+    align-items: flex-start;
+    gap: 20px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--oh-border);
+    margin-bottom: 0;
+}
+.oh-lc-title-strip .oh-lc-back {
+    padding: 6px 10px;
+    font-size: 0.8125rem;
+    color: var(--oh-text-secondary);
+    background: transparent;
+    border: 1px solid var(--oh-border);
+    border-radius: var(--oh-radius-sm);
+    cursor: pointer;
+    transition: var(--oh-transition);
+    text-decoration: none;
+    display: inline-flex; align-items: center; gap: 6px;
+}
+.oh-lc-title-strip .oh-lc-back:hover { color: var(--oh-primary); border-color: var(--oh-primary-light); }
+.oh-lc-title-strip h1 {
+    font-family: var(--oh-font-heading);
+    font-size: var(--oh-fs-2xl, 1.75rem);
+    color: var(--oh-primary);
+    margin: 0;
+    line-height: 1.2;
+}
+.oh-lc-title-sub {
+    font-size: 0.875rem;
+    color: var(--oh-text-secondary);
+    margin-top: 4px;
+    display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+}
+.oh-lc-title-actions { margin-left: auto; display: flex; gap: 8px; align-items: center; }
+
+.oh-lc-tabs {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    border-bottom: 1px solid var(--oh-border);
+    background: var(--oh-surface);
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    margin: 0 -40px 24px;
+    padding: 0 40px;
+}
+.oh-lc-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 12px 18px;
+    min-height: 44px;
+    border: none;
+    border-bottom: 3px solid transparent;
+    background: transparent;
+    color: var(--oh-text-secondary);
+    font: 600 0.875rem var(--oh-font-body);
+    cursor: pointer;
+    transition: 0.15s;
+    margin-bottom: -1px;
+}
+.oh-lc-tab i { font-size: 0.9375rem; opacity: 0.7; }
+.oh-lc-tab:hover { color: var(--oh-primary); }
+.oh-lc-tab.active { color: var(--oh-primary); border-bottom-color: var(--oh-primary); }
+.oh-lc-tab.active i { opacity: 1; color: var(--oh-primary-light); }
+.oh-lc-tab .oh-lc-count {
+    font-family: var(--oh-font-mono);
+    font-size: 0.75rem;
+    color: var(--oh-text-secondary);
+    background: var(--oh-surface-alt);
+    border: 1px solid var(--oh-border);
+    border-radius: 99px;
+    padding: 1px 7px;
+    min-width: 22px;
+    text-align: center;
+    font-weight: 500;
+}
+.oh-lc-tab.active .oh-lc-count {
+    color: var(--oh-primary);
+    border-color: rgba(74, 124, 52, 0.3);
+    background: var(--oh-primary-surface);
+}
+
+/* --- Section labels (used in Upravit + Skrýše) --- */
+.oh-lc-sect {
+    margin-bottom: 28px;
+}
+.oh-lc-sect-label {
+    font-family: var(--oh-font-body);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--oh-text-secondary);
+    padding-bottom: 8px;
+    margin: 0 0 14px;
+    border-bottom: 1px solid var(--oh-border);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.oh-lc-sect-label i { color: var(--oh-primary-light); font-size: 0.875rem; }
+
+/* --- Karta (parchment card) — fresh rules, coexist with legacy .location-card-* --- */
+.oh-lc-card {
+    position: relative;
+    background: linear-gradient(145deg, #f5f0e8 0%, #ebe4d4 40%, #e8dcc8 100%);
+    border: 1px solid #d4c5a9;
+    border-radius: 6px;
+    padding: 1.75rem 2rem 1.5rem;
+    min-height: 420px;
+    overflow: hidden;
+}
+.oh-lc-card::before {
+    content: ''; position: absolute; inset: 0;
+    background:
+        radial-gradient(ellipse at 20% 10%, rgba(139,119,80,.06) 0%, transparent 60%),
+        radial-gradient(ellipse at 85% 90%, rgba(139,119,80,.05) 0%, transparent 55%);
+    pointer-events: none;
+}
+.oh-lc-card > * { position: relative; z-index: 1; }
+.oh-lc-card-title {
+    font: 900 2.4rem var(--oh-font-heading);
+    color: #3a2e1e;
+    text-align: right;
+    margin: 0;
+    line-height: 1.1;
+}
+.oh-lc-card-region {
+    font: italic 1rem Georgia, serif;
+    color: #8b7750;
+    text-align: right;
+    margin: 4px 0 20px;
+    letter-spacing: 0.02em;
+}
+.oh-lc-card-body {
+    display: grid;
+    grid-template-columns: 42fr 58fr;
+    gap: 28px;
+    align-items: start;
+}
+@media (max-width: 820px) {
+    .oh-lc-card-body { grid-template-columns: 1fr; }
+}
+.oh-lc-card-text p {
+    font: 400 1.05rem/1.65 Georgia, serif;
+    color: #3a2e1e;
+    text-align: justify;
+    hyphens: auto;
+    margin: 0 0 0.75em;
+}
+.oh-lc-card-text p:last-child { margin-bottom: 0; }
+.oh-lc-card-right { display: flex; flex-direction: column; gap: 12px; }
+.oh-lc-card-img {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    border: 2px solid #c4b494;
+    border-radius: 4px;
+    box-shadow: 2px 3px 12px rgba(58, 46, 30, 0.2);
+    overflow: hidden;
+    position: relative;
+    background: linear-gradient(145deg, #ede1c8, #c4b494);
+}
+.oh-lc-card-img img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.oh-lc-card-img-caption {
+    display: flex; align-items: center; justify-content: space-between;
+    font: italic 0.8125rem Georgia, serif;
+    color: #8b7750;
+    padding: 0 2px;
+}
+
+.oh-lc-card-details {
+    margin-top: 20px; padding-top: 14px;
+    border-top: 1px solid #c4b494;
+    display: flex; gap: 16px; align-items: flex-start;
+}
+.oh-lc-card-id {
+    font: 700 1.5rem var(--oh-font-mono);
+    color: #b0a48a;
+    border: 2px solid rgba(178, 98, 35, 0.35);
+    padding: 4px 10px;
+    border-radius: 6px;
+    background: rgba(255, 248, 240, 0.35);
+    line-height: 1;
+}
+.oh-lc-card-details p {
+    font: 400 0.82rem/1.6 Georgia, serif;
+    color: #5a4f3f;
+    margin: 0;
+    text-align: justify;
+    flex: 1;
+}
+
+.oh-lc-card-potential {
+    margin-top: 18px;
+    padding: 12px 16px;
+    background: rgba(255, 248, 240, 0.55);
+    border: 1px solid rgba(178, 98, 35, 0.25);
+    border-left: 3px solid var(--oh-card-border);
+    border-radius: 4px;
+    font: 400 0.95rem/1.55 Georgia, serif;
+    color: #3a2e1e;
+}
+.oh-lc-card-potential strong {
+    color: #3a2e1e;
+    font-weight: 700;
+    font-family: var(--oh-font-heading);
+    margin-right: 4px;
+}
+
+.oh-lc-card-variants {
+    margin-top: 18px; padding-top: 12px;
+    border-top: 1px dashed #c4b494;
+    font: 400 0.875rem Georgia, serif;
+    color: #5a4f3f;
+    display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.oh-lc-card-variants .oh-lc-vlbl {
+    font-weight: 700; color: #3a2e1e;
+    font-family: var(--oh-font-heading);
+}
+.oh-lc-vchip {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 3px 10px;
+    border-radius: 99px;
+    background: rgba(255, 248, 240, 0.6);
+    border: 1px solid #c4b494;
+    color: var(--oh-primary);
+    text-decoration: none;
+    font: 500 0.8125rem var(--oh-font-body);
+    transition: 0.15s;
+}
+.oh-lc-vchip:hover {
+    background: #fff;
+    border-color: var(--oh-primary-light);
+    box-shadow: 0 1px 3px rgba(45, 80, 22, 0.15);
+}
+.oh-lc-vchip i { font-size: 0.75rem; opacity: 0.7; }
+
+.oh-lc-card-empty {
+    min-height: 340px;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    text-align: center;
+    padding: 20px;
+    border: 1.5px dashed #c4b494;
+    border-radius: 4px;
+    color: #8b7750;
+    background: rgba(255, 248, 240, 0.3);
+}
+.oh-lc-card-empty .oh-lc-empty-title {
+    font: italic 700 1.05rem Georgia, serif;
+    color: #5a4f3f;
+    margin-bottom: 4px;
+}
+.oh-lc-card-empty .oh-lc-empty-copy {
+    font: 400 0.9rem Georgia, serif;
+    color: #8b7750;
+    max-width: 280px;
+    line-height: 1.5;
+}
+
+/* --- Upravit: inline map panel on GPS row --- */
+.oh-lc-gps-block {
+    display: grid;
+    grid-template-columns: 1fr 260px;
+    gap: 20px;
+    align-items: start;
+    margin-bottom: 18px;
+}
+@media (max-width: 900px) { .oh-lc-gps-block { grid-template-columns: 1fr; } }
+.oh-lc-gps-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+.oh-lc-gps-map {
+    width: 100%;
+    height: 195px;
+    border: 1px solid var(--oh-border);
+    border-radius: var(--oh-radius);
+    overflow: hidden;
+    background: linear-gradient(135deg, #c8d4b8 0%, #9fb68a 50%, #7a9a6a 100%);
+    position: relative;
+    cursor: pointer;
+}
+.oh-lc-gps-map-empty {
+    width: 100%; height: 195px;
+    border: 1.5px dashed var(--oh-border);
+    border-radius: var(--oh-radius);
+    background: var(--oh-surface-alt);
+    display: flex; align-items: center; justify-content: center;
+    color: var(--oh-text-secondary);
+    font-size: 0.8125rem;
+    text-align: center;
+    padding: 16px;
+}
+.oh-lc-gps-map-footer {
+    margin-top: 6px;
+    display: flex; justify-content: space-between;
+    font-size: 0.75rem; color: var(--oh-text-secondary);
+}
+.oh-lc-gps-map-footer .oh-lc-gps-coords { font-family: var(--oh-font-mono); }
+
+/* --- Upravit: image slot pair (main 1:1, placement 4:3) --- */
+.oh-lc-visual-slots {
+    display: grid;
+    grid-template-columns: auto auto;
+    gap: 28px;
+    align-items: start;
+}
+@media (max-width: 820px) {
+    .oh-lc-visual-slots { grid-template-columns: 1fr; }
+}
+
+/* --- Lore two-pane --- */
+.oh-lc-lore-cols {
+    display: grid;
+    grid-template-columns: 60fr 40fr;
+    gap: 24px;
+    align-items: start;
+}
+@media (max-width: 1024px) { .oh-lc-lore-cols { grid-template-columns: 1fr; } }
+.oh-lc-lore-preview {
+    padding: 28px 32px;
+    border: 1px solid #d4c5a9;
+    border-radius: var(--oh-radius);
+    background: linear-gradient(145deg, #f5f0e8 0%, #ebe4d4 40%, #e8dcc8 100%);
+    min-height: 520px;
+    position: relative;
+    overflow: hidden;
+    box-shadow: inset 0 0 30px rgba(139, 119, 80, 0.08);
+}
+.oh-lc-lore-preview::before {
+    content: ''; position: absolute; inset: 0; pointer-events: none;
+    background:
+        radial-gradient(ellipse at 20% 10%, rgba(139,119,80,.06) 0%, transparent 60%),
+        radial-gradient(ellipse at 85% 90%, rgba(139,119,80,.05) 0%, transparent 55%);
+}
+.oh-lc-lore-preview p {
+    font: 400 1.1rem/1.75 Georgia, serif;
+    color: #3a2e1e;
+    text-align: justify;
+    hyphens: auto;
+    margin: 0 0 1em;
+    position: relative;
+}
+.oh-lc-lore-preview p:last-child { margin-bottom: 0; }
+.oh-lc-lore-memo {
+    width: 100%;
+    min-height: 520px;
+    padding: 16px 18px;
+    background: var(--oh-surface);
+    border: 1px solid var(--oh-border);
+    border-radius: var(--oh-radius);
+    font: 400 1rem/1.65 var(--oh-font-body);
+    color: var(--oh-text);
+    resize: vertical;
+    transition: 0.2s;
+}
+.oh-lc-lore-memo:focus {
+    outline: none;
+    border-color: var(--oh-primary-light);
+    box-shadow: 0 0 0 3px rgba(74, 124, 52, 0.15);
+    background: #fff;
+}
+.oh-lc-lore-edit-head {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 10px;
+}
+.oh-lc-lore-toggle {
+    display: inline-flex;
+    background: var(--oh-surface-alt);
+    border: 1px solid var(--oh-border);
+    border-radius: 99px;
+    padding: 2px; gap: 2px;
+}
+.oh-lc-lore-toggle button {
+    border: none; background: transparent;
+    padding: 5px 11px;
+    border-radius: 99px;
+    font: 600 0.75rem var(--oh-font-body);
+    color: var(--oh-text-secondary);
+    cursor: pointer;
+    transition: 0.15s;
+}
+.oh-lc-lore-toggle button.on {
+    background: var(--oh-primary);
+    color: #fff;
+}
+
+/* --- Skrýše: MTG card-sized tiles (5:7, 2.5×3.5 in) --- */
+.oh-lc-stash-head {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 18px;
+}
+.oh-lc-stash-head h3 {
+    margin: 0;
+    font-size: 1.15rem;
+    display: flex; align-items: center; gap: 8px;
+}
+.oh-lc-stash-head h3 .oh-lc-stash-count {
+    font-family: var(--oh-font-mono);
+    color: var(--oh-text-secondary);
+    font-weight: 500;
+    font-size: 0.9375rem;
+}
+.oh-lc-stash-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px 20px;
+}
+@media (max-width: 1024px) { .oh-lc-stash-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 640px)  { .oh-lc-stash-grid { grid-template-columns: 1fr; } }
+
+.oh-lc-tile {
+    background: var(--oh-surface);
+    border: 1px solid var(--oh-border);
+    border-radius: var(--oh-radius);
+    overflow: hidden;
+    cursor: pointer;
+    transition: 0.2s;
+    display: flex; flex-direction: column;
+    box-shadow: var(--oh-shadow);
+    text-decoration: none;
+    color: inherit;
+}
+.oh-lc-tile:hover {
+    transform: translateY(-2px);
+    background: var(--oh-primary-surface);
+    border-color: var(--oh-primary-light);
+    box-shadow: 0 4px 12px rgba(45, 80, 22, 0.14);
+}
+.oh-lc-tile-img {
+    width: 100%;
+    aspect-ratio: 5 / 7;
+    position: relative;
+    overflow: hidden;
+    background: linear-gradient(145deg, #3a3226 0%, #2c1810 100%);
+}
+.oh-lc-tile-img img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.oh-lc-tile-img-empty {
+    position: absolute; inset: 0;
+    display: flex; align-items: center; justify-content: center;
+    color: rgba(255, 248, 240, 0.4);
+    font: italic 500 0.75rem Georgia, serif;
+}
+.oh-lc-tile-mtgtag {
+    position: absolute; bottom: 8px; right: 8px;
+    font-family: var(--oh-font-mono);
+    font-size: 0.625rem;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: rgba(255, 248, 240, 0.85);
+    color: var(--oh-text-secondary);
+    letter-spacing: 0.04em;
+}
+.oh-lc-tile-body {
+    padding: 12px 14px;
+    flex: 1;
+    display: flex; flex-direction: column; gap: 8px;
+}
+.oh-lc-tile-name {
+    font: 700 1rem var(--oh-font-heading);
+    color: var(--oh-primary);
+    line-height: 1.25;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.oh-lc-tile-sep { height: 1px; background: rgba(178, 98, 35, 0.3); }
+.oh-lc-tile-quests {
+    display: flex; flex-direction: column; gap: 4px; margin: 0; padding: 0; list-style: none;
+}
+.oh-lc-tile-quest {
+    display: flex; align-items: center; gap: 6px;
+    font-size: 0.8125rem;
+    color: var(--oh-text);
+    line-height: 1.3;
+}
+.oh-lc-tile-quest::before {
+    content: "";
+    width: 3px; height: 3px;
+    border-radius: 50%;
+    background: var(--oh-text-secondary);
+    flex-shrink: 0;
+}
+.oh-lc-tile-quest-name {
+    flex: 1; min-width: 0;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.oh-lc-tile-quest-pill {
+    flex-shrink: 0;
+    padding: 1px 7px;
+    border-radius: 99px;
+    background: rgba(249, 168, 37, 0.2);
+    border: 1px solid rgba(200, 135, 30, 0.4);
+    color: #7a5210;
+    font: 600 0.625rem var(--oh-font-body);
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+.oh-lc-tile-more {
+    margin-top: auto;
+    font: italic 500 0.75rem var(--oh-font-body);
+    color: var(--oh-text-secondary);
+}
+

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -218,3 +218,85 @@ window.ovcinaMap = {
         return div.innerHTML;
     }
 };
+
+// ----------------------------------------------------------------------
+// Mini-map helper: single-pin read-only mini maps, keyed by element id.
+// Used by LocationDetail › Upravit to preview a location's GPS position
+// alongside the editable coords. Multiple instances can coexist on the
+// page without conflicting with the main ovcinaMap used on /map.
+// ----------------------------------------------------------------------
+window.ovcinaMiniMap = {
+    _instances: {},
+
+    _rasterStyle: function (apiKey) {
+        if (apiKey && apiKey.length > 5) {
+            return {
+                version: 8,
+                sources: {
+                    'mapy-cz': {
+                        type: 'raster',
+                        tiles: ['https://api.mapy.cz/v1/maptiles/outdoor/256/{z}/{x}/{y}?apikey=' + apiKey],
+                        tileSize: 256,
+                        maxzoom: 19,
+                        attribution: '&copy; Mapy.cz'
+                    }
+                },
+                layers: [{ id: 'mapy-cz-tiles', type: 'raster', source: 'mapy-cz', minzoom: 0, maxzoom: 19 }]
+            };
+        }
+        return {
+            version: 8,
+            sources: {
+                'osm': {
+                    type: 'raster',
+                    tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+                    tileSize: 256,
+                    maxzoom: 19,
+                    attribution: '&copy; OpenStreetMap'
+                }
+            },
+            layers: [{ id: 'osm-tiles', type: 'raster', source: 'osm', minzoom: 0, maxzoom: 19 }]
+        };
+    },
+
+    init: function (elementId, lat, lon, zoom, kindColor, mapyCzApiKey) {
+        var el = document.getElementById(elementId);
+        if (!el || typeof maplibregl === 'undefined') return;
+        // If already initialized with same coords, no-op.
+        var existing = this._instances[elementId];
+        if (existing) {
+            this.update(elementId, lat, lon);
+            return;
+        }
+
+        var map = new maplibregl.Map({
+            container: el,
+            style: this._rasterStyle(mapyCzApiKey),
+            center: [lon, lat],
+            zoom: zoom || 12,
+            interactive: false,       // read-only mini preview
+            attributionControl: false
+        });
+
+        var el2 = document.createElement('div');
+        el2.style.cssText = 'width:16px;height:16px;border-radius:50%;background:' +
+            (kindColor || '#2D5016') + ';border:2px solid #fff;box-shadow:0 1px 3px rgba(0,0,0,.35);';
+        var marker = new maplibregl.Marker({ element: el2 }).setLngLat([lon, lat]).addTo(map);
+
+        this._instances[elementId] = { map: map, marker: marker };
+    },
+
+    update: function (elementId, lat, lon) {
+        var inst = this._instances[elementId];
+        if (!inst) return;
+        inst.marker.setLngLat([lon, lat]);
+        inst.map.jumpTo({ center: [lon, lat] });
+    },
+
+    dispose: function (elementId) {
+        var inst = this._instances[elementId];
+        if (!inst) return;
+        try { inst.map.remove(); } catch (e) { /* ignore */ }
+        delete this._instances[elementId];
+    }
+};


### PR DESCRIPTION
New /locations/{id:int} page from the Claude Design handoff (Option B — map inline on Upravit, not a separate tab):

* Four tabs: Karta · Upravit · Lore · Skrýše
* Scoped .oh-lc-* theme CSS (~300 lines, no conflicts with legacy .location-card-*)
* LocationStashTile component — 5:7 (2.5×3.5 in MTG) portrait tiles
* Inline MapLibre mini-map (window.ovcinaMiniMap — new helper, single-pin read-only, keyed by element id so it coexists with the main /map)
* "Otevřít detail →" jump-link added to the existing LocationEditPopup's Karta tab

Brief: docs/design/dialogs/location-detail.md

## Test plan
- [ ] /locations/{id} renders all four tabs
- [ ] Mini-map shows pin in correct LocationKind color after coords entered
- [ ] Stash tiles click through to /secret-stashes/{id}
- [ ] Save on Upravit round-trips all fields
- [ ] Quick-peek popup's "Otevřít detail →" navigates correctly