### PR TITLE
feat(locations): click row → detail + drop mockup labels [v0.11.2]

### DIFF
--- a/src/OvcinaHra.Client/Components/LocationStashTile.razor
+++ b/src/OvcinaHra.Client/Components/LocationStashTile.razor
@@ -11,7 +11,6 @@
         {
             <div class="oh-lc-tile-img-empty">bez obrázku</div>
         }
-        <span class="oh-lc-tile-mtgtag">5:7</span>
     </div>
     <div class="oh-lc-tile-body">
         <div class="oh-lc-tile-name">@Stash.Name</div>

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.11.1</Version>
+    <Version>0.11.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -136,10 +136,6 @@ else
                                     <img src="@mainImageUrl" alt="@loc.Name" />
                                 }
                             </div>
-                            <div class="oh-lc-card-img-caption">
-                                <span>Znak lokace</span>
-                                <span>1:1</span>
-                            </div>
                         </div>
                     </div>
 

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -36,7 +36,7 @@ else if (!Catalog && locations.Count == 0)
 else
 {
     <OvcinaGrid Data="@locations" KeyFieldName="Id" LayoutKey="grid-layout-locations-v2"
-                RowClick="@(async e => await locationPopup.OpenAsync(((LocationListDto)e.Grid.GetDataItem(e.VisibleIndex)).Id))">
+                RowClick="@(e => Nav.NavigateTo($"/locations/{((LocationListDto)e.Grid.GetDataItem(e.VisibleIndex)).Id}"))">
         <Columns>
             <DxGridDataColumn FieldName="" Caption="" Width="40px" AllowSort="false" FixedPosition="GridColumnFixedPosition.Left">
                 <CellDisplayTemplate>
@@ -59,14 +59,14 @@ else
                         if (loc.ParentLocationId.HasValue)
                         {
                             var parent = locations.FirstOrDefault(l => l.Id == loc.ParentLocationId.Value);
-                            <a href="#" class="text-muted" @onclick="async () => await locationPopup.OpenAsync(loc.ParentLocationId.Value)" @onclick:preventDefault @onclick:stopPropagation>↳ @(parent?.Name ?? $"#{loc.ParentLocationId}")</a>
+                            <a href="/locations/@loc.ParentLocationId.Value" class="text-muted" @onclick:stopPropagation>↳ @(parent?.Name ?? $"#{loc.ParentLocationId}")</a>
                         }
                         else
                         {
                             var variants = locations.Where(l => l.ParentLocationId == loc.Id).ToList();
                             @foreach (var v in variants)
                             {
-                                <a href="#" class="badge bg-secondary text-decoration-none me-1" @onclick="async () => await locationPopup.OpenAsync(v.Id)" @onclick:preventDefault @onclick:stopPropagation>@v.Name</a>
+                                <a href="/locations/@v.Id" class="badge bg-secondary text-decoration-none me-1" @onclick:stopPropagation>@v.Name</a>
                             }
                         }
                     }


### PR DESCRIPTION
Small follow-up polish on top of #60:

* **Row click goes to `/locations/{id}` directly** — the quick-peek popup auto-opening on every click was confusing now that the detail page exists. Parent `↳` link and variant chips also use real `href="/locations/{id}"` so keyboard nav + open-in-new-tab work properly. The popup stays wired for **+ Nová lokace** and the context-menu flows.
* **LocationDetail Karta tab:** remove the leftover "Znak lokace / 1:1" caption block — mockup scaffolding that shouldn't have shipped.
* **LocationStashTile:** remove the "5:7" aspect-ratio tag overlay — same story.
* Version bump 0.11.1 → 0.11.2.

## Test plan
- [ ] Clicking any row on `/locations` navigates to `/locations/{id}` (no popup)
- [ ] Parent `↳` link and variant chips navigate to the target location's detail
- [ ] Ctrl-click opens the detail in a new tab
- [ ] `+ Nová lokace` still opens the create popup
- [ ] Context-menu "Upravit" still opens the edit popup
- [ ] Karta tab no longer shows "Znak lokace / 1:1" under the image
- [ ] Stash tiles no longer show "5:7" overlay