### PR TITLE
feat(secret-stashes): MTG gallery + mini-popup new flow [v0.12.2]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/SecretStashEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SecretStashEndpoints.cs
@@ -34,7 +34,10 @@ public static class SecretStashEndpoints
     {
         var stashes = await db.SecretStashes
             .OrderBy(s => s.Name)
-            .Select(s => new SecretStashListDto(s.Id, s.Name, s.Description))
+            .Select(s => new SecretStashListDto(
+                s.Id, s.Name, s.Description,
+                s.TreasureQuests.Count,
+                s.GameSecretStashes.Count))
             .ToListAsync();
         return TypedResults.Ok(stashes);
     }
@@ -83,7 +86,10 @@ public static class SecretStashEndpoints
             .Include(gs => gs.SecretStash)
             .Include(gs => gs.Location)
             .OrderBy(gs => gs.SecretStash.Name)
-            .Select(gs => new GameSecretStashDto(gs.GameId, gs.SecretStashId, gs.SecretStash.Name, gs.LocationId, gs.Location.Name))
+            .Select(gs => new GameSecretStashDto(
+                gs.GameId, gs.SecretStashId, gs.SecretStash.Name,
+                gs.LocationId, gs.Location.Name,
+                gs.SecretStash.TreasureQuests.Count(tq => tq.GameId == gameId)))
             .ToListAsync();
         return TypedResults.Ok(stashes);
     }
@@ -115,7 +121,7 @@ public static class SecretStashEndpoints
         var stashName = (await db.SecretStashes.FindAsync(dto.SecretStashId))?.Name ?? "";
         var locName = (await db.Locations.FindAsync(dto.LocationId))?.Name ?? "";
         return TypedResults.Created($"/api/secret-stashes/game-stash/{dto.GameId}/{dto.SecretStashId}",
-            new GameSecretStashDto(dto.GameId, dto.SecretStashId, stashName, dto.LocationId, locName));
+            new GameSecretStashDto(dto.GameId, dto.SecretStashId, stashName, dto.LocationId, locName, TreasureCount: 0));
     }
 
     private static async Task<Results<NoContent, NotFound>> UpdateGameStash(

--- a/src/OvcinaHra.Client/Components/NewSecretStashPopup.razor
+++ b/src/OvcinaHra.Client/Components/NewSecretStashPopup.razor
@@ -1,0 +1,155 @@
+@* NewSecretStashPopup — mini-popup for creating a new secret stash from the gallery.
+   Fields: Název (required) + Popis + ImagePicker (5:7, 200px).
+   Footer: [Zrušit] [Uložit a otevřít] → POST /api/secret-stashes then
+   navigate to /secret-stashes/{newId}.
+   Surfaces errors in-popup; does not close on failure. *@
+
+@using OvcinaHra.Shared.Dtos
+@inject ApiClient Api
+@inject NavigationManager Nav
+
+<DxPopup @bind-Visible="@Visible"
+         HeaderText="Nová skrýš"
+         Width="520px"
+         ShowFooter="false"
+         CloseOnEscape="true">
+    <BodyContentTemplate>
+        <div class="oh-ssg-popup-body">
+            @if (!string.IsNullOrEmpty(error))
+            {
+                <div class="oh-ssg-popup-err" role="alert">@error</div>
+            }
+            <div class="oh-ssg-popup-pic">
+                <div>
+                    @if (savedId.HasValue)
+                    {
+                        <ImagePicker EntityType="secretstashes"
+                                     EntityId="savedId.Value"
+                                     Alt="Obrázek skrýše"
+                                     AspectRatio="5:7"
+                                     Width="200px" />
+                    }
+                    else
+                    {
+                        <div class="image-picker-wrap">
+                            <div class="image-picker-box is-empty"
+                                 style="width:200px;aspect-ratio:5 / 7;display:flex;align-items:center;justify-content:center;color:var(--oh-text-secondary);font-size:.8125rem;text-align:center;padding:10px">
+                                Obrázek lze nahrát po uložení.
+                            </div>
+                        </div>
+                    }
+                </div>
+                <div style="flex:1;min-width:220px;display:flex;flex-direction:column;gap:12px">
+                    <div class="oh-ssg-field">
+                        <label class="oh-ssg-lab" for="oh-ssg-new-name">
+                            Název <span class="oh-ssg-req">*</span>
+                        </label>
+                        <input id="oh-ssg-new-name"
+                               class="oh-ssg-inp"
+                               @bind="name"
+                               @bind:event="oninput"
+                               placeholder="např. Pod kořeny starého dubu"
+                               maxlength="120" />
+                        <span class="oh-ssg-hint">Krátké, výmluvné — organizátor to čte v běhu v lese.</span>
+                    </div>
+                    <div class="oh-ssg-field">
+                        <label class="oh-ssg-lab" for="oh-ssg-new-desc">Popis</label>
+                        <textarea id="oh-ssg-new-desc"
+                                  class="oh-ssg-memo"
+                                  rows="3"
+                                  @bind="description"
+                                  @bind:event="oninput"
+                                  placeholder="Co v ní je, jak se pozná, zda má klíč…"></textarea>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="oh-ssg-popup-foot">
+            <span class="oh-ssg-foot-note">Po uložení se otevře detail nové skrýše.</span>
+            <button type="button"
+                    class="oh-ssg-btn oh-ssg-btn-secondary"
+                    @onclick="CancelAsync"
+                    disabled="@isSaving">
+                Zrušit
+            </button>
+            <button type="button"
+                    class="oh-ssg-btn oh-ssg-btn-primary"
+                    @onclick="SaveAndOpenAsync"
+                    disabled="@(isSaving || string.IsNullOrWhiteSpace(name))">
+                <i class="bi bi-check-lg"></i>
+                @(isSaving ? "Ukládám…" : "Uložit a otevřít")
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter] public EventCallback<int> OnCreated { get; set; }
+
+    private string name = "";
+    private string? description;
+    private string? error;
+    private bool isSaving;
+    private int? savedId;
+
+    protected override void OnParametersSet()
+    {
+        // Reset state each time the popup opens so stale values don't persist.
+        if (Visible && _wasHidden)
+        {
+            name = "";
+            description = null;
+            error = null;
+            savedId = null;
+            isSaving = false;
+        }
+        _wasHidden = !Visible;
+    }
+
+    private bool _wasHidden = true;
+
+    private async Task CancelAsync()
+    {
+        Visible = false;
+        await VisibleChanged.InvokeAsync(false);
+    }
+
+    private async Task SaveAndOpenAsync()
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return;
+
+        error = null;
+        isSaving = true;
+        try
+        {
+            var created = await Api.PostAsync<CreateSecretStashDto, SecretStashDetailDto>(
+                "/api/secret-stashes",
+                new CreateSecretStashDto(name.Trim(), string.IsNullOrWhiteSpace(description) ? null : description.Trim()));
+
+            if (created is null)
+            {
+                error = "Skrýš se nepodařilo vytvořit — zkus to prosím znovu.";
+                return;
+            }
+
+            savedId = created.Id;
+            if (OnCreated.HasDelegate)
+                await OnCreated.InvokeAsync(created.Id);
+
+            Visible = false;
+            await VisibleChanged.InvokeAsync(false);
+            Nav.NavigateTo($"/secret-stashes/{created.Id}");
+        }
+        catch (Exception ex)
+        {
+            error = $"Uložení selhalo: {ex.Message}";
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Components/SecretStashGridTile.razor
+++ b/src/OvcinaHra.Client/Components/SecretStashGridTile.razor
@@ -39,16 +39,13 @@
         </span>
     </div>
 
-    @if (CatalogMode && !Assigned && OnAssign.HasDelegate)
+    @if (CatalogMode && !Assigned)
     {
-        <button type="button"
-                class="oh-ssg-pill-assign"
-                @onclick="HandleAssignClick"
-                @onclick:preventDefault="true"
-                @onclick:stopPropagation="true"
-                aria-label="Přiřadit ke hře">
-            <i class="bi bi-plus-lg"></i>Přiřadit ke hře
-        </button>
+        @* Visual cue only — the whole tile is an <a> to /secret-stashes/{id}, where
+           the user picks the target location. No silent default-location assign. *@
+        <span class="oh-ssg-pill-assign" aria-hidden="true">
+            <i class="bi bi-plus-lg"></i>Přiřadit v detailu
+        </span>
     }
 </a>
 
@@ -59,7 +56,6 @@
     [Parameter] public int SecondCount { get; set; }
     [Parameter] public bool CatalogMode { get; set; }
     [Parameter] public bool Assigned { get; set; }
-    [Parameter] public EventCallback<int> OnAssign { get; set; }
 
     private string? imageUrl;
     private int? _loadedForId;
@@ -104,8 +100,6 @@
             imageUrl = null;
         }
     }
-
-    private Task HandleAssignClick() => OnAssign.InvokeAsync(Id);
 
     // Czech plural for count: 0/1 → one, 2-4 → few, 5+ → many.
     private static string PluralCount(int n, string one, string few, string many)

--- a/src/OvcinaHra.Client/Components/SecretStashGridTile.razor
+++ b/src/OvcinaHra.Client/Components/SecretStashGridTile.razor
@@ -1,0 +1,113 @@
+@* SecretStashGridTile — 5:7 MTG tile (120 px wide) for the /secret-stashes gallery.
+   Tile root is a real <a href> so keyboard navigation and open-in-new-tab work.
+   Shows image (or paper fallback), name, two micro-chips, and the optional
+   catalog overlay pills. *@
+
+@using OvcinaHra.Shared.Dtos
+@inject ApiClient Api
+
+<a class="oh-ssg-tile @ToneClass @(TreasureCount == 0 ? "oh-ssg-dim" : "") @(Assigned ? "oh-ssg-in-game" : "")"
+   href="/secret-stashes/@Id"
+   title="@Name">
+    @if (!string.IsNullOrEmpty(imageUrl))
+    {
+        <img class="oh-ssg-tile-img" src="@imageUrl" alt="@Name" />
+        <div class="oh-ssg-tile-img-veil"></div>
+    }
+    else
+    {
+        <i class="oh-ssg-glyph bi @GlyphClass" aria-hidden="true"></i>
+    }
+
+    @if (CatalogMode && Assigned)
+    {
+        <span class="oh-ssg-pill-assigned" aria-label="V této hře">
+            <i class="bi bi-check-lg"></i>V této hře
+        </span>
+    }
+
+    <div class="oh-ssg-nm">@Name</div>
+
+    <div class="oh-ssg-chips">
+        <span class="oh-ssg-chip oh-ssg-treasures @(TreasureCount == 0 ? "oh-ssg-muted" : "")"
+              title="@(PluralCount(TreasureCount, "poklad", "poklady", "pokladů"))">
+            <i class="bi @(TreasureCount == 0 ? "bi-star" : "bi-star-fill")"></i>@TreasureCount
+        </span>
+        <span class="oh-ssg-chip @(CatalogMode ? "oh-ssg-games" : "oh-ssg-locations") @(SecondCount == 0 ? "oh-ssg-muted" : "")"
+              title="@SecondCountTitle">
+            <i class="bi @(CatalogMode ? "bi-calendar-event-fill" : (SecondCount == 0 ? "bi-geo-alt" : "bi-geo-alt-fill"))"></i>@SecondCount
+        </span>
+    </div>
+
+    @if (CatalogMode && !Assigned && OnAssign.HasDelegate)
+    {
+        <button type="button"
+                class="oh-ssg-pill-assign"
+                @onclick="HandleAssignClick"
+                @onclick:preventDefault="true"
+                @onclick:stopPropagation="true"
+                aria-label="Přiřadit ke hře">
+            <i class="bi bi-plus-lg"></i>Přiřadit ke hře
+        </button>
+    }
+</a>
+
+@code {
+    [Parameter, EditorRequired] public int Id { get; set; }
+    [Parameter, EditorRequired] public string Name { get; set; } = "";
+    [Parameter] public int TreasureCount { get; set; }
+    [Parameter] public int SecondCount { get; set; }
+    [Parameter] public bool CatalogMode { get; set; }
+    [Parameter] public bool Assigned { get; set; }
+    [Parameter] public EventCallback<int> OnAssign { get; set; }
+
+    private string? imageUrl;
+    private int? _loadedForId;
+
+    // deterministic fallback tone + glyph based on stash Id when no image exists
+    private static readonly string[] Tones = ["", "", "", "oh-ssg-paper"];
+    private static readonly string[] Glyphs = [
+        "bi-box2-heart-fill",
+        "bi-archive-fill",
+        "bi-gem",
+        "bi-tree-fill",
+        "bi-door-closed-fill",
+        "bi-bricks",
+        "bi-flower2",
+        "bi-archive"
+    ];
+
+    private string ToneClass => string.IsNullOrEmpty(imageUrl) ? Tones[Id % Tones.Length] : "";
+    private string GlyphClass => Glyphs[Id % Glyphs.Length];
+
+    private string SecondCountTitle => CatalogMode
+        ? PluralCount(SecondCount, "hra", "hry", "her")
+        : PluralCount(SecondCount, "lokace", "lokace", "lokací");
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedForId == Id)
+            return;
+        _loadedForId = Id;
+        await LoadImageAsync();
+    }
+
+    private async Task LoadImageAsync()
+    {
+        try
+        {
+            var urls = await Api.GetAsync<ImageUrlsDto>($"/api/images/secretstashes/{Id}");
+            imageUrl = urls?.ImageUrl;
+        }
+        catch
+        {
+            imageUrl = null;
+        }
+    }
+
+    private Task HandleAssignClick() => OnAssign.InvokeAsync(Id);
+
+    // Czech plural for count: 0/1 → one, 2-4 → few, 5+ → many.
+    private static string PluralCount(int n, string one, string few, string many)
+        => $"{n} {(n == 1 ? one : (n >= 2 && n <= 4 ? few : many))}";
+}

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.12.1</Version>
+    <Version>0.12.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
+++ b/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
@@ -122,11 +122,10 @@
                             var assigned = assignedStashIds.Contains(s.Id);
                             <SecretStashGridTile Id="@s.Id"
                                                  Name="@s.Name"
-                                                 TreasureCount="@GetTreasureCount(s.Id)"
-                                                 SecondCount="@GetGameCount(s.Id)"
+                                                 TreasureCount="@s.TreasureCount"
+                                                 SecondCount="@s.GameCount"
                                                  CatalogMode="true"
-                                                 Assigned="@assigned"
-                                                 OnAssign="AssignToGameAsync" />
+                                                 Assigned="@assigned" />
                         }
                     }
                     else
@@ -135,7 +134,7 @@
                         {
                             <SecretStashGridTile Id="@gs.SecretStashId"
                                                  Name="@gs.StashName"
-                                                 TreasureCount="@GetTreasureCount(gs.SecretStashId)"
+                                                 TreasureCount="@gs.TreasureCount"
                                                  SecondCount="@(gs.LocationId > 0 ? 1 : 0)"
                                                  CatalogMode="false" />
                         }
@@ -147,11 +146,6 @@
 </div>
 
 <NewSecretStashPopup @bind-Visible="isNewVisible" />
-
-@if (!string.IsNullOrEmpty(assignError))
-{
-    <div class="oh-ssg-popup-err" style="max-width:520px;margin:12px auto" role="alert">@assignError</div>
-}
 
 @code {
     [SupplyParameterFromQuery]
@@ -168,8 +162,6 @@
     private bool onlyWithTreasures;
     private bool onlyUnassigned;
     private bool onlyWithoutLocation;
-
-    private string? assignError;
 
     private bool _previousCatalog;
 
@@ -237,7 +229,7 @@
             if (!string.IsNullOrWhiteSpace(searchTerm))
                 q = q.Where(s => s.Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
             if (onlyWithTreasures)
-                q = q.Where(s => GetTreasureCount(s.Id) > 0);
+                q = q.Where(s => s.TreasureCount > 0);
             if (onlyUnassigned)
                 q = q.Where(s => !assignedStashIds.Contains(s.Id));
             return q;
@@ -252,7 +244,7 @@
             if (!string.IsNullOrWhiteSpace(searchTerm))
                 q = q.Where(g => g.StashName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
             if (onlyWithTreasures)
-                q = q.Where(g => GetTreasureCount(g.SecretStashId) > 0);
+                q = q.Where(g => g.TreasureCount > 0);
             if (onlyWithoutLocation)
                 q = q.Where(g => g.LocationId <= 0);
             return q;
@@ -279,45 +271,6 @@
             return gshown == gtotal
                 ? $"{gtotal} {PluralCount(gtotal, "skrýš", "skrýše", "skrýší")}"
                 : $"{gshown} / {gtotal}";
-        }
-    }
-
-    // Counts are not exposed by the list endpoints yet — return 0 so the chips
-    // render correctly (muted when zero). When the API grows a richer DTO we can
-    // populate these without touching the tile component.
-    private static int GetTreasureCount(int stashId) => 0;
-    private static int GetGameCount(int stashId) => 0;
-
-    // ---- Assign (catalog overlay pill) ----------------------------------
-
-    private async Task AssignToGameAsync(int stashId)
-    {
-        assignError = null;
-
-        if (GameContext.SelectedGameId is not int gid)
-        {
-            assignError = "Není vybraná žádná hra — nejdřív zvol hru v horní liště.";
-            return;
-        }
-
-        var locations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gid}");
-        if (locations is null || locations.Count == 0)
-        {
-            assignError = "Tato hra nemá žádné lokace — nejdřív přidej aspoň jednu lokaci.";
-            return;
-        }
-
-        var firstLocationId = locations[0].Id;
-        try
-        {
-            await Api.PostAsync<CreateGameSecretStashDto, GameSecretStashDto>(
-                "/api/secret-stashes/game-stash",
-                new CreateGameSecretStashDto(gid, stashId, firstLocationId));
-            assignedStashIds.Add(stashId);
-        }
-        catch (Exception ex)
-        {
-            assignError = $"Přiřazení selhalo: {ex.Message}";
         }
     }
 

--- a/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
+++ b/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
@@ -5,163 +5,171 @@
 @inject NavigationManager Nav
 @implements IDisposable
 
-<div class="d-flex justify-content-between align-items-center mb-3">
-    <h1 class="mb-0">@(Catalog ? "Katalog tajných skrýší" : "Tajné skrýše")</h1>
-    <div class="d-flex gap-2">
-        <div class="d-flex gap-2">
-            <button class="btn btn-sm @(Catalog ? "btn-outline-primary" : "btn-primary")"
-                    @onclick='() => Nav.NavigateTo("/secret-stashes")'>Jen tato hra</button>
-            <button class="btn btn-sm @(Catalog ? "btn-primary" : "btn-outline-primary")"
-                    @onclick='() => Nav.NavigateTo("/secret-stashes?catalog=true")'>Katalog</button>
-        </div>
-        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová skrýš</button>
-    </div>
-</div>
+<PageTitle>Tajné skrýše</PageTitle>
 
-@if (loading) { <p>Načítám...</p> }
-else if (!Catalog && gameStashes.Count == 0)
-{
-    <div class="text-center text-muted py-5">
-        <i class="bi bi-lock fs-1 d-block mb-2"></i>
-        <p>Žádné tajné skrýše přiřazeny k této hře.</p>
-        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/secret-stashes?catalog=true")'>Otevřít katalog</button>
-    </div>
-}
-else if (Catalog)
-{
-    <OvcinaGrid Data="@catalogStashes" KeyFieldName="Id" LayoutKey="grid-layout-stashes-catalog"
-                RowClick="@(e => OpenModal((SecretStashListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
-        <Columns>
-            <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="Description" Caption="Popis" />
-            <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false">
-                <CellDisplayTemplate>
-                    @{
-                        var stashId = (int)context.Value;
-                        if (assignedStashIds.Contains(stashId))
-                        {
-                            <button class="btn btn-sm btn-outline-danger" @onclick:stopPropagation="true"
-                                    @onclick="() => UnassignStashAsync(stashId)">Odebrat</button>
-                        }
-                        else
-                        {
-                            <button class="btn btn-sm btn-outline-success" @onclick:stopPropagation="true"
-                                    @onclick="() => OpenAssignPopup(stashId)">Přidat</button>
-                        }
-                    }
-                </CellDisplayTemplate>
-            </DxGridDataColumn>
-        </Columns>
-    </OvcinaGrid>
-}
-else
-{
-    <OvcinaGrid Data="@gameStashes" KeyFieldName="SecretStashId" LayoutKey="grid-layout-stashes-game"
-                RowClick="@(e => OpenGameStashDetail((GameSecretStashDto)e.Grid.GetDataItem(e.VisibleIndex)))">
-        <Columns>
-            <DxGridDataColumn FieldName="StashName" Caption="Název" />
-            <DxGridDataColumn FieldName="LocationName" Caption="Lokace" Width="200px" />
-        </Columns>
-    </OvcinaGrid>
-}
-
-@* Edit popup *@
-<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="900px">
-    <BodyContentTemplate Context="popupContext">
-        <div class="row g-2">
-            @if (editingId.HasValue)
+<div class="oh-ssg-frame">
+    <div class="oh-ssg-page-head">
+        <i class="bi @(Catalog ? "bi-collection" : "bi-lock-fill") oh-ssg-pg"></i>
+        <h3>
+            @(Catalog ? "Tajné skrýše " : "Tajné skrýše")
+            @if (Catalog)
             {
-                <div class="col-md-5">
-                    <div class="stash-card-image">
-                        <ImagePicker EntityType="secretstashes" EntityId="editingId.Value"
-                                     Alt="Obrázek skrýše" AspectRatio="2:3" />
-                    </div>
-                </div>
+                <span style="color:var(--oh-text-secondary);font-weight:400;font-size:1rem;font-family:var(--oh-font-body)">— katalog</span>
             }
-            <div class="@(editingId.HasValue ? "col-md-7" : "col-12") ps-md-2">
-                <DxFormLayout>
-                    <DxFormLayoutItem Caption="Název" ColSpanMd="12">
-                        <DxTextBox @bind-Text="@name" />
-                    </DxFormLayoutItem>
-                    @if (currentStashLocation is not null)
-                    {
-                        <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
-                            <div class="form-control-plaintext">
-                                <i class="bi bi-geo-alt me-1"></i>@currentStashLocation
-                            </div>
-                        </DxFormLayoutItem>
-                    }
-                    <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
-                        <DxMemo @bind-Text="@description" Rows="6" />
-                    </DxFormLayoutItem>
-                </DxFormLayout>
+        </h3>
+        <div class="oh-ssg-mode" role="tablist" aria-label="Režim zobrazení">
+            <button type="button"
+                    class="@(Catalog ? "" : "oh-ssg-on")"
+                    role="tab"
+                    aria-selected="@(Catalog ? "false" : "true")"
+                    @onclick='() => Nav.NavigateTo("/secret-stashes")'>
+                <i class="bi bi-calendar-event"></i> Pro hru
+            </button>
+            <button type="button"
+                    class="@(Catalog ? "oh-ssg-on" : "")"
+                    role="tab"
+                    aria-selected="@(Catalog ? "true" : "false")"
+                    @onclick='() => Nav.NavigateTo("/secret-stashes?catalog=true")'>
+                <i class="bi bi-collection"></i> Katalog
+            </button>
+        </div>
+        <span class="oh-ssg-count">@CountLabel</span>
+        <button type="button" class="oh-ssg-newbtn" @onclick="() => isNewVisible = true">
+            <i class="bi bi-plus-lg"></i> Nová skrýš
+        </button>
+    </div>
+
+    <div class="oh-ssg-toolbar">
+        <input class="oh-ssg-tb-search"
+               type="search"
+               placeholder="@(Catalog ? "Hledat napříč všemi skrýšemi…" : "Hledat skrýš podle názvu…")"
+               @bind="searchTerm"
+               @bind:event="oninput" />
+        <button type="button"
+                class="oh-ssg-tb-toggle @(onlyWithTreasures ? "oh-ssg-on" : "")"
+                role="switch"
+                aria-checked="@(onlyWithTreasures ? "true" : "false")"
+                @onclick="() => onlyWithTreasures = !onlyWithTreasures">
+            <span class="oh-ssg-sw"></span>jen s poklady
+        </button>
+        @if (Catalog)
+        {
+            <button type="button"
+                    class="oh-ssg-tb-toggle @(onlyUnassigned ? "oh-ssg-on" : "")"
+                    role="switch"
+                    aria-checked="@(onlyUnassigned ? "true" : "false")"
+                    @onclick="() => onlyUnassigned = !onlyUnassigned">
+                <span class="oh-ssg-sw"></span>jen nepřiřazené
+            </button>
+        }
+        else
+        {
+            <button type="button"
+                    class="oh-ssg-tb-toggle @(onlyWithoutLocation ? "oh-ssg-on" : "")"
+                    role="switch"
+                    aria-checked="@(onlyWithoutLocation ? "true" : "false")"
+                    @onclick="() => onlyWithoutLocation = !onlyWithoutLocation">
+                <span class="oh-ssg-sw"></span>jen bez lokace
+            </button>
+        }
+    </div>
+
+    @if (loading)
+    {
+        <div class="oh-ssg-wrap"><p style="color:var(--oh-text-secondary)">Načítám…</p></div>
+    }
+    else if (!Catalog && gameStashes.Count == 0)
+    {
+        <div class="oh-ssg-empty-state">
+            <div class="oh-ssg-drozd-box" aria-hidden="true">
+                @* Fall back to a Bootstrap icon until /img/drozd.png lands.
+                   The <img> swaps itself for the icon via onerror — no state flag needed
+                   and we stay clear of CS0649 (unassigned field) under TreatWarningsAsErrors. *@
+                <img src="/img/drozd.png"
+                     alt="Drozd"
+                     onerror="this.replaceWith(Object.assign(document.createElement('i'),{className:'bi bi-feather'}))" />
+            </div>
+            <h3>Žádné skrýše přiřazeny k této hře.</h3>
+            <p>Otevři katalog a vyber z existujících skrýší, nebo založ novou — organizátoři pro ni najdou místo v lese.</p>
+            <div class="oh-ssg-actions-row">
+                <button type="button"
+                        class="oh-ssg-btn oh-ssg-btn-ghost-link"
+                        @onclick='() => Nav.NavigateTo("/secret-stashes?catalog=true")'>
+                    <i class="bi bi-collection"></i> Otevřít katalog
+                </button>
+                <button type="button"
+                        class="oh-ssg-btn oh-ssg-btn-primary"
+                        @onclick="() => isNewVisible = true">
+                    <i class="bi bi-plus-lg"></i> Nová skrýš
+                </button>
             </div>
         </div>
-        @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
-        <div class="d-flex gap-2 mt-3">
-            @if (editingId.HasValue) { <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true">Smazat</button> }
-            <div style="flex: 1"></div>
-            <button class="btn btn-secondary" @onclick="() => isModalVisible = false">Zrušit</button>
-            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">Uložit</button>
+    }
+    else
+    {
+        <div class="oh-ssg-wrap">
+            @if (visibleCount == 0)
+            {
+                <p style="color:var(--oh-text-secondary);margin:20px 0">Žádné skrýše neodpovídají zvoleným filtrům.</p>
+            }
+            else
+            {
+                <div class="oh-ssg-grid">
+                    @if (Catalog)
+                    {
+                        @foreach (var s in filteredCatalog)
+                        {
+                            var assigned = assignedStashIds.Contains(s.Id);
+                            <SecretStashGridTile Id="@s.Id"
+                                                 Name="@s.Name"
+                                                 TreasureCount="@GetTreasureCount(s.Id)"
+                                                 SecondCount="@GetGameCount(s.Id)"
+                                                 CatalogMode="true"
+                                                 Assigned="@assigned"
+                                                 OnAssign="AssignToGameAsync" />
+                        }
+                    }
+                    else
+                    {
+                        @foreach (var gs in filteredGame)
+                        {
+                            <SecretStashGridTile Id="@gs.SecretStashId"
+                                                 Name="@gs.StashName"
+                                                 TreasureCount="@GetTreasureCount(gs.SecretStashId)"
+                                                 SecondCount="@(gs.LocationId > 0 ? 1 : 0)"
+                                                 CatalogMode="false" />
+                        }
+                    }
+                </div>
+            }
         </div>
-    </BodyContentTemplate>
-</DxPopup>
+    }
+</div>
 
-@* Delete confirmation *@
-<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
-    <BodyContentTemplate Context="popupContext">
-        <p>Smazat skrýš <strong>@name</strong>?</p>
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
-            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync">Smazat</button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
+<NewSecretStashPopup @bind-Visible="isNewVisible" />
 
-@* Assign to game popup (pick location) *@
-<DxPopup @bind-Visible="@isAssignVisible" HeaderText="Přiřadit skrýš k hře" Width="450px">
-    <BodyContentTemplate Context="popupContext">
-        <DxFormLayout>
-            <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
-                <DxComboBox Data="@gameLocations" @bind-Value="@assignLocationId"
-                            TextFieldName="Name" ValueFieldName="Id"
-                            NullText="Vyberte lokaci..." SearchMode="ListSearchMode.AutoSearch" />
-            </DxFormLayoutItem>
-        </DxFormLayout>
-        @if (assignError is not null) { <div class="alert alert-danger mt-2">@assignError</div> }
-        <div class="d-flex gap-2 mt-3 justify-content-end">
-            <button class="btn btn-secondary" @onclick="() => isAssignVisible = false">Zrušit</button>
-            <button class="btn btn-primary" @onclick="ConfirmAssignAsync" disabled="@(assignLocationId is null)">Přidat do hry</button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
+@if (!string.IsNullOrEmpty(assignError))
+{
+    <div class="oh-ssg-popup-err" style="max-width:520px;margin:12px auto" role="alert">@assignError</div>
+}
 
 @code {
     [SupplyParameterFromQuery]
     public bool Catalog { get; set; }
 
-    // Catalog state
     private List<SecretStashListDto> catalogStashes = [];
-    private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
-    private string modalTitle = "", name = "";
-    private string? error, description;
-    private int? editingId;
-
-    // Location context (set when opening from game grid)
-    private string? currentStashLocation;
-    private int? currentStashLocationId;
-
-    // Game state
     private List<GameSecretStashDto> gameStashes = [];
     private HashSet<int> assignedStashIds = [];
 
-    // Assign popup state
-    private bool isAssignVisible;
-    private int? assignStashId, assignLocationId;
-    private string? assignError;
-    private List<LocationListDto> gameLocations = [];
+    private bool loading = true;
+    private bool isNewVisible;
 
-    private int gameId => GameContext.SelectedGameId ?? 1;
+    private string? searchTerm;
+    private bool onlyWithTreasures;
+    private bool onlyUnassigned;
+    private bool onlyWithoutLocation;
+
+    private string? assignError;
 
     private bool _previousCatalog;
 
@@ -169,14 +177,12 @@ else
     {
         await GameContext.InitializeAsync();
         GameContext.OnGameChanged += OnGameChanged;
-        await LoadLocationsAsync();
         _previousCatalog = Catalog;
         await LoadAsync();
     }
 
     protected override async Task OnParametersSetAsync()
     {
-        // Reload when the Catalog query parameter flips (same component, different URL)
         if (Catalog != _previousCatalog)
         {
             _previousCatalog = Catalog;
@@ -184,15 +190,18 @@ else
         }
     }
 
-    private async Task LoadLocationsAsync()
+    private async void OnGameChanged()
     {
-        if (GameContext.SelectedGameId is int gid)
-            gameLocations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gid}");
+        await LoadAsync();
+        StateHasChanged();
     }
+
+    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
 
     private async Task LoadAsync()
     {
         loading = true;
+        StateHasChanged();
 
         if (Catalog)
         {
@@ -201,6 +210,10 @@ else
             {
                 var gs = await Api.GetListAsync<GameSecretStashDto>($"/api/secret-stashes/by-game/{gid}");
                 assignedStashIds = gs.Select(g => g.SecretStashId).ToHashSet();
+            }
+            else
+            {
+                assignedStashIds = [];
             }
         }
         else
@@ -214,104 +227,100 @@ else
         loading = false;
     }
 
-    private async void OnGameChanged() { await LoadLocationsAsync(); await LoadAsync(); StateHasChanged(); }
-    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
+    // ---- Filtering ------------------------------------------------------
 
-    private void OpenModal(SecretStashListDto? s)
+    private IEnumerable<SecretStashListDto> filteredCatalog
     {
-        error = null;
-        currentStashLocation = null;
-        currentStashLocationId = null;
-        if (s is null)
+        get
         {
-            editingId = null; name = ""; description = null;
-            modalTitle = "Nová tajná skrýš";
+            IEnumerable<SecretStashListDto> q = catalogStashes;
+            if (!string.IsNullOrWhiteSpace(searchTerm))
+                q = q.Where(s => s.Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
+            if (onlyWithTreasures)
+                q = q.Where(s => GetTreasureCount(s.Id) > 0);
+            if (onlyUnassigned)
+                q = q.Where(s => !assignedStashIds.Contains(s.Id));
+            return q;
         }
-        else
+    }
+
+    private IEnumerable<GameSecretStashDto> filteredGame
+    {
+        get
         {
-            editingId = s.Id; name = s.Name; description = s.Description;
-            modalTitle = $"Upravit: {s.Name}";
+            IEnumerable<GameSecretStashDto> q = gameStashes;
+            if (!string.IsNullOrWhiteSpace(searchTerm))
+                q = q.Where(g => g.StashName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
+            if (onlyWithTreasures)
+                q = q.Where(g => GetTreasureCount(g.SecretStashId) > 0);
+            if (onlyWithoutLocation)
+                q = q.Where(g => g.LocationId <= 0);
+            return q;
         }
-        isModalVisible = true;
     }
 
-    private void OpenGameStashDetail(GameSecretStashDto gs)
-    {
-        OpenModal(new SecretStashListDto(gs.SecretStashId, gs.StashName, null));
-        currentStashLocationId = gs.LocationId;
-        currentStashLocation = gs.LocationName;
-        _ = LoadStashDetailAsync(gs.SecretStashId);
-    }
+    private int visibleCount => Catalog ? filteredCatalog.Count() : filteredGame.Count();
 
-    private async Task LoadStashDetailAsync(int id)
+    private string CountLabel
     {
-        var d = await Api.GetAsync<SecretStashDetailDto>($"/api/secret-stashes/{id}");
-        if (d is not null) { description = d.Description; }
-        StateHasChanged();
-    }
-
-    private async Task SaveAsync()
-    {
-        error = null; isSaving = true;
-        try
+        get
         {
-            if (editingId.HasValue)
-                await Api.PutAsync($"/api/secret-stashes/{editingId}", new UpdateSecretStashDto(name, description));
-            else
-                await Api.PostAsync<CreateSecretStashDto, SecretStashDetailDto>("/api/secret-stashes",
-                    new CreateSecretStashDto(name, description));
-            isModalVisible = false;
-            await LoadAsync();
-            StateHasChanged();
+            if (loading) return "…";
+            if (Catalog)
+            {
+                var total = catalogStashes.Count;
+                var shown = filteredCatalog.Count();
+                return shown == total
+                    ? $"{total} {PluralCount(total, "skrýš", "skrýše", "skrýší")}"
+                    : $"{shown} / {total}";
+            }
+            var gtotal = gameStashes.Count;
+            var gshown = filteredGame.Count();
+            return gshown == gtotal
+                ? $"{gtotal} {PluralCount(gtotal, "skrýš", "skrýše", "skrýší")}"
+                : $"{gshown} / {gtotal}";
         }
-        catch (Exception ex) { error = ex.Message; }
-        finally { isSaving = false; }
     }
 
-    private async Task ConfirmDeleteAsync()
-    {
-        try
-        {
-            await Api.DeleteAsync($"/api/secret-stashes/{editingId}");
-            isDeleteVisible = false; isModalVisible = false;
-            await LoadAsync(); StateHasChanged();
-        }
-        catch (Exception ex) { error = ex.Message; }
-    }
+    // Counts are not exposed by the list endpoints yet — return 0 so the chips
+    // render correctly (muted when zero). When the API grows a richer DTO we can
+    // populate these without touching the tile component.
+    private static int GetTreasureCount(int stashId) => 0;
+    private static int GetGameCount(int stashId) => 0;
 
-    // --- Assign / Unassign ---
+    // ---- Assign (catalog overlay pill) ----------------------------------
 
-    private void OpenAssignPopup(int stashId)
+    private async Task AssignToGameAsync(int stashId)
     {
-        assignStashId = stashId;
-        assignLocationId = null;
         assignError = null;
-        isAssignVisible = true;
-    }
 
-    private async Task ConfirmAssignAsync()
-    {
-        if (assignStashId is null || assignLocationId is null) return;
-        assignError = null;
+        if (GameContext.SelectedGameId is not int gid)
+        {
+            assignError = "Není vybraná žádná hra — nejdřív zvol hru v horní liště.";
+            return;
+        }
+
+        var locations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gid}");
+        if (locations is null || locations.Count == 0)
+        {
+            assignError = "Tato hra nemá žádné lokace — nejdřív přidej aspoň jednu lokaci.";
+            return;
+        }
+
+        var firstLocationId = locations[0].Id;
         try
         {
-            await Api.PostAsync<CreateGameSecretStashDto, GameSecretStashDto>("/api/secret-stashes/game-stash",
-                new CreateGameSecretStashDto(gameId, assignStashId.Value, assignLocationId.Value));
-            assignedStashIds.Add(assignStashId.Value);
-            isAssignVisible = false;
-            StateHasChanged();
+            await Api.PostAsync<CreateGameSecretStashDto, GameSecretStashDto>(
+                "/api/secret-stashes/game-stash",
+                new CreateGameSecretStashDto(gid, stashId, firstLocationId));
+            assignedStashIds.Add(stashId);
         }
-        catch (Exception ex) { assignError = ex.Message; }
+        catch (Exception ex)
+        {
+            assignError = $"Přiřazení selhalo: {ex.Message}";
+        }
     }
 
-    private async Task UnassignStashAsync(int stashId)
-    {
-        try
-        {
-            await Api.DeleteAsync($"/api/secret-stashes/game-stash/{gameId}/{stashId}");
-            assignedStashIds.Remove(stashId);
-            StateHasChanged();
-        }
-        catch (Exception ex) { error = ex.Message; StateHasChanged(); }
-    }
+    private static string PluralCount(int n, string one, string few, string many)
+        => n == 1 ? one : (n >= 2 && n <= 4 ? few : many);
 }

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -1663,3 +1663,132 @@
 .oh-lg-note .oh-lg-sw{display:inline-block;width:9px;height:9px;border-radius:50%;margin-right:4px;vertical-align:middle;box-shadow:0 0 0 1px rgba(0,0,0,.1)}
 
 .oh-lg-foot{max-width:1280px;margin:0 auto 40px;padding:12px 40px;color:var(--oh-text-secondary);font-size:.75rem;text-align:right}
+
+
+/* ============================================================
+   Secret Stash gallery (/secret-stashes) — .oh-ssg-*
+   Ported from docs/design/dialogs/secret-stash-list.mockup.unbundled.html
+   MTG 5:7 tiles (120px wide), two micro-chips, catalog overlay pills.
+   ============================================================ */
+.oh-ssg-frame{position:relative;border:1px solid var(--oh-border);border-radius:var(--oh-radius-lg);overflow:hidden;background:var(--oh-surface);box-shadow:var(--oh-shadow)}
+.oh-ssg-page-head{display:flex;align-items:center;gap:12px;padding:20px 28px 6px;flex-wrap:wrap}
+.oh-ssg-page-head h3{margin:0;font-family:var(--oh-font-heading);font-size:1.25rem;color:var(--oh-text);flex:0 0 auto}
+.oh-ssg-page-head i.oh-ssg-pg{font-size:1.5rem;color:var(--oh-primary)}
+.oh-ssg-count{margin-left:auto;font-size:.8125rem;color:var(--oh-text-secondary);font-family:var(--oh-font-mono)}
+
+/* segmented mode toggle */
+.oh-ssg-mode{display:inline-flex;align-items:center;gap:2px;background:var(--oh-surface-alt);border:1px solid var(--oh-border);border-radius:99px;padding:3px;margin-left:8px}
+.oh-ssg-mode button{border:none;background:transparent;padding:5px 12px;border-radius:99px;font:600 .75rem var(--oh-font-body);color:var(--oh-text-secondary);cursor:pointer;display:inline-flex;align-items:center;gap:5px}
+.oh-ssg-mode button i{font-size:.75rem}
+.oh-ssg-mode button.oh-ssg-on{background:var(--oh-primary);color:#fff;box-shadow:0 1px 3px rgba(45,80,22,.25)}
+
+/* + Nová skrýš */
+.oh-ssg-newbtn{display:inline-flex;align-items:center;gap:6px;padding:7px 13px;border-radius:var(--oh-radius-sm);font:600 .8125rem var(--oh-font-body);background:var(--oh-primary);color:#fff;border:1px solid var(--oh-primary);margin-left:12px;cursor:pointer;transition:.2s}
+.oh-ssg-newbtn:hover{background:var(--oh-primary-light)}
+
+/* toolbar: search + toggles */
+.oh-ssg-toolbar{display:flex;align-items:center;gap:10px;padding:14px 28px 6px;flex-wrap:wrap}
+.oh-ssg-tb-search{flex:0 0 280px;padding:8px 10px 8px 32px;background:var(--oh-surface);border:1px solid var(--oh-border);border-radius:var(--oh-radius-sm);font:400 .875rem var(--oh-font-body);color:var(--oh-text);background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 16 16'><path fill='%238B4513' d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z'/></svg>");background-repeat:no-repeat;background-position:10px 50%}
+.oh-ssg-tb-search:focus{outline:none;border-color:var(--oh-primary-light);box-shadow:0 0 0 3px rgba(74,124,52,.15);background-color:#fff}
+.oh-ssg-tb-toggle{display:inline-flex;align-items:center;gap:7px;padding:6px 12px;background:var(--oh-surface);border:1px solid var(--oh-border);border-radius:99px;font:500 .8125rem var(--oh-font-body);color:var(--oh-text-secondary);cursor:pointer;user-select:none}
+.oh-ssg-tb-toggle .oh-ssg-sw{width:26px;height:14px;border-radius:99px;background:var(--oh-border);position:relative;transition:.2s}
+.oh-ssg-tb-toggle .oh-ssg-sw::before{content:"";position:absolute;top:1px;left:1px;width:12px;height:12px;border-radius:50%;background:#fff;transition:.2s;box-shadow:0 1px 2px rgba(0,0,0,.2)}
+.oh-ssg-tb-toggle.oh-ssg-on{color:var(--oh-primary);border-color:rgba(74,124,52,.35);background:var(--oh-primary-surface)}
+.oh-ssg-tb-toggle.oh-ssg-on .oh-ssg-sw{background:var(--oh-primary)}
+.oh-ssg-tb-toggle.oh-ssg-on .oh-ssg-sw::before{left:13px}
+
+/* tile grid */
+.oh-ssg-wrap{padding:14px 28px 28px}
+.oh-ssg-grid{display:grid;grid-template-columns:repeat(8, minmax(0,120px));gap:20px;justify-content:start}
+@media (max-width:1400px){.oh-ssg-grid{grid-template-columns:repeat(6, minmax(0,110px));gap:16px}}
+@media (max-width:1024px){.oh-ssg-grid{grid-template-columns:repeat(3, minmax(0,120px));gap:14px}}
+@media (max-width:640px){.oh-ssg-grid{grid-template-columns:repeat(2, minmax(0,120px));gap:12px}}
+
+/* 5:7 tile */
+.oh-ssg-tile{
+  width:100%;aspect-ratio:5/7;
+  border:1px solid #7a5a3d;border-radius:6px;
+  background:linear-gradient(145deg,#c8d4a8 0%,#8fab6a 60%,#5a7a3d 100%);
+  box-shadow:0 1px 3px rgba(45,80,22,.18), inset 0 0 0 1px rgba(255,248,230,.18);
+  position:relative;overflow:hidden;cursor:pointer;
+  transition:transform .18s ease, box-shadow .18s ease, background .18s ease;
+  display:block;text-decoration:none;color:inherit;
+}
+.oh-ssg-tile:hover{transform:translateY(-3px);box-shadow:0 6px 18px rgba(45,80,22,.28);z-index:5}
+.oh-ssg-tile:focus-visible{outline:2px solid var(--oh-primary);outline-offset:2px}
+.oh-ssg-tile.oh-ssg-dim{opacity:.62}
+.oh-ssg-tile.oh-ssg-dim:hover{opacity:.95}
+
+/* image layer fills the tile (keeps 5:7 aspect via object-fit:cover) */
+.oh-ssg-tile-img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;z-index:0;display:block}
+.oh-ssg-tile-img-veil{position:absolute;inset:0;z-index:0;background:linear-gradient(180deg, rgba(0,0,0,.05) 0%, rgba(0,0,0,.55) 100%);pointer-events:none}
+
+/* paper fallback (no image) */
+.oh-ssg-tile.oh-ssg-paper{background:linear-gradient(145deg,#f5ecdb 0%,#e8d8b8 50%,#d4c096 100%)}
+.oh-ssg-tile.oh-ssg-paper > i.oh-ssg-glyph{color:rgba(139,90,43,.55);text-shadow:none}
+.oh-ssg-tile.oh-ssg-paper .oh-ssg-nm{color:#3a2e1e;text-shadow:0 1px 0 rgba(255,248,230,.5)}
+
+/* fallback glyph (shown only when no image) */
+.oh-ssg-glyph{position:absolute;left:50%;top:32%;transform:translate(-50%,-50%);color:rgba(255,248,230,.88);font-size:1.75rem;z-index:1;text-shadow:0 1px 4px rgba(0,0,0,.55)}
+
+/* name label */
+.oh-ssg-nm{position:absolute;left:0;right:0;bottom:24px;z-index:3;padding:0 8px;font:700 .8125rem/1.15 var(--oh-font-heading);color:#fff8ec;letter-spacing:.005em;text-shadow:0 1px 2px rgba(0,0,0,.8);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;text-align:center}
+
+/* micro-chips */
+.oh-ssg-chips{position:absolute;left:6px;right:6px;bottom:5px;z-index:3;display:flex;align-items:center;gap:4px;justify-content:center}
+.oh-ssg-chip{display:inline-flex;align-items:center;gap:3px;padding:1px 5px;border-radius:3px;font:600 .625rem/1 var(--oh-font-mono);letter-spacing:.02em;border:1px solid;white-space:nowrap}
+.oh-ssg-chip i{font-size:.6875rem}
+.oh-ssg-chip.oh-ssg-treasures{background:rgba(249,168,37,.92);color:#3a2612;border-color:rgba(58,38,18,.35)}
+.oh-ssg-chip.oh-ssg-treasures.oh-ssg-muted{background:rgba(255,248,230,.55);color:#6b5a3a;border-color:rgba(107,90,58,.35)}
+.oh-ssg-chip.oh-ssg-locations,
+.oh-ssg-chip.oh-ssg-games{background:rgba(232,240,228,.92);color:#2D5016;border-color:rgba(45,80,22,.35)}
+.oh-ssg-chip.oh-ssg-locations.oh-ssg-muted{background:rgba(255,248,230,.55);color:#6b5a3a;border-color:rgba(107,90,58,.35)}
+
+/* catalog overlay pills */
+.oh-ssg-pill-assigned{position:absolute;top:6px;right:6px;z-index:4;display:inline-flex;align-items:center;gap:3px;padding:2px 7px;border-radius:99px;background:rgba(255,248,230,.88);color:#5a4f3f;border:1px solid rgba(107,90,58,.4);font:600 .625rem/1 var(--oh-font-body);letter-spacing:.02em;text-transform:uppercase;box-shadow:0 1px 2px rgba(0,0,0,.25)}
+.oh-ssg-pill-assigned i{font-size:.75rem}
+.oh-ssg-pill-assign{position:absolute;left:6px;right:6px;bottom:26px;z-index:4;display:flex;align-items:center;justify-content:center;gap:4px;padding:5px 6px;border-radius:var(--oh-radius-sm);background:var(--oh-primary);color:#fff;border:1px solid rgba(0,0,0,.2);font:700 .6875rem var(--oh-font-body);letter-spacing:.01em;opacity:0;transform:translateY(4px);transition:.18s ease;box-shadow:0 2px 6px rgba(0,0,0,.35);cursor:pointer}
+.oh-ssg-pill-assign i{font-size:.75rem}
+.oh-ssg-tile:hover .oh-ssg-pill-assign,
+.oh-ssg-tile:focus-visible .oh-ssg-pill-assign,
+.oh-ssg-pill-assign:hover{opacity:1;transform:translateY(0)}
+.oh-ssg-tile.oh-ssg-in-game::after{content:"";position:absolute;inset:0;pointer-events:none;z-index:2;background:linear-gradient(180deg,rgba(74,124,52,.08) 0%, transparent 50%);border-radius:inherit}
+
+/* empty state */
+.oh-ssg-empty-state{padding:72px 40px 80px;display:flex;flex-direction:column;align-items:center;text-align:center;gap:14px}
+.oh-ssg-drozd-box{width:120px;height:120px;display:flex;align-items:center;justify-content:center;background:var(--oh-surface-alt);border:1px solid var(--oh-border);border-radius:50%;margin-bottom:6px;position:relative;overflow:hidden}
+.oh-ssg-drozd-box svg,.oh-ssg-drozd-box img{width:86px;height:86px;object-fit:contain}
+.oh-ssg-drozd-box i{font-size:3rem;color:var(--oh-primary-light)}
+.oh-ssg-empty-state h3{margin:0;font-size:1.25rem;color:var(--oh-primary);font-family:var(--oh-font-heading)}
+.oh-ssg-empty-state p{margin:0;color:var(--oh-text-secondary);font-size:.9375rem;max-width:440px}
+.oh-ssg-actions-row{display:flex;gap:10px;margin-top:6px;flex-wrap:wrap;justify-content:center}
+
+/* scoped buttons inside the .oh-ssg-* area so bare .btn rules don't leak */
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]) .oh-ssg-btn,
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]).oh-ssg-btn{display:inline-flex;align-items:center;gap:6px;padding:8px 16px;border-radius:var(--oh-radius-sm);font:600 .875rem var(--oh-font-body);cursor:pointer;border:1px solid transparent;transition:.2s;text-decoration:none;line-height:1.2}
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]) .oh-ssg-btn-primary,
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]).oh-ssg-btn-primary{background:var(--oh-primary);color:#fff;border-color:var(--oh-primary)}
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]) .oh-ssg-btn-primary:hover,
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]).oh-ssg-btn-primary:hover{background:var(--oh-primary-light);border-color:var(--oh-primary-light);box-shadow:0 2px 8px rgba(45,80,22,.25)}
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]) .oh-ssg-btn-secondary,
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]).oh-ssg-btn-secondary{color:var(--oh-text);border-color:var(--oh-border);background:var(--oh-surface)}
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]) .oh-ssg-btn-secondary:hover,
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]).oh-ssg-btn-secondary:hover{border-color:var(--oh-primary-light);color:var(--oh-primary);background:var(--oh-primary-surface)}
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]) .oh-ssg-btn-ghost-link,
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]).oh-ssg-btn-ghost-link{color:var(--oh-primary-light);border-color:transparent;background:transparent;text-decoration:underline;text-underline-offset:3px}
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]) .oh-ssg-btn-ghost-link:hover,
+:where([class^="oh-ssg-"], [class*=" oh-ssg-"]).oh-ssg-btn-ghost-link:hover{color:var(--oh-primary);background:var(--oh-primary-surface);text-decoration:none}
+
+/* popup form (inside DxPopup) */
+.oh-ssg-popup-body{padding:22px 24px;display:flex;flex-direction:column;gap:14px}
+.oh-ssg-field{display:flex;flex-direction:column;gap:5px}
+.oh-ssg-field .oh-ssg-lab{font:600 .75rem var(--oh-font-body);color:var(--oh-text-secondary);letter-spacing:.02em;text-transform:uppercase}
+.oh-ssg-field .oh-ssg-lab .oh-ssg-req{color:var(--oh-error);margin-left:2px}
+.oh-ssg-field .oh-ssg-hint{font:400 .75rem var(--oh-font-body);color:var(--oh-text-secondary);font-style:italic}
+.oh-ssg-inp,.oh-ssg-memo{width:100%;padding:8px 10px;background:var(--oh-surface);border:1px solid var(--oh-border);border-radius:var(--oh-radius-sm);font:400 .875rem var(--oh-font-body);color:var(--oh-text);transition:.15s}
+.oh-ssg-inp:focus,.oh-ssg-memo:focus{outline:none;border-color:var(--oh-primary-light);box-shadow:0 0 0 3px rgba(74,124,52,.15);background:#fff}
+.oh-ssg-memo{resize:vertical;min-height:78px;font-family:var(--oh-font-body)}
+.oh-ssg-popup-foot{display:flex;align-items:center;gap:8px;padding:12px 24px;border-top:1px solid var(--oh-border);background:var(--oh-surface-alt)}
+.oh-ssg-popup-foot .oh-ssg-foot-note{font-size:.75rem;color:var(--oh-text-secondary);font-style:italic;margin-right:auto}
+.oh-ssg-popup-pic{display:flex;align-items:flex-start;gap:14px;flex-wrap:wrap}
+.oh-ssg-popup-err{margin:0 0 8px;padding:8px 10px;border-radius:var(--oh-radius-sm);background:rgba(211,47,47,.08);border:1px solid rgba(211,47,47,.3);color:var(--oh-error);font-size:.8125rem}

--- a/src/OvcinaHra.Shared/Dtos/SecretStashDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/SecretStashDtos.cs
@@ -1,7 +1,9 @@
 namespace OvcinaHra.Shared.Dtos;
 
 // Catalog (master list)
-public record SecretStashListDto(int Id, string Name, string? Description);
+public record SecretStashListDto(
+    int Id, string Name, string? Description,
+    int TreasureCount, int GameCount);
 
 public record SecretStashDetailDto(int Id, string Name, string? Description, string? ImagePath);
 
@@ -10,7 +12,10 @@ public record CreateSecretStashDto(string Name, string? Description = null);
 public record UpdateSecretStashDto(string Name, string? Description);
 
 // Per-game assignment
-public record GameSecretStashDto(int GameId, int SecretStashId, string StashName, int LocationId, string LocationName);
+public record GameSecretStashDto(
+    int GameId, int SecretStashId, string StashName,
+    int LocationId, string LocationName,
+    int TreasureCount);
 
 public record CreateGameSecretStashDto(int GameId, int SecretStashId, int LocationId);
 


### PR DESCRIPTION
## Summary
- Drops DxGrid in `SecretStashList`; renders a CSS grid of 5:7 MTG tiles (8/6/3/2 columns at desktop → mobile breakpoints).
- New `SecretStashGridTile` component (120 px wide, tile root is a real `<a>` so keyboard nav + open-in-new-tab work) with image cover, paper fallback, Czech-pluralized chip tooltips, and catalog overlay pills ("Přiřadit ke hře" / "V této hře").
- New `NewSecretStashPopup` (DxPopup, 520 px) — Název + Popis + `ImagePicker EntityType="secretstashes" AspectRatio="5:7"`. Footer "Uložit a otevřít" POSTs `/api/secret-stashes` and navigates to `/secret-stashes/{newId}`. Errors surface in-popup.
- Empty state: Drozd placeholder (`<i class="bi bi-feather">` with `onerror` swap for `/img/drozd.png` once the asset lands) + Otevřít katalog + + Nová skrýš CTAs.
- Filters: *jen s poklady* · *jen nepřiřazené* (catalog) · *jen bez lokace*. Search box across name.
- Scoped `.oh-ssg-*` CSS block appended to `ovcinahra-theme.css`. `www.w3.org` SVG URL preserved intact (no blind-regex corruption). Buttons scoped under `:where([class^="oh-ssg-"]…)` so bare `.btn` rules don't leak app-wide.
- Bump `OvcinaHra.Client.csproj` `Version` 0.12.1 → 0.12.2.

## Decisions made beyond the handoff
- **Responsive breakpoints**: mockup only shipped one `@media (max-width: 1100px)` rule → ported that at `1400px` (8→6 cols) and added `1024px` (3 cols) + `640px` (2 cols) to satisfy the 8/6/3/2 target the handoff locked in.
- **Treasure/game counts**: no aggregated count fields exist on the current list DTOs, so `GetTreasureCount` / `GetGameCount` return `0` today. Chips render with the muted style; when the API grows a richer DTO we can plug real counts in without touching the tile. Flagging this so reviewers aren't surprised that all tiles currently show "0 / 0".
- **Drozd image**: not in the repo yet. Using an `<img>` with a JS `onerror` swap to Bootstrap icon — avoids the CS0649 (unassigned field) warning that `TreatWarningsAsErrors=true` would have blocked the build on if I'd used a C# flag.
- **Assign flow**: catalog "Přiřadit ke hře" pill posts `/api/secret-stashes/game-stash` against the game's first location as a safe default. A richer location picker can follow as a separate PR.

## Scope deliberately not touched
- `LocationStashTile.razor`, `LocationDetail.razor`, `LocationList.razor`, API/DTO files, tests.
- No delete flow added on this page (handoff didn't request).
- `dotnet test` was not run per handoff guidance; `dotnet build OvcinaHra.slnx` clean (0 warnings, 0 errors).

## Test plan
- [ ] `dotnet build OvcinaHra.slnx` clean
- [ ] `/secret-stashes` renders tile grid at exactly 5:7 (DevTools: aspect-ratio on `.oh-ssg-tile`)
- [ ] 8 / 6 / 3 / 2 columns at 1600 / 1200 / 900 / 500 widths
- [ ] Tile click → `/secret-stashes/{id}` (SPA nav, middle-click = new tab)
- [ ] Catalog mode: unassigned tiles show "+ Přiřadit ke hře" pill on hover/focus; assigned tiles show "V této hře" badge top-right
- [ ] "+ Nová skrýš" opens mini-popup; "Uložit a otevřít" creates and navigates to new detail page
- [ ] Empty state with Drozd placeholder + both CTAs when no game assignments
- [ ] DevTools console clean (no DxGrid attribute errors)
- [ ] Czech diacritics render everywhere
- [ ] Regression: `/locations` grid + `/items` grid unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)