### PR TITLE
feat(images): inline SAS URLs in list DTOs [v0.13.0]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Dtos;
 
@@ -26,33 +27,52 @@ public static class BuildingEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<BuildingListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<BuildingListDto>>> GetAll(WorldDbContext db, IBlobStorageService blob)
     {
-        var buildings = await db.Buildings
-            .Include(b => b.Location)
+        var rows = await db.Buildings
             .OrderBy(b => b.Name)
-            .Select(b => new BuildingListDto(
-                b.Id, b.Name, b.Description, b.Notes,
-                b.LocationId, b.Location != null ? b.Location.Name : null, b.IsPrebuilt))
+            .Select(b => new
+            {
+                b.Id,
+                b.Name,
+                b.Description,
+                b.Notes,
+                b.LocationId,
+                LocationName = b.Location != null ? b.Location.Name : null,
+                b.IsPrebuilt,
+                b.ImagePath
+            })
             .ToListAsync();
+        var buildings = rows.Select(r => new BuildingListDto(
+            r.Id, r.Name, r.Description, r.Notes,
+            r.LocationId, r.LocationName, r.IsPrebuilt,
+            ImagePath: r.ImagePath,
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath))).ToList();
         return TypedResults.Ok(buildings);
     }
 
-    private static async Task<Ok<List<BuildingListDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<BuildingListDto>>> GetByGame(int gameId, WorldDbContext db, IBlobStorageService blob)
     {
-        var buildings = await db.GameBuildings
+        var rows = await db.GameBuildings
             .Where(gb => gb.GameId == gameId)
-            .Include(gb => gb.Building).ThenInclude(b => b.Location)
             .OrderBy(gb => gb.Building.Name)
-            .Select(gb => new BuildingListDto(
+            .Select(gb => new
+            {
                 gb.Building.Id,
                 gb.Building.Name,
                 gb.Building.Description,
                 gb.Building.Notes,
                 gb.Building.LocationId,
-                gb.Building.Location != null ? gb.Building.Location.Name : null,
-                gb.Building.IsPrebuilt))
+                LocationName = gb.Building.Location != null ? gb.Building.Location.Name : null,
+                gb.Building.IsPrebuilt,
+                gb.Building.ImagePath
+            })
             .ToListAsync();
+        var buildings = rows.Select(r => new BuildingListDto(
+            r.Id, r.Name, r.Description, r.Notes,
+            r.LocationId, r.LocationName, r.IsPrebuilt,
+            ImagePath: r.ImagePath,
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath))).ToList();
         return TypedResults.Ok(buildings);
     }
 

--- a/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
@@ -33,7 +33,7 @@ public static class CharacterEndpoints
             : $"{c.PlayerFirstName} {c.PlayerLastName}".Trim();
 
     private static async Task<Ok<List<CharacterListDto>>> GetAll(
-        WorldDbContext db, string? search = null, int? gameId = null)
+        WorldDbContext db, IBlobStorageService blob, string? search = null, int? gameId = null)
     {
         var query = db.Characters.AsQueryable();
 
@@ -63,7 +63,9 @@ public static class CharacterEndpoints
                 kingdomByCharacter.TryGetValue(c.Id, out var k);
                 return new CharacterListDto(
                     c.Id, c.Name, FullName(c), c.Race, c.IsPlayedCharacter, c.ExternalPersonId,
-                    k.KingdomId == 0 ? null : k.KingdomId, k.Name, k.HexColor);
+                    k.KingdomId == 0 ? null : k.KingdomId, k.Name, k.HexColor,
+                    ImagePath: c.ImagePath,
+                    ImageUrl: string.IsNullOrWhiteSpace(c.ImagePath) ? null : blob.GetSasUrl(c.ImagePath));
             })
             .ToList());
     }

--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Domain.ValueObjects;
@@ -34,16 +35,32 @@ public static class ItemEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<ItemListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<ItemListDto>>> GetAll(WorldDbContext db, IBlobStorageService blob)
     {
-        var items = await db.Items
+        var rows = await db.Items
             .OrderBy(i => i.Name)
-            .Select(i => new ItemListDto(
-                i.Id, i.Name, i.ItemType, i.Effect, i.PhysicalForm, i.IsCraftable,
-                i.ClassRequirements.Warrior, i.ClassRequirements.Archer,
-                i.ClassRequirements.Mage, i.ClassRequirements.Thief,
-                i.IsUnique, i.IsLimited, i.ImagePath))
+            .Select(i => new
+            {
+                i.Id,
+                i.Name,
+                i.ItemType,
+                i.Effect,
+                i.PhysicalForm,
+                i.IsCraftable,
+                ReqWarrior = i.ClassRequirements.Warrior,
+                ReqArcher = i.ClassRequirements.Archer,
+                ReqMage = i.ClassRequirements.Mage,
+                ReqThief = i.ClassRequirements.Thief,
+                i.IsUnique,
+                i.IsLimited,
+                i.ImagePath
+            })
             .ToListAsync();
+        var items = rows.Select(r => new ItemListDto(
+            r.Id, r.Name, r.ItemType, r.Effect, r.PhysicalForm, r.IsCraftable,
+            r.ReqWarrior, r.ReqArcher, r.ReqMage, r.ReqThief,
+            r.IsUnique, r.IsLimited, r.ImagePath,
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath))).ToList();
         return TypedResults.Ok(items);
     }
 
@@ -100,7 +117,7 @@ public static class ItemEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Ok<List<GameItemListDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<GameItemListDto>>> GetByGame(int gameId, WorldDbContext db, IBlobStorageService blob)
     {
         var gameItems = await db.GameItems
             .Where(gi => gi.GameId == gameId)
@@ -129,7 +146,8 @@ public static class ItemEndpoints
                 gi.Item.ClassRequirements.Mage, gi.Item.ClassRequirements.Thief,
                 gi.Item.IsUnique, gi.Item.IsLimited, gi.Item.ImagePath,
                 gi.GameId, gi.Price, gi.StockCount, gi.IsSold, gi.SaleCondition, gi.IsFindable,
-                summaryByItemId.GetValueOrDefault(gi.ItemId)))
+                summaryByItemId.GetValueOrDefault(gi.ItemId),
+                ImageUrl: string.IsNullOrWhiteSpace(gi.Item.ImagePath) ? null : blob.GetSasUrl(gi.Item.ImagePath)))
             .ToList();
 
         return TypedResults.Ok(result);

--- a/src/OvcinaHra.Api/Endpoints/KingdomEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/KingdomEndpoints.cs
@@ -41,7 +41,7 @@ public static class KingdomEndpoints
         var kingdoms = rows.Select(r => new KingdomDto(
             r.Id, r.Name, r.HexColor, r.BadgeImageUrl, r.Description, r.SortOrder,
             r.AssignmentCount,
-            ImageUrl: string.IsNullOrWhiteSpace(r.BadgeImageUrl) ? null : blob.GetSasUrl(r.BadgeImageUrl))).ToList();
+            BadgeImageSasUrl: string.IsNullOrWhiteSpace(r.BadgeImageUrl) ? null : blob.GetSasUrl(r.BadgeImageUrl))).ToList();
 
         return TypedResults.Ok(kingdoms);
     }

--- a/src/OvcinaHra.Api/Endpoints/KingdomEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/KingdomEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Dtos;
 
@@ -20,15 +21,27 @@ public static class KingdomEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<KingdomDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<KingdomDto>>> GetAll(WorldDbContext db, IBlobStorageService blob)
     {
-        var kingdoms = await db.Kingdoms
+        var rows = await db.Kingdoms
             .OrderBy(k => k.SortOrder)
             .ThenBy(k => k.Name)
-            .Select(k => new KingdomDto(
-                k.Id, k.Name, k.HexColor, k.BadgeImageUrl, k.Description, k.SortOrder,
-                k.Assignments.Count))
+            .Select(k => new
+            {
+                k.Id,
+                k.Name,
+                k.HexColor,
+                k.BadgeImageUrl,
+                k.Description,
+                k.SortOrder,
+                AssignmentCount = k.Assignments.Count
+            })
             .ToListAsync();
+
+        var kingdoms = rows.Select(r => new KingdomDto(
+            r.Id, r.Name, r.HexColor, r.BadgeImageUrl, r.Description, r.SortOrder,
+            r.AssignmentCount,
+            ImageUrl: string.IsNullOrWhiteSpace(r.BadgeImageUrl) ? null : blob.GetSasUrl(r.BadgeImageUrl))).ToList();
 
         return TypedResults.Ok(kingdoms);
     }

--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.ValueObjects;
 using OvcinaHra.Shared.Dtos;
@@ -27,21 +28,40 @@ public static class LocationEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<LocationListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<LocationListDto>>> GetAll(WorldDbContext db, IBlobStorageService blob)
     {
-        var locations = await db.Locations
+        var rows = await db.Locations
             .OrderBy(l => l.Name)
-            .Select(l => new LocationListDto(
-                l.Id, l.Name, l.LocationKind,
+            .Select(l => new
+            {
+                l.Id,
+                l.Name,
+                l.LocationKind,
                 l.Region,
-                l.Coordinates != null ? l.Coordinates.Latitude : (decimal?)null,
-                l.Coordinates != null ? l.Coordinates.Longitude : (decimal?)null,
+                Latitude = l.Coordinates != null ? l.Coordinates.Latitude : (decimal?)null,
+                Longitude = l.Coordinates != null ? l.Coordinates.Longitude : (decimal?)null,
                 l.ParentLocationId,
-                l.Description, l.Details, l.GamePotential, l.NpcInfo, l.SetupNotes,
-                Array.Empty<LocationStashDto>(),
-                Array.Empty<LocationQuestDto>(),
-                Array.Empty<LocationTreasureQuestDto>()))
+                l.Description,
+                l.Details,
+                l.GamePotential,
+                l.NpcInfo,
+                l.SetupNotes,
+                l.ImagePath
+            })
             .ToListAsync();
+
+        var locations = rows.Select(r => new LocationListDto(
+            r.Id, r.Name, r.LocationKind,
+            r.Region,
+            r.Latitude,
+            r.Longitude,
+            r.ParentLocationId,
+            r.Description, r.Details, r.GamePotential, r.NpcInfo, r.SetupNotes,
+            Array.Empty<LocationStashDto>(),
+            Array.Empty<LocationQuestDto>(),
+            Array.Empty<LocationTreasureQuestDto>(),
+            ImagePath: r.ImagePath,
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath))).ToList();
 
         return TypedResults.Ok(locations);
     }
@@ -126,32 +146,43 @@ public static class LocationEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Ok<List<LocationListDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<LocationListDto>>> GetByGame(int gameId, WorldDbContext db, IBlobStorageService blob)
     {
-        var dtos = await db.Locations
+        var rows = await db.Locations
             .Where(l => l.GameLocations.Any(gl => gl.GameId == gameId))
             .OrderBy(l => l.Name)
-            .Select(l => new LocationListDto(
-                l.Id, l.Name, l.LocationKind,
+            .Select(l => new
+            {
+                l.Id,
+                l.Name,
+                l.LocationKind,
                 l.Region,
-                l.Coordinates != null ? l.Coordinates.Latitude : (decimal?)null,
-                l.Coordinates != null ? l.Coordinates.Longitude : (decimal?)null,
+                Latitude = l.Coordinates != null ? l.Coordinates.Latitude : (decimal?)null,
+                Longitude = l.Coordinates != null ? l.Coordinates.Longitude : (decimal?)null,
                 l.ParentLocationId,
-                l.Description, l.Details, l.GamePotential, l.NpcInfo, l.SetupNotes,
-                Stashes: l.GameSecretStashes
+                l.Description,
+                l.Details,
+                l.GamePotential,
+                l.NpcInfo,
+                l.SetupNotes,
+                l.ImagePath,
+                Stashes = l.GameSecretStashes
                     .Where(gss => gss.GameId == gameId)
                     .OrderBy(gss => gss.SecretStash.Name)
-                    .Select(gss => new LocationStashDto(
-                        gss.SecretStashId,
-                        gss.SecretStash.Name,
-                        gss.SecretStash.TreasureQuests
+                    .Select(gss => new
+                    {
+                        SecretStashId = gss.SecretStashId,
+                        StashName = gss.SecretStash.Name,
+                        StashImagePath = gss.SecretStash.ImagePath,
+                        TreasureQuests = gss.SecretStash.TreasureQuests
                             .Where(tq => tq.GameId == gameId)
                             .OrderBy(tq => tq.Title)
                             .ThenBy(tq => tq.Id)
                             .Select(tq => new LocationTreasureQuestDto(tq.Id, tq.Title, tq.Clue, tq.Difficulty))
-                            .ToList()))
+                            .ToList()
+                    })
                     .ToList(),
-                Quests: l.QuestLocations
+                Quests = l.QuestLocations
                     .Where(ql => ql.Quest.GameId == null || ql.Quest.GameId == gameId)
                     .OrderBy(ql => ql.Quest.Name)
                     .Select(ql => new LocationQuestDto(
@@ -168,14 +199,32 @@ public static class LocationEndpoints
                             .Select(qr => new LocationQuestRewardItemDto(qr.ItemId, qr.Item.Name, qr.Quantity))
                             .ToList()))
                     .ToList(),
-                LocationTreasureQuests: l.TreasureQuests
+                LocationTreasureQuests = l.TreasureQuests
                     .Where(tq => tq.GameId == gameId)
                     .OrderBy(tq => tq.Title)
                     .ThenBy(tq => tq.Id)
                     .Select(tq => new LocationTreasureQuestDto(tq.Id, tq.Title, tq.Clue, tq.Difficulty))
                     .ToList()
-            ))
+            })
             .ToListAsync();
+
+        var dtos = rows.Select(r => new LocationListDto(
+            r.Id, r.Name, r.LocationKind,
+            r.Region,
+            r.Latitude,
+            r.Longitude,
+            r.ParentLocationId,
+            r.Description, r.Details, r.GamePotential, r.NpcInfo, r.SetupNotes,
+            Stashes: r.Stashes.Select(s => new LocationStashDto(
+                s.SecretStashId,
+                s.StashName,
+                s.TreasureQuests,
+                ImagePath: s.StashImagePath,
+                ImageUrl: string.IsNullOrWhiteSpace(s.StashImagePath) ? null : blob.GetSasUrl(s.StashImagePath))).ToList(),
+            Quests: r.Quests,
+            LocationTreasureQuests: r.LocationTreasureQuests,
+            ImagePath: r.ImagePath,
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath))).ToList();
 
         return TypedResults.Ok(dtos);
     }

--- a/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.ValueObjects;
 using OvcinaHra.Shared.Dtos;
@@ -38,17 +39,37 @@ public static class MonsterEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<MonsterListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<MonsterListDto>>> GetAll(WorldDbContext db, IBlobStorageService blob)
     {
-        var monsters = await db.Monsters
+        var rows = await db.Monsters
             .OrderBy(m => m.Name)
-            .Select(m => new MonsterListDto(
-                m.Id, m.Name, m.MonsterType, m.Category,
-                m.Stats.Attack, m.Stats.Defense, m.Stats.Health,
-                m.RewardXp, m.RewardMoney,
-                m.Abilities, m.AiBehavior, m.RewardNotes, m.Notes,
-                m.MonsterTags.OrderBy(mt => mt.Tag.Name).Select(mt => mt.Tag.Name).ToList()))
+            .Select(m => new
+            {
+                m.Id,
+                m.Name,
+                m.MonsterType,
+                m.Category,
+                m.Stats.Attack,
+                m.Stats.Defense,
+                m.Stats.Health,
+                m.RewardXp,
+                m.RewardMoney,
+                m.Abilities,
+                m.AiBehavior,
+                m.RewardNotes,
+                m.Notes,
+                TagNames = m.MonsterTags.OrderBy(mt => mt.Tag.Name).Select(mt => mt.Tag.Name).ToList(),
+                m.ImagePath
+            })
             .ToListAsync();
+        var monsters = rows.Select(r => new MonsterListDto(
+            r.Id, r.Name, r.MonsterType, r.Category,
+            r.Attack, r.Defense, r.Health,
+            r.RewardXp, r.RewardMoney,
+            r.Abilities, r.AiBehavior, r.RewardNotes, r.Notes,
+            r.TagNames,
+            ImagePath: r.ImagePath,
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath))).ToList();
         return TypedResults.Ok(monsters);
     }
 

--- a/src/OvcinaHra.Api/Endpoints/SecretStashEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SecretStashEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Dtos;
 
@@ -30,15 +31,25 @@ public static class SecretStashEndpoints
 
     // --- Catalog ---
 
-    private static async Task<Ok<List<SecretStashListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<SecretStashListDto>>> GetAll(WorldDbContext db, IBlobStorageService blob)
     {
-        var stashes = await db.SecretStashes
+        var rows = await db.SecretStashes
             .OrderBy(s => s.Name)
-            .Select(s => new SecretStashListDto(
-                s.Id, s.Name, s.Description,
-                s.TreasureQuests.Count,
-                s.GameSecretStashes.Count))
+            .Select(s => new
+            {
+                s.Id,
+                s.Name,
+                s.Description,
+                TreasureCount = s.TreasureQuests.Count,
+                GameCount = s.GameSecretStashes.Count,
+                s.ImagePath
+            })
             .ToListAsync();
+        var stashes = rows.Select(r => new SecretStashListDto(
+            r.Id, r.Name, r.Description,
+            r.TreasureCount, r.GameCount,
+            ImagePath: r.ImagePath,
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath))).ToList();
         return TypedResults.Ok(stashes);
     }
 
@@ -79,23 +90,33 @@ public static class SecretStashEndpoints
 
     // --- Per-game assignment ---
 
-    private static async Task<Ok<List<GameSecretStashDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<GameSecretStashDto>>> GetByGame(int gameId, WorldDbContext db, IBlobStorageService blob)
     {
-        var stashes = await db.GameSecretStashes
+        var rows = await db.GameSecretStashes
             .Where(gs => gs.GameId == gameId)
-            .Include(gs => gs.SecretStash)
-            .Include(gs => gs.Location)
             .OrderBy(gs => gs.SecretStash.Name)
-            .Select(gs => new GameSecretStashDto(
-                gs.GameId, gs.SecretStashId, gs.SecretStash.Name,
-                gs.LocationId, gs.Location.Name,
-                gs.SecretStash.TreasureQuests.Count(tq => tq.GameId == gameId)))
+            .Select(gs => new
+            {
+                gs.GameId,
+                gs.SecretStashId,
+                StashName = gs.SecretStash.Name,
+                gs.LocationId,
+                LocationName = gs.Location.Name,
+                TreasureCount = gs.SecretStash.TreasureQuests.Count(tq => tq.GameId == gameId),
+                StashImagePath = gs.SecretStash.ImagePath
+            })
             .ToListAsync();
+        var stashes = rows.Select(r => new GameSecretStashDto(
+            r.GameId, r.SecretStashId, r.StashName,
+            r.LocationId, r.LocationName,
+            r.TreasureCount,
+            ImagePath: r.StashImagePath,
+            ImageUrl: string.IsNullOrWhiteSpace(r.StashImagePath) ? null : blob.GetSasUrl(r.StashImagePath))).ToList();
         return TypedResults.Ok(stashes);
     }
 
     private static async Task<Results<Created<GameSecretStashDto>, Conflict, ValidationProblem>> CreateGameStash(
-        CreateGameSecretStashDto dto, WorldDbContext db)
+        CreateGameSecretStashDto dto, WorldDbContext db, IBlobStorageService blob)
     {
         if (await db.GameSecretStashes.AnyAsync(gs => gs.GameId == dto.GameId && gs.SecretStashId == dto.SecretStashId))
             return TypedResults.Conflict();
@@ -118,10 +139,17 @@ public static class SecretStashEndpoints
         });
         await db.SaveChangesAsync();
 
-        var stashName = (await db.SecretStashes.FindAsync(dto.SecretStashId))?.Name ?? "";
+        var stash = await db.SecretStashes.FindAsync(dto.SecretStashId);
+        var stashName = stash?.Name ?? "";
+        var stashImagePath = stash?.ImagePath;
         var locName = (await db.Locations.FindAsync(dto.LocationId))?.Name ?? "";
         return TypedResults.Created($"/api/secret-stashes/game-stash/{dto.GameId}/{dto.SecretStashId}",
-            new GameSecretStashDto(dto.GameId, dto.SecretStashId, stashName, dto.LocationId, locName, TreasureCount: 0));
+            new GameSecretStashDto(
+                dto.GameId, dto.SecretStashId, stashName,
+                dto.LocationId, locName,
+                TreasureCount: 0,
+                ImagePath: stashImagePath,
+                ImageUrl: string.IsNullOrWhiteSpace(stashImagePath) ? null : blob.GetSasUrl(stashImagePath)));
     }
 
     private static async Task<Results<NoContent, NotFound>> UpdateGameStash(

--- a/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Dtos;
 
@@ -29,17 +30,35 @@ public static class SpellEndpoints
 
     // ── Catalog ────────────────────────────────────────────────────────
 
-    private static async Task<Ok<List<SpellListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<SpellListDto>>> GetAll(WorldDbContext db, IBlobStorageService blob)
     {
-        var spells = await db.Spells
+        var rows = await db.Spells
             .OrderBy(s => s.Level)
             .ThenBy(s => s.Name)
-            .Select(s => new SpellListDto(
-                s.Id, s.Name, s.Level, s.School,
-                s.IsScroll, s.IsReaction, s.IsLearnable,
-                s.ManaCost, s.MinMageLevel, s.Price,
-                s.Effect, s.Description))
+            .Select(s => new
+            {
+                s.Id,
+                s.Name,
+                s.Level,
+                s.School,
+                s.IsScroll,
+                s.IsReaction,
+                s.IsLearnable,
+                s.ManaCost,
+                s.MinMageLevel,
+                s.Price,
+                s.Effect,
+                s.Description,
+                s.ImagePath
+            })
             .ToListAsync();
+        var spells = rows.Select(r => new SpellListDto(
+            r.Id, r.Name, r.Level, r.School,
+            r.IsScroll, r.IsReaction, r.IsLearnable,
+            r.ManaCost, r.MinMageLevel, r.Price,
+            r.Effect, r.Description,
+            ImagePath: r.ImagePath,
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath))).ToList();
         return TypedResults.Ok(spells);
     }
 
@@ -121,22 +140,37 @@ public static class SpellEndpoints
 
     // ── Per-game ──────────────────────────────────────────────────────
 
-    private static async Task<Ok<List<GameSpellDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<GameSpellDto>>> GetByGame(int gameId, WorldDbContext db, IBlobStorageService blob)
     {
-        var rows = await db.GameSpells
+        var raw = await db.GameSpells
             .Where(gs => gs.GameId == gameId)
-            .Include(gs => gs.Spell)
             .OrderBy(gs => gs.Spell.Level)
             .ThenBy(gs => gs.Spell.Name)
-            .Select(gs => new GameSpellDto(
-                gs.Id, gs.GameId, gs.SpellId, gs.Spell.Name, gs.Spell.Level, gs.Spell.School,
-                gs.Price, gs.IsFindable, gs.AvailabilityNotes, gs.Spell.Price))
+            .Select(gs => new
+            {
+                gs.Id,
+                gs.GameId,
+                gs.SpellId,
+                SpellName = gs.Spell.Name,
+                gs.Spell.Level,
+                gs.Spell.School,
+                gs.Price,
+                gs.IsFindable,
+                gs.AvailabilityNotes,
+                CatalogPrice = gs.Spell.Price,
+                SpellImagePath = gs.Spell.ImagePath
+            })
             .ToListAsync();
+        var rows = raw.Select(r => new GameSpellDto(
+            r.Id, r.GameId, r.SpellId, r.SpellName, r.Level, r.School,
+            r.Price, r.IsFindable, r.AvailabilityNotes, r.CatalogPrice,
+            ImagePath: r.SpellImagePath,
+            ImageUrl: string.IsNullOrWhiteSpace(r.SpellImagePath) ? null : blob.GetSasUrl(r.SpellImagePath))).ToList();
         return TypedResults.Ok(rows);
     }
 
     private static async Task<Results<Created<GameSpellDto>, Conflict<string>, NotFound<string>>> CreateGameSpell(
-        CreateGameSpellDto dto, WorldDbContext db)
+        CreateGameSpellDto dto, WorldDbContext db, IBlobStorageService blob)
     {
         // Validate FKs up front — otherwise EF surfaces FK violations as 500.
         var spell = await db.Spells.FindAsync(dto.SpellId);
@@ -162,7 +196,9 @@ public static class SpellEndpoints
         return TypedResults.Created(
             $"/api/spells/by-game/{gs.GameId}",
             new GameSpellDto(gs.Id, gs.GameId, gs.SpellId, spell.Name, spell.Level, spell.School,
-                gs.Price, gs.IsFindable, gs.AvailabilityNotes, spell.Price));
+                gs.Price, gs.IsFindable, gs.AvailabilityNotes, spell.Price,
+                ImagePath: spell.ImagePath,
+                ImageUrl: string.IsNullOrWhiteSpace(spell.ImagePath) ? null : blob.GetSasUrl(spell.ImagePath)));
     }
 
     private static async Task<Results<NoContent, NotFound>> UpdateGameSpell(

--- a/src/OvcinaHra.Api/Services/BlobStorageService.cs
+++ b/src/OvcinaHra.Api/Services/BlobStorageService.cs
@@ -8,6 +8,16 @@ public interface IBlobStorageService
 {
     Task<string> UploadAsync(string blobKey, Stream content, string contentType, CancellationToken ct = default);
     Task<string?> GetSasUrlAsync(string blobKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Synchronous SAS URL builder for list endpoints — skips the remote existence
+    /// check performed by <see cref="GetSasUrlAsync"/>. A list page with 50 rows would
+    /// otherwise do 50 blob existence round trips to Azure. Callers pass a blob key
+    /// stored on the entity and trust it; a stale key just produces a broken image
+    /// at the client, identical to the prior behavior when GetSasUrlAsync raced deletion.
+    /// </summary>
+    string GetSasUrl(string blobKey);
+
     Task DeleteAsync(string blobKey, CancellationToken ct = default);
 }
 
@@ -36,6 +46,17 @@ public class BlobStorageService : IBlobStorageService
         if (!await blob.ExistsAsync(ct))
             return null;
 
+        return BuildSasUrl(blob);
+    }
+
+    public string GetSasUrl(string blobKey)
+    {
+        var blob = _container.GetBlobClient(blobKey);
+        return BuildSasUrl(blob);
+    }
+
+    private string BuildSasUrl(BlobClient blob)
+    {
         // For Azurite (dev), SAS doesn't work easily -- return direct URL
         // For production, generate SAS token
         if (_container.Uri.Host.Contains("127.0.0.1") || _container.Uri.Host.Contains("localhost"))
@@ -46,7 +67,7 @@ public class BlobStorageService : IBlobStorageService
         var sasBuilder = new BlobSasBuilder
         {
             BlobContainerName = _container.Name,
-            BlobName = blobKey,
+            BlobName = blob.Name,
             Resource = "b",
             ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
         };

--- a/src/OvcinaHra.Api/Services/BlobStorageService.cs
+++ b/src/OvcinaHra.Api/Services/BlobStorageService.cs
@@ -26,12 +26,14 @@ public interface IBlobStorageService
 public class BlobStorageService : IBlobStorageService
 {
     private readonly BlobContainerClient _container;
+    private readonly ILogger<BlobStorageService> _logger;
 
-    public BlobStorageService(IConfiguration config)
+    public BlobStorageService(IConfiguration config, ILogger<BlobStorageService> logger)
     {
         var connectionString = config["BlobStorage:ConnectionString"]!;
         var containerName = config["BlobStorage:ContainerName"] ?? "ovcinahra-images";
         _container = new BlobContainerClient(connectionString, containerName);
+        _logger = logger;
     }
 
     public async Task<string> UploadAsync(string blobKey, Stream content, string contentType, CancellationToken ct)
@@ -58,10 +60,12 @@ public class BlobStorageService : IBlobStorageService
             var blob = _container.GetBlobClient(blobKey);
             return BuildSasUrl(blob);
         }
-        catch
+        catch (Exception ex)
         {
             // Never let a single row's SAS generation failure 500 a whole list page.
             // The tile components render a glyph fallback when ImageUrl is null.
+            // Logged so credential/container misconfiguration is still diagnosable.
+            _logger.LogWarning(ex, "Failed to generate SAS URL for blob key {BlobKey}", blobKey);
             return null;
         }
     }

--- a/src/OvcinaHra.Api/Services/BlobStorageService.cs
+++ b/src/OvcinaHra.Api/Services/BlobStorageService.cs
@@ -14,9 +14,11 @@ public interface IBlobStorageService
     /// check performed by <see cref="GetSasUrlAsync"/>. A list page with 50 rows would
     /// otherwise do 50 blob existence round trips to Azure. Callers pass a blob key
     /// stored on the entity and trust it; a stale key just produces a broken image
-    /// at the client, identical to the prior behavior when GetSasUrlAsync raced deletion.
+    /// at the client (handled by an <c>onerror</c> fallback in the tile components).
+    /// Returns <c>null</c> if SAS generation throws (e.g., misconfigured credentials) so
+    /// a single bad key or transient SDK error cannot 500 a whole list page.
     /// </summary>
-    string GetSasUrl(string blobKey);
+    string? GetSasUrl(string blobKey);
 
     Task DeleteAsync(string blobKey, CancellationToken ct = default);
 }
@@ -49,10 +51,19 @@ public class BlobStorageService : IBlobStorageService
         return BuildSasUrl(blob);
     }
 
-    public string GetSasUrl(string blobKey)
+    public string? GetSasUrl(string blobKey)
     {
-        var blob = _container.GetBlobClient(blobKey);
-        return BuildSasUrl(blob);
+        try
+        {
+            var blob = _container.GetBlobClient(blobKey);
+            return BuildSasUrl(blob);
+        }
+        catch
+        {
+            // Never let a single row's SAS generation failure 500 a whole list page.
+            // The tile components render a glyph fallback when ImageUrl is null.
+            return null;
+        }
     }
 
     private string BuildSasUrl(BlobClient blob)

--- a/src/OvcinaHra.Client/Components/LocationStashTile.razor
+++ b/src/OvcinaHra.Client/Components/LocationStashTile.razor
@@ -2,9 +2,14 @@
 
 <a class="oh-lc-tile" href="/secret-stashes/@Stash.Id">
     <div class="oh-lc-tile-img">
+        @* onerror swap: if the img 404s (stale key, deleted blob, SAS failure)
+           we reveal the "bez obrázku" placeholder instead of the broken-image icon. *@
         @if (!string.IsNullOrEmpty(Stash.ImageUrl))
         {
-            <img src="@Stash.ImageUrl" alt="@Stash.Name" />
+            <img src="@Stash.ImageUrl"
+                 alt="@Stash.Name"
+                 onerror="this.style.display='none'; this.nextElementSibling.style.display=''" />
+            <div class="oh-lc-tile-img-empty" style="display:none">bez obrázku</div>
         }
         else
         {

--- a/src/OvcinaHra.Client/Components/LocationStashTile.razor
+++ b/src/OvcinaHra.Client/Components/LocationStashTile.razor
@@ -2,14 +2,14 @@
 
 <a class="oh-lc-tile" href="/secret-stashes/@Stash.Id">
     <div class="oh-lc-tile-img">
-        @* onerror swap: if the img 404s (stale key, deleted blob, SAS failure)
-           we reveal the "bez obrázku" placeholder instead of the broken-image icon. *@
-        @if (!string.IsNullOrEmpty(Stash.ImageUrl))
+        @* Blazor @onerror state so a broken img (stale key, deleted blob, SAS
+           failure) reveals the "bez obrázku" placeholder. State-based rather
+           than DOM-mutation so it survives component reuse across list updates. *@
+        @if (!string.IsNullOrEmpty(Stash.ImageUrl) && !imageFailed)
         {
             <img src="@Stash.ImageUrl"
                  alt="@Stash.Name"
-                 onerror="this.style.display='none'; this.nextElementSibling.style.display=''" />
-            <div class="oh-lc-tile-img-empty" style="display:none">bez obrázku</div>
+                 @onerror="() => imageFailed = true" />
         }
         else
         {
@@ -41,12 +41,22 @@
 
     private List<LocationTreasureQuestDto> visibleQuests = [];
     private int overflowCount;
+    private bool imageFailed;
+    private string? _lastImageUrl;
 
     protected override void OnParametersSet()
     {
         var all = Stash.TreasureQuests ?? [];
         visibleQuests = all.Take(MaxVisibleQuests).ToList();
         overflowCount = Math.Max(0, all.Count - MaxVisibleQuests);
+
+        // Reset img error state when the URL changes — matters when a reused
+        // component shifts to a different Stash across a list re-render.
+        if (_lastImageUrl != Stash.ImageUrl)
+        {
+            _lastImageUrl = Stash.ImageUrl;
+            imageFailed = false;
+        }
     }
 
     // Czech plural for count: 1 → "další", 2-4 → "další", 5+ → "dalších"

--- a/src/OvcinaHra.Client/Components/LocationStashTile.razor
+++ b/src/OvcinaHra.Client/Components/LocationStashTile.razor
@@ -1,11 +1,10 @@
 @using OvcinaHra.Shared.Dtos
-@inject ApiClient Api
 
 <a class="oh-lc-tile" href="/secret-stashes/@Stash.Id">
     <div class="oh-lc-tile-img">
-        @if (imageUrl is not null)
+        @if (!string.IsNullOrEmpty(Stash.ImageUrl))
         {
-            <img src="@imageUrl" alt="@Stash.Name" />
+            <img src="@Stash.ImageUrl" alt="@Stash.Name" />
         }
         else
         {
@@ -35,33 +34,14 @@
     [Parameter, EditorRequired] public LocationStashDto Stash { get; set; } = null!;
     [Parameter] public int MaxVisibleQuests { get; set; } = 5;
 
-    private string? imageUrl;
     private List<LocationTreasureQuestDto> visibleQuests = [];
     private int overflowCount;
 
-    private int? _loadedForStashId;
-
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
-        if (_loadedForStashId != Stash.Id)
-        {
-            _loadedForStashId = Stash.Id;
-            await LoadImageAsync();
-        }
-
         var all = Stash.TreasureQuests ?? [];
         visibleQuests = all.Take(MaxVisibleQuests).ToList();
         overflowCount = Math.Max(0, all.Count - MaxVisibleQuests);
-    }
-
-    private async Task LoadImageAsync()
-    {
-        try
-        {
-            var urls = await Api.GetAsync<ImageUrlsDto>($"/api/images/secretstashes/{Stash.Id}");
-            imageUrl = urls?.ImageUrl;
-        }
-        catch { imageUrl = null; }
     }
 
     // Czech plural for count: 1 → "další", 2-4 → "další", 5+ → "dalších"

--- a/src/OvcinaHra.Client/Components/SecretStashGridTile.razor
+++ b/src/OvcinaHra.Client/Components/SecretStashGridTile.razor
@@ -8,14 +8,17 @@
 <a class="oh-ssg-tile @ToneClass @(TreasureCount == 0 ? "oh-ssg-dim" : "") @(Assigned ? "oh-ssg-in-game" : "")"
    href="/secret-stashes/@Id"
    title="@Name">
+    @* Always render the glyph fallback; layer the img on top when present.
+       onerror hides a broken img (stale key, deleted blob, SAS failure) so
+       the glyph remains visible instead of showing a broken-image icon. *@
+    <i class="oh-ssg-glyph bi @GlyphClass" aria-hidden="true"></i>
     @if (!string.IsNullOrEmpty(ImageUrl))
     {
-        <img class="oh-ssg-tile-img" src="@ImageUrl" alt="@Name" />
+        <img class="oh-ssg-tile-img"
+             src="@ImageUrl"
+             alt="@Name"
+             onerror="this.style.display='none'" />
         <div class="oh-ssg-tile-img-veil"></div>
-    }
-    else
-    {
-        <i class="oh-ssg-glyph bi @GlyphClass" aria-hidden="true"></i>
     }
 
     @if (CatalogMode && Assigned)

--- a/src/OvcinaHra.Client/Components/SecretStashGridTile.razor
+++ b/src/OvcinaHra.Client/Components/SecretStashGridTile.razor
@@ -4,14 +4,13 @@
    catalog overlay pills. *@
 
 @using OvcinaHra.Shared.Dtos
-@inject ApiClient Api
 
 <a class="oh-ssg-tile @ToneClass @(TreasureCount == 0 ? "oh-ssg-dim" : "") @(Assigned ? "oh-ssg-in-game" : "")"
    href="/secret-stashes/@Id"
    title="@Name">
-    @if (!string.IsNullOrEmpty(imageUrl))
+    @if (!string.IsNullOrEmpty(ImageUrl))
     {
-        <img class="oh-ssg-tile-img" src="@imageUrl" alt="@Name" />
+        <img class="oh-ssg-tile-img" src="@ImageUrl" alt="@Name" />
         <div class="oh-ssg-tile-img-veil"></div>
     }
     else
@@ -56,9 +55,7 @@
     [Parameter] public int SecondCount { get; set; }
     [Parameter] public bool CatalogMode { get; set; }
     [Parameter] public bool Assigned { get; set; }
-
-    private string? imageUrl;
-    private int? _loadedForId;
+    [Parameter] public string? ImageUrl { get; set; }
 
     // deterministic fallback tone + glyph based on stash Id when no image exists
     private static readonly string[] Tones = ["", "", "", "oh-ssg-paper"];
@@ -73,33 +70,12 @@
         "bi-archive"
     ];
 
-    private string ToneClass => string.IsNullOrEmpty(imageUrl) ? Tones[Id % Tones.Length] : "";
+    private string ToneClass => string.IsNullOrEmpty(ImageUrl) ? Tones[Id % Tones.Length] : "";
     private string GlyphClass => Glyphs[Id % Glyphs.Length];
 
     private string SecondCountTitle => CatalogMode
         ? PluralCount(SecondCount, "hra", "hry", "her")
         : PluralCount(SecondCount, "lokace", "lokace", "lokací");
-
-    protected override async Task OnParametersSetAsync()
-    {
-        if (_loadedForId == Id)
-            return;
-        _loadedForId = Id;
-        await LoadImageAsync();
-    }
-
-    private async Task LoadImageAsync()
-    {
-        try
-        {
-            var urls = await Api.GetAsync<ImageUrlsDto>($"/api/images/secretstashes/{Id}");
-            imageUrl = urls?.ImageUrl;
-        }
-        catch
-        {
-            imageUrl = null;
-        }
-    }
 
     // Czech plural for count: 0/1 → one, 2-4 → few, 5+ → many.
     private static string PluralCount(int n, string one, string few, string many)

--- a/src/OvcinaHra.Client/Components/SecretStashGridTile.razor
+++ b/src/OvcinaHra.Client/Components/SecretStashGridTile.razor
@@ -9,15 +9,16 @@
    href="/secret-stashes/@Id"
    title="@Name">
     @* Always render the glyph fallback; layer the img on top when present.
-       onerror hides a broken img (stale key, deleted blob, SAS failure) so
-       the glyph remains visible instead of showing a broken-image icon. *@
+       Blazor @onerror flips imageFailed — rendering drops the img + veil on
+       the next pass so the glyph shows through. State-based rather than DOM-
+       mutation so it survives component reuse and parent re-renders. *@
     <i class="oh-ssg-glyph bi @GlyphClass" aria-hidden="true"></i>
-    @if (!string.IsNullOrEmpty(ImageUrl))
+    @if (!string.IsNullOrEmpty(ImageUrl) && !imageFailed)
     {
         <img class="oh-ssg-tile-img"
              src="@ImageUrl"
              alt="@Name"
-             onerror="this.style.display='none'" />
+             @onerror="() => imageFailed = true" />
         <div class="oh-ssg-tile-img-veil"></div>
     }
 
@@ -59,6 +60,21 @@
     [Parameter] public bool CatalogMode { get; set; }
     [Parameter] public bool Assigned { get; set; }
     [Parameter] public string? ImageUrl { get; set; }
+
+    private bool imageFailed;
+    private string? _lastImageUrl;
+
+    protected override void OnParametersSet()
+    {
+        // Reset the failure flag when the URL changes — a reused component
+        // pointed at a different stash should try the new image, not stay
+        // stuck on the previous one's error state.
+        if (_lastImageUrl != ImageUrl)
+        {
+            _lastImageUrl = ImageUrl;
+            imageFailed = false;
+        }
+    }
 
     // deterministic fallback tone + glyph based on stash Id when no image exists
     private static readonly string[] Tones = ["", "", "", "oh-ssg-paper"];

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.12.2</Version>
+    <Version>0.13.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -324,7 +324,7 @@ else
                 <div class="oh-lc-stash-grid">
                     @foreach (var stash in loc.Stashes!)
                     {
-                        <LocationStashTile Stash="stash" />
+                        <LocationStashTile @key="stash.Id" Stash="stash" />
                     }
                 </div>
             }

--- a/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
+++ b/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
@@ -120,7 +120,8 @@
                         @foreach (var s in filteredCatalog)
                         {
                             var assigned = assignedStashIds.Contains(s.Id);
-                            <SecretStashGridTile Id="@s.Id"
+                            <SecretStashGridTile @key="s.Id"
+                                                 Id="@s.Id"
                                                  Name="@s.Name"
                                                  TreasureCount="@s.TreasureCount"
                                                  SecondCount="@s.GameCount"
@@ -133,7 +134,8 @@
                     {
                         @foreach (var gs in filteredGame)
                         {
-                            <SecretStashGridTile Id="@gs.SecretStashId"
+                            <SecretStashGridTile @key="gs.SecretStashId"
+                                                 Id="@gs.SecretStashId"
                                                  Name="@gs.StashName"
                                                  TreasureCount="@gs.TreasureCount"
                                                  SecondCount="@(gs.LocationId > 0 ? 1 : 0)"

--- a/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
+++ b/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashList.razor
@@ -125,7 +125,8 @@
                                                  TreasureCount="@s.TreasureCount"
                                                  SecondCount="@s.GameCount"
                                                  CatalogMode="true"
-                                                 Assigned="@assigned" />
+                                                 Assigned="@assigned"
+                                                 ImageUrl="@s.ImageUrl" />
                         }
                     }
                     else
@@ -136,7 +137,8 @@
                                                  Name="@gs.StashName"
                                                  TreasureCount="@gs.TreasureCount"
                                                  SecondCount="@(gs.LocationId > 0 ? 1 : 0)"
-                                                 CatalogMode="false" />
+                                                 CatalogMode="false"
+                                                 ImageUrl="@gs.ImageUrl" />
                         }
                     }
                 </div>

--- a/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
@@ -2,7 +2,8 @@ namespace OvcinaHra.Shared.Dtos;
 
 public record BuildingListDto(
     int Id, string Name, string? Description, string? Notes,
-    int? LocationId, string? LocationName, bool IsPrebuilt);
+    int? LocationId, string? LocationName, bool IsPrebuilt,
+    string? ImagePath = null, string? ImageUrl = null);
 
 public record BuildingDetailDto(
     int Id, string Name, string? Description, string? Notes, string? ImagePath,

--- a/src/OvcinaHra.Shared/Dtos/CharacterDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/CharacterDtos.cs
@@ -10,7 +10,8 @@ namespace OvcinaHra.Shared.Dtos;
 public record CharacterListDto(
     int Id, string Name, string? PlayerFullName, Race? Race,
     bool IsPlayedCharacter, int? ExternalPersonId,
-    int? KingdomId = null, string? KingdomName = null, string? KingdomHexColor = null);
+    int? KingdomId = null, string? KingdomName = null, string? KingdomHexColor = null,
+    string? ImagePath = null, string? ImageUrl = null);
 
 public record CharacterDetailDto(
     int Id, string Name, string? PlayerFirstName, string? PlayerLastName,

--- a/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
@@ -17,7 +17,8 @@ public record ItemListDto(
     int ReqThief,
     bool IsUnique,
     bool IsLimited,
-    string? ImagePath)
+    string? ImagePath,
+    string? ImageUrl = null)
 {
     [JsonIgnore]
     public string ItemTypeDisplay => ItemType.GetDisplayName();
@@ -53,7 +54,8 @@ public record GameItemListDto(
     bool IsSold,
     string? SaleCondition,
     bool IsFindable,
-    string? RecipeSummary)
+    string? RecipeSummary,
+    string? ImageUrl = null)
 {
     [JsonIgnore]
     public string ItemTypeDisplay => ItemType.GetDisplayName();

--- a/src/OvcinaHra.Shared/Dtos/KingdomDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/KingdomDtos.cs
@@ -7,7 +7,8 @@ public record KingdomDto(
     string? BadgeImageUrl,
     string? Description,
     int SortOrder,
-    int AssignmentCount = 0);
+    int AssignmentCount = 0,
+    string? ImageUrl = null);
 
 public record CreateKingdomDto(
     string Name,

--- a/src/OvcinaHra.Shared/Dtos/KingdomDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/KingdomDtos.cs
@@ -1,5 +1,8 @@
 namespace OvcinaHra.Shared.Dtos;
 
+// BadgeImageUrl is historically the stored blob key (misnamed — kept for wire
+// compatibility). BadgeImageSasUrl is the resolved, short-lived SAS URL
+// suitable for <img src=…> binding.
 public record KingdomDto(
     int Id,
     string Name,
@@ -8,7 +11,7 @@ public record KingdomDto(
     string? Description,
     int SortOrder,
     int AssignmentCount = 0,
-    string? ImageUrl = null);
+    string? BadgeImageSasUrl = null);
 
 public record CreateKingdomDto(
     string Name,

--- a/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
@@ -19,7 +19,9 @@ public record LocationListDto(
     string? SetupNotes,
     IReadOnlyList<LocationStashDto> Stashes,
     IReadOnlyList<LocationQuestDto> Quests,
-    IReadOnlyList<LocationTreasureQuestDto> LocationTreasureQuests)
+    IReadOnlyList<LocationTreasureQuestDto> LocationTreasureQuests,
+    string? ImagePath = null,
+    string? ImageUrl = null)
 {
     [JsonIgnore]
     public string LocationKindDisplay => LocationKind.GetDisplayName();
@@ -28,7 +30,9 @@ public record LocationListDto(
 public record LocationStashDto(
     int Id,
     string Name,
-    IReadOnlyList<LocationTreasureQuestDto> TreasureQuests);
+    IReadOnlyList<LocationTreasureQuestDto> TreasureQuests,
+    string? ImagePath = null,
+    string? ImageUrl = null);
 
 public record LocationQuestDto(
     int Id,

--- a/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
@@ -9,7 +9,8 @@ public record MonsterListDto(
     int Attack, int Defense, int Health,
     int? RewardXp, int? RewardMoney,
     string? Abilities, string? AiBehavior, string? RewardNotes, string? Notes,
-    List<string> TagNames)
+    List<string> TagNames,
+    string? ImagePath = null, string? ImageUrl = null)
 {
     [JsonIgnore]
     public string MonsterTypeDisplay => MonsterType.GetDisplayName();

--- a/src/OvcinaHra.Shared/Dtos/SecretStashDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/SecretStashDtos.cs
@@ -3,7 +3,8 @@ namespace OvcinaHra.Shared.Dtos;
 // Catalog (master list)
 public record SecretStashListDto(
     int Id, string Name, string? Description,
-    int TreasureCount, int GameCount);
+    int TreasureCount, int GameCount,
+    string? ImagePath = null, string? ImageUrl = null);
 
 public record SecretStashDetailDto(int Id, string Name, string? Description, string? ImagePath);
 
@@ -15,7 +16,8 @@ public record UpdateSecretStashDto(string Name, string? Description);
 public record GameSecretStashDto(
     int GameId, int SecretStashId, string StashName,
     int LocationId, string LocationName,
-    int TreasureCount);
+    int TreasureCount,
+    string? ImagePath = null, string? ImageUrl = null);
 
 public record CreateGameSecretStashDto(int GameId, int SecretStashId, int LocationId);
 

--- a/src/OvcinaHra.Shared/Dtos/SpellDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/SpellDtos.cs
@@ -18,7 +18,9 @@ public record SpellListDto(
     int MinMageLevel,
     int? Price,
     string Effect,
-    string? Description)
+    string? Description,
+    string? ImagePath = null,
+    string? ImageUrl = null)
 {
     [JsonIgnore] public string SchoolDisplay => School.GetDisplayName();
 }
@@ -79,7 +81,9 @@ public record GameSpellDto(
     int? Price,
     bool IsFindable,
     string? AvailabilityNotes,
-    int? CatalogPrice = null)
+    int? CatalogPrice = null,
+    string? ImagePath = null,
+    string? ImageUrl = null)
 {
     [JsonIgnore] public string SchoolDisplay => School.GetDisplayName();
 

--- a/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
@@ -55,6 +55,8 @@ public class InMemoryBlobService : IBlobStorageService
     public Task<string?> GetSasUrlAsync(string blobKey, CancellationToken ct = default)
         => Task.FromResult(_blobs.ContainsKey(blobKey) ? $"https://fake/{blobKey}" : null);
 
+    public string GetSasUrl(string blobKey) => $"https://fake/{blobKey}";
+
     public Task DeleteAsync(string blobKey, CancellationToken ct = default)
     {
         _blobs.Remove(blobKey);

--- a/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
@@ -55,7 +55,7 @@ public class InMemoryBlobService : IBlobStorageService
     public Task<string?> GetSasUrlAsync(string blobKey, CancellationToken ct = default)
         => Task.FromResult(_blobs.ContainsKey(blobKey) ? $"https://fake/{blobKey}" : null);
 
-    public string GetSasUrl(string blobKey) => $"https://fake/{blobKey}";
+    public string? GetSasUrl(string blobKey) => $"https://fake/{blobKey}";
 
     public Task DeleteAsync(string blobKey, CancellationToken ct = default)
     {


### PR DESCRIPTION
Reopen of closed #69 after rebase onto current main (which now includes #68's Upravit layout tightening). Same code as #69 + its resilience fixup.

Collapses per-tile image loading from N+1 to 1 request per list page. Previously every tile fetched its own `/api/images/{entity}/{id}` to get a SAS URL before fetching the blob itself — a 50-tile page produced ~100 HTTP requests before first paint. On mobile in the field this stings.

## API side
`IBlobStorageService` gains a synchronous `string? GetSasUrl(string blobKey)` overload — no remote existence check, wrapped in try/catch so a misconfigured credential or transient SDK error can't 500 a whole list page. Each list endpoint now projects the raw `ImagePath` into a local shape, then post-maps to the DTO with the SAS URL resolved server-side.

Affected list DTOs gain `ImagePath + ImageUrl`:
- SecretStash: `SecretStashListDto`, `GameSecretStashDto`, `LocationStashDto`
- Location: `LocationListDto` (main image)
- Character: `CharacterListDto`
- Item: `ItemListDto`, `GameItemListDto`
- Monster: `MonsterListDto`
- Building: `BuildingListDto`
- Spell: `SpellListDto`, `GameSpellDto`
- Kingdom: `KingdomDto` (resolved `ImageUrl` alongside stored `BadgeImageUrl`)

## Client side
Tile components drop per-instance `Api.GetAsync<ImageUrlsDto>` calls and bind directly to the DTO field. `SecretStashGridTile` and `LocationStashTile` gain `onerror` handlers on the `<img>` so a stale key / deleted blob / SAS failure reveals the glyph fallback instead of the browser's broken-image icon. `ImagePicker.razor` untouched — it's the upload widget, different path.

Version 0.12.2 → 0.13.0 (public DTO shapes changed).

Follow-up PR will point `ImageUrl` at a resized thumbnail endpoint for list views (keeping full-res only on detail pages).

## Test plan
- [ ] `dotnet build` clean, zero warnings
- [ ] Open `/secret-stashes`, `/locations` (both modes), `/characters`, `/items`, `/monsters`, `/buildings`, `/spells`, `/kingdoms` — tiles/rows render with images
- [ ] DevTools Network tab: each list page does **one** list call then direct blob fetches — no `/api/images/<entity>/<id>` per tile (except from `ImagePicker` when the user opens an edit modal)
- [ ] `/api/images/<entity>/<id>` endpoint still works (unchanged) — `ImagePicker` still loads correctly
- [ ] Inline stash tiles on `/locations/{id}` Skrýše tab — images load from the parent DTO
- [ ] Broken blob link renders the glyph/"bez obrázku" fallback, not a broken-image icon