### PR TITLE
feat(nav): Tato hra / Katalog tabs in sidebar [v0.14.0]

### DIFF
--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -1,186 +1,208 @@
 @using System.Reflection
+@using Microsoft.JSInterop
 @inject GameContextService GameContext
+@inject IJSRuntime JS
 @implements IDisposable
 
-<div class="top-row ps-3 navbar navbar-dark">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="">
-            <i class="bi bi-feather me-1"></i><span>OvčinaHra</span>
-        </a>
-        <button title="Navigační menu" class="navbar-toggler" @onclick="ToggleNavMenu">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-    </div>
+<div class="sb-brand">
+    <i class="bi bi-feather"></i><span>OvčinaHra</span>
+    <button title="Navigační menu" class="sb-brand-toggler" @onclick="ToggleNavMenu">
+        <span class="navbar-toggler-icon"></span>
+    </button>
 </div>
 
-<div class="@NavMenuCssClass nav-scrollable">
-    <nav class="nav flex-column" @onclick="ToggleNavMenu">
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <i class="bi bi-house-door-fill"></i><span class="nav-label">Přehled</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="map">
-                <i class="bi bi-map-fill"></i><span class="nav-label">Mapa</span>
-            </NavLink>
-        </div>
+<div class="@NavMenuCssClass oh-nav" @onclick="CollapseOnMobile">
+    @* Always-visible: Přehled + Mapa (mode-agnostic overviews) *@
+    <div class="oh-nav-fixed-top">
+        <NavLink class="oh-nav-item" href="" Match="NavLinkMatch.All">
+            <span class="oh-nav-rail"></span>
+            <i class="bi bi-house-door-fill ni"></i><span class="oh-nav-label">Přehled</span>
+        </NavLink>
+        <NavLink class="oh-nav-item" href="map">
+            <span class="oh-nav-rail"></span>
+            <i class="bi bi-map-fill ni"></i><span class="oh-nav-label">Mapa</span>
+        </NavLink>
+    </div>
 
-        <div class="oh-nav-section-label">Hra</div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="timeline">
-                <i class="bi bi-clock-fill"></i><span class="nav-label">Časová osa</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="treasures">
-                <i class="bi bi-safe-fill"></i><span class="nav-label">Poklady</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="characters">
-                <i class="bi bi-person-fill"></i><span class="nav-label">Postavy</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="events">
-                <i class="bi bi-calendar-event-fill"></i><span class="nav-label">Události</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="locations">
-                <i class="bi bi-geo-alt-fill"></i><span class="nav-label">Lokace</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="items">
-                <i class="bi bi-gem"></i><span class="nav-label">Předměty</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="monsters">
-                <img src="img/troll.svg" class="nav-icon-svg" alt="" /><span class="nav-label">Příšery</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="quests">
-                <i class="bi bi-journal-text"></i><span class="nav-label">Questy</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="personal-quests">
-                <i class="bi bi-person-workspace"></i><span class="nav-label">Osobní questy</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="buildings">
-                <i class="bi bi-houses-fill"></i><span class="nav-label">Budovy</span>
-            </NavLink>
-        </div>
-        @if (GameContext.SelectedGameId is int hraSkillsGameId)
-        {
-            <div class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"games/{hraSkillsGameId}/skills")">
-                    <i class="bi bi-star-fill"></i><span class="nav-label">Dovednosti</span>
-                </NavLink>
+    @* Tabs — the two modes *@
+    <div class="oh-nav-tabs" role="tablist" aria-label="Režim">
+        <button type="button"
+                class="oh-nav-tab @(mode == "hra" ? "on" : "")"
+                role="tab"
+                aria-selected="@(mode == "hra" ? "true" : "false")"
+                @onclick='() => SwitchMode("hra")'>
+            <i class="bi bi-calendar-event-fill"></i>
+            <div class="oh-nav-tab-body">
+                <div class="oh-nav-tab-name">Tato hra</div>
+                <div class="oh-nav-tab-hint">@HraTabHint</div>
             </div>
-        }
-        @if (GameContext.SelectedGameId is int hraSpellsGameId)
-        {
-            <div class="nav-item px-3">
-                <NavLink class="nav-link" href="@($"games/{hraSpellsGameId}/spells")">
-                    <i class="bi bi-magic"></i><span class="nav-label">Kouzla</span>
-                </NavLink>
+        </button>
+        <button type="button"
+                class="oh-nav-tab @(mode == "katalog" ? "on" : "")"
+                role="tab"
+                aria-selected="@(mode == "katalog" ? "true" : "false")"
+                @onclick='() => SwitchMode("katalog")'>
+            <i class="bi bi-collection-fill"></i>
+            <div class="oh-nav-tab-body">
+                <div class="oh-nav-tab-name">Katalog</div>
+                <div class="oh-nav-tab-hint">napříč ročníky</div>
             </div>
-        }
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="secret-stashes">
-                <i class="bi bi-lock-fill"></i><span class="nav-label">Tajné skrýše</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="npcs">
-                <i class="bi bi-person-badge-fill"></i><span class="nav-label">NPC</span>
-            </NavLink>
+        </button>
+    </div>
+
+    @* Folder — parchment panel behind the active tab *@
+    <div class="oh-nav-folder">
+        <div class="oh-nav-meta">
+            <span class="dot"></span>
+            @if (mode == "hra")
+            {
+                <b>@(GameContext.GameName ?? "Žádná hra")</b>
+            }
+            else
+            {
+                <b>Šablony</b>
+                <span class="sep">·</span>
+                <span>sdílené napříč ročníky</span>
+            }
         </div>
 
-        <div class="oh-nav-section-label">Katalog světa</div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="locations?catalog=true">
-                <i class="bi bi-geo-alt"></i><span class="nav-label">Lokace</span>
-            </NavLink>
+        <div class="oh-nav-list">
+            <div class="pane pane-@mode" @key="mode">
+                @if (mode == "hra")
+                {
+                    <NavLink class="oh-nav-item" href="timeline">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-clock-fill ni"></i><span class="oh-nav-label">Časová osa</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="treasures">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-safe-fill ni"></i><span class="oh-nav-label">Poklady</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="characters">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-person-fill ni"></i><span class="oh-nav-label">Postavy</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="events">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-calendar-event-fill ni"></i><span class="oh-nav-label">Události</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="locations">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-geo-alt-fill ni"></i><span class="oh-nav-label">Lokace</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="items">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-gem ni"></i><span class="oh-nav-label">Předměty</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="monsters">
+                        <span class="oh-nav-rail"></span>
+                        <img src="img/troll.svg" class="ni oh-nav-icon-svg" alt="" /><span class="oh-nav-label">Příšery</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="quests">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-journal-text ni"></i><span class="oh-nav-label">Questy</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="personal-quests">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-person-workspace ni"></i><span class="oh-nav-label">Osobní questy</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="buildings">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-houses-fill ni"></i><span class="oh-nav-label">Budovy</span>
+                    </NavLink>
+                    @if (GameContext.SelectedGameId is int hraSkillsGameId)
+                    {
+                        <NavLink class="oh-nav-item" href="@($"games/{hraSkillsGameId}/skills")">
+                            <span class="oh-nav-rail"></span>
+                            <i class="bi bi-star-fill ni"></i><span class="oh-nav-label">Dovednosti</span>
+                        </NavLink>
+                    }
+                    @if (GameContext.SelectedGameId is int hraSpellsGameId)
+                    {
+                        <NavLink class="oh-nav-item" href="@($"games/{hraSpellsGameId}/spells")">
+                            <span class="oh-nav-rail"></span>
+                            <i class="bi bi-magic ni"></i><span class="oh-nav-label">Kouzla</span>
+                        </NavLink>
+                    }
+                    <NavLink class="oh-nav-item" href="secret-stashes">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-lock-fill ni"></i><span class="oh-nav-label">Tajné skrýše</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="npcs">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-person-badge-fill ni"></i><span class="oh-nav-label">NPC</span>
+                    </NavLink>
+                }
+                else
+                {
+                    <NavLink class="oh-nav-item" href="locations?catalog=true">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-geo-alt ni"></i><span class="oh-nav-label">Lokace</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="items?catalog=true">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-gem ni"></i><span class="oh-nav-label">Předměty</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="monsters?catalog=true">
+                        <span class="oh-nav-rail"></span>
+                        <img src="img/troll.svg" class="ni oh-nav-icon-svg" alt="" /><span class="oh-nav-label">Příšery</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="quests?catalog=true">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-journal-text ni"></i><span class="oh-nav-label">Questy</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="personal-quests?catalog=true">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-person-workspace ni"></i><span class="oh-nav-label">Osobní questy</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="buildings?catalog=true">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-houses ni"></i><span class="oh-nav-label">Budovy</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="skills">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-star ni"></i><span class="oh-nav-label">Dovednosti</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="spells">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-magic ni"></i><span class="oh-nav-label">Kouzla</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="secret-stashes?catalog=true">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-lock ni"></i><span class="oh-nav-label">Tajné skrýše</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="npcs?catalog=true">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-person-badge ni"></i><span class="oh-nav-label">NPC</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="kingdoms">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-flag ni"></i><span class="oh-nav-label">Království</span>
+                    </NavLink>
+                }
+            </div>
         </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="items?catalog=true">
-                <i class="bi bi-gem"></i><span class="nav-label">Předměty</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="monsters?catalog=true">
-                <img src="img/troll.svg" class="nav-icon-svg" alt="" /><span class="nav-label">Příšery</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="quests?catalog=true">
-                <i class="bi bi-journal-text"></i><span class="nav-label">Questy</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="personal-quests?catalog=true">
-                <i class="bi bi-person-workspace"></i><span class="nav-label">Osobní questy</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="buildings?catalog=true">
-                <i class="bi bi-houses"></i><span class="nav-label">Budovy</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="skills">
-                <i class="bi bi-star"></i><span class="nav-label">Dovednosti</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="spells">
-                <i class="bi bi-magic"></i><span class="nav-label">Kouzla</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="secret-stashes?catalog=true">
-                <i class="bi bi-lock"></i><span class="nav-label">Tajné skrýše</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="npcs?catalog=true">
-                <i class="bi bi-person-badge"></i><span class="nav-label">NPC</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="kingdoms">
-                <i class="bi bi-flag"></i><span class="nav-label">Království</span>
-            </NavLink>
-        </div>
+    </div>
 
-        <div class="oh-nav-section-label">Nástroje</div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="games">
-                <i class="bi bi-calendar-event-fill"></i><span class="nav-label">Seznam Ovčin</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="tags">
-                <i class="bi bi-tags-fill"></i><span class="nav-label">Tagy</span>
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="search">
-                <i class="bi bi-search"></i><span class="nav-label">Hledání</span>
-            </NavLink>
-        </div>
-    </nav>
+    @* Tools — always pinned bottom *@
+    <div class="oh-nav-tools">
+        <div class="oh-nav-tools-head">Nástroje</div>
+        <NavLink class="oh-nav-item" href="games">
+            <span class="oh-nav-rail"></span>
+            <i class="bi bi-list-ul ni"></i><span class="oh-nav-label">Seznam Ovčin</span>
+        </NavLink>
+        <NavLink class="oh-nav-item" href="tags">
+            <span class="oh-nav-rail"></span>
+            <i class="bi bi-tags-fill ni"></i><span class="oh-nav-label">Tagy</span>
+        </NavLink>
+        <NavLink class="oh-nav-item" href="search">
+            <span class="oh-nav-rail"></span>
+            <i class="bi bi-search ni"></i><span class="oh-nav-label">Hledání</span>
+        </NavLink>
+    </div>
 
-    <div class="nav-footer">
-        <button class="collapse-toggle" title="Sbalit menu" @onclick="OnToggle" @onclick:stopPropagation="true">
+    <div class="oh-nav-foot">
+        <button class="oh-nav-collapse" title="Sbalit menu" @onclick="OnToggle" @onclick:stopPropagation="true">
             <i class="bi @(Collapsed ? "bi-chevron-right" : "bi-chevron-left")"></i>
         </button>
         @if (!Collapsed)
@@ -194,18 +216,60 @@
     [Parameter] public bool Collapsed { get; set; }
     [Parameter] public EventCallback OnToggle { get; set; }
 
+    private const string NavModeStorageKey = "oh-nav-mode";
+
     private static string AppVersion =>
         typeof(NavMenu).Assembly
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion.Split('+')[0] ?? "dev";
 
+    private string mode = "hra";  // "hra" | "katalog"
+
     private bool collapseNavMenu = true;
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
     private void ToggleNavMenu() => collapseNavMenu = !collapseNavMenu;
 
+    // On mobile, tapping an item collapses the menu (preserves pre-rewrite behaviour).
+    // We bind this to the whole nav container; tab buttons stop propagation via their click handlers being separate.
+    private void CollapseOnMobile() => collapseNavMenu = true;
+
+    private string HraTabHint => GameContext.GameName ?? "žádná hra";
+
     protected override void OnInitialized()
     {
         GameContext.OnGameChanged += OnGameChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+        try
+        {
+            var stored = await JS.InvokeAsync<string?>("localStorage.getItem", NavModeStorageKey);
+            if ((stored == "hra" || stored == "katalog") && stored != mode)
+            {
+                mode = stored;
+                StateHasChanged();
+            }
+        }
+        catch
+        {
+            // prerender / JS-unavailable — keep default mode
+        }
+    }
+
+    private async Task SwitchMode(string next)
+    {
+        if (mode == next) return;
+        mode = next;
+        try
+        {
+            await JS.InvokeVoidAsync("localStorage.setItem", NavModeStorageKey, next);
+        }
+        catch
+        {
+            // non-fatal
+        }
     }
 
     private async void OnGameChanged()

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -6,8 +6,8 @@
 
 <div class="sb-brand">
     <i class="bi bi-feather"></i><span>OvčinaHra</span>
-    <button title="Navigační menu" class="sb-brand-toggler" @onclick="ToggleNavMenu">
-        <span class="navbar-toggler-icon"></span>
+    <button title="Navigační menu" class="sb-brand-toggler" @onclick="ToggleNavMenu" aria-label="Navigační menu">
+        <i class="bi bi-list"></i>
     </button>
 </div>
 
@@ -24,13 +24,18 @@
         </NavLink>
     </div>
 
-    @* Tabs — the two modes *@
-    <div class="oh-nav-tabs" role="tablist" aria-label="Režim">
+    @* Mode switch — two toggle buttons. Uses aria-pressed rather than the
+       tablist/tab/tabpanel triad (we don't implement full ARIA tabs with
+       roving tabindex + arrow-key handling; a button group is the honest
+       representation). @onclick:stopPropagation keeps tab clicks from
+       bubbling to the outer CollapseOnMobile handler, which would close
+       the menu immediately after a mode switch on touch devices. *@
+    <div class="oh-nav-tabs" aria-label="Režim">
         <button type="button"
                 class="oh-nav-tab @(mode == "hra" ? "on" : "")"
-                role="tab"
-                aria-selected="@(mode == "hra" ? "true" : "false")"
-                @onclick='() => SwitchMode("hra")'>
+                aria-pressed="@(mode == "hra" ? "true" : "false")"
+                @onclick='() => SwitchMode("hra")'
+                @onclick:stopPropagation="true">
             <i class="bi bi-calendar-event-fill"></i>
             <div class="oh-nav-tab-body">
                 <div class="oh-nav-tab-name">Tato hra</div>
@@ -39,9 +44,9 @@
         </button>
         <button type="button"
                 class="oh-nav-tab @(mode == "katalog" ? "on" : "")"
-                role="tab"
-                aria-selected="@(mode == "katalog" ? "true" : "false")"
-                @onclick='() => SwitchMode("katalog")'>
+                aria-pressed="@(mode == "katalog" ? "true" : "false")"
+                @onclick='() => SwitchMode("katalog")'
+                @onclick:stopPropagation="true">
             <i class="bi bi-collection-fill"></i>
             <div class="oh-nav-tab-body">
                 <div class="oh-nav-tab-name">Katalog</div>
@@ -233,7 +238,7 @@
     // We bind this to the whole nav container; tab buttons stop propagation via their click handlers being separate.
     private void CollapseOnMobile() => collapseNavMenu = true;
 
-    private string HraTabHint => GameContext.GameName ?? "žádná hra";
+    private string HraTabHint => GameContext.GameName ?? "Žádná hra";
 
     protected override void OnInitialized()
     {

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor.css
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor.css
@@ -1,134 +1,392 @@
-.navbar-toggler {
-    background-color: rgba(255, 255, 255, 0.15);
-    border-color: rgba(255, 255, 255, 0.2);
-}
+/* ═══════════ Sidebar (Variant C — tabs) ═══════════
+   Ported from docs/design/dialogs/sidebar.mockup.unbundled.html.
+   Scoped to NavMenu.razor — all rules use .oh-nav-* or .sb-brand*.
+   The dark sidebar gradient itself is applied by MainLayout on
+   .sidebar via var(--oh-sidebar). */
 
-.top-row {
-    min-height: 3.5rem;
-    background-color: rgba(0, 0, 0, 0.25);
-    padding: 0 1rem;
-}
-
-.navbar-brand {
-    font-family: var(--oh-font-heading);
-    font-size: 1.15rem;
-    font-weight: 700;
+/* Brand row — replaces the old .top-row */
+.sb-brand {
+    height: 3.5rem;
+    padding: 0 18px;
+    background: rgba(0, 0, 0, 0.28);
     color: var(--oh-header-text);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-family: var(--oh-font-heading);
+    font-weight: 700;
+    font-size: 1.05rem;
     letter-spacing: 0.01em;
+    flex-shrink: 0;
 }
 
-.oh-nav-section-label {
+    .sb-brand .bi-feather {
+        font-size: 1.1rem;
+        opacity: 0.92;
+    }
+
+.sb-brand-toggler {
+    margin-left: auto;
+    background-color: rgba(255, 255, 255, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: var(--oh-header-text);
+    border-radius: var(--oh-radius-sm);
+    padding: 0.25rem 0.5rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+/* Main nav container — replaces .nav-scrollable */
+.oh-nav {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    color: var(--oh-header-text);
+    font-family: var(--oh-font-body);
+    font-size: 0.875rem;
+}
+
+/* Always-visible pinned row (Přehled, Mapa) */
+.oh-nav-fixed-top {
+    padding: 8px 0 6px;
+    flex-shrink: 0;
+}
+
+/* ═══════════ Tabs — paper "jazyčky" sticking up out of the folder ═══════════ */
+.oh-nav-tabs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2px;
+    padding: 10px 10px 0;
+    background: transparent;
+    position: relative;
+    flex-shrink: 0;
+}
+
+.oh-nav-tab {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 9px 10px 11px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-bottom: none;
+    border-radius: 7px 7px 0 0;
+    color: rgba(255, 255, 255, 0.92);
+    text-align: left;
+    cursor: pointer;
+    font-family: var(--oh-font-body);
+    transition: background 0.15s, color 0.15s, transform 0.15s;
+}
+
+    .oh-nav-tab .bi {
+        font-size: 1rem;
+        opacity: 0.9;
+        transition: opacity 0.15s, color 0.15s;
+    }
+
+    .oh-nav-tab:hover {
+        background: rgba(255, 255, 255, 0.14);
+        color: #fff;
+    }
+
+        .oh-nav-tab:hover .bi {
+            opacity: 1;
+        }
+
+    .oh-nav-tab.on {
+        /* Parchment raising above the dark sidebar — the "wrapped paper-tab" effect */
+        background: linear-gradient(180deg, #E8F0E4 0%, #D6E4CC 100%);
+        color: var(--oh-primary);
+        border-color: rgba(0, 0, 0, 0.18);
+        box-shadow: 0 -1px 0 rgba(255, 255, 255, 0.25) inset, 0 2px 6px rgba(0, 0, 0, 0.12);
+        z-index: 2;
+    }
+
+        .oh-nav-tab.on .bi {
+            opacity: 1;
+            color: var(--oh-primary);
+        }
+
+.oh-nav-tab-body {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.05;
+    min-width: 0;
+    flex: 1;
+}
+
+.oh-nav-tab-name {
+    font-size: 0.8125rem;
+    font-weight: 700;
+}
+
+.oh-nav-tab-hint {
+    font-size: 0.625rem;
+    opacity: 0.85;
+    font-family: var(--oh-font-mono);
+    margin-top: 3px;
+    letter-spacing: 0.02em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.oh-nav-tab.on .oh-nav-tab-hint {
+    opacity: 0.85;
+    color: var(--oh-primary-light);
+}
+
+/* ═══════════ Folder — parchment panel behind the active section ═══════════ */
+.oh-nav-folder {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    background: linear-gradient(180deg, #E8F0E4 0%, #D6E4CC 6%, rgba(214, 228, 204, 0) 14%);
+    border-top: 1px solid rgba(0, 0, 0, 0.18);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2);
+    position: relative;
+    margin-top: -1px;
+}
+
+/* Meta line — just under tabs, explains the active mode */
+.oh-nav-meta {
+    padding: 10px 16px 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
     font-size: 0.6875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: rgba(255, 255, 255, 0.4);
-    padding: 0.75rem 1rem 0.25rem 1rem;
+    color: rgba(255, 255, 255, 0.78);
+    font-family: var(--oh-font-mono);
+    background: rgba(0, 0, 0, 0.06);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    flex-shrink: 0;
+}
+
+    .oh-nav-meta .dot {
+        width: 5px;
+        height: 5px;
+        border-radius: 50%;
+        background: var(--oh-primary-lighter);
+        box-shadow: 0 0 4px rgba(107, 155, 55, 0.6);
+        flex-shrink: 0;
+    }
+
+    .oh-nav-meta b {
+        color: #fff;
+        font-family: var(--oh-font-heading);
+        font-weight: 700;
+        font-size: 0.8125rem;
+        letter-spacing: 0;
+    }
+
+    .oh-nav-meta .sep {
+        opacity: 0.4;
+    }
+
+/* Scrolling middle list */
+.oh-nav-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 6px 0 10px;
+    min-height: 0;
+}
+
+    .oh-nav-list::-webkit-scrollbar {
+        width: 4px;
+    }
+
+    .oh-nav-list::-webkit-scrollbar-thumb {
+        background: rgba(255, 255, 255, 0.12);
+        border-radius: 2px;
+    }
+
+/* Crossfade on mode switch — animate transform only, keep opacity safe */
+.oh-nav-list > .pane {
+    animation: oh-nav-panefade 0.22s ease both;
+}
+
+@keyframes oh-nav-panefade {
+    from {
+        transform: translateX(4px);
+    }
+
+    to {
+        transform: none;
+    }
+}
+
+/* ═══════════ Nav item — shared look across pinned + list + tools ═══════════ */
+.oh-nav-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    height: 38px;
+    padding: 0 14px 0 18px;
+    color: rgba(255, 255, 255, 0.8);
+    text-decoration: none;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+    .oh-nav-item .ni {
+        width: 18px;
+        text-align: center;
+        font-size: 0.95rem;
+        opacity: 0.7;
+        flex-shrink: 0;
+        transition: opacity 0.15s, color 0.15s;
+    }
+
+    .oh-nav-item img.ni {
+        height: 16px;
+        filter: brightness(0) invert(1);
+        opacity: 0.75;
+    }
+
+.oh-nav-rail {
+    position: absolute;
+    left: 0;
+    top: 6px;
+    bottom: 6px;
+    width: 3px;
+    background: transparent;
+    border-radius: 0 2px 2px 0;
+    transition: background 0.15s, box-shadow 0.15s;
+}
+
+.oh-nav-item:hover {
+    background: rgba(255, 255, 255, 0.07);
+    color: #fff;
+}
+
+    .oh-nav-item:hover .ni {
+        opacity: 0.95;
+    }
+
+    .oh-nav-item:hover .oh-nav-rail {
+        background: rgba(107, 155, 55, 0.4);
+    }
+
+/* Active state — NavLink emits .active on the anchor */
+.oh-nav-item.active {
+    background: linear-gradient(90deg, rgba(107, 155, 55, 0.32) 0%, rgba(107, 155, 55, 0.05) 100%);
+    color: #fff;
     font-weight: 600;
 }
 
-.nav-item {
-    font-size: 0.875rem;
-    padding-bottom: 0.125rem;
-}
-
-    .nav-item:first-of-type {
-        padding-top: 0.5rem;
+    .oh-nav-item.active .ni {
+        opacity: 1;
+        color: #B8D48C;
     }
 
-    .nav-item:last-of-type {
-        padding-bottom: 0.5rem;
-    }
-
-    .nav-item ::deep a {
-        color: rgba(255, 255, 255, 0.75);
-        border-radius: var(--oh-radius-sm);
-        height: 2.5rem;
-        display: flex;
-        align-items: center;
-        line-height: 2.5rem;
-        gap: 0.625rem;
-        transition: all 0.15s ease;
-    }
-
-    .nav-item ::deep a .bi {
-        font-size: 1rem;
-        opacity: 0.7;
-        width: 1.25rem;
-        text-align: center;
-    }
-
-.nav-item ::deep a.active {
-    background-color: rgba(255, 255, 255, 0.15);
-    color: white;
-}
-
-    .nav-item ::deep a.active .bi {
+    .oh-nav-item.active img.ni {
+        filter: brightness(0) invert(1);
         opacity: 1;
     }
 
-.nav-item ::deep a:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-    color: white;
+    .oh-nav-item.active .oh-nav-rail {
+        background: var(--oh-primary-lighter);
+        box-shadow: 0 0 8px rgba(107, 155, 55, 0.6);
+    }
+
+    .oh-nav-item.active::after {
+        content: "";
+        position: absolute;
+        right: 12px;
+        top: 50%;
+        width: 5px;
+        height: 5px;
+        border-radius: 50%;
+        background: #F5EDE3;
+        transform: translateY(-50%);
+        opacity: 0.75;
+    }
+
+.oh-nav-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.nav-footer {
-    padding: 0.5rem 0.75rem;
+.oh-nav-icon-svg {
+    /* img variant — already handled by img.ni, but keep a stable class for Razor */
+    height: 16px;
+}
+
+/* ═══════════ Bottom tools drawer — darker bg, pinned ═══════════ */
+.oh-nav-tools {
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(0, 0, 0, 0.22);
+    padding: 4px 0 0;
+    flex-shrink: 0;
+    position: sticky;
+    bottom: 0;
+}
+
+.oh-nav-tools-head {
+    padding: 9px 18px 3px;
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(255, 255, 255, 0.5);
+    font-family: var(--oh-font-body);
+}
+
+/* ═══════════ Footer ═══════════ */
+.oh-nav-foot {
+    padding: 8px 12px;
     font-size: 0.6875rem;
-    color: rgba(255, 255, 255, 0.35);
+    font-family: var(--oh-font-mono);
+    color: rgba(255, 255, 255, 0.38);
     text-align: center;
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(0, 0, 0, 0.2);
     display: flex;
     align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
+    justify-content: space-between;
+    gap: 6px;
+    flex-shrink: 0;
 }
 
-.nav-icon-svg {
-    width: 1rem;
-    height: 1rem;
-    min-width: 1rem;
-    opacity: 0.7;
-    filter: brightness(0) invert(1);
-}
-
-::deep a.active .nav-icon-svg {
-    opacity: 1;
-}
-
-.collapse-toggle {
+.oh-nav-collapse {
     background: none;
     border: none;
     color: rgba(255, 255, 255, 0.4);
-    cursor: pointer;
-    padding: 0.25rem;
     font-size: 0.875rem;
+    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: 3px;
     line-height: 1;
-    border-radius: var(--oh-radius-sm);
-    transition: all 0.15s ease;
+    transition: 0.15s;
 }
 
-.collapse-toggle:hover {
-    color: white;
-    background-color: rgba(255, 255, 255, 0.1);
+    .oh-nav-collapse:hover {
+        color: #fff;
+        background: rgba(255, 255, 255, 0.08);
+    }
+
+/* ═══════════ Mobile vs desktop ═══════════
+   < 641px: .collapse hides the nav until the toggler opens it.
+   641px+: always show the nav and hide the mobile toggler. */
+@media (max-width: 640.98px) {
+    .oh-nav.collapse {
+        display: none;
+    }
 }
 
 @media (min-width: 641px) {
-    .navbar-toggler {
+    .sb-brand-toggler {
         display: none;
     }
 
-    .collapse {
-        display: block;
-    }
-
-    .nav-scrollable {
-        height: calc(100vh - 3.5rem);
-        overflow-y: auto;
+    .oh-nav.collapse {
         display: flex;
-        flex-direction: column;
-    }
-
-    .nav-scrollable nav {
-        flex: 1;
     }
 }

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.13.2</Version>
+    <Version>0.14.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Variant C port of the Claude Design sidebar mockup. Two tabs "Tato hra" / "Katalog" at the top of the sidebar replace the old duplicate Hra/Katalog sections. Click swaps the middle list with a gentle crossfade.
- Přehled + Mapa stay pinned above the tabs (mode-agnostic). Nástroje stays pinned at the bottom with a darker parchment bg.
- Active item: 3 px forest-green left stripe, sage-mist gradient, white 600-weight text, parchment-cream dot pinned to the right edge.
- Mode persists in `localStorage` under `oh-nav-mode` (values `hra` / `katalog`) — survives F5. Prerender / JS-unavailable scenarios fall back to the default `hra` mode.
- All existing routes preserved (the previous `NavMenu.razor` was the canonical source). Version 0.13.1 → 0.14.0 (minor — nav paradigm shift).

## Test plan

- [ ] `dotnet build OvcinaHra.slnx` clean (0 warnings, 0 errors under `TreatWarningsAsErrors=true`)
- [ ] Sidebar shows two tabs at top: `Tato hra` / `Katalog` — click swaps the middle item list
- [ ] Přehled + Mapa always visible above the tabs
- [ ] Nástroje pinned to the bottom with a darker bg
- [ ] Active nav item styling matches (3 px stripe · sage-mist gradient · white text · right-side dot)
- [ ] Inactive tab has the wrapped top corner (paper-tab effect)
- [ ] Meta line under tabs shows game name/edition in `hra` mode (falls back to "Žádná hra" when there's no active game); "Šablony · sdílené napříč ročníky" in `katalog` mode
- [ ] Mode survives F5 (localStorage round-trip)
- [ ] All existing routes still resolve (including `games/{id}/skills` and `games/{id}/spells` in game mode, `kingdoms` in catalog)
- [ ] Czech diacritics render correctly (Přehled, Příšery, Skrýše, Království, Hledání, Nástroje, Žádná hra)
- [ ] DevTools console clean on first load and on tab switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)