### PR TITLE
fix(images): absolute URLs + anon thumb — fix broken tile images [v0.13.2]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
@@ -27,7 +27,7 @@ public static class BuildingEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<BuildingListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<BuildingListDto>>> GetAll(WorldDbContext db, HttpContext http)
     {
         var rows = await db.Buildings
             .OrderBy(b => b.Name)
@@ -47,11 +47,11 @@ public static class BuildingEndpoints
             r.Id, r.Name, r.Description, r.Notes,
             r.LocationId, r.LocationName, r.IsPrebuilt,
             ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : $"/api/images/buildings/{r.Id}/thumb?size=small")).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "buildings", r.Id, "small"))).ToList();
         return TypedResults.Ok(buildings);
     }
 
-    private static async Task<Ok<List<BuildingListDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<BuildingListDto>>> GetByGame(int gameId, WorldDbContext db, HttpContext http)
     {
         var rows = await db.GameBuildings
             .Where(gb => gb.GameId == gameId)
@@ -72,7 +72,7 @@ public static class BuildingEndpoints
             r.Id, r.Name, r.Description, r.Notes,
             r.LocationId, r.LocationName, r.IsPrebuilt,
             ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : $"/api/images/buildings/{r.Id}/thumb?size=small")).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "buildings", r.Id, "small"))).ToList();
         return TypedResults.Ok(buildings);
     }
 

--- a/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
@@ -33,7 +33,7 @@ public static class CharacterEndpoints
             : $"{c.PlayerFirstName} {c.PlayerLastName}".Trim();
 
     private static async Task<Ok<List<CharacterListDto>>> GetAll(
-        WorldDbContext db, string? search = null, int? gameId = null)
+        WorldDbContext db, HttpContext http, string? search = null, int? gameId = null)
     {
         var query = db.Characters.AsQueryable();
 
@@ -65,7 +65,7 @@ public static class CharacterEndpoints
                     c.Id, c.Name, FullName(c), c.Race, c.IsPlayedCharacter, c.ExternalPersonId,
                     k.KingdomId == 0 ? null : k.KingdomId, k.Name, k.HexColor,
                     ImagePath: c.ImagePath,
-                    ImageUrl: string.IsNullOrWhiteSpace(c.ImagePath) ? null : $"/api/images/characters/{c.Id}/thumb?size=portrait");
+                    ImageUrl: string.IsNullOrWhiteSpace(c.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "characters", c.Id, "portrait"));
             })
             .ToList());
     }

--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -29,9 +29,20 @@ public static class ImageEndpoints
     /// Needed because the frontend (hra.ovcina.cz) and API (api.hra.ovcina.cz)
     /// live on different origins — a relative "/api/images/..." URL would be
     /// resolved by the browser against the frontend host and 404.
+    ///
+    /// Prefers a configured <c>Api:PublicBaseUrl</c> (set in prod via the
+    /// Azure Container App env var <c>Api__PublicBaseUrl=https://api.hra.ovcina.cz</c>)
+    /// to sidestep host-header injection — <c>AllowedHosts</c> is permissive
+    /// ("*") and <c>Request.Host</c> reflects the inbound header. Falls back to
+    /// <c>Request.Scheme+Host</c> for local dev where no config is set.
     /// </summary>
-    public static string ThumbUrl(HttpContext http, string entityType, int entityId, string size) =>
-        $"{http.Request.Scheme}://{http.Request.Host}/api/images/{entityType}/{entityId}/thumb?size={size}";
+    public static string ThumbUrl(HttpContext http, string entityType, int entityId, string size)
+    {
+        var config = http.RequestServices.GetRequiredService<IConfiguration>();
+        var baseUrl = config["Api:PublicBaseUrl"]?.TrimEnd('/')
+            ?? $"{http.Request.Scheme}://{http.Request.Host}";
+        return $"{baseUrl}/api/images/{entityType}/{entityId}/thumb?size={size}";
+    }
 
     private static async Task<IResult> GetThumbnail(
         string entityType, int entityId,

--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -18,11 +18,20 @@ public static class ImageEndpoints
 
         group.MapPost("/{entityType}/{entityId:int}", Upload).DisableAntiforgery();
         group.MapGet("/{entityType}/{entityId:int}", GetUrls);
-        group.MapGet("/{entityType}/{entityId:int}/thumb", GetThumbnail);
+        group.MapGet("/{entityType}/{entityId:int}/thumb", GetThumbnail).AllowAnonymous();
         group.MapDelete("/{entityType}/{entityId:int}", Delete);
 
         return group;
     }
+
+    /// <summary>
+    /// Builds an absolute URL to the thumbnail endpoint for a given entity.
+    /// Needed because the frontend (hra.ovcina.cz) and API (api.hra.ovcina.cz)
+    /// live on different origins — a relative "/api/images/..." URL would be
+    /// resolved by the browser against the frontend host and 404.
+    /// </summary>
+    public static string ThumbUrl(HttpContext http, string entityType, int entityId, string size) =>
+        $"{http.Request.Scheme}://{http.Request.Host}/api/images/{entityType}/{entityId}/thumb?size={size}";
 
     private static async Task<IResult> GetThumbnail(
         string entityType, int entityId,

--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -35,7 +35,7 @@ public static class ItemEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<ItemListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<ItemListDto>>> GetAll(WorldDbContext db, HttpContext http)
     {
         var rows = await db.Items
             .OrderBy(i => i.Name)
@@ -60,7 +60,7 @@ public static class ItemEndpoints
             r.Id, r.Name, r.ItemType, r.Effect, r.PhysicalForm, r.IsCraftable,
             r.ReqWarrior, r.ReqArcher, r.ReqMage, r.ReqThief,
             r.IsUnique, r.IsLimited, r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : $"/api/images/items/{r.Id}/thumb?size=small")).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "items", r.Id, "small"))).ToList();
         return TypedResults.Ok(items);
     }
 
@@ -117,7 +117,7 @@ public static class ItemEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Ok<List<GameItemListDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<GameItemListDto>>> GetByGame(int gameId, WorldDbContext db, HttpContext http)
     {
         var gameItems = await db.GameItems
             .Where(gi => gi.GameId == gameId)
@@ -147,7 +147,7 @@ public static class ItemEndpoints
                 gi.Item.IsUnique, gi.Item.IsLimited, gi.Item.ImagePath,
                 gi.GameId, gi.Price, gi.StockCount, gi.IsSold, gi.SaleCondition, gi.IsFindable,
                 summaryByItemId.GetValueOrDefault(gi.ItemId),
-                ImageUrl: string.IsNullOrWhiteSpace(gi.Item.ImagePath) ? null : $"/api/images/items/{gi.Item.Id}/thumb?size=small"))
+                ImageUrl: string.IsNullOrWhiteSpace(gi.Item.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "items", gi.Item.Id, "small")))
             .ToList();
 
         return TypedResults.Ok(result);

--- a/src/OvcinaHra.Api/Endpoints/KingdomEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/KingdomEndpoints.cs
@@ -21,7 +21,7 @@ public static class KingdomEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<KingdomDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<KingdomDto>>> GetAll(WorldDbContext db, HttpContext http)
     {
         var rows = await db.Kingdoms
             .OrderBy(k => k.SortOrder)
@@ -41,7 +41,7 @@ public static class KingdomEndpoints
         var kingdoms = rows.Select(r => new KingdomDto(
             r.Id, r.Name, r.HexColor, r.BadgeImageUrl, r.Description, r.SortOrder,
             r.AssignmentCount,
-            BadgeImageSasUrl: string.IsNullOrWhiteSpace(r.BadgeImageUrl) ? null : $"/api/images/kingdoms/{r.Id}/thumb?size=small")).ToList();
+            BadgeImageSasUrl: string.IsNullOrWhiteSpace(r.BadgeImageUrl) ? null : ImageEndpoints.ThumbUrl(http, "kingdoms", r.Id, "small"))).ToList();
 
         return TypedResults.Ok(kingdoms);
     }

--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -28,7 +28,7 @@ public static class LocationEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<LocationListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<LocationListDto>>> GetAll(WorldDbContext db, HttpContext http)
     {
         var rows = await db.Locations
             .OrderBy(l => l.Name)
@@ -61,7 +61,7 @@ public static class LocationEndpoints
             Array.Empty<LocationQuestDto>(),
             Array.Empty<LocationTreasureQuestDto>(),
             ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : $"/api/images/locations/{r.Id}/thumb?size=small")).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"))).ToList();
 
         return TypedResults.Ok(locations);
     }
@@ -146,7 +146,7 @@ public static class LocationEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Ok<List<LocationListDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<LocationListDto>>> GetByGame(int gameId, WorldDbContext db, HttpContext http)
     {
         var rows = await db.Locations
             .Where(l => l.GameLocations.Any(gl => gl.GameId == gameId))
@@ -220,11 +220,11 @@ public static class LocationEndpoints
                 s.StashName,
                 s.TreasureQuests,
                 ImagePath: s.StashImagePath,
-                ImageUrl: string.IsNullOrWhiteSpace(s.StashImagePath) ? null : $"/api/images/secretstashes/{s.SecretStashId}/thumb?size=medium")).ToList(),
+                ImageUrl: string.IsNullOrWhiteSpace(s.StashImagePath) ? null : ImageEndpoints.ThumbUrl(http, "secretstashes", s.SecretStashId, "medium"))).ToList(),
             Quests: r.Quests,
             LocationTreasureQuests: r.LocationTreasureQuests,
             ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : $"/api/images/locations/{r.Id}/thumb?size=small")).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"))).ToList();
 
         return TypedResults.Ok(dtos);
     }

--- a/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
@@ -39,7 +39,7 @@ public static class MonsterEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<MonsterListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<MonsterListDto>>> GetAll(WorldDbContext db, HttpContext http)
     {
         var rows = await db.Monsters
             .OrderBy(m => m.Name)
@@ -69,7 +69,7 @@ public static class MonsterEndpoints
             r.Abilities, r.AiBehavior, r.RewardNotes, r.Notes,
             r.TagNames,
             ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : $"/api/images/monsters/{r.Id}/thumb?size=small")).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "monsters", r.Id, "small"))).ToList();
         return TypedResults.Ok(monsters);
     }
 

--- a/src/OvcinaHra.Api/Endpoints/SecretStashEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SecretStashEndpoints.cs
@@ -31,7 +31,7 @@ public static class SecretStashEndpoints
 
     // --- Catalog ---
 
-    private static async Task<Ok<List<SecretStashListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<SecretStashListDto>>> GetAll(WorldDbContext db, HttpContext http)
     {
         var rows = await db.SecretStashes
             .OrderBy(s => s.Name)
@@ -49,7 +49,7 @@ public static class SecretStashEndpoints
             r.Id, r.Name, r.Description,
             r.TreasureCount, r.GameCount,
             ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : $"/api/images/secretstashes/{r.Id}/thumb?size=medium")).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "secretstashes", r.Id, "medium"))).ToList();
         return TypedResults.Ok(stashes);
     }
 
@@ -90,7 +90,7 @@ public static class SecretStashEndpoints
 
     // --- Per-game assignment ---
 
-    private static async Task<Ok<List<GameSecretStashDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<GameSecretStashDto>>> GetByGame(int gameId, WorldDbContext db, HttpContext http)
     {
         var rows = await db.GameSecretStashes
             .Where(gs => gs.GameId == gameId)
@@ -111,12 +111,12 @@ public static class SecretStashEndpoints
             r.LocationId, r.LocationName,
             r.TreasureCount,
             ImagePath: r.StashImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.StashImagePath) ? null : $"/api/images/secretstashes/{r.SecretStashId}/thumb?size=medium")).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.StashImagePath) ? null : ImageEndpoints.ThumbUrl(http, "secretstashes", r.SecretStashId, "medium"))).ToList();
         return TypedResults.Ok(stashes);
     }
 
     private static async Task<Results<Created<GameSecretStashDto>, Conflict, ValidationProblem>> CreateGameStash(
-        CreateGameSecretStashDto dto, WorldDbContext db)
+        CreateGameSecretStashDto dto, WorldDbContext db, HttpContext http)
     {
         if (await db.GameSecretStashes.AnyAsync(gs => gs.GameId == dto.GameId && gs.SecretStashId == dto.SecretStashId))
             return TypedResults.Conflict();
@@ -149,7 +149,7 @@ public static class SecretStashEndpoints
                 dto.LocationId, locName,
                 TreasureCount: 0,
                 ImagePath: stashImagePath,
-                ImageUrl: string.IsNullOrWhiteSpace(stashImagePath) ? null : $"/api/images/secretstashes/{dto.SecretStashId}/thumb?size=medium"));
+                ImageUrl: string.IsNullOrWhiteSpace(stashImagePath) ? null : ImageEndpoints.ThumbUrl(http, "secretstashes", dto.SecretStashId, "medium")));
     }
 
     private static async Task<Results<NoContent, NotFound>> UpdateGameStash(

--- a/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
@@ -30,7 +30,7 @@ public static class SpellEndpoints
 
     // ── Catalog ────────────────────────────────────────────────────────
 
-    private static async Task<Ok<List<SpellListDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<SpellListDto>>> GetAll(WorldDbContext db, HttpContext http)
     {
         var rows = await db.Spells
             .OrderBy(s => s.Level)
@@ -58,7 +58,7 @@ public static class SpellEndpoints
             r.ManaCost, r.MinMageLevel, r.Price,
             r.Effect, r.Description,
             ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : $"/api/images/spells/{r.Id}/thumb?size=small")).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "spells", r.Id, "small"))).ToList();
         return TypedResults.Ok(spells);
     }
 
@@ -140,7 +140,7 @@ public static class SpellEndpoints
 
     // ── Per-game ──────────────────────────────────────────────────────
 
-    private static async Task<Ok<List<GameSpellDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<GameSpellDto>>> GetByGame(int gameId, WorldDbContext db, HttpContext http)
     {
         var raw = await db.GameSpells
             .Where(gs => gs.GameId == gameId)
@@ -165,12 +165,12 @@ public static class SpellEndpoints
             r.Id, r.GameId, r.SpellId, r.SpellName, r.Level, r.School,
             r.Price, r.IsFindable, r.AvailabilityNotes, r.CatalogPrice,
             ImagePath: r.SpellImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.SpellImagePath) ? null : $"/api/images/spells/{r.SpellId}/thumb?size=small")).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.SpellImagePath) ? null : ImageEndpoints.ThumbUrl(http, "spells", r.SpellId, "small"))).ToList();
         return TypedResults.Ok(rows);
     }
 
     private static async Task<Results<Created<GameSpellDto>, Conflict<string>, NotFound<string>>> CreateGameSpell(
-        CreateGameSpellDto dto, WorldDbContext db)
+        CreateGameSpellDto dto, WorldDbContext db, HttpContext http)
     {
         // Validate FKs up front — otherwise EF surfaces FK violations as 500.
         var spell = await db.Spells.FindAsync(dto.SpellId);
@@ -198,7 +198,7 @@ public static class SpellEndpoints
             new GameSpellDto(gs.Id, gs.GameId, gs.SpellId, spell.Name, spell.Level, spell.School,
                 gs.Price, gs.IsFindable, gs.AvailabilityNotes, spell.Price,
                 ImagePath: spell.ImagePath,
-                ImageUrl: string.IsNullOrWhiteSpace(spell.ImagePath) ? null : $"/api/images/spells/{gs.SpellId}/thumb?size=small"));
+                ImageUrl: string.IsNullOrWhiteSpace(spell.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "spells", gs.SpellId, "small")));
     }
 
     private static async Task<Results<NoContent, NotFound>> UpdateGameSpell(

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.13.1</Version>
+    <Version>0.13.2</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hotfix for PR #71 — tile images are broken on prod because:

1. `ImageUrl` in list DTOs was a **relative** path `/api/images/{entity}/{id}/thumb?size=…`. Frontend at `hra.ovcina.cz`, API at `api.hra.ovcina.cz` — browser resolved the relative URL against the frontend origin and got nothing. Service worker logged `TypeError: Failed to fetch` for every tile.
2. Even with an absolute URL, the thumb endpoint inherited auth from the `/api/images` group. `<img>` tags can't send auth headers on cross-origin requests → every thumb would 401.

## Fixes

- **Thumb endpoint `.AllowAnonymous()`** — thumbnails are not secret (matches the pre-PR-#71 SAS model); sibling Upload/GetUrls/Delete endpoints keep auth.
- **`ImageEndpoints.ThumbUrl(http, entity, id, size)` helper** — builds absolute URLs via `HttpContext.Request.Scheme + Host`. All 15 list-DTO projections across 8 endpoint files (Building, Character, Item, Kingdom, Location, Monster, SecretStash, Spell) switched to it. Handler signatures gained `HttpContext http` params.

## Test plan
- [ ] `dotnet build` clean (verified locally: 0 warnings, 0 errors)
- [ ] `curl -v https://api.hra.ovcina.cz/api/images/secretstashes/1/thumb?size=medium` returns 200 without auth header
- [ ] DTO JSON for `/api/secret-stashes` (auth'd) shows absolute `ImageUrl` starting with `https://api.hra.ovcina.cz/`
- [ ] `/secret-stashes`, `/locations`, `/characters`, `/items`, `/monsters`, `/buildings`, `/spells`, `/kingdoms` — tiles render with images
- [ ] DevTools Network tab: tile requests hit `api.hra.ovcina.cz/api/images/.../thumb?size=…` and return 200

Version 0.13.1 → 0.13.2.