### PR TITLE
fix(items): remove/assign from game refresh grid + surface failures [v0.11.3]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.11.2</Version>
+    <Version>0.11.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -703,11 +703,17 @@ else
     private async Task RemoveGameItemAsync()
     {
         if (editingId is null || GameContext.SelectedGameId is null) return;
-        isSaving = true;
+        error = null; isSaving = true;
         try
         {
-            await Api.DeleteAsync($"/api/items/game-item/{GameContext.SelectedGameId}/{editingId}");
+            var deleted = await Api.DeleteAsync($"/api/items/game-item/{GameContext.SelectedGameId}/{editingId}");
+            if (!deleted)
+            {
+                error = "Odebrání předmětu ze hry se nezdařilo.";
+                return;
+            }
             gameItemExists = false;
+            await LoadAsync();
         }
         catch (Exception ex) { error = ex.Message; }
         finally { isSaving = false; StateHasChanged(); }
@@ -716,12 +722,14 @@ else
     private async Task AssignItemAsync(int itemId)
     {
         if (GameContext.SelectedGameId is null) return;
+        error = null;
         try
         {
             await Api.PostAsync<CreateGameItemDto, GameItemDto>("/api/items/game-item",
                 new CreateGameItemDto(GameContext.SelectedGameId.Value, itemId));
-            assignedItemIds.Add(itemId);
-            StateHasChanged();
+            // Reload so gameItems + assignedItemIds reflect the new link — local
+            // Add(itemId) alone wasn't enough because the main grid binds to gameItems.
+            await LoadAsync();
         }
         catch (Exception ex) { error = ex.Message; StateHasChanged(); }
     }
@@ -729,11 +737,20 @@ else
     private async Task UnassignItemAsync(int itemId)
     {
         if (GameContext.SelectedGameId is null) return;
+        error = null;
         try
         {
-            await Api.DeleteAsync($"/api/items/game-item/{GameContext.SelectedGameId}/{itemId}");
-            assignedItemIds.Remove(itemId);
-            StateHasChanged();
+            var deleted = await Api.DeleteAsync($"/api/items/game-item/{GameContext.SelectedGameId}/{itemId}");
+            if (!deleted)
+            {
+                error = "Odebrání předmětu ze hry se nezdařilo.";
+                StateHasChanged();
+                return;
+            }
+            // Reload so both gameItems (main grid) and assignedItemIds (catalog
+            // Přidat/Odebrat flip) reflect the server state — local mutation of
+            // assignedItemIds alone left stale rows in the main-view grid.
+            await LoadAsync();
         }
         catch (Exception ex) { error = ex.Message; StateHasChanged(); }
     }

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -713,10 +713,10 @@ else
                 return;
             }
             gameItemExists = false;
-            await LoadAsync();
+            await ReloadGameLinkAsync();
         }
         catch (Exception ex) { error = ex.Message; }
-        finally { isSaving = false; StateHasChanged(); }
+        finally { isSaving = false; }
     }
 
     private async Task AssignItemAsync(int itemId)
@@ -727,11 +727,9 @@ else
         {
             await Api.PostAsync<CreateGameItemDto, GameItemDto>("/api/items/game-item",
                 new CreateGameItemDto(GameContext.SelectedGameId.Value, itemId));
-            // Reload so gameItems + assignedItemIds reflect the new link — local
-            // Add(itemId) alone wasn't enough because the main grid binds to gameItems.
-            await LoadAsync();
+            await ReloadGameLinkAsync();
         }
-        catch (Exception ex) { error = ex.Message; StateHasChanged(); }
+        catch (Exception ex) { error = ex.Message; }
     }
 
     private async Task UnassignItemAsync(int itemId)
@@ -744,15 +742,25 @@ else
             if (!deleted)
             {
                 error = "Odebrání předmětu ze hry se nezdařilo.";
-                StateHasChanged();
                 return;
             }
-            // Reload so both gameItems (main grid) and assignedItemIds (catalog
-            // Přidat/Odebrat flip) reflect the server state — local mutation of
-            // assignedItemIds alone left stale rows in the main-view grid.
-            await LoadAsync();
+            await ReloadGameLinkAsync();
         }
-        catch (Exception ex) { error = ex.Message; StateHasChanged(); }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    // Targeted refresh after assign/unassign operations. In main ("Jen tato hra")
+    // mode the grid binds to gameItems, so we re-pull the per-game list and
+    // derive assignedItemIds from it. In catalog mode the catalog itself hasn't
+    // changed — only the set of linked ids — so we skip re-fetching /api/items
+    // and only refresh assignedItemIds. Avoids reloading the full ~180-item
+    // catalog on every Přidat/Odebrat click.
+    private async Task ReloadGameLinkAsync()
+    {
+        if (GameContext.SelectedGameId is not int gid) return;
+        var linked = await Api.GetListAsync<GameItemListDto>($"/api/items/by-game/{gid}");
+        assignedItemIds = linked.Select(gi => gi.Id).ToHashSet();
+        if (!Catalog) gameItems = linked;
     }
 
     private async Task SaveAsync()


### PR DESCRIPTION
Fixes the reported bug where clicking **Odebrat z hry** (from the 3-dots context menu on `/items`, from the edit modal, or the catalog "Odebrat" button) appeared to do nothing.

## Root cause

Three handlers (`UnassignItemAsync`, `RemoveGameItemAsync`, `AssignItemAsync`) had the same two issues:

1. `Api.DeleteAsync` returns `bool` and never throws — the handlers ignored it, so 4xx/5xx failures looked like success.
2. They only mutated `assignedItemIds` (used for the catalog Přidat/Odebrat flip). The main `/items` grid binds to `gameItems`, which was never reloaded — so removed rows stayed visible, added rows never appeared.

## Fix

- `UnassignItemAsync` + `RemoveGameItemAsync` — inspect the bool return, surface a Czech error on failure (modal/dialog stays open), `await LoadAsync()` on success so both `gameItems` and `assignedItemIds` match the server.
- `AssignItemAsync` — mirror-fix: `await LoadAsync()` so a newly added item appears in the main grid, not just flip the catalog button.
- Version bump 0.11.2 → 0.11.3.

## Test plan
- [ ] `/items` (Jen tato hra) → 3-dots → "Odebrat z hry" → row disappears from grid
- [ ] `/items?catalog=true` → click "Odebrat" button → button flips to "Přidat", on switch to "Jen tato hra" item is gone
- [ ] `/items?catalog=true` → click "Přidat" button → switch to "Jen tato hra" → item appears
- [ ] Edit modal → "Odebrat z hry" button → modal stays on catalog fields, close modal → item gone from main grid
- [ ] Server returns 4xx/5xx on the delete → Czech error surfaced, row stays