### PR TITLE
feat(locations): tighten Upravit layout [v0.12.2]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.12.1</Version>
+    <Version>0.12.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -197,19 +197,30 @@ else
             </div>
 
             <div class="oh-lc-sect">
-                <div class="oh-lc-sect-label"><i class="bi bi-geo-alt"></i> GPS</div>
-                <div class="oh-lc-gps-block">
-                    <div class="oh-lc-gps-row">
-                        <DxFormLayout>
-                            <DxFormLayoutItem Caption="Latitude" ColSpanMd="12">
-                                <DxTextBox @bind-Text="@latitudeStr" NullText="např. 49,4543192" />
-                            </DxFormLayoutItem>
-                            <DxFormLayoutItem Caption="Longitude" ColSpanMd="12">
-                                <DxTextBox @bind-Text="@longitudeStr" NullText="např. 18,0203280" />
-                            </DxFormLayoutItem>
-                        </DxFormLayout>
-                    </div>
-                    <div>
+                <div class="oh-lc-sect-label"><i class="bi bi-card-text"></i> Obsah</div>
+                <DxFormLayout>
+                    <DxFormLayoutItem Caption="Popis (pro kartu)" ColSpanMd="12">
+                        <DxMemo @bind-Text="@description" Rows="4" NullText="Čtenářský popis lokace…" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Detaily (pravidlové poznámky)" ColSpanMd="12">
+                        <DxMemo @bind-Text="@details" Rows="5" NullText="Pravidlové poznámky, vazby…" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Herní potenciál" ColSpanMd="12">
+                        <DxMemo @bind-Text="@gamePotential" Rows="3" NullText="Co lokace nabízí hrám…" />
+                    </DxFormLayoutItem>
+                </DxFormLayout>
+            </div>
+
+            <div class="oh-lc-sect">
+                <div class="oh-lc-sect-label"><i class="bi bi-geo-alt"></i> Mapa a vizuál</div>
+                <div class="oh-lc-mv-gps">
+                    <label>Lat</label>
+                    <DxTextBox @bind-Text="@latitudeStr" NullText="49,4543192" CssClass="oh-lc-mv-gps-input" />
+                    <label>Lon</label>
+                    <DxTextBox @bind-Text="@longitudeStr" NullText="18,0203280" CssClass="oh-lc-mv-gps-input" />
+                </div>
+                <div class="oh-lc-mv-row">
+                    <div class="oh-lc-mv-col oh-lc-mv-map-col">
                         @if (HasGps)
                         {
                             <div class="oh-lc-gps-map" id="oh-lc-gps-map-@Id"
@@ -223,42 +234,21 @@ else
                         else
                         {
                             <div class="oh-lc-gps-map-empty">
-                                <span><i class="bi bi-geo"></i> Nastav souřadnice vlevo, mini-mapa se objeví.</span>
+                                <span><i class="bi bi-geo"></i> Nastav souřadnice nahoře, mini-mapa se objeví.</span>
                             </div>
                         }
                     </div>
-                </div>
-            </div>
-
-            <div class="oh-lc-sect">
-                <div class="oh-lc-sect-label"><i class="bi bi-image"></i> Vizuál</div>
-                <div class="oh-lc-visual-slots">
-                    <div>
+                    <div class="oh-lc-mv-col">
                         <small class="text-muted d-block mb-1">Hlavní obrázek (1:1)</small>
                         <ImagePicker EntityType="locations" EntityId="@Id"
-                                     AspectRatio="1:1" Width="280px" Alt="Hlavní obrázek" />
+                                     AspectRatio="1:1" Width="240px" Alt="Hlavní obrázek" />
                     </div>
-                    <div>
+                    <div class="oh-lc-mv-col">
                         <small class="text-muted d-block mb-1">Fotka umístění (4:3)</small>
                         <ImagePicker EntityType="locations" EntityId="@Id" Field="placement"
-                                     AspectRatio="4:3" Width="360px" Alt="Fotka umístění" />
+                                     AspectRatio="4:3" Width="280px" Alt="Fotka umístění" />
                     </div>
                 </div>
-            </div>
-
-            <div class="oh-lc-sect">
-                <div class="oh-lc-sect-label"><i class="bi bi-card-text"></i> Obsah</div>
-                <DxFormLayout>
-                    <DxFormLayoutItem Caption="Popis (pro kartu)" ColSpanMd="12">
-                        <DxMemo @bind-Text="@description" Rows="4" NullText="Čtenářský popis lokace…" />
-                    </DxFormLayoutItem>
-                    <DxFormLayoutItem Caption="Detaily (pravidlové poznámky)" ColSpanMd="12">
-                        <DxMemo @bind-Text="@details" Rows="5" NullText="Pravidlové poznámky, vazby…" />
-                    </DxFormLayoutItem>
-                    <DxFormLayoutItem Caption="Herní potenciál" ColSpanMd="12">
-                        <DxMemo @bind-Text="@gamePotential" Rows="3" NullText="Co lokace nabízí hrám…" />
-                    </DxFormLayoutItem>
-                </DxFormLayout>
             </div>
 
             <div class="oh-lc-sect">

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -1056,7 +1056,43 @@
 }
 .oh-lc-gps-map-footer .oh-lc-gps-coords { font-family: var(--oh-font-mono); }
 
-/* --- Upravit: image slot pair (main 1:1, placement 4:3) --- */
+/* --- Upravit: Mapa a vizuál — compact GPS row above 3-column map+images row --- */
+.oh-lc-mv-gps {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    align-items: center;
+    margin-bottom: 14px;
+    font-size: 0.8125rem;
+}
+.oh-lc-mv-gps > label {
+    color: var(--oh-text-secondary);
+    margin-bottom: 0;
+    min-width: 24px;
+    font-weight: 500;
+}
+.oh-lc-mv-gps .oh-lc-mv-gps-input { width: 170px; }
+.oh-lc-mv-gps .oh-lc-mv-gps-input input {
+    font-family: var(--oh-font-mono);
+    font-size: 0.8125rem;
+}
+.oh-lc-mv-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    align-items: flex-start;
+}
+.oh-lc-mv-col { flex: 0 0 auto; }
+.oh-lc-mv-map-col {
+    flex: 1 1 240px;
+    min-width: 240px;
+    max-width: 280px;
+}
+@media (max-width: 820px) {
+    .oh-lc-mv-map-col { max-width: none; }
+}
+
+/* --- Upravit: image slot pair (main 1:1, placement 4:3) — legacy, kept for any callers --- */
 .oh-lc-visual-slots {
     display: grid;
     grid-template-columns: auto auto;


### PR DESCRIPTION
## Summary
Reorder + compact the Location **Upravit** tab so the first screen isn't empty.

- **Order:** Identita → Obsah → Mapa a vizuál → Organizační (Obsah moves up from the bottom; Organizační drops below everything).
- **Mapa a vizuál** is a single combined section now:
  - Top: compact horizontal GPS row (Lat / Lon, mono inputs, small font). These rarely change after creation, so they stop occupying a full section.
  - Below: one flex row with the map, the main 1:1 image and the 4:3 placement photo side by side. Image widths trimmed (240 / 280 px) so three columns fit on desktop and wrap cleanly below 820 px.

## Why
The previous layout floated the mini-map right of the GPS inputs in a dedicated 2-column section, then started Vizuál on the next row, then Obsah lower down. On a wide viewport this produced a tall empty gap under the tabs before any content appeared.

## Test plan
- [x] Build clean, 0 warnings
- [ ] Smoke: open any location → Upravit → verify Obsah is the first thing below Identita; map + both images sit on one row on desktop; narrow viewport wraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)