### PR TITLE
docs(design): SecretStash + Monster briefs + stash port handoff

### DIFF
--- a/.claude/restart-prompts/hra-ovcina-monster-detail-port.md
+++ b/.claude/restart-prompts/hra-ovcina-monster-detail-port.md
@@ -1,0 +1,143 @@
+# Handoff — port the Monster detail page (2026-04-23)
+
+Load the `hra-ovcina-tinkerer` skill first. Then read this file and `docs/design/dialogs/monster-detail.md` (the designer brief) before touching code.
+
+## What this is
+
+Claude Design shipped the mockup for `/monsters/{id:int}` — an illuminated bestiary page with 5 tabs (Karta · Upravit · Bojovka · Kořist · Výskyt). Your job is to port it to production Blazor on a new branch and ship it via PR.
+
+- **Bundled mockup:** `C:\Users\TomášPajonk\Downloads\P_era - Detail _standalone_.html` (1.37 MB, gitignored when copied in).
+- **Decoded HTML:** copy the bundled file into `docs/design/dialogs/monster-detail.mockup.html` (already gitignored) and decode via:
+  ```python
+  import re, json
+  with open("docs/design/dialogs/monster-detail.mockup.html", encoding="utf-8") as f: h = f.read()
+  with open("docs/design/dialogs/monster-detail.mockup.unbundled.html", "w", encoding="utf-8") as o:
+      o.write(json.loads(re.search(r'<script type="__bundler/template"[^>]*>(.*?)</script>', h, re.S).group(1).strip()))
+  ```
+- Designer notes at the bottom of the decoded file (h4 sections): *Iluminovaná stránka, ne statblok*, *Bojovka = presenter view*, *Kořist a Výskyt*.
+
+## Decisions the designer locked
+
+Confirmed from the mockup markup, CSS, and h4 notes.
+
+| Area | Choice |
+|---|---|
+| Tabs | **5, in order:** Karta · Upravit · Bojovka · Kořist · Výskyt. Default = Karta. Sticky under the title strip. |
+| Tab count badges | Kořist and Výskyt carry a mono count badge (e.g. "Kořist 5", "Výskyt 4"). Karta/Upravit/Bojovka have no count. |
+| Karta layout | 2-col `62fr 38fr`: LEFT = illustration 4:3 with parchment frame · RIGHT = vertical stat block with icon + LABEL + value rows. |
+| Hero illustration AR | **4:3 landscape** (aspect-ratio: 4/3, object-fit: cover). Parchment frame = 2 px `#c4b494` border + inset gold radial. |
+| Stat block icons | bi-lightning-charge Útok · bi-shield-shaded Obrana · bi-heart-pulse Životy · bi-star-fill XP · bi-coin Groše. Mono right-aligned values. Subtle hairline between rows. |
+| Under-Karta content | h3 Schopnosti · h3 AI chování · h3 Tagy (chips) · h3 Poznámka organizátorů (the `Notes` field, muted beige callout). |
+| Upravit sections | Identita · Vizuál · Bojovka · Odměna · Tagy · Poznámky. 2-col DxFormLayout. Sticky footer (Smazat ghost-bordeaux far-left when editing; Uložit disabled until Name is set). |
+| Bojovka tab | Presenter view for live-encounter use on a 10" tablet. Three big stat boxes (`repeat(3,1fr)`) with 3rem mono numerals for Útok/Obrana/Životy. Abilities as numbered bullets, AI chování as Georgia italic pull-quote. Sticky top row: `[−1 Život] [+1 Život] [resetovat]` — **advisory only, local state, no API**. |
+| Kořist tab | Per-game grouping. Each game header (h4 "Ovčina 2026 — Stíny Rhovanionu" etc.) followed by a `repeat(auto-fill, minmax(160px, 1fr))` grid of MTG 5:7 item tiles. Each tile shows the item photo, name, and × N quantity pill. "+ Přidat kořist" at end of each row. "+ Přiřadit do další hry" header action. |
+| Výskyt tab | Summary row "Přiřazené hry: 4 hry · 11 questů · 23 encounterů". Then a per-game list: Hra · Questy (N) · Encounters (N) · Odebrat. Row click → that game's per-game page. Odebrat confirms via DxPopup (MEMORY §D) with header "Odebrat z hry Ovčina 2023?". |
+| HP counter on Bojovka | Purely local `int tempHp` state — no API call, no persistence. "resetovat" button pulls it back to full Health. |
+| Title strip subline | `{MonsterType display} · Kategorie {N} · #M{ID:D3}` — e.g. "Humanoid · Kategorie 2 · #M042". |
+
+## Class prefixes in the mockup
+
+Flat class names (`best-*`, `mtype`, `stat/num/val/lab`, `ref`, `sect-*`, `actions`, `state`, `dotsep`, `count`, `tab`, `chip`, `field`). **When porting, prefix all new classes with `.oh-mon-d-*`** (monster-detail) to avoid collision with:
+- `.oh-mon-*` (from the monster-list port, if already shipped) — the list page uses `.oh-mon-row-*` and `.oh-mon-pill-*`
+- `.oh-lc-*` (location)
+- `.oh-ssg-*` (secret-stash grid)
+
+If you find yourself adding stat-pill styling that looks duplicative between MonsterList and MonsterDetail's Bojovka, extract `.oh-stat-pill-*` as a shared rule (brief hints at this).
+
+## Aspect ratios confirmed in CSS
+
+- **4:3** — Karta hero illustration
+- **5:7** — Kořist item tiles (MTG)
+- **1:1** — probably the tiny round MonsterType/Kategorie chips or tag dots; verify
+
+## Grid templates in CSS
+
+- `62fr 38fr` — Karta columns (illustration vs stats)
+- `repeat(3, 1fr)` — Bojovka three big stat boxes
+- `360px 1fr` — likely a sub-layout (check context — possibly Upravit's image-slot + form side)
+- `repeat(auto-fill, minmax(160px, 1fr))` — Kořist item tile grid
+- `22px 1fr auto` — stat row (icon + label + value)
+
+## Starting state
+
+### Branches
+- `main` currently at v0.12.1.
+- **Your new branch:** `feat/monster-detail-port` off latest `main`.
+
+### Files already in place
+- `docs/design/dialogs/monster-detail.md` — designer brief
+- `docs/design/dialogs/monster-list.md` — sibling brief; may be ported as `feat/monster-list-port` in flight or merged
+- `src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor` — existing list page; row click currently opens an edit popup. On this branch you rewire row click → `NavigationManager.NavigateTo($"/monsters/{id}")` (or keep quick-peek popup + "Otevřít detail →" button, matching LocationList pattern).
+- `src/OvcinaHra.Client/Components/LocationStashTile.razor` — reference for the 5:7 MTG tile pattern used by the Kořist tab
+
+## Target files (this branch)
+
+- **New page:** `src/OvcinaHra.Client/Pages/Monsters/MonsterDetail.razor` — route `/monsters/{id:int}`
+- **New component:** `src/OvcinaHra.Client/Components/MonsterLootTile.razor` — 5:7 MTG tile showing an Item drop (image + name + × qty pill). Reuses the `.oh-mtg-tile-*` common rules if extracted, otherwise a standalone local CSS block.
+- **New component (recommended):** `src/OvcinaHra.Client/Components/TagChipPicker.razor` — multi-select chip picker from the Tag catalog. Will be reused on Quests, Items later. If time-pressed, inline it and extract later.
+- **Append** `src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css` — `.oh-mon-d-*` scoped block.
+- **Modify** `src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor` — row click now navigates to `/monsters/{id}`. If the monster-list-port branch already merged, coordinate — don't re-port the list, just update the navigation path.
+
+## Acceptance criteria
+
+- [ ] `dotnet build OvcinaHra.slnx` clean, zero new warnings (`TreatWarningsAsErrors=true`)
+- [ ] `dotnet test` green
+- [ ] `/monsters/{id}` renders with the 5-tab strip sticky under a title strip showing `{MonsterType display} · Kategorie {N} · #M{Id:D3}`
+- [ ] Karta: 2-col layout, hero at 4:3, stat block right-aligned mono values, Schopnosti/AI/Tagy/Poznámka sections below
+- [ ] Upravit: 6 sections (Identita · Vizuál · Bojovka · Odměna · Tagy · Poznámky) in DxFormLayout; sticky footer
+- [ ] Bojovka: three big 3rem numerals for ÚT/OBR/ŽIV; local-only HP counter (−1 / +1 / resetovat) that never hits the API
+- [ ] Kořist: per-game grouped MTG 5:7 tiles (`auto-fill minmax(160px, 1fr)`); shows the quantity pill; "+ Přidat kořist" per game row
+- [ ] Výskyt: summary row + per-game list; Odebrat routed through DxPopup confirm (MEMORY §D)
+- [ ] DevTools console clean
+- [ ] Czech diacritics render
+- [ ] MonsterType chip uses neutral palette (no kingdom colors — MEMORY `feedback_ovcina_kingdom_seal_palette`)
+
+## Testing expectations
+
+- **Integration tests:** verify there's no per-game monster loot aggregate endpoint yet — if not, add `/api/monsters/{id}/loot?gameId=X` returning `List<MonsterLootDto>` grouped/filtered appropriately. Cover with a Testcontainers integration test.
+- **Playwright E2E:** navigate `/monsters` → click first row → verify detail page renders with the Karta tab, click Bojovka tab, verify HP counter local state increments and resets. Check Kořist tab shows per-game grouping.
+
+## PR workflow
+
+```
+git checkout -b feat/monster-detail-port main
+# ... implement ...
+dotnet build OvcinaHra.slnx
+dotnet test
+git add -p && git commit   # [v0.12.x] tag in commit msg per skill
+git push -u origin feat/monster-detail-port
+gh pr create --base main --head feat/monster-detail-port \
+  --title "feat(monsters): /monsters/{id} detail page with 5 tabs + Bojovka presenter [v0.12.x]" \
+  --body "See docs/design/dialogs/monster-detail.md and .claude/restart-prompts/hra-ovcina-monster-detail-port.md for decisions. Illuminated bestiary page with Karta, Upravit, Bojovka (presenter view), Kořist (per-game MTG loot tiles), and Výskyt tabs. Uses existing MonsterDetailDto and MonsterLootDto; add aggregate loot endpoint if needed."
+```
+
+Squash-merge with `gh pr merge <N> --squash --delete-branch` after CI + Copilot. Verify deploy via `curl https://api.hra.ovcina.cz/api/version`.
+
+## Gotchas
+
+- **`TreatWarningsAsErrors=true`** — watch out in the Razor: pattern-match `@if (x is int y)` warns when `y` unused; prefer `.HasValue` / `is not null`.
+- **`CombatStats` is a value object** (Attack/Defense/Health). On Upravit, edit flat in DxSpinEdit; rebuild the VO in the save handler before PUT.
+- **`Category` is an int** (level/rank 0-10). Clamp in DxSpinEdit.
+- **Bojovka HP counter is LOCAL ONLY** — do NOT wire to any API. A `private int tempHp` in @code, reset to `loc!.Stats.Health` on tab enter or when "resetovat" is clicked. This is advisory for the organizer running the encounter live.
+- **MonsterType chip must NOT carry kingdom colors** (MEMORY `feedback_ovcina_kingdom_seal_palette`). Use the neutral chip palette — same as ItemType elsewhere.
+- **Tags:** `MonsterDetailDto` has `List<TagDto> Tags` (not the flattened `TagsDisplay` from the list DTO). Use `Tags` directly.
+- **Kořist endpoint may not exist yet** — `MonsterLootDto` shape is already defined. If `/api/monsters/{id}/loot?gameId=X` isn't there, extend `MonsterEndpoints` before wiring the tab. Add Testcontainers integration test.
+- **"Odebrat z hry" confirm** — the header text matters: "Odebrat {Name} z hry Ovčina 2023?" — interpolate the game name so the confirmation is unambiguous. The mockup uses this exact phrasing.
+- **"+ Přidat kořist"** opens an Item picker + quantity input. Inline popup (tiny DxPopup with a searchable item combo + DxSpinEdit quantity). POSTs `CreateMonsterLootDto`, refreshes the tab.
+- **`PhysicalForm` (enum)** shows on Item chips — not on Monsters. Don't confuse the two.
+
+## Follow-ups
+
+1. **Playwright E2E** covering navigation into detail + Bojovka counter + Kořist tab.
+2. **Aggregate occurrences endpoint** `/api/monsters/{id}/occurrences` bundling QuestEncounter and GameMonster counts — feeds the Výskyt summary. Add if it doesn't exist.
+3. **Extract `.oh-stat-pill-*`** base rules shared between MonsterList (5 inline pills) and MonsterDetail Bojovka (3 big stat boxes) — if the duplication becomes obvious. Not required in this PR.
+4. **TagChipPicker** — if extracted, plumb it into Items and Quests in a follow-up PR.
+
+## Companion references
+
+- Brief: `docs/design/dialogs/monster-detail.md`
+- Sibling list brief: `docs/design/dialogs/monster-list.md`
+- Prior port for reference: `.claude/restart-prompts/hra-ovcina-monster-list-port.md`
+- MTG tile pattern: `src/OvcinaHra.Client/Components/LocationStashTile.razor`
+- Design system onboarding: `docs/design/CLAUDE-DESIGN-SETUP.md`
+- Builder template: `docs/design/BUILDER-BRIEF-TEMPLATE.md`

--- a/.claude/restart-prompts/hra-ovcina-monster-list-port.md
+++ b/.claude/restart-prompts/hra-ovcina-monster-list-port.md
@@ -1,0 +1,129 @@
+# Handoff — port the Monster bestiary list (2026-04-23)
+
+Load the `hra-ovcina-tinkerer` skill first. Then read this file and `docs/design/dialogs/monster-list.md` (the designer brief) before touching code.
+
+## What this is
+
+Claude Design shipped the mockup for `/monsters` — a card-row bestiary replacing the current 13-col DxGrid. Your job is to port it to production Blazor on a new branch and ship it via PR.
+
+- **Bundled mockup:** `C:\Users\TomášPajonk\Downloads\P_ery - Bestiary List _standalone_.html` (1.37 MB, gitignored when copied into the repo).
+- **Decoded HTML:** copy the bundled file into `docs/design/dialogs/monster-list.mockup.html` (gitignored) and decode the `__bundler/template` JSON script with:
+  ```python
+  import re, json
+  with open("docs/design/dialogs/monster-list.mockup.html", encoding="utf-8") as f: h = f.read()
+  with open("docs/design/dialogs/monster-list.mockup.unbundled.html", "w", encoding="utf-8") as o:
+      o.write(json.loads(re.search(r'<script type="__bundler/template"[^>]*>(.*?)</script>', h, re.S).group(1).strip()))
+  ```
+- Designer notes live in h4 sections at the bottom of the decoded file — read *Proč card-rows a ne DxGrid?*, *Barvy & chipy*, *Interakce* before making structural choices.
+
+## Decisions the designer locked
+
+Confirmed from mockup markup + h4 notes.
+
+| Area | Choice |
+|---|---|
+| Layout | **Card-row list**, not a DxGrid. Each row is a horizontal card with thumb + name + chips + stats + hover actions. |
+| Row grid template | `grid-template-columns: 96px 1fr auto auto` (per-hra) / `96px 1fr auto auto auto` (catalog has extra column for assign pill). |
+| Row height | 96 px. |
+| Thumbnail | 96 × 72 px, **aspect-ratio 4:3**, rounded corners, left edge of row. |
+| Stat pills | 5 inline mono pills per row: Útok · Obrana · Životy · XP · Groše. Class pattern: `.mon-pill` with `.lbl` (label) + `.val` (mono value). Groše pill uses the gold accent treatment (class `gold`). |
+| MonsterType chip | Compact `.mtype` chip on the row, inherits the neutral palette (no per-type color mapping — keep it muted). |
+| Kingdom/category badge | Small `.kbadge` beside the name for Kategorie rank (NOT the kingdom palette — reuses the class name but is advisory only). |
+| Hover icons | Right-edge hover-reveal group (`.hi-*` classes): Upravit · Přidat kořist · Zkoušet (→ /monsters/{id} Bojovka tab) · Smazat (ghost-bordeaux). Opacity 0 → 0.8 on row hover. |
+| Quick-peek popup | DxPopup Karta view: 400 px illustration left, stats block right (`grid-template-columns: 400px 1fr`), footer `[Zavřít]  [Otevřít detail →]` (navigates to /monsters/{id}). |
+| Filters | Druh · Kategorie · Tagy multi-select · toggle *jen s kořistí* · toggle *jen nepřiřazené* (catalog only). |
+| Mode toggle | Segmented control [Pro hru] / [Katalog] in title strip. |
+| Empty state | Drozd 120×120 + "Žádné příšery přiřazeny k této hře." + [Otevřít katalog] secondary + [+ Nová příšera] primary. |
+
+## Class prefixes the mockup uses
+
+Flat names in the mockup. **Prefix everything with `.oh-mon-*`** when porting to avoid collision with existing `.oh-lc-*` and `.oh-ssg-*` blocks:
+
+- `mon-*` (row shell, name, chips) → `.oh-mon-*`
+- `pill` / `lbl` / `val` → `.oh-mon-pill`, `.oh-mon-pill-lbl`, `.oh-mon-pill-val`
+- `hi-*` (hover icons) → `.oh-mon-hi-*`
+- `mtype` → `.oh-mon-mtype`
+- `kbadge` → `.oh-mon-kbadge` (keep the `k` prefix locally — it's advisory only, NOT the kingdom palette)
+- `gold` → `.oh-mon-gold` (the Groše pill accent)
+- `karta-*` → `.oh-mon-karta-*` (popup's Karta view)
+- `state-*` → `.oh-mon-state-*` (empty state)
+- `assign-*` → `.oh-mon-assign-*` (catalog assign pill)
+- `danger-*` → `.oh-mon-danger-*` or reuse `.oh-btn-ghost-bordeaux` from existing theme
+
+## Starting state
+
+### Branches
+- `main` currently at v0.12.1 with the location redesign merged. Verify before branching.
+- **Your new branch:** `feat/monster-list-port` off latest `main`.
+
+### Files already in place
+- `docs/design/dialogs/monster-list.md` — designer brief
+- `docs/design/dialogs/monster-detail.md` — sibling brief for the detail page (the "Otevřít detail →" target; may not be ported yet)
+- `src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor` — existing DxGrid version to replace
+- `src/OvcinaHra.Client/Components/LocationStashTile.razor` — reference for the 5:7 MTG tile pattern (not directly reused here, but shows our tile component pattern)
+
+## Target files (this branch)
+
+- **Rewrite** `src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor` — drop DxGrid, render a scrollable div of card rows; keep dual-mode routing (`?catalog=true`).
+- **New** `src/OvcinaHra.Client/Components/MonsterRow.razor` — card-row component. Takes a `MonsterListDto`, renders thumb + name + chips + 5 stat pills + hover actions.
+- **Append** `src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css` — `.oh-mon-*` block.
+- **Modify** `LocationList.razor`-style quick-peek popup reuse? No — monster card has different layout (4:3 illustration, 5 big stats). Build a dedicated `MonsterQuickPeek.razor` inside the page or as a small component.
+
+## Acceptance criteria
+
+- [ ] `dotnet build OvcinaHra.slnx` clean, zero new warnings (`TreatWarningsAsErrors=true`)
+- [ ] `dotnet test` green (no API changes; regression only)
+- [ ] `/monsters` renders as a vertical list of 96 px card rows
+- [ ] Each row has: 96×72 4:3 thumb · Name (Merriweather 700) · MonsterType chip · Kategorie badge · up to 3 tag chips · 5 stat pills (ÚT/OBR/ŽIV/XP/Groše, mono) · hover-reveal right-edge icons
+- [ ] `?catalog=true` adds a per-row assign state (muted "✓ v této hře" or hover-reveal "+ Přiřadit ke hře" pill)
+- [ ] Row click (outside hover icons) opens the quick-peek DxPopup; popup's "Otevřít detail →" navigates to `/monsters/{id}`
+- [ ] Filters Druh · Kategorie · Tagy · jen s kořistí · jen nepřiřazené all functional
+- [ ] Empty state shows Drozd + CTAs
+- [ ] DevTools console clean — no DxGrid attribute errors (MEMORY `feedback_ovcinahra_devexpress_runtime_attrs`)
+- [ ] Czech diacritics render in toolbar + filters + row labels + popup
+
+## Testing expectations
+
+- **Integration tests:** no new endpoints — run `dotnet test` to confirm nothing regressed.
+- **Playwright E2E:** add a test that navigates to `/monsters`, filters by Druh, clicks a row, verifies quick-peek popup opens, clicks "Otevřít detail →", URL lands on `/monsters/{id}`. Reference existing tests in `tests/OvcinaHra.E2E/`.
+
+## PR workflow
+
+```
+git checkout -b feat/monster-list-port main
+# ... implement ...
+dotnet build OvcinaHra.slnx
+dotnet test
+git add -p && git commit   # [v0.12.x] tag in commit msg per skill
+git push -u origin feat/monster-list-port
+gh pr create --base main --head feat/monster-list-port \
+  --title "feat(monsters): card-row bestiary replaces DxGrid + quick-peek popup [v0.12.x]" \
+  --body "See docs/design/dialogs/monster-list.md and .claude/restart-prompts/hra-ovcina-monster-list-port.md for design intent. Drops 13-col DxGrid. New component: MonsterRow. Preserves dual-mode routing."
+```
+
+Wait for CI + Copilot review. Fixup commit if needed. Merge with `gh pr merge <N> --squash --delete-branch`. Verify deploy via `curl https://api.hra.ovcina.cz/api/version` after ~8 min.
+
+## Gotchas
+
+- **`TreatWarningsAsErrors=true`** — watch out for unused variables in the MonsterRow component; Razor pattern-match `@if (x is int y)` warns when `y` is unused.
+- **Card-row is not DxGrid** — dropping DxGrid means losing its LayoutKey persistence, column-chooser, and built-in filter UI. The brief accepts this; if you want filter/sort/grouping to persist, implement localStorage manually. Call it out in the PR body.
+- **MonsterListDto.TagsDisplay** is `string.Join(", ", TagNames)` — use it as a scratch string for the tag chip cluster rendering, but render per-tag chips individually (don't show the comma-joined string verbatim).
+- **MonsterType has its own palette on the mockup chips** — but per the brief and `feedback_ovcina_kingdom_seal_palette`, DO NOT use kingdom colors here. The mockup's `.mtype` chip is neutral forest-green / parchment — keep it that way.
+- **Stats are integers on the flat DTO**, not the CombatStats value object (the ListDto flattens them: `Attack`, `Defense`, `Health`). Pull directly.
+- **Groše pill (`.oh-mon-gold`)** is subtly amber-tinted to distinguish currency from skill stats — keep the accent, don't use the kingdom Arnor color.
+- **Hover actions (`.oh-mon-hi-*`)** should use `bi-play-fill` for Zkoušet → `/monsters/{id}?tab=bojovka` (the detail page's Bojovka tab). The query-string isn't implemented yet on detail page — either add it (routes the detail page to Bojovka on load) or open plain `/monsters/{id}` and let the user switch tabs.
+- **Kořist icon (`bi-plus-square`)** is the "add loot" shortcut — on click it can open a tiny flyout picker or just navigate to the detail's Kořist tab. Start with navigate-to-tab if that's simpler.
+
+## Follow-ups
+
+1. **Playwright E2E** — navigation + filter + quick-peek + detail-jump flow.
+2. **Monster detail page** — the "Otevřít detail →" target. Brief at `docs/design/dialogs/monster-detail.md`; no mockup or port yet. If the detail page doesn't exist when this lands, the Otevřít detail button will 404 — **flag this prominently in the PR** so reviewers know.
+3. **Consider extracting stat-pill styling** (`.oh-mon-pill-*`) as a generic `.oh-stat-pill-*` for reuse when MonsterDetail and Quests land (they'll want similar inline stat displays).
+
+## Companion references
+
+- Brief: `docs/design/dialogs/monster-list.md`
+- Sibling detail brief: `docs/design/dialogs/monster-detail.md`
+- Design system onboarding: `docs/design/CLAUDE-DESIGN-SETUP.md`
+- Builder template: `docs/design/BUILDER-BRIEF-TEMPLATE.md`
+- Prior port for reference: `.claude/restart-prompts/hra-ovcina-secret-stash-list-port.md`

--- a/.claude/restart-prompts/hra-ovcina-secret-stash-list-port.md
+++ b/.claude/restart-prompts/hra-ovcina-secret-stash-list-port.md
@@ -1,0 +1,115 @@
+# Handoff — port the SecretStash gallery (2026-04-23)
+
+Load the `hra-ovcina-tinkerer` skill first. Then read this file and `docs/design/dialogs/secret-stash-list.md` (the designer brief) before touching code.
+
+## What this is
+
+Claude Design shipped the mockup for `/secret-stashes` — a gallery of 5:7 MTG tiles replacing the current DxGrid. Your job is to port it to production Blazor on a new branch and ship it via PR.
+
+- **Bundled mockup:** `C:\Users\TomášPajonk\Downloads\Tajn_ skr_e - Gallery _standalone_.html` (1.3 MB, gitignored when copied into the repo).
+- **Decoded HTML:** copy the bundled file into `docs/design/dialogs/secret-stash-list.mockup.html` (already gitignored) and decode the `__bundler/template` JSON script to get raw HTML:
+  ```python
+  import re, json
+  with open("docs/design/dialogs/secret-stash-list.mockup.html", encoding="utf-8") as f: h = f.read()
+  with open("docs/design/dialogs/secret-stash-list.mockup.unbundled.html", "w", encoding="utf-8") as o:
+      o.write(json.loads(re.search(r'<script type="__bundler/template"[^>]*>(.*?)</script>', h, re.S).group(1).strip()))
+  ```
+
+Designer notes live in h4 sections at the bottom of the decoded file — read *Proč MTG-dlaždice?*, *Režimy & chipy*, *Interakce* before making structural choices.
+
+## Decisions the designer locked
+
+Confirmed from the mockup + h4 notes.
+
+| Area | Choice |
+|---|---|
+| Layout | Gallery of 5:7 MTG tiles, **not** a DxGrid. |
+| Tile density | **6–8 columns** on wide desktop (`repeat(8, minmax(0, 120px))`), 6 at midsize (`repeat(6, minmax(0, 110px))`), 3 at tablet, 2 at mobile. Denser than the original 4-col brief draft — keep the designer's values. |
+| Tile aspect | Exactly 5:7 (2.5 × 3.5 in MTG). |
+| Tile content | Image · Name · TWO micro-chips (count of Poklady + count of Hry/Lokace). No description. |
+| Mode toggle | Segmented control "Pro hru" / "Katalog" in the toolbar. |
+| Filters | Toggles: *jen s poklady* · *jen nepřiřazené* (catalog) · *jen bez lokace*. |
+| Catalog overlay | Per-tile "Přiřadit ke hře" pill (forest-green) for unassigned · "V této hře" muted pill for assigned. |
+| Click behavior | Tile → direct navigation to `/secret-stashes/{id}`. No quick-peek popup — the tile IS the peek. |
+| Empty state | Drozd 120×120 + "Žádné skrýše přiřazeny k této hře." + [Otevřít katalog] secondary + [+ Nová skrýš] primary. |
+| New-stash flow | Mini-popup with Název + Popis + ImagePicker; footer CTA = **"Uložit a otevřít"** → POST + navigate to the new stash's detail page. |
+
+## Starting state
+
+### Branches
+- `main` currently at v0.12.1. The earlier character-kingdom + location-list + location-detail work is already merged.
+- **Your new branch:** `feat/secret-stash-list-port` off latest `main`.
+
+### Files already in place
+- `docs/design/dialogs/secret-stash-list.md` — designer brief
+- `docs/design/dialogs/secret-stash-detail.md` — brief for the detail page (the click target; may not be ported yet — check)
+- `src/OvcinaHra.Client/Components/LocationStashTile.razor` — starting point for the tile. Either extend with a `Size` parameter, or build a new `SecretStashGridTile` component (recommended; brief mentions extracting `.oh-mtg-tile-*` common rules if the duplication hurts — do it if it helps, otherwise skip).
+
+### Class prefixes in the mockup
+The decoded file uses flat class names (`ss-*`, `chip-*`, `glyph-*`, `treasures`, `locations`, `state`, `tb-*`). When porting, **prefix everything with `.oh-ssg-*`** (secret-stash-grid) to avoid colliding with the existing `.oh-lc-*` detail page and `.oh-lc-tile-*` Skrýše-tab styling.
+
+## Target files (this branch)
+
+- **Rewrite** `src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor` — drop DxGrid; render a CSS grid of tile links; keep dual-mode routing (`?catalog=true`).
+- **New** `src/OvcinaHra.Client/Components/SecretStashGridTile.razor` — tile component (different sizing from `LocationStashTile` — 120 px wide here vs 70 px in the grid's inline Skrýše cell).
+- **New** `src/OvcinaHra.Client/Components/NewSecretStashPopup.razor` — mini-popup: Název · Popis · ImagePicker (`EntityType="secretstashes"`, `AspectRatio="5:7"`, `Width="200px"`). Footer `[Zrušit]  [Uložit a otevřít]` → POSTs then navigates to `/secret-stashes/{newId}`.
+- **Append** `src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css` — `.oh-ssg-*` block.
+
+## Acceptance criteria
+
+- [ ] `dotnet build OvcinaHra.slnx` clean, zero new warnings (`TreatWarningsAsErrors=true`)
+- [ ] `dotnet test` green (no API changes expected; regression check only)
+- [ ] `/secret-stashes` renders a grid of MTG tiles at 5:7 (check with devtools — aspect-ratio must hold at every breakpoint)
+- [ ] Tile count per row: 6–8 desktop, 6 medium, 3 tablet, 2 mobile
+- [ ] Each tile shows name + two micro-chips (count of treasures + count of games-or-locations)
+- [ ] Click → navigates to `/secret-stashes/{id}`
+- [ ] `?catalog=true` toggles show the overlay "Přiřadit ke hře" pills on unassigned tiles
+- [ ] "+ Nová skrýš" opens the mini-popup; "Uložit a otevřít" POSTs and navigates to the new detail page
+- [ ] Empty state shows Drozd + CTAs (Drozd art: still placeholder — see `feedback_midjourney_creature_style` memory for tool guidance, Recraft.ai is the current recommendation for the real asset)
+- [ ] DevTools console clean — no DxGrid attribute errors (MEMORY `feedback_ovcinahra_devexpress_runtime_attrs`)
+- [ ] Czech diacritics render in toolbar + tiles + popup
+
+## Testing expectations
+
+- **Integration tests:** no new endpoints — run `dotnet test` to confirm nothing regressed. The existing stash CRUD endpoints cover the POST/PUT/DELETE.
+- **Playwright E2E:** add a test that navigates to `/secret-stashes`, clicks a tile, verifies the URL lands on `/secret-stashes/{id}`. Reference existing tests in `tests/OvcinaHra.E2E/`.
+
+## PR workflow
+
+```
+git checkout -b feat/secret-stash-list-port main
+# ... implement ...
+dotnet build OvcinaHra.slnx
+dotnet test
+git add -p && git commit   # [v0.12.x] tag in commit msg per skill
+git push -u origin feat/secret-stash-list-port
+gh pr create --base main --head feat/secret-stash-list-port \
+  --title "feat(secret-stashes): MTG gallery replaces grid + mini-popup new flow [v0.12.x]" \
+  --body "See docs/design/dialogs/secret-stash-list.md and this file for design intent. Drops DxGrid; gallery is CSS-only. New component: SecretStashGridTile + NewSecretStashPopup."
+```
+
+Wait for CI + Copilot review. Fixup commit if needed. Merge with `gh pr merge <N> --squash --delete-branch`. Verify deploy via `curl https://api.hra.ovcina.cz/api/version` after ~8 min.
+
+## Gotchas
+
+- **`TreatWarningsAsErrors=true`** — watch out for unused variables in tile components; Razor pattern-match `@if (x is int y)` warns when `y` is unused.
+- **Czech pluralization:** "N Poklady" is wrong. Use 0/1/2-4/5+ rule: "žádný poklad" / "1 poklad" / "2 poklady" / "5 pokladů". Reuse a helper if the project has one, or crib from `LocationStashTile.PluralForm`.
+- **Tile aspect ratio** must be 5:7 **exactly** — `aspect-ratio: 5/7; object-fit: cover`. Never skew or crop non-uniformly.
+- **ImagePicker `EntityType` is lowercase plural** — `secretstashes` (not `SecretStash`). MEMORY note for the Character port caught the same bug.
+- **Route English, UI Czech** — the route is `/secret-stashes`, not `/tajne-skryse`. Page title and all chrome in Czech.
+- **No description on tiles** — the brief is firm on this. The detail page shows the description; the tile only shows name + count chips.
+- **Mockup mini-popup CTA is "Uložit a otevřít"** — not "Uložit". Matters because it changes the flow (POST + navigate vs just POST).
+
+## Follow-ups
+
+1. **Extract `.oh-mtg-tile-*` common base** — if duplication between `LocationStashTile` and `SecretStashGridTile` becomes obvious. Not required.
+2. **Playwright E2E** for the gallery.
+3. **SecretStash detail page** — the tile click target. Brief is at `docs/design/dialogs/secret-stash-detail.md`; may not be ported yet. If the tile click would currently 404, flag it in your PR so reviewers know.
+
+## Companion references
+
+- Brief: `docs/design/dialogs/secret-stash-list.md`
+- Sibling detail brief: `docs/design/dialogs/secret-stash-detail.md`
+- Design system onboarding: `docs/design/CLAUDE-DESIGN-SETUP.md`
+- Builder template: `docs/design/BUILDER-BRIEF-TEMPLATE.md`
+- MJ / Drozd art pipeline: `feedback_midjourney_creature_style` in Azra's MEMORY

--- a/.claude/restart-prompts/hra-ovcina-sidebar-port.md
+++ b/.claude/restart-prompts/hra-ovcina-sidebar-port.md
@@ -1,0 +1,195 @@
+# Handoff — port the sidebar redesign (2026-04-23)
+
+Load the `hra-ovcina-tinkerer` skill first. Then read this file before touching code.
+
+## What this is
+
+Claude Design shipped **Variant C — záložky (tabs)** for the sidebar nav. The designer wrote implementation notes directly into the mockup (unusual + very useful). Your job is to port it to production Blazor on a new branch and ship it via PR.
+
+- **Bundled mockup:** `C:\Users\TomášPajonk\Downloads\Sidebar - Final _standalone_ (1).html` (2.5 MB, gitignored when copied in).
+- **Decoded HTML:** copy the bundled file into `docs/design/dialogs/sidebar.mockup.html` (gitignored), then decode via:
+  ```python
+  import re, json
+  with open("docs/design/dialogs/sidebar.mockup.html", encoding="utf-8") as f: h = f.read()
+  with open("docs/design/dialogs/sidebar.mockup.unbundled.html", "w", encoding="utf-8") as o:
+      o.write(json.loads(re.search(r'<script type="__bundler/template"[^>]*>(.*?)</script>', h, re.S).group(1).strip()))
+  ```
+
+**Note:** This mockup is a **React component**, not raw HTML. The state logic (`mode === 'hra'`, `useState`, `localStorage` persistence) will port directly to Blazor as plain C# state in `NavMenu.razor` — no React needed. Only the markup structure + CSS get copied.
+
+## Designer's notes (verbatim from the mockup's "Co se změnilo" section)
+
+> **Záložky „Tato hra" / „Katalog"** replace two duplicate sections. You see EITHER this year's game OR templates across years — not both at once.
+>
+> **Přehled** and **Mapa** stay at the top — not tied to mode.
+>
+> **Nástroje** is anchored at the bottom with a darkened background (it's meta, not content).
+>
+> Active item: **3 px green left stripe**, sage gradient, white bolder typography, subtle parchment **•** on the right ("you are here").
+>
+> Inactive tab has a **wrapped top corner** — an actual paper tab, not just a different bg color.
+>
+> Mode preference is remembered in **localStorage** so F5 doesn't lose the user's work-in-progress.
+>
+> "Sidebar structure is 1:1 with NavMenu.razor — CSS just needs to be added to NavMenu.razor.css."
+
+## Decisions the designer locked
+
+| Area | Choice |
+|---|---|
+| Mode switch | **Tabs at the top** (not a segmented control elsewhere). Two tabs: "Tato hra" / "Katalog". Inactive tab has a wrapped/angled top corner like a paper tab sticking out. |
+| Meta line | Under the tab row. For "Tato hra" mode: active game edition name + month (e.g. "Ovčina 2026 — Stíny Rhovanionu · květen 2026"). For "Katalog" mode: "sdílené napříč ročníky". |
+| Fixed top | Přehled + Mapa stay visible in both modes (they're not game-scoped nor catalog-scoped). |
+| Scrollable middle | Mode-dependent item list. Items crossfade on tab switch. |
+| Fixed bottom | Nástroje section (darker bg, sticky). |
+| Active-item styling | 3 px forest-green left stripe · sage-mist gradient bg · white 600-weight text · small parchment-cream `•` pinned to the right edge ("you are here") |
+| Persistence | `mode` value in `localStorage` — survives F5 |
+| Collapsed (60 px) variant | **Out of scope for this port.** Designer offered it as follow-up — open an issue; don't try to build it in this PR. |
+
+## NAV lists (port 1:1 from existing `NavMenu.razor`)
+
+Existing hrefs stay exactly as they are. Don't invent new routes. The mockup's NAV_HRA and NAV_KATALOG arrays are guides — map them to the routes already in `NavMenu.razor`.
+
+**NAV_HRA (mode = "Tato hra"):**
+```
+Časová osa         timeline            bi-clock-history
+Poklady            treasures           bi-safe-fill
+Postavy            characters          bi-person-fill
+Události           events              bi-calendar-event
+Lokace             locations           bi-geo-alt-fill
+Předměty           items               bi-gem
+Příšery            monsters            (local SVG: img/troll.svg)
+Questy             quests              bi-journal-text
+Osobní questy      personal-quests     bi-journal-bookmark
+Budovy             buildings           bi-houses
+Dovednosti         games/{id}/skills   bi-star-fill
+Kouzla             games/{id}/spells   bi-magic
+Tajné skrýše       secret-stashes      bi-lock-fill
+NPC                npcs                bi-person-badge-fill
+```
+
+**NAV_KATALOG (mode = "Katalog"):**
+```
+Lokace             locations?catalog=true         bi-geo-alt
+Předměty           items?catalog=true             bi-gem
+Příšery            monsters?catalog=true          (local SVG: troll.svg)
+Questy             quests?catalog=true            bi-journal-text
+Osobní questy      personal-quests?catalog=true   bi-person-workspace
+Budovy             buildings?catalog=true         bi-houses
+Dovednosti         skills                         bi-star
+Kouzla             spells                         bi-magic
+Tajné skrýše       secret-stashes?catalog=true    bi-lock
+NPC                npcs?catalog=true              bi-person-badge
+Království         kingdoms                       bi-flag
+Tagy               tags                           bi-tags
+```
+
+**Always visible (top of sidebar, both modes):**
+```
+Přehled            /                   bi-feather
+Mapa               map                 bi-map-fill
+```
+
+**Bottom anchored (Nástroje):**
+```
+Seznam Ovčin       games               bi-calendar-event-fill
+Import             import              bi-box-arrow-in-down
+Nastavení          settings            bi-gear-fill
+```
+
+Compare against current `src/OvcinaHra.Client/Layout/NavMenu.razor` for the canonical href list — the current file is the source of truth for routes. If a route differs from the above table, trust the current file.
+
+## Starting state
+
+### Branches
+- `main` currently at v0.12.1 with location redesign merged.
+- **Your new branch:** `feat/sidebar-redesign` off latest `main`.
+
+### Files to modify
+- `src/OvcinaHra.Client/Layout/NavMenu.razor` — rewrite with the new tab structure.
+- `src/OvcinaHra.Client/Layout/NavMenu.razor.css` — isolated CSS; append/replace with the sidebar's scoped rules. Prefix any new classes with `.oh-nav-*`.
+- `src/OvcinaHra.Client/Layout/MainLayout.razor` — likely no change; the sidebar fits the existing frame. Verify.
+- `src/OvcinaHra.Client/wwwroot/js/nav-mode.js` (NEW, small) — 3-line helper for localStorage get/set so the component can read the stored mode on first render without a flash-of-wrong-content.
+
+### State to add to NavMenu.razor
+```csharp
+private string mode = "hra";   // "hra" | "katalog"
+
+protected override async Task OnAfterRenderAsync(bool firstRender)
+{
+    if (firstRender)
+    {
+        var stored = await JS.InvokeAsync<string?>("localStorage.getItem", "oh-nav-mode");
+        if (stored == "hra" || stored == "katalog") { mode = stored; StateHasChanged(); }
+    }
+}
+
+private async Task SwitchMode(string next)
+{
+    mode = next;
+    await JS.InvokeVoidAsync("localStorage.setItem", "oh-nav-mode", next);
+}
+```
+
+## Acceptance criteria
+
+- [ ] `dotnet build OvcinaHra.slnx` clean, zero new warnings (`TreatWarningsAsErrors=true`)
+- [ ] `dotnet test` green (no API changes)
+- [ ] Sidebar shows two tabs at top: `Tato hra` / `Katalog` — click swaps the item list
+- [ ] Přehled + Mapa stay visible in both modes at the top
+- [ ] Nástroje section is pinned to the bottom with darker bg
+- [ ] Active nav item has: 3 px forest-green left stripe · sage gradient bg · white 600-weight text · right-side parchment dot
+- [ ] Inactive tab has a wrapped top corner (paper-tab effect)
+- [ ] Meta line under tab row shows the active game name/edition when mode=hra; "sdílené napříč ročníky" when mode=katalog
+- [ ] After tab click, items crossfade (short CSS opacity transition is fine — don't over-engineer)
+- [ ] Mode survives F5 (localStorage round-trip working)
+- [ ] All existing routes still resolve (no 404s when clicking nav items)
+- [ ] Czech diacritics render cleanly
+- [ ] DevTools console clean
+
+## Testing expectations
+
+- **Integration tests:** no API changes — run `dotnet test` to confirm nothing regressed.
+- **Playwright E2E:** add a tiny test that visits `/`, clicks the `Katalog` tab, verifies a catalog-only nav item ("Království") becomes visible, then reloads the page and verifies the Katalog tab is still selected. Reference existing tests in `tests/OvcinaHra.E2E/`.
+
+## PR workflow
+
+```
+git checkout -b feat/sidebar-redesign main
+# ... implement ...
+dotnet build OvcinaHra.slnx
+dotnet test
+git add -p && git commit   # [v0.12.x] tag in commit msg per skill
+git push -u origin feat/sidebar-redesign
+gh pr create --base main --head feat/sidebar-redesign \
+  --title "feat(nav): Tato hra / Katalog tabs in sidebar [v0.12.x]" \
+  --body "Variant C sidebar redesign from Claude Design mockup. Collapses the old duplicate Hra/Katalog sections into a tab switch at the top of the sidebar. Persists mode in localStorage. Přehled+Mapa always visible; Nástroje anchored at bottom. See .claude/restart-prompts/hra-ovcina-sidebar-port.md for the full decision log."
+```
+
+Wait for CI + Copilot review. Fixup commit if needed. Merge with `gh pr merge <N> --squash --delete-branch`. Verify deploy via `curl https://api.hra.ovcina.cz/api/version` after ~8 min.
+
+## Gotchas
+
+- **React code in the mockup ≠ your implementation.** The mockup uses `mode === 'hra' ? NAV_HRA : NAV_KATALOG`. In Blazor, use a C# property + `@if (mode == "hra")` branches. Don't try to port `useState` or `ReactDOM.render`.
+- **Existing CSS for nav lives in `NavMenu.razor.css`** (Blazor scoped CSS). When you append new rules, they auto-scope. Prefix your new class names with `.oh-nav-*` anyway — consistency with the rest of the theme.
+- **`MainLayout.razor` holds the sidebar width** (250 px) and toggle state. Confirm the new NavMenu fits within the existing frame before touching layout.
+- **localStorage access during prerender** throws — use `OnAfterRenderAsync(firstRender)` not `OnInitializedAsync`.
+- **Tab wrapped-corner effect:** use CSS `border-top-left-radius` on the inactive-side + `clip-path` or overflow masking for the active tab's curved cut. The designer's CSS in the decoded mockup is the reference — copy it straight.
+- **Active game edition name** on the meta line under tabs — pull from `GameContextService.GameName`. Null-handle for "no active game" state.
+- **bi-feather** is the brand glyph — used for Přehled AND Mapa currently; pick `bi-house-door-fill` for Přehled and `bi-map-fill` for Mapa (verify against current NavMenu — those are what's shipping today).
+- **DON'T rename routes.** The mockup labels are design intent; the existing hrefs in NavMenu.razor are the canonical routes.
+
+## Follow-ups (create issues or stack)
+
+1. **Collapsed 60 px variant** — icons only, mode toggle via top icon. Designer offered to ship this as Phase 2. Open an issue tagged `ux-sidebar-collapse`.
+2. **Keyboard nav** — Tab/arrow key traversal of the sidebar items. Accessibility.
+3. **Search inside sidebar** — for organizers with 20+ nav items, a fuzzy "Najdi stránku…" field above the list would help. Defer.
+
+## Companion references
+
+- Current sidebar source: `src/OvcinaHra.Client/Layout/NavMenu.razor`
+- Current sidebar CSS: `src/OvcinaHra.Client/Layout/NavMenu.razor.css`
+- Design system onboarding: `docs/design/CLAUDE-DESIGN-SETUP.md`
+- Builder template: `docs/design/BUILDER-BRIEF-TEMPLATE.md`
+- Prior port for reference: `.claude/restart-prompts/hra-ovcina-secret-stash-list-port.md`, `.claude/restart-prompts/hra-ovcina-monster-list-port.md`
+- GameContextService (for the meta line under tabs): `src/OvcinaHra.Client/Services/GameContextService.cs`

--- a/docs/design/dialogs/item-detail.md
+++ b/docs/design/dialogs/item-detail.md
@@ -1,0 +1,208 @@
+# Design Brief — Item detail `/items/{id}`
+
+**Status:** v1 · 2026-04-23
+**Target surface:** Claude Design (Ovčina org, design system inherited)
+**Implementation target:** new `src/OvcinaHra.Client/Pages/Items/ItemDetail.razor`
+
+## Why it matters
+
+Items anchor multiple gameplay systems: crafting (ingredients + outputs), quest rewards, monster loot tables, treasure quest contents, per-game shop. The detail page needs to make these interconnections legible — organizers should see at a glance "this sword is crafted from iron + hilt, drops from 3 monsters, is a reward in 2 quests, sold in shop X."
+
+## Current state
+
+- No dedicated detail page
+- `ItemList.razor` opens a popup edit form on row click
+- Entity: `Item { Name, ItemType, Effect, PhysicalForm, IsCraftable, ClassRequirements (VO: 4 ints), IsUnique, IsLimited, ImagePath }`
+- Relationships: GameItems (per-game pricing/stock) · CraftingIngredients (used IN recipes) · MonsterLoots · QuestRewards · TreasureItems
+- CraftingRecipe has `OutputItemId` — recipes that PRODUCE this item are queried that way
+
+## Prompt for Claude Design
+
+```
+Design the Item detail page at /items/{id:int} for OvčinaHra — an
+organizer's single-item deep view. Must feel like an illuminated
+shop ledger: real photograph, clear stats, and all the interconnections
+(crafting · loot · rewards · shop) laid out plainly.
+
+AUDIENCE & DEVICE
+Organizers planning encounters, shop economies, quest rewards.
+Desktop first, 10" tablet secondary. Czech only.
+
+PAGE SKELETON
+
+  Breadcrumb: Předměty / {Item Name}
+  Title strip (sticky):
+    [← zpět]  {Name}  (h1 Merriweather 900 2rem)
+    Subline:  ItemType chip · PhysicalForm chip · UNIKÁT ribbon · LIMIT stripe
+    Right actions: [Upravit] / [Smazat] (read)
+                   [Zrušit] / [Uložit] (edit)
+
+  Tab strip (sticky, default=Karta):
+    Karta · Upravit · Crafting · Výskyt · Obchod
+
+============================================================
+TAB 1 — Karta (illuminated ledger)
+============================================================
+
+Two-column desktop (60fr 40fr):
+
+  LEFT: Hero photo at 4:3, heavy parchment frame (2 px #c4b494 border,
+  inset gold radial, green-tinted shadow). Caption below:
+    "Zbraň · Karta"  (type · physical form)
+
+  RIGHT: stat block — vertical list of rows:
+    [icon] LABEL ............. value
+  Using:
+    bi-shield-shaded   Válečník      Lv 3     (muted when 0)
+    bi-bullseye        Lučištník     Lv 0     (muted)
+    bi-magic           Mág           Lv 0
+    bi-incognito       Zloděj        Lv 0
+    hairline
+    bi-stars           Unikát        ANO  (or hidden if false)
+    bi-boxes           Limit         ANO
+    bi-hammer          Craftable     ANO
+  Mono values, right-aligned.
+
+BELOW both columns:
+  h3 "Efekt" + paragraph (Effect field, Georgia serif, justified).
+  h3 "Fyzická podoba" + muted paragraph (PhysicalForm).
+  If Effect is empty: italic grey "Efekt zatím není popsán."
+
+============================================================
+TAB 2 — Upravit
+============================================================
+
+DxFormLayout in sections:
+
+  Identita:    Název · Typ (DxComboBox 19 items) · Fyzická podoba
+  Vizuál:      ImagePicker EntityType="items", AspectRatio="4:3",
+               Width="360px"
+  Vlastnosti:  IsCraftable · IsUnique · IsLimited (3 DxCheckBox)
+  Požadavky:   4-col row of DxSpinEdit — Válečník / Lučištník / Mág /
+               Zloděj, each 0-10. Preview below renders the 4 class
+               pips as they'll appear on Karta.
+  Obsah:       Effect (DxMemo Rows=4)
+
+Footer fixed at bottom: Smazat (ghost-bordeaux, far-left, editing
+only) · spacer · Zrušit (secondary) · Uložit (primary, disabled until
+Name set).
+
+============================================================
+TAB 3 — Crafting (both sides of the recipe graph)
+============================================================
+
+Two panels side-by-side (or stacked on narrow):
+
+  PANEL A — "Vyrábí se z" (recipes that PRODUCE this item):
+    Header: "Vyrábí se z (N receptů)"  + [+ Nový recept] button
+    List of CraftingRecipe cards, one per game:
+      · Game name + edition badge
+      · Left-to-right ingredient chain:
+          [ ingredient tile 72×96 ]  [ × 2 ]  +  [ ingredient tile ]
+          [ × 1 ]  +  [ ingredient tile ]  [ × 3 ]   →   [ THIS ITEM ]
+        Each ingredient tile is a mini 3:4 portrait of the ingredient
+        photo + item name (small). Arrow chevron separators.
+      · Row below the chain:
+          [ bi-buildings Požadovaná budova: Kovárna ]
+          [ bi-tools Dovednost: Kovářství Lv 3 ]
+          [ bi-geo-alt Lokace: Kovárna u řeky ]
+      · Small muted "GameId: {id} · edit" link on card top-right
+
+  PANEL B — "Používá se v" (recipes that CONSUME this item as ingredient):
+    Header: "Používá se v (N receptech)"
+    Compact list of rows:
+      [ output tile 48×64 ]  [ output name ]  [ × N ]  [ game badge ]
+    Click → navigates to /items/{outputItemId}?tab=crafting
+
+Empty states per panel: "Tento předmět se zatím nikde nevyrábí." /
+"Tento předmět se nikde nepoužívá."
+
+============================================================
+TAB 4 — Výskyt (drops, rewards, treasures)
+============================================================
+
+Three grouped sub-sections with header row + items:
+
+  "Kořist u příšer" (MonsterLoot):
+    Mini-cards: monster thumbnail 72×54 + monster name + "× N" quantity
+    pill + game badge. Click → /monsters/{id}.
+
+  "Odměny v questech" (QuestReward):
+    Compact list: quest name + difficulty badge + "× N quantity" mono
+    pill + game badge. Click → /quests/{id}.
+
+  "V pokladech" (TreasureItem):
+    Treasure name + treasure difficulty + "× N" + game badge. Click →
+    /treasures/{id}.
+
+Each section has its own empty-state note if no rows.
+
+============================================================
+TAB 5 — Obchod (per-game shop configuration)
+============================================================
+
+Table-like list of GameItem rows, one per Game:
+  | Hra | Cena | Sklad | Prodává | Nalezitelný | Podmínka prodeje | Akce |
+
+  · Cena: mono "15 g" (gold accent pill)
+  · Sklad: "3 / 10" mono (current / max, if max set) or "—"
+  · Prodává / Nalezitelný: small badge (forest-green ANO / muted NE)
+  · Podmínka prodeje: italic Georgia (e.g. "jen hrdinové 5+", "tajný
+    obchod")
+  · Akce: icons — Upravit (bi-pencil) + Odebrat (bi-trash ghost-bordeaux)
+
+Empty state: "Tento předmět není v žádné hře." + "+ Přidat do hry"
+primary button.
+
+============================================================
+STATES TO RENDER (stack vertically)
+============================================================
+
+  1. Karta — example "Meč elfů ze Stínového hvozdu": hero photo 4:3,
+     Válečník Lv 3 / others 0, UNIKÁT, effect paragraph "2 životy, +1
+     proti Nemrtvým".
+  2. Upravit — same item, form populated, 4-col requirement row.
+  3. Crafting — Panel A shows 2 recipes (current game + prior game)
+     each with 3 ingredients + forge/skill requirements. Panel B shows
+     this sword is used in 0 other recipes (empty).
+  4. Výskyt — 2 monsters drop it (×1 each), 1 quest reward (×1), 1
+     treasure (×1).
+  5. Obchod — 2 games in table: current game 15g/3of10 sold/findable,
+     prior game 12g/0of10 not-sold/findable, with a sale condition
+     "jen po questu Tajemství hvozdu".
+  6. Karta empty state — new item, no photo, no effect; Drozd perch
+     in the photo slot.
+
+ANTI-PATTERNS
+  · No kingdom colors on ItemType chips.
+  · No emoji.
+  · No cinematic 16:9 hero — locked 4:3.
+  · No Drozd on populated tabs.
+  · Ingredient chain arrows must be clear — don't reduce to plain
+    "+" without directionality.
+```
+
+---
+
+## Builder addendum — Item detail
+
+TARGET FILES
+- New page: `src/OvcinaHra.Client/Pages/Items/ItemDetail.razor` (route `/items/{id:int}`)
+- Theme additions: `.oh-it-detail-*` + `.oh-class-pips` block in `ovcinahra-theme.css`
+- New components:
+  - `src/OvcinaHra.Client/Components/ItemClassPips.razor` — reusable 4-pip row (used on tiles + detail + quest rewards)
+  - `src/OvcinaHra.Client/Components/CraftingRecipeCard.razor` — the ingredient-chain display (used on Panel A of Crafting tab, and later on CraftingRecipe list pages)
+- Update `ItemList.razor` row click → `NavigationManager.NavigateTo($"/items/{id}")` (replace popup-open-on-click with detail-page-navigation)
+
+DATA BINDINGS
+- GET `/api/items/{id}` → `ItemDetailDto` (exists; verify it carries crafting + loot + rewards, extend if not)
+- Crafting Panel A: GET `/api/crafting/recipes?outputItemId={id}` — may need new endpoint
+- Crafting Panel B: GET `/api/crafting/recipes?ingredientItemId={id}` — may need new endpoint
+- Výskyt: existing MonsterLoot / QuestReward / TreasureItem queries; may need aggregate endpoint `/api/items/{id}/occurrences`
+- Obchod: existing GameItem CRUD endpoints
+
+NOTES
+- Class-pip icons must match between ItemList tiles, ItemDetail Karta, and future QuestReward renders. Extract to shared component day 1.
+- Ingredient chain rendering is a common pattern — future `CraftingRecipeDetail` page will want it too. Keep `CraftingRecipeCard` general (inputs · outputs · requirements).
+- `Crafting` tab is the richest. If it starts to feel heavy in the first port, ship Tab 1/2/4/5 and stub Tab 3 with "Coming soon" — note it in the PR.
+- `Item.ClassRequirements` is a value object (owned type). Edit flat via form, rebuild VO on save.

--- a/docs/design/dialogs/item-list.md
+++ b/docs/design/dialogs/item-list.md
@@ -1,0 +1,177 @@
+# Design Brief — Item grid `/items`
+
+**Status:** v1 · 2026-04-23
+**Target surface:** Claude Design (Ovčina org, design system inherited)
+**Implementation target:** rewrite `src/OvcinaHra.Client/Pages/Items/ItemList.razor`
+
+## Why it matters
+
+Items are **real hand-photographed LARP artifacts** — weapons, potions, jewelry, hand-sewn card props. The photo IS the artifact's identity. The current grid hides the photo behind a `HasImage` boolean column — organizers browsing by name can't see what they're looking at.
+
+At the same time, in per-game mode the operational view matters — price, stock, unique/limited flags — because organizers run the shop economy from this page.
+
+## Current state
+
+- Dual mode: `/items` (per-hra) vs `?catalog=true` (all items across games)
+- DxGrid with Name · ItemTypeDisplay · Effect · class requirement columns · unique/limited flags · (hidden) HasImage
+- Per-hra mode adds Price / StockCount / IsSold / SaleCondition / IsFindable / RecipeSummary columns
+- Row click → popup edit form
+- `LayoutKey = "grid-layout-items-catalog-v2"` — bump to v3 on ship
+
+## Entity facts (for the prompt)
+
+- 19 ItemTypes in Czech: Zbraň · Štít · Zbroj · Helma · Střelná zbraň · Kůň · Ovládaný tvor · Životy · Svitek · Lektvar · Surovina · Peníze · Herní zvíře · Drobný artefakt · Šperk · Artefakt · Ingredience · Komodita · Ostatní.
+- `ClassRequirements` value object: 4 integers (Warrior/Archer/Mage/Thief) — a class can use the item if the player's class level ≥ the Req for that class.
+- `IsUnique` (one-of-a-kind) and `IsLimited` (bounded supply) are separate flags.
+- `IsCraftable` flag; real crafting tree lives in `CraftingRecipe` per-game.
+
+## User decisions already locked
+
+| Decision | Value |
+|---|---|
+| Dual mode | Keep both |
+| Primary visual | **Photo gallery in catalog mode** · **card-row in per-hra mode** — hybrid, because catalog is visual browse and per-hra is operational shop management |
+| Photo aspect | **4:3 landscape** (smartphone photo format) — real LARP props are shot this way. Let designer confirm 4:3 vs 3:2 in the mockup. |
+| Class-requirement display | Four tiny pips — Warrior (sword icon) / Archer (bow) / Mage (staff) / Thief (dagger). Muted when Req=0, lit in forest-green when Req≥1. Hover tooltip with exact req level. |
+| Unique/Limited flags | Small ribbon/badge on the tile — gold ribbon top-right for "unikát", amber stripe for "limit". |
+| Grid thumbnail (catalog) | Gallery tile: 4:3 photo at top, name, type chip, class pips, unique/limited ribbon |
+| Per-hra row | Card-row: left-side 4:3 photo thumb (96×72) + identity + **price/stock pills prominently** (mono) + IsSold/IsFindable toggles on hover |
+
+## Prompt for Claude Design
+
+```
+Design the Items page at /items for OvčinaHra — organizer view of every
+item in the LARP world. Real hand-photographed weapons, armor, potions,
+jewelry. The photo IS the artifact; the grid should treat it as such.
+
+AUDIENCE & DEVICE
+Organizers. Two different jobs on the same page:
+  · Catalog mode — visual browse for encounter planning, quest reward
+    picking, monster loot assignment
+  · Per-hra mode — operational view of the game's shop: prices, stock,
+    sale flags
+
+Desktop-first, 10" tablet secondary. Czech only.
+
+MODES (?catalog=true)
+
+  Per-hra (default)
+  Katalog
+
+LAYOUT DIFFERS BY MODE — this is the key decision for the page.
+
+============================================================
+CATALOG MODE — Photo gallery
+============================================================
+
+Title strip:
+  h1 "Katalog předmětů"
+  Mode toggle: [Jen tato hra] [Katalog]
+  Right:  [+ Nový předmět] primary
+
+Filter row (sticky below title):
+  [ Hledat… ]  [ Typ ▼ (19 types, searchable) ]  [ Třída ▼ ]
+  [ toggle jen unikáty ]  [ toggle jen limit ]  [ toggle je craftable ]
+  Right: [ N předmětů ] count
+
+Gallery: responsive CSS grid of 4:3 photo tiles.
+  · Desktop (≥1280 px): 5 cols
+  · Desktop (1024–1280): 4 cols
+  · Tablet (768–1024): 3 cols
+  · Mobile: 2 cols
+  · Gap: 24 px row, 20 px col
+
+TILE COMPOSITION (4:3 landscape, 220 × 165 px desktop)
+  · Photo top, object-fit:cover, fallback muted parchment gradient
+  · Ribbon top-right if IsUnique: gold satin band with "UNIKÁT" (small mono)
+  · Stripe top-left if IsLimited: amber stripe with "LIMIT"
+  · Body (parchment cream, 12 px padding):
+      - Name (Merriweather 700 0.9375rem, forest green, 2-line clamp)
+      - ItemType chip (small, neutral)
+      - Class pip row: 4 small icons (Warrior sword · Archer bow · Mage
+        staff · Thief dagger). Muted when Req=0, forest-green filled
+        when Req≥1, tooltip shows exact req value.
+  · Hover: lift -2 px, sage tint, shadow deepens
+
+============================================================
+PER-HRA MODE — Card-row shop view
+============================================================
+
+Title strip:
+  h1 "Předměty"
+  Mode toggle: [Jen tato hra] [Katalog]
+  Right:  [+ Nový předmět] primary
+
+Filter row: same as catalog, plus:
+  [ toggle IsSold ]  [ toggle IsFindable ]
+
+CARD-ROW LIST (not DxGrid)
+
+Each row: 96 px tall, full-width, parchment bg, warm-beige border,
+green-tinted shadow. Content left→right:
+
+  [ photo thumb 96×72 4:3 rounded corners ]
+  [ Name (Merriweather 700) · ItemType chip · class pips ]
+  [ spacer ]
+  [ price-stock cluster (mono pills):
+      [ Cena 15 g ]   [ Skladem 3 / 10 ]   [ Prodává ANO ]
+      [ Nalezitelný ANO ]   [ Podmínka: "jen hrdinové 5+" ]
+    Price pill uses the gold accent (Groše color). If IsSold=false,
+    price pill is muted/struck. ]
+  [ hover icons: bi-pencil Upravit · bi-boxes Crafting · bi-trash Smazat ]
+
+Row click (outside icons) opens a quick-peek popup — 720×480 with the
+Karta view (hero photo + core fields + effect text). Popup footer:
+[Zavřít] [Otevřít detail →] navigates to /items/{id}.
+
+EMPTY STATE (per-hra)
+Drozd 120×120 + "Žádné předměty přiřazeny k této hře." +
+[Otevřít katalog] secondary + [+ Nový předmět] primary.
+
+CLASS PIP ICONS (proposal — confirm in mockup)
+  Warrior → bi-shield-shaded         (forest green when lit)
+  Archer  → bi-bullseye               (forest green when lit)
+  Mage    → bi-magic                  (forest green when lit)
+  Thief   → bi-incognito              (forest green when lit)
+Each pip is 18×18, muted at #d4c4b0 when Req=0. Stack horizontally with
+6 px gaps.
+
+STATES TO RENDER (stack vertically)
+
+  1. Catalog gallery — 10 tiles mixing categories (Zbraň, Zbroj,
+     Lektvar, Šperk, Artefakt), 2 marked UNIKÁT, 1 marked LIMIT,
+     various class-pip combos.
+  2. Per-hra card-rows — 6 rows, one hovered with icons visible.
+     Mix of IsSold (struck-through price), IsFindable, stock levels.
+  3. Empty state with Drozd.
+  4. Quick-peek popup — example "Meč elfů ze Stínového hvozdu",
+     hero photo at 4:3 400px, type chip, 4 class pips (only Mage
+     muted), effect paragraph.
+
+ANTI-PATTERNS
+  · No DxGrid in catalog mode.
+  · No kingdom colors on ItemType chips (muted neutral only).
+  · No emoji — Bootstrap Icons.
+  · No photo cropping beyond object-fit:cover — photos are the
+    artifact, don't mangle them.
+```
+
+---
+
+## Builder addendum — Item grid
+
+TARGET FILES
+- Rewrite `src/OvcinaHra.Client/Pages/Items/ItemList.razor`
+- New component: `src/OvcinaHra.Client/Components/ItemGalleryTile.razor` (catalog mode, 220×165 tile)
+- New component: `src/OvcinaHra.Client/Components/ItemShopRow.razor` (per-hra mode, 96 px row)
+- Theme additions: `.oh-it-*` scoped block in `ovcinahra-theme.css`
+
+DATA BINDINGS
+- Catalog: existing `GET /api/items` → `List<ItemListDto>`
+- Per-hra: existing `GET /api/items/by-game/{gameId}` → `List<GameItemListDto>`
+- No API changes expected
+
+NOTES
+- `ItemListDto.ImageUrl` is already populated by the backend (SAS URL) — use it directly on the tile/row; no separate ImagePicker fetch per item.
+- ClassRequirements is already flattened as `ReqWarrior/ReqArcher/ReqMage/ReqThief` on the DTO — easy to light up the 4 pips.
+- Consider extracting a `.oh-class-pips` component for reuse on ItemDetail's Karta and Quest reward displays.

--- a/docs/design/dialogs/monster-detail.md
+++ b/docs/design/dialogs/monster-detail.md
@@ -1,0 +1,195 @@
+# Design Brief — Monster detail `/monsters/{id}`
+
+**Status:** v1 · 2026-04-23
+**Target surface:** Claude Design (Ovčina org, design system inherited)
+**Implementation target:** new `src/OvcinaHra.Client/Pages/Monsters/MonsterDetail.razor`
+
+## Why it matters
+
+The bestiary is an iconic Ovčina surface — organizers want to **feel** the creature, not stare at a row of integer stats. Current MonsterList popup is a functional form, not a creature card.
+
+## Current state
+
+- `MonsterList.razor` at `/monsters` — DxGrid with Name · TypDisplay · Category · Attack · Defense · Health · RewardXp · RewardMoney · TagsDisplay · (hidden) Abilities / AiBehavior / RewardNotes / Notes
+- Row click → popup edit form (single tab)
+- Entity: `Monster { Name, Category (int level/rank), MonsterType (enum), Abilities, AiBehavior, Stats (CombatStats VO: Attack, Defense, Health), RewardXp, RewardMoney, RewardNotes, Notes, ImagePath }`
+- Relationships: `MonsterTagLink[]`, `MonsterLoot[]` (items dropped per game), `GameMonster[]` (per-game assignments), `QuestEncounter[]`
+
+## Data prereqs — none
+
+Everything is on the entity + existing DTOs (`MonsterListDto`, `MonsterDetailDto`, `MonsterLootDto`).
+
+## Prompt for Claude Design
+
+```
+Design the Monster detail page at /monsters/{id:int} for OvčinaHra —
+the organizer's bestiary entry for a single creature. Feel: illustrated
+bestiary page, not an RPG stat block.
+
+AUDIENCE & DEVICE
+Organizers planning encounters, desktop first (1440 nominal), 10"
+tablet secondary. Czech only.
+
+AESTHETIC
+This page is more "illuminated bestiary" than the location card.
+Parchment stays, but the creature illustration is the dominant visual
+(4:3 landscape). Stats read like a block quote in the margin, not a
+spreadsheet. AiBehavior and Abilities get room to breathe.
+
+PAGE SKELETON
+
+  Breadcrumb:  Příšery / {Name}
+  Title strip (sticky):
+    [← zpět]  {Name}  (h1, Merriweather 900, 2rem)
+    Subline:  MonsterType chip · Kategorie N · úroveň-badge mono
+    Right actions: [Upravit] / [Smazat] (read mode)
+                   [Zrušit] / [Uložit]    (edit mode)
+
+  Tab strip (sticky, default=Karta):
+    Karta · Upravit · Bojovka · Kořist · Výskyt
+
+============================================================
+TAB 1 — Karta (bestiary page)
+============================================================
+
+Two-column layout on desktop (65fr 35fr):
+
+  LEFT: creature illustration at 4:3 (aspect-ratio:4/3, object-fit:
+  cover), heavy parchment frame (2 px #c4b494 border, inset gold
+  radial, green-tinted shadow). Caption below: MonsterType · Kategorie.
+
+  RIGHT: stats block — vertical list, each row is:
+    [icon] LABEL ........... value
+  Using:
+    bi-lightning-charge  Útok      12
+    bi-shield-shaded     Obrana     8
+    bi-heart-pulse       Životy    45
+    bi-star-fill         XP       150
+    bi-coin              Groše     20
+  Mono values, right-aligned. Subtle hairline between rows.
+
+BELOW both columns:
+  h3 "Schopnosti" + paragraph (Abilities field, Georgia serif,
+  left-aligned, hyphens auto). If empty, show italic grey
+  "Žádné zvláštní schopnosti zaznamenány."
+
+  h3 "AI chování" + same treatment (AiBehavior field).
+
+  h3 "Tagy" + horizontal list of tag chips (burnt-orange outline,
+  muted parchment bg). Existing tag palette — no kingdom colors.
+
+  Organizer notes footer: small italic "Poznámky" block if Notes
+  is set; same muted beige callout treatment.
+
+============================================================
+TAB 2 — Upravit
+============================================================
+
+DxFormLayout 2-col sections:
+
+  Identita:    Název · MonsterType (DxComboBox, Czech chips)
+               Kategorie (DxSpinEdit 0-10)
+  Vizuál:      ImagePicker locations-style, EntityType="monsters",
+               AspectRatio="4:3", Width="360px"
+  Bojovka:     Attack · Defense · Health  (3-col SpinEdit row)
+               Abilities (DxMemo, Rows=4)
+               AiBehavior (DxMemo, Rows=3)
+  Odměna:      RewardXp · RewardMoney  (2-col SpinEdit row)
+               RewardNotes (DxMemo, Rows=2)
+  Tagy:        Multi-select chip picker from existing Tag catalog
+  Poznámky:    Notes (DxMemo, Rows=3)
+
+Footer fixed at page bottom during scroll:
+  Smazat (ghost-bordeaux, far-left, only when editing) · spacer
+  Zrušit (secondary) · Uložit (primary, disabled until Name filled)
+
+============================================================
+TAB 3 — Bojovka (combat sheet — presenter view for event runners)
+============================================================
+
+Large-type presenter view, optimized for the organizer glancing
+at a tablet during a live encounter:
+  · Creature illustration (smaller, 3:2, top)
+  · Three big stat boxes across: ÚTOK / OBRANA / ŽIVOTY in 3rem
+    mono numerals, parchment-alt background, burnt-orange ribbon
+  · Abilities rendered as numbered bullets (1. 2. 3. …) in 1.1rem
+  · AI chování rendered as a pull-quote (Georgia italic, indented)
+  · Sticky top: quick [−1 Život] [+1 Život] counter — NO state
+    (advisory only, local to session)
+
+This tab is read-only; edits happen on Upravit.
+
+============================================================
+TAB 4 — Kořist (loot table, per-game)
+============================================================
+
+Per-game grouping. For each Game where the monster is active:
+  · Game header (Name, Edition badge)
+  · Row of item mini-tiles — 5:7 MTG-sized, same pattern as
+    LocationStashTile but each tile is an Item drop:
+      · Item image
+      · Item name (Merriweather)
+      · "× N" multiplier chip (if Quantity > 1)
+  · "+ Přidat kořist" small button at end of row
+
+When no loot assigned in a game: "Bez kořisti" muted italic.
+
+Admin-only header row: "+ Přidat do hry" — wraps MonsterListDto's
+per-game assignment endpoint.
+
+============================================================
+TAB 5 — Výskyt (where this monster appears)
+============================================================
+
+Compact table:
+  | Hra | Questy (N) | Encounters (N) | Odebrat |
+
+Row click → navigates to that game's monster page or quest page
+(designer's judgement). Odebrat confirms via DxPopup (MEMORY §D).
+
+============================================================
+STATES TO RENDER
+============================================================
+
+  1. Karta populated — example: "Skřetí lukostřelec" (Goblin archer),
+     Category 2, Humanoid, full stats, 2 abilities, 3 tags, small
+     notes footer.
+  2. Upravit — form populated with same creature.
+  3. Bojovka — presenter view with the big stat boxes.
+  4. Kořist — 2 games, 3 items in current game (one with ×2 pill),
+     empty state in prior game.
+  5. Karta empty — new creature, no image, no abilities; Drozd perch
+     empty-state in the illustration slot.
+
+ANTI-PATTERNS
+  · No kingdom colors on MonsterType chips.
+  · No emoji.
+  · No cinematic 16:9 illustration — locked 4:3 matches the existing
+    game-art format.
+  · No Drozd on populated tabs.
+  · The "counter" on Bojovka is advisory only — do NOT persist.
+```
+
+---
+
+## Builder addendum — Monster detail
+
+TARGET FILES
+- New page: `src/OvcinaHra.Client/Pages/Monsters/MonsterDetail.razor` (route `/monsters/{id:int}`)
+- Theme additions: `.oh-mon-*` scoped block in `ovcinahra-theme.css`
+- New component: `src/OvcinaHra.Client/Components/MonsterLootTile.razor` (reuses 5:7 MTG pattern)
+- Optional: `src/OvcinaHra.Client/Components/TagChipPicker.razor` — multi-select chip from Tag catalog (reusable for Quests, Items)
+
+DATA BINDINGS
+- GET `/api/monsters/{id}` → `MonsterDetailDto`
+- Upravit form → PUT `/api/monsters/{id}` with `UpdateMonsterDto`
+- Kořist tab → GET `/api/monsters/{id}/loot?gameId=X` → `List<MonsterLootDto>`
+  (verify endpoint; may need to add per-game-grouped variant)
+- Výskyt → `GameMonster[]` from dedicated endpoint
+
+NOTES
+- `Category` is an integer (looks like level/rank). Cap at 0-10 in the SpinEdit; user can adjust.
+- `CombatStats` is a value object (Attack/Defense/Health). Edit flat in the form; rebuild the VO on save.
+- Existing `TagsDisplay` on `MonsterListDto` is a computed `string.Join(", ", TagNames)`. On the detail DTO we have `List<TagDto> Tags` — use those.
+- The "counter" on Bojovka tab should be purely local (a simple `int tempHp` state) — no API call, no persistence.
+- Big stat boxes on Bojovka may benefit from `font-variant-numeric: tabular-nums` so digits align.

--- a/docs/design/dialogs/monster-list.md
+++ b/docs/design/dialogs/monster-list.md
@@ -1,0 +1,137 @@
+# Design Brief — Monster grid `/monsters`
+
+**Status:** v1 · 2026-04-23
+**Target surface:** Claude Design (Ovčina org, design system inherited)
+**Implementation target:** rewrite `src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor`
+
+## Why it matters
+
+The bestiary list should **read like an index of creatures**, not a spreadsheet of integers. Current grid is 13 columns wide and feels like a report — organizers scan for "which creature fits this encounter," not sort-by-attack.
+
+## Current state
+
+- Dual mode (per-hra / catalog)
+- DxGrid with 13 columns, 9 hidden by default
+- Row click → single-tab popup edit form
+- `LayoutKey = "grid-layout-monsters-v2"` (bump to v3 on ship)
+- Search, filters minimal
+
+## User decisions already locked
+
+| Decision | Value |
+|---|---|
+| Dual mode | Keep both |
+| Layout | **Hybrid** — card-row list, not a pure grid. Each row is a full-width horizontal card with a thumbnail + stats inline |
+| Thumbnail | Left edge of row, 96 × 72 px (4:3), same as detail page illustration ratio, rounded corners |
+| Stats visible inline | ÚT · OBR · ŽIV · XP · Groše (5 compact mono chips on each row) |
+| Tags | Small chip cluster inline |
+| Filter strip | Hledat · Druh (MonsterType) · Kategorie range · Tagy multi-select · toggle "jen s kořistí" · toggle "jen nepřiřazené" (catalog-only) |
+| Row click | Opens a quick-peek popup (the Karta tab view) or navigates to `/monsters/{id}` — **designer's call** |
+| Row actions | Hover icons on right edge: Upravit · Přidat kořist · Zkoušet (navigates to Bojovka tab) · Smazat |
+
+## Prompt for Claude Design
+
+```
+Design the Monster bestiary list at /monsters for OvčinaHra — organizer
+view of all creatures in the LARP world. Card-row hybrid between a
+grid and an image list.
+
+AUDIENCE & DEVICE
+Organizers browsing for encounter planning. Desktop-first 1440 nominal,
+tablet 10". Czech only.
+
+MODES (?catalog=true)
+
+  Per-hra (default): creatures assigned to the current game.
+  Katalog: all creatures, plus per-row "Přiřadit ke hře" pill.
+
+LAYOUT
+
+Title strip:
+  h1 "Příšery"
+  Mode toggle: [Jen tato hra] [Katalog]  (segmented control)
+  Right:       [+ Nová příšera] primary
+
+Filter row (sticky below title):
+  [ Hledat… ]  [ Druh ▼ ]  [ Kategorie ▼ ]  [ Tagy ▼ ]
+  [ toggle s kořistí ]  [ toggle nepřiřazené (katalog) ]
+  Right-aligned: [ N příšer ] count
+
+CARD-ROW LIST (not DxGrid, scrollable div)
+
+Each monster row is a full-width horizontal card, 96 px tall,
+parchment-cream bg, 1 px warm-beige border, 6 px radius, green-tinted
+shadow. Content left→right:
+
+  [ thumbnail 96×72 4:3, rounded ]
+
+  [ Name (Merriweather 700 1rem, forest green)
+    MonsterType chip · Kategorie N mono badge · 3 tag chips ]
+
+  [ Spacer grows ]
+
+  [ stat pill cluster (5 pills, monospace):
+      ÚT 12   OBR 8   ŽIV 45   XP 150   GR 20
+    Each pill: 8 px padding, surface-alt bg, burnt-orange outline for
+    the label, mono value. On mobile/tablet, stack or wrap. ]
+
+  [ Hover icons appearing on right edge on row hover (0 → 0.8 opacity):
+      bi-pencil      Upravit
+      bi-plus-square Přidat kořist
+      bi-play-fill   Zkoušet (→ /monsters/{id} tab=Bojovka)
+      bi-trash       Smazat (ghost-bordeaux)
+    28×28 each, 6 px gap ]
+
+Row hover: background shifts to sage mist, image slightly brightens,
+icons fade in. Row click (anywhere outside the icons) opens a
+720 × 520 quick-peek popup.
+
+QUICK-PEEK POPUP
+Shows the Karta view (creature illustration 4:3 at 400 px + right-
+column stats block + ability paragraph + AI-behavior paragraph), plus
+footer [Zavřít] [Otevřít detail →] (navigates to /monsters/{id}).
+
+EMPTY STATE (per-hra)
+Drozd 120×120 + "Žádné příšery přiřazeny k této hře." +
+[Otevřít katalog] secondary + [+ Nová příšera] primary.
+
+STATES TO RENDER (stack vertically)
+
+  1. Per-hra mode with 6 card rows: mix of high/low stats (Skřetí
+     lukostřelec ÚT 12, Vlkodlak ÚT 25, Krysa ÚT 2). One row hovered
+     showing icons + sage tint.
+  2. Catalog mode with 6 rows; 2 already-assigned (muted "✓" pill)
+     and 4 not-yet-assigned (hover-reveal "+ Přiřadit").
+  3. Empty state with Drozd.
+  4. Quick-peek popup — example "Vlkodlak", full Karta view.
+
+ANTI-PATTERNS
+  · No DxGrid with 13 columns.
+  · No kingdom colors on MonsterType chips.
+  · No emoji — Bootstrap Icons only.
+  · No reliance on tiny icon-only badges without text labels —
+    organizers need to scan by name, not decipher pictograms.
+```
+
+---
+
+## Builder addendum — Monster grid
+
+TARGET FILES
+- Rewrite `src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor` — drop DxGrid for the main list (keep DxPopup for quick-peek)
+- Theme additions: `.oh-mon-row-*` scoped block in `ovcinahra-theme.css`
+- Optional: `src/OvcinaHra.Client/Components/MonsterRow.razor` for the card row
+
+DATA BINDINGS
+- `GET /api/monsters` / `GET /api/monsters/by-game/{gid}` already returns `MonsterListDto` with all the fields + `TagNames`. No API changes.
+- Quick-peek popup loads `MonsterDetailDto` via `GET /api/monsters/{id}` (for ImagePath + full Abilities + AiBehavior)
+
+GRID COLUMN CHANGES
+- `LayoutKey` concept doesn't apply — this is no longer a DxGrid (MEMORY §L still applies: if you KEEP a DxGrid anywhere, bump its LayoutKey)
+- Drop DxGrid persistence; the card-row list doesn't need user-configurable columns
+
+NOTES
+- Filters could still persist in localStorage manually (e.g. Hledat text, selected filter chips). Optional.
+- MonsterType chip colors: keep the neutral palette (no semantic color per type unless canon exists — check `hra-ovcina-tinkerer` skill memory for any MonsterType color mapping).
+- Tag chips reuse the same style as LocationDetail's `.oh-lc-tag` — worth extracting to `.oh-tag` as a shared rule.
+- Quick-peek popup CAN reuse the MonsterDetail Karta tab component if we refactor the Karta section into its own component. Call it out in the PR if you do.

--- a/docs/design/dialogs/secret-stash-detail.md
+++ b/docs/design/dialogs/secret-stash-detail.md
@@ -1,0 +1,170 @@
+# Design Brief — SecretStash detail `/secret-stashes/{id}`
+
+**Status:** v1 · 2026-04-23
+**Target surface:** Claude Design (Ovčina org, design system inherited)
+**Implementation target:** new `src/OvcinaHra.Client/Pages/SecretStashes/SecretStashDetail.razor`
+
+## Why it matters
+
+`LocationStashTile` (shipped in LocationDetail) already links to `/secret-stashes/{id}`. That page needs to exist and visually continue the MTG-card aesthetic — a stash opens from a tiny MTG tile on a Location page, it should read as the **same artifact blown up to card size**.
+
+## Current state
+
+- `SecretStashList.razor` at `/secret-stashes` — DxGrid with Name/Description columns, dual mode (per-hra vs catalog), `+ Nová skrýš` popup
+- No dedicated detail page
+- Entity: `SecretStash { Id, Name, Description, ImagePath }`
+- Relationships:
+  - `GameSecretStash` — per-game assignment (binds stash to a Location in a given Game, with 3-per-location CHECK constraint)
+  - `TreasureQuest` — what's hidden in the stash (list of titles + reward hints)
+
+## Data prereqs — none
+
+No schema changes. Everything needed is already on the entity + existing DTOs (`SecretStashListDto`, `SecretStashDetailDto`).
+
+## Prompt for Claude Design
+
+Paste into a new project in the Ovčina org.
+
+```
+Design the SecretStash detail page at /secret-stashes/{id:int} for
+OvčinaHra — the organizer view of a single hidden cache in the LARP world.
+
+AUDIENCE & DEVICE
+Organizers, 30–60, desktop first (1440 nominal), 10" tablet secondary.
+Czech only, diacritics must render.
+
+CONTEXT (READ THIS FIRST)
+This page opens from clicking a Magic-The-Gathering-sized tile on the
+LocationDetail › Skrýše tab. Visually it should feel like "the same
+artifact, blown up". Same parchment warmth, same 5:7 portrait image,
+same Poklad pill, same restraint on decoration.
+
+PAGE SKELETON
+
+  Breadcrumb:  Tajné skrýše / {Stash Name}
+  Title strip (sticky):
+    [← zpět]  {Stash Name} (h1, Merriweather)
+    Subline: "tajná skrýš" italic muted + "v N hrách" count badge
+    Right-side actions:
+      Read mode: [Upravit] secondary · [Smazat] ghost-bordeaux
+      Edit mode: [Zrušit] secondary · [Uložit] primary
+
+  Tab strip (sticky under title):
+    Karta · Upravit · Poklady · Výskyt
+    Default: Karta.
+
+============================================================
+TAB 1 — Karta (the MTG card, large)
+============================================================
+
+A single large MTG tile (5:7, 2.5 × 3.5 in physical ratio, displayed
+at 320 × 448 px on desktop) centered in the content column with some
+parchment breathing room around it. The card composition (top → bottom):
+
+  · Image area at 5:7 (aspect-ratio:5/7, object-fit:cover) with a dark
+    parchment-brown gradient fallback when empty
+  · Bottom-of-image overlay: stash id chip top-left (#42 in JetBrains
+    Mono, dark translucent bg), 5:7 tag bottom-right
+  · Card body (parchment cream, 16 px padding):
+      - Name in Merriweather 700, forest green, 1.5rem
+      - Hairline burnt-orange separator
+      - Description paragraph — Georgia serif 1rem, line-height 1.55,
+        max 4 lines before "…" with a "Zobrazit celý popis" toggle
+      - Treasure count: "3 poklady ukryté zde" in mono muted
+
+To the right of the card (or below on narrower): "Odhalené 2× / Zatím
+neodhalené" — small organizer-note area. If none: empty.
+
+============================================================
+TAB 2 — Upravit
+============================================================
+
+DxFormLayout:
+  Název (DxTextBox, required, full width)
+  ImagePicker — EntityType="secretstashes", AspectRatio="5:7",
+    Width="260px". Centered in the form column.
+  Popis (DxMemo, Rows=5, NullText="Co je to za místo, jak je skrýš
+    utajená, co v ní může být…")
+
+Below the form:
+  Footer: Uložit (primary) / Zrušit (secondary); Smazat (ghost-
+  bordeaux) far-left, only when editing existing.
+
+NOTE: per MEMORY feedback_ovcina_card_text_sacred, do not propose
+changes to existing stash card templates without user approval — this
+form is for metadata only, never for the text of printed cards.
+
+============================================================
+TAB 3 — Poklady (treasure quests assigned to this stash)
+============================================================
+
+Grid of mini-cards, one per TreasureQuest bound to this stash. Each
+card (desktop 260 × 120 px, tablet full-width):
+
+  · Title (Merriweather 600, forest green)
+  · Difficulty badge (Start / Rozvoj hry / Střed hry / Závěr hry —
+    colored pill, existing canon)
+  · Reward summary: "💰 N grošů · ⚔ N XP" in mono — NO emoji, use
+    bi-currency-exchange + bi-star instead
+  · "Upravit" icon button → navigates to /treasures/{id}
+
+Header row: "Poklady ukryté zde (N)" + [+ Přidat poklad] primary
+button. Empty state: Drozd perch + "Tato skrýš zatím nic neukrývá."
+
+============================================================
+TAB 4 — Výskyt (where this stash appears across games)
+============================================================
+
+Table of GameSecretStash rows:
+  | Hra | Lokace | Přiřazeno | Odebrat |
+Sorted by game start date descending. Click on a row → navigates to
+that Location's detail page. "Odebrat" opens a DxPopup confirm (per
+MEMORY §D).
+
+If stash has no assignments: empty state with "+ Přiřadit ke hře"
+button opening a tiny popup (game picker + location picker).
+
+============================================================
+STATES TO RENDER (stack vertically for mockup)
+============================================================
+
+  1. Karta — populated. Example: "Hadr pod kamenem u studny",
+     description 2 paragraphs, treasure count "2 poklady".
+  2. Upravit — same stash, form populated.
+  3. Poklady — 4 treasure-quest mini-cards (one "+ Přidat" slot).
+  4. Výskyt — 3 assignments across different games.
+  5. Karta — empty state (no description, no image). Drozd perch,
+     "Napiš první popis této skrýše."
+
+ANTI-PATTERNS
+  · No emoji (bi-* icons only, per hra-ovcina-tinkerer skill).
+  · No kingdom colors on tab chips.
+  · No Drozd on populated Karta / Upravit.
+  · No text modifications to the 3 printed card templates — those are
+    sacred (MEMORY feedback_ovcina_card_text_sacred). This is metadata.
+  · Card image must render at exact 5:7 — never crop or skew.
+
+DEVEXPRESS MAPPING (for the builder)
+  · DxGrid not needed on this page. DxFormLayout for Upravit.
+  · Poklady grid is a custom CSS grid of mini-cards (NOT DxGrid).
+  · Výskyt can be a plain table or DxGrid — designer's call.
+```
+
+---
+
+## Builder addendum — SecretStash detail
+
+TARGET FILES
+- New page: `src/OvcinaHra.Client/Pages/SecretStashes/SecretStashDetail.razor` (route `/secret-stashes/{id:int}`)
+- Theme additions: append `.oh-ss-*` scoped block to `ovcinahra-theme.css`
+- Optional new component: `src/OvcinaHra.Client/Components/TreasureMiniCard.razor` for the Poklady tab
+
+DATA BINDINGS
+- Page loads `GET /api/secret-stashes/{id}` (verify endpoint exists; add if needed)
+- Výskyt tab calls `GET /api/secret-stashes/{id}/assignments` (likely needs a new endpoint)
+- Upravit uses existing `PUT /api/secret-stashes/{id}`
+- Poklady tab uses `SecretStashDetailDto.TreasureQuests[]` (verify DTO carries them)
+
+NOTES
+- MTG tile styling is already in `ovcinahra-theme.css` as `.oh-lc-tile-*` — copy/adapt into `.oh-ss-card-*` for the blown-up version, or extract common `.oh-mtg-*` base classes for reuse.
+- Do NOT edit the printed card text anywhere — if the DxMemo label says "Popis na tištěné kartě" or similar, it's metadata for the organizer's record, not the card itself.

--- a/docs/design/dialogs/secret-stash-list.md
+++ b/docs/design/dialogs/secret-stash-list.md
@@ -1,0 +1,128 @@
+# Design Brief — SecretStash grid `/secret-stashes`
+
+**Status:** v1 · 2026-04-23
+**Target surface:** Claude Design (Ovčina org, design system inherited)
+**Implementation target:** rewrite `src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor`
+
+## Why it matters
+
+Stashes are small but numerous (3 max per Location per Game, but dozens catalog-wide). The current list is a plain DxGrid with Name/Description — organizers can't see at a glance which stash is which, which are under-used, or which have no treasures assigned.
+
+## Current state
+
+- Dual mode: `/secret-stashes` (per-hra) vs `?catalog=true` (global)
+- Columns: Name · Description · (catalog) Přiřadit/Odebrat button
+- Row click opens a small edit popup
+- No visual identity — stashes look identical in the list
+
+## User decisions already locked
+
+| Decision | Value |
+|---|---|
+| Dual mode | Keep both |
+| Primary visual | **Gallery of MTG tiles** (not a traditional grid) — 5:7 portrait cards matching LocationStashTile |
+| Tile size | Small: 120 × 168 px desktop (6–8 cols), 96 × 134 px tablet (3 cols), 2 cols mobile |
+| Card content | Image · Name · small count badges (treasures / games-using) |
+| Catalog-mode toggle | Per-tile "Přiřadit ke hře" pill button overlaid |
+| Row/tile click | Navigate straight to `/secret-stashes/{id}` — tile IS the peek |
+
+## Prompt for Claude Design
+
+```
+Design the SecretStash catalog grid for OvčinaHra — organizer view of all
+hidden caches in the world. This replaces a generic table with a
+Magic-The-Gathering-style card gallery matching the tiles on
+LocationDetail › Skrýše.
+
+AUDIENCE & DEVICE
+Organizers, desktop-first, 10" tablet secondary.
+
+DUAL MODE (?catalog=true toggles)
+
+  Mode A — "Pro hru" (default)
+    Shows only stashes assigned to the currently-active game.
+    Small caption on each tile: "v N lokacích" (number of locations
+    using this stash in this game).
+
+  Mode B — "Katalog"
+    All stashes across history. Each tile has an overlay pill:
+    "Přiřadit ke hře +" (if not in current game) or "V této hře ✓"
+    (greyed, unclickable — edit from per-hra mode).
+
+LAYOUT
+
+Title strip: "Tajné skrýše" h1 · mode toggle (Pro hru / Katalog) ·
+"+ Nová skrýš" primary.
+
+Toolbar row:
+  [ Hledat… ]  [ jen s poklady ]  [ jen bez lokace ]       [ N skrýší ]
+
+Gallery: responsive CSS grid of MTG tiles.
+  · Desktop (≥1280px): 8 columns of 120 px
+  · Wide desktop (1024-1280): 6 columns of 110 px
+  · Tablet (768-1024): 3 columns
+  · Mobile (<768): 2 columns
+  · Gap: 20 px
+
+TILE COMPOSITION (5:7 portrait, 120 × 168 px desktop)
+  · Image at 5:7 top, object-fit:cover, fallback gradient
+  · Name (Merriweather 700, 0.875rem, forest green, 2-line clamp)
+  · Below name: 2 micro-chips
+      "◆ 3 poklady" (mono, amber background)
+      "⌘ 2 lokace"   (mono, sage background)
+    Replace the glyphs with bi-star-fill and bi-geo-alt-fill
+    respectively — no emoji.
+  · On hover: lift -2 px, sage-mist tint, shadow deepens
+  · On catalog mode + not assigned: bottom overlay pill "+ Přiřadit ke hře"
+    (forest green bg, white text, fades in on hover)
+  · On catalog mode + assigned: muted "✓ v této hře" pill top-right
+
+EMPTY STATE (per-hra, no assignments)
+Drozd 120×120 + "Žádné skrýše přiřazeny k této hře." +
+[Otevřít katalog] secondary link + [+ Nová skrýš] primary.
+
+CLICK BEHAVIOUR
+Tile click → navigates to /secret-stashes/{id} (full detail page).
+No quick-peek popup — the tile IS the peek.
+
+NEW-STASH MINI-POPUP
++ Nová skrýš opens a small DxPopup with three fields — Název (required),
+Popis (memo), Obrázek (ImagePicker 5:7 × 200 px). Footer CTA is
+"Uložit a otevřít" — POSTs and navigates to /secret-stashes/{newId}.
+
+STATES TO RENDER (stack vertically for mockup)
+
+  1. Per-hra, 8 stashes populated, 2 with zero treasures (visibly
+     dimmer + "0 pokladů" chip turns muted grey).
+  2. Catalog mode showing 8 stashes; 3 already in current game
+     (checkmark pills) and 5 not (hover pills visible on one).
+  3. Empty state.
+  4. New-stash mini-popup.
+
+ANTI-PATTERNS
+  · No DxGrid (this page replaces a table with a gallery).
+  · No emoji.
+  · No kingdom colors on the chips — stash tiles use neutral
+    parchment + amber Poklad accent.
+  · No description preview on tiles — name + chips only.
+```
+
+---
+
+## Builder addendum — SecretStash grid
+
+TARGET FILES
+- Rewrite `src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor` — drop DxGrid, use CSS grid of tiles
+- New component: `src/OvcinaHra.Client/Components/SecretStashGridTile.razor` — reuses `.oh-ss-card-*` styling from the detail page brief
+- Theme additions: append `.oh-ss-grid-*` rules
+- New small popup: `Components/NewSecretStashPopup.razor` — Name + Description + ImagePicker, then POST + navigate
+
+DATA BINDINGS
+- GET `/api/secret-stashes?gameId={gid}&mode={pro-hru|catalog}`
+  If the endpoint doesn't support query filters yet, extend it
+- Tile click → `NavigationManager.NavigateTo($"/secret-stashes/{id}")`
+- "+ Přiřadit ke hře" pill on catalog tile → POSTs `GameSecretStash { gameId, stashId }` with a quick location-picker flyout (or navigates to /secret-stashes/{id} › Výskyt tab)
+
+NOTES
+- LocationStashTile and this grid's tile both render 5:7 MTG tiles — extract `.oh-mtg-tile-*` common rules if the duplication hurts.
+- Dropping DxGrid means losing its LayoutKey persistence — not a problem for a gallery, but call it out in the PR.


### PR DESCRIPTION
## Summary
Recreates five documentation files lost when a worktree was reaped before they could land. All briefs inherit the Ovčina Claude Design org's design system — no token boilerplate in the prompts.

- \`docs/design/dialogs/secret-stash-list.md\` — MTG-tile gallery replacing DxGrid, 6–8 cols desktop, new-stash mini-popup with \"Uložit a otevřít\" flow
- \`docs/design/dialogs/secret-stash-detail.md\` — \`/secret-stashes/{id}\` page; 4 tabs (Karta as blown-up MTG card · Upravit · Poklady · Výskyt); honors \`feedback_ovcina_card_text_sacred\`
- \`docs/design/dialogs/monster-list.md\` — card-row bestiary (drops 13-col DxGrid); 96 px rows with 4:3 thumb + 5 stat pills + hover icons
- \`docs/design/dialogs/monster-detail.md\` — \`/monsters/{id}\`; 5 tabs including **Bojovka** presenter view with local-only HP counter
- \`.claude/restart-prompts/hra-ovcina-secret-stash-list-port.md\` — port handoff for the already-shipped Claude Design mockup; loads \`hra-ovcina-tinkerer\` skill, full acceptance criteria + PR workflow

No code. No schema. Briefs only.

## Test plan
- [x] git commit clean, no sensitive files
- [ ] Reviewer scans briefs for Czech accuracy (diacritics, pluralization hints)
- [ ] Reviewer confirms \`.claude/restart-prompts/\` is acceptable as a tracked location (or move to a gitignored spot)