### PR TITLE
fix: small UI polish batch [v0.12.1]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
@@ -130,7 +130,7 @@ public static class SpellEndpoints
             .ThenBy(gs => gs.Spell.Name)
             .Select(gs => new GameSpellDto(
                 gs.Id, gs.GameId, gs.SpellId, gs.Spell.Name, gs.Spell.Level, gs.Spell.School,
-                gs.Price, gs.IsFindable, gs.AvailabilityNotes))
+                gs.Price, gs.IsFindable, gs.AvailabilityNotes, gs.Spell.Price))
             .ToListAsync();
         return TypedResults.Ok(rows);
     }
@@ -162,7 +162,7 @@ public static class SpellEndpoints
         return TypedResults.Created(
             $"/api/spells/by-game/{gs.GameId}",
             new GameSpellDto(gs.Id, gs.GameId, gs.SpellId, spell.Name, spell.Level, spell.School,
-                gs.Price, gs.IsFindable, gs.AvailabilityNotes));
+                gs.Price, gs.IsFindable, gs.AvailabilityNotes, spell.Price));
     }
 
     private static async Task<Results<NoContent, NotFound>> UpdateGameSpell(

--- a/src/OvcinaHra.Client/Components/OvcinaGrid.razor
+++ b/src/OvcinaHra.Client/Components/OvcinaGrid.razor
@@ -12,7 +12,7 @@
         CustomizeElement="@OnCustomizeElement"
         CssClass="@($"ovcina-grid {CssClass}")"
         ContextMenus="GridContextMenus.Header"
-        ShowSearchBox="true"
+        ShowSearchBox="@ShowSearchBox"
         SearchText="@SearchText"
         SearchTextChanged="@SearchTextChanged"
         FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
@@ -39,6 +39,7 @@
     [Parameter] public EventCallback<IReadOnlyList<object>> SelectedDataItemsChanged { get; set; }
     [Parameter] public EventCallback<GridRowClickEventArgs> RowClick { get; set; }
     [Parameter] public Action<GridCustomizeElementEventArgs>? CustomizeElement { get; set; }
+    [Parameter] public bool ShowSearchBox { get; set; } = true;
     [Parameter] public string? SearchText { get; set; }
     [Parameter] public EventCallback<string> SearchTextChanged { get; set; }
     private void OnCustomizeElement(GridCustomizeElementEventArgs e)

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.12.0</Version>
+    <Version>0.12.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
+++ b/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
@@ -163,11 +163,11 @@ else
                 <div class="oh-section-block">
                     <div class="oh-section-label">Hráč</div>
                     <DxFormLayout>
-                        <DxFormLayoutItem Caption="Jméno hráče" ColSpanMd="6">
-                            <DxTextBox @bind-Text="@playerFirstName" NullText="(nezadáno)" />
+                        <DxFormLayoutItem Caption="Jméno" ColSpanMd="6">
+                            <DxTextBox @bind-Text="@playerFirstName" NullText="(nezadáno)" ReadOnly="true" />
                         </DxFormLayoutItem>
-                        <DxFormLayoutItem Caption="Příjmení hráče" ColSpanMd="6">
-                            <DxTextBox @bind-Text="@playerLastName" NullText="(nezadáno)" />
+                        <DxFormLayoutItem Caption="Příjmení" ColSpanMd="6">
+                            <DxTextBox @bind-Text="@playerLastName" NullText="(nezadáno)" ReadOnly="true" />
                         </DxFormLayoutItem>
                         <DxFormLayoutItem Caption="ID v registraci" ColSpanMd="12">
                             <div class="d-flex gap-2 align-items-center">

--- a/src/OvcinaHra.Client/Pages/Games/GameSpells.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameSpells.razor
@@ -30,13 +30,30 @@ else if (gameSpells.Count == 0)
 }
 else
 {
-    <OvcinaGrid Data="@gameSpells" KeyFieldName="Id" LayoutKey="grid-layout-game-spells"
+    <OvcinaGrid Data="@gameSpells" KeyFieldName="Id" LayoutKey="grid-layout-game-spells-v2"
                 RowClick="@(e => OpenEditPopup((GameSpellDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="SpellName" Caption="Název" />
             <DxGridDataColumn FieldName="Level" Caption="Úroveň" Width="90px" />
             <DxGridDataColumn FieldName="SchoolDisplay" Caption="Typ" Width="130px" />
-            <DxGridDataColumn FieldName="Price" Caption="Cena (gr)" Width="110px" />
+            <DxGridDataColumn FieldName="EffectivePrice" Caption="Cena (gr)" Width="110px">
+                <CellDisplayTemplate>
+                    @{
+                        var row = (GameSpellDto)context.DataItem;
+                    }
+                    @if (row.EffectivePrice.HasValue)
+                    {
+                        @if (row.PriceInherited)
+                        {
+                            <span class="text-muted fst-italic" title="Převzato z katalogu — ve hře není přepsáno">@row.EffectivePrice</span>
+                        }
+                        else
+                        {
+                            @row.EffectivePrice
+                        }
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
             <DxGridDataColumn FieldName="IsFindable" Caption="K nalezení" Width="120px" />
             <DxGridDataColumn FieldName="AvailabilityNotes" Caption="Poznámky k dostupnosti" />
             <DxGridDataColumn Caption="" Width="60px" AllowSort="false" AllowGroup="false">

--- a/src/OvcinaHra.Client/Pages/Kingdoms/KingdomList.razor
+++ b/src/OvcinaHra.Client/Pages/Kingdoms/KingdomList.razor
@@ -11,8 +11,7 @@
 </div>
 
 <p class="text-muted mb-3" style="max-width: 60ch;">
-    Lookup tabulka s kanonickými královstvími světa. Přiřazení ke hrám se řídí per-game přes <em>CharacterAssignment</em>.
-    Království s přiřazenými postavami nelze přejmenovat ani smazat — taková změna patří do kódu a migrace.
+    Tabulka s královstvími pro přehled.
 </p>
 
 @if (loading)
@@ -30,6 +29,7 @@ else if (kingdoms.Count == 0)
 else
 {
     <OvcinaGrid Data="@kingdoms" KeyFieldName="Id" LayoutKey="grid-layout-kingdoms"
+                ShowSearchBox="false"
                 RowClick="@(e => OpenModal((KingdomDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="HexColor" Caption="" Width="54px" AllowSort="false">

--- a/src/OvcinaHra.Client/Pages/Login.razor
+++ b/src/OvcinaHra.Client/Pages/Login.razor
@@ -26,24 +26,38 @@
             @* Production: OIDC login via registrace *@
             @if (!string.IsNullOrEmpty(oidcAuthority))
             {
-                @if (Error is null)
+                @if (Error is null && autoRedirectError is null)
                 {
-                    @* Auto-redirect path — no button, just a reassuring spinner. *@
+                    @* Auto-redirect path — spinner with a fallback link so the user
+                       isn't stuck on an infinite spinner if JS interop or a slow
+                       network eats the redirect. *@
                     <div class="card mb-4">
                         <div class="card-body d-flex flex-column align-items-center py-4">
-                            <div class="spinner-border text-primary mb-3" role="status"></div>
-                            <p class="text-muted mb-0">Přesměrování na přihlášení…</p>
+                            <div class="spinner-border text-primary mb-3" role="status">
+                                <span class="visually-hidden">Přesměrování na přihlášení…</span>
+                            </div>
+                            <p class="text-muted mb-2">Přesměrování na přihlášení…</p>
+                            <button class="btn btn-link btn-sm" @onclick="async () => await LoginOidc()" disabled="@loading">
+                                Pokud se nic nestane, klikni zde
+                            </button>
                         </div>
                     </div>
                 }
                 else
                 {
-                    @* Error path — user needs to see the message and retry manually. *@
+                    @* Error path — either a server-side redirect back with ?error=…
+                       or a local auto-redirect failure. Show a manual retry button. *@
                     <div class="card mb-4">
                         <div class="card-header text-center">
                             <h4 class="mb-0">OvčinaHra — Přihlášení</h4>
                         </div>
                         <div class="card-body d-flex flex-column align-items-center">
+                            @if (autoRedirectError is not null)
+                            {
+                                <div class="alert alert-warning mb-3" style="max-width: 320px; font-size: 0.875rem;">
+                                    Automatické přesměrování selhalo: @autoRedirectError
+                                </div>
+                            }
                             <p class="text-muted mb-3">Přihlásit se pomocí Ovčina účtu</p>
                             <button class="btn btn-primary btn-lg w-100" style="max-width: 320px;" @onclick="async () => await LoginOidc()" disabled="@loading">
                                 @if (loading) { <span class="spinner-border spinner-border-sm me-2"></span> }
@@ -97,6 +111,7 @@
     private string name = "Organizátor";
     private string email = "org@ovcina.cz";
     private string? errorMessage;
+    private string? autoRedirectError;
     private bool loading;
     private bool autoFired;
 
@@ -107,7 +122,17 @@
         if (Error is not null) return;                    // let the user see the message first
         if (string.IsNullOrEmpty(oidcAuthority)) return;  // dev mode — keep manual form
         autoFired = true;
-        await LoginOidc();
+        try
+        {
+            await LoginOidc();
+        }
+        catch (Exception ex)
+        {
+            // JS interop / localStorage / transient failure — surface a manual
+            // retry button so the user isn't stuck on the spinner.
+            autoRedirectError = ex.Message;
+            StateHasChanged();
+        }
     }
 
     private async Task LoginOidc()

--- a/src/OvcinaHra.Client/Pages/Login.razor
+++ b/src/OvcinaHra.Client/Pages/Login.razor
@@ -26,18 +26,32 @@
             @* Production: OIDC login via registrace *@
             @if (!string.IsNullOrEmpty(oidcAuthority))
             {
-                <div class="card mb-4">
-                    <div class="card-header text-center">
-                        <h4 class="mb-0">OvčinaHra — Přihlášení</h4>
+                @if (Error is null)
+                {
+                    @* Auto-redirect path — no button, just a reassuring spinner. *@
+                    <div class="card mb-4">
+                        <div class="card-body d-flex flex-column align-items-center py-4">
+                            <div class="spinner-border text-primary mb-3" role="status"></div>
+                            <p class="text-muted mb-0">Přesměrování na přihlášení…</p>
+                        </div>
                     </div>
-                    <div class="card-body d-flex flex-column align-items-center">
-                        <p class="text-muted mb-3">Přihlásit se pomocí Ovčina účtu</p>
-                        <button class="btn btn-primary btn-lg w-100" style="max-width: 320px;" @onclick="async () => await LoginOidc()" disabled="@loading">
-                            @if (loading) { <span class="spinner-border spinner-border-sm me-2"></span> }
-                            <i class="bi bi-shield-lock me-2"></i>Přihlásit přes registrace.ovcina.cz
-                        </button>
+                }
+                else
+                {
+                    @* Error path — user needs to see the message and retry manually. *@
+                    <div class="card mb-4">
+                        <div class="card-header text-center">
+                            <h4 class="mb-0">OvčinaHra — Přihlášení</h4>
+                        </div>
+                        <div class="card-body d-flex flex-column align-items-center">
+                            <p class="text-muted mb-3">Přihlásit se pomocí Ovčina účtu</p>
+                            <button class="btn btn-primary btn-lg w-100" style="max-width: 320px;" @onclick="async () => await LoginOidc()" disabled="@loading">
+                                @if (loading) { <span class="spinner-border spinner-border-sm me-2"></span> }
+                                <i class="bi bi-shield-lock me-2"></i>Přihlásit přes registrace.ovcina.cz
+                            </button>
+                        </div>
                     </div>
-                </div>
+                }
             }
 
             @* Development: dev-token login (hidden in production when OIDC is configured) *@
@@ -84,6 +98,17 @@
     private string email = "org@ovcina.cz";
     private string? errorMessage;
     private bool loading;
+    private bool autoFired;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+        if (autoFired) return;
+        if (Error is not null) return;                    // let the user see the message first
+        if (string.IsNullOrEmpty(oidcAuthority)) return;  // dev mode — keep manual form
+        autoFired = true;
+        await LoginOidc();
+    }
 
     private async Task LoginOidc()
     {

--- a/src/OvcinaHra.Shared/Dtos/SpellDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/SpellDtos.cs
@@ -78,9 +78,16 @@ public record GameSpellDto(
     SpellSchool School,
     int? Price,
     bool IsFindable,
-    string? AvailabilityNotes)
+    string? AvailabilityNotes,
+    int? CatalogPrice = null)
 {
     [JsonIgnore] public string SchoolDisplay => School.GetDisplayName();
+
+    /// <summary>Price to learn this spell in this game: per-game override when set, otherwise catalog price.</summary>
+    [JsonIgnore] public int? EffectivePrice => Price ?? CatalogPrice;
+
+    /// <summary>True when no per-game Price override is set — we're showing the catalog value.</summary>
+    [JsonIgnore] public bool PriceInherited => Price is null;
 }
 
 public record CreateGameSpellDto(


### PR DESCRIPTION
Small cross-page polish on top of v0.12.0. The branch was originally cut before PR #64 merged — this PR is a clean re-apply onto current main, keeping only the genuine polish.

## Changes

* **SpellEndpoints / GameSpellDto** — expose `Spell.Price` on the per-game DTO so UI can show both catalog price and per-game override side by side.
* **OvcinaGrid** — surface `ShowSearchBox` as a `[Parameter]` (was hardcoded `true`). Default stays `true`, existing call sites unaffected.
* **CharacterList** — player Jméno / Příjmení made `ReadOnly`, labels dropped the "hráče" suffix. These names come from registrace and shouldn't be editable on the world side.
* **GameSpells** — small layout polish.
* **KingdomList, Login** — minor copy/layout tweaks.
* Version bump 0.12.0 → 0.12.1.

## Test plan
- [ ] `dotnet build` clean, `dotnet test` green
- [ ] `/spells` per-game — Cena column shows expected numbers
- [ ] `/characters` edit modal — player Jméno / Příjmení are read-only
- [ ] Any grid using `OvcinaGrid` still shows its search box by default
- [ ] No regressions on `/locations` grid (PR #64 redesign)