### PR TITLE
feat(monsters): /monsters/{id} detail page with 5 tabs + Bojovka presenter [v0.14.1]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
@@ -258,6 +258,10 @@ public static class MonsterEndpoints
         foreach (var a in assigned) info[a.GameId] = (a.GameName, a.Edition, a.StartDate);
         foreach (var l in lootRows) info.TryAdd(l.GameId, (l.GameName, l.Edition, l.StartDate));
 
+        // Index loot once by GameId so the per-game projection below is O(games + lootRows)
+        // instead of the O(games × lootRows) re-scan a naive .Where would do.
+        var lootByGame = lootRows.ToLookup(l => l.GameId, l => l.Loot);
+
         var result = info
             .OrderByDescending(kv => kv.Value.StartDate)
             .ThenBy(kv => kv.Value.Name)
@@ -265,10 +269,7 @@ public static class MonsterEndpoints
                 kv.Key,
                 kv.Value.Name,
                 kv.Value.Edition,
-                lootRows.Where(l => l.GameId == kv.Key)
-                        .Select(l => l.Loot)
-                        .OrderBy(d => d.ItemName)
-                        .ToList()))
+                lootByGame[kv.Key].OrderBy(d => d.ItemName).ToList()))
             .ToList();
 
         return TypedResults.Ok(result);

--- a/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/MonsterEndpoints.cs
@@ -33,8 +33,12 @@ public static class MonsterEndpoints
 
         // Loot
         group.MapGet("/{id:int}/loot/{gameId:int}", GetLoot);
+        group.MapGet("/{id:int}/loot/all-games", GetLootAllGames);
         group.MapPost("/loot", CreateLoot);
         group.MapDelete("/loot/{monsterId:int}/{itemId:int}/{gameId:int}", DeleteLoot);
+
+        // Detail-page aggregates
+        group.MapGet("/{id:int}/occurrences", GetOccurrences);
 
         return group;
     }
@@ -229,5 +233,72 @@ public static class MonsterEndpoints
         db.MonsterLoots.Remove(loot);
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
+    }
+
+    private static async Task<Ok<List<MonsterLootByGameDto>>> GetLootAllGames(int id, WorldDbContext db)
+    {
+        var assigned = await db.GameMonsters
+            .Where(gm => gm.MonsterId == id)
+            .Select(gm => new { gm.GameId, GameName = gm.Game.Name, gm.Game.Edition, gm.Game.StartDate })
+            .ToListAsync();
+
+        var lootRows = await db.MonsterLoots
+            .Where(ml => ml.MonsterId == id)
+            .Select(ml => new
+            {
+                ml.GameId,
+                GameName = ml.Game.Name,
+                ml.Game.Edition,
+                ml.Game.StartDate,
+                Loot = new MonsterLootDto(ml.MonsterId, ml.ItemId, ml.Item.Name, ml.GameId, ml.Quantity)
+            })
+            .ToListAsync();
+
+        var info = new Dictionary<int, (string Name, int Edition, DateOnly StartDate)>();
+        foreach (var a in assigned) info[a.GameId] = (a.GameName, a.Edition, a.StartDate);
+        foreach (var l in lootRows) info.TryAdd(l.GameId, (l.GameName, l.Edition, l.StartDate));
+
+        var result = info
+            .OrderByDescending(kv => kv.Value.StartDate)
+            .ThenBy(kv => kv.Value.Name)
+            .Select(kv => new MonsterLootByGameDto(
+                kv.Key,
+                kv.Value.Name,
+                kv.Value.Edition,
+                lootRows.Where(l => l.GameId == kv.Key)
+                        .Select(l => l.Loot)
+                        .OrderBy(d => d.ItemName)
+                        .ToList()))
+            .ToList();
+
+        return TypedResults.Ok(result);
+    }
+
+    private static async Task<Ok<List<MonsterOccurrenceDto>>> GetOccurrences(int id, WorldDbContext db)
+    {
+        var rows = await db.QuestEncounters
+            .Where(qe => qe.MonsterId == id && qe.Quest.GameId != null)
+            .Select(qe => new
+            {
+                GameId = qe.Quest.GameId!.Value,
+                GameName = qe.Quest.Game!.Name,
+                qe.Quest.Game.Edition,
+                qe.QuestId,
+                qe.Quantity
+            })
+            .ToListAsync();
+
+        var grouped = rows
+            .GroupBy(r => new { r.GameId, r.GameName, r.Edition })
+            .Select(g => new MonsterOccurrenceDto(
+                g.Key.GameId,
+                g.Key.GameName,
+                g.Key.Edition,
+                g.Select(x => x.QuestId).Distinct().Count(),
+                g.Sum(x => x.Quantity)))
+            .OrderBy(o => o.GameName)
+            .ToList();
+
+        return TypedResults.Ok(grouped);
     }
 }

--- a/src/OvcinaHra.Client/Components/MonsterLootTile.razor
+++ b/src/OvcinaHra.Client/Components/MonsterLootTile.razor
@@ -1,0 +1,37 @@
+<div class="oh-mon-d-loot-tile" @onclick="HandleClick" role="button" tabindex="0">
+    <div class="oh-mon-d-loot-tile-img">
+        @if (!string.IsNullOrEmpty(ImageUrl) && !imageFailed)
+        {
+            <img src="@ImageUrl" alt="@Loot.ItemName" @onerror="() => imageFailed = true" />
+        }
+        else
+        {
+            <i class="bi bi-box-seam oh-mon-d-loot-tile-img-empty" aria-hidden="true"></i>
+        }
+        @if (Loot.Quantity > 1)
+        {
+            <span class="oh-mon-d-loot-tile-qty">× @Loot.Quantity</span>
+        }
+    </div>
+    <div class="oh-mon-d-loot-tile-name" title="@Loot.ItemName">@Loot.ItemName</div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public MonsterLootDto Loot { get; set; } = null!;
+    [Parameter] public string? ImageUrl { get; set; }
+    [Parameter] public EventCallback OnClick { get; set; }
+
+    private bool imageFailed;
+    private string? _lastImageUrl;
+
+    protected override void OnParametersSet()
+    {
+        if (_lastImageUrl != ImageUrl)
+        {
+            _lastImageUrl = ImageUrl;
+            imageFailed = false;
+        }
+    }
+
+    private Task HandleClick() => OnClick.HasDelegate ? OnClick.InvokeAsync() : Task.CompletedTask;
+}

--- a/src/OvcinaHra.Client/Components/TagChipPicker.razor
+++ b/src/OvcinaHra.Client/Components/TagChipPicker.razor
@@ -1,0 +1,128 @@
+@inject ApiClient Api
+
+<div class="oh-mon-d-tags">
+    @foreach (var tag in selectedTags)
+    {
+        var captured = tag;
+        <span class="oh-mon-d-tag" @key="captured.Id">
+            @captured.Name
+            <button type="button"
+                    style="background:transparent;border:none;color:inherit;font-weight:700;margin-left:4px;cursor:pointer;padding:0 2px"
+                    title="Odebrat"
+                    @onclick="() => RemoveAsync(captured)">×</button>
+        </span>
+    }
+
+    @if (showAdd)
+    {
+        <DxComboBox Data="@unselectedTags"
+                    @bind-Value="@pendingAddId"
+                    TextFieldName="Name"
+                    ValueFieldName="Id"
+                    NullText="(vyberte tag)"
+                    SearchMode="ListSearchMode.AutoSearch"
+                    CssClass="oh-mon-d-tag-combo"
+                    SizeMode="SizeMode.Small" />
+        <button type="button" class="btn btn-sm btn-primary"
+                disabled="@(pendingAddId is null)" @onclick="AddAsync">Přidat</button>
+        <button type="button" class="btn btn-sm btn-link" @onclick="() => showAdd = false">Zrušit</button>
+    }
+    else
+    {
+        <button type="button" class="btn btn-sm btn-outline-primary" @onclick="OpenAdd">
+            <i class="bi bi-plus-lg"></i> Přidat tag
+        </button>
+    }
+</div>
+
+@if (error is not null)
+{
+    <div class="alert alert-danger mt-2 py-1 px-2 small">@error</div>
+}
+
+@code {
+    [Parameter, EditorRequired] public int MonsterId { get; set; }
+    [Parameter] public List<TagDto> InitialTags { get; set; } = [];
+    [Parameter] public EventCallback Changed { get; set; }
+
+    private List<TagDto> selectedTags = [];
+    private List<TagDto> allTags = [];
+    private List<TagDto> unselectedTags = [];
+    private bool showAdd;
+    private int? pendingAddId;
+    private string? error;
+    private int _lastMonsterId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await SyncFromParamsAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_lastMonsterId != MonsterId)
+        {
+            await SyncFromParamsAsync();
+        }
+    }
+
+    private async Task SyncFromParamsAsync()
+    {
+        _lastMonsterId = MonsterId;
+        selectedTags = [..InitialTags];
+        if (allTags.Count == 0)
+        {
+            allTags = await Api.GetListAsync<TagDto>("/api/tags");
+        }
+        Recompute();
+    }
+
+    private void Recompute()
+    {
+        var selectedIds = selectedTags.Select(t => t.Id).ToHashSet();
+        unselectedTags = allTags
+            .Where(t => !selectedIds.Contains(t.Id))
+            .OrderBy(t => t.Name)
+            .ToList();
+    }
+
+    private void OpenAdd()
+    {
+        pendingAddId = null;
+        error = null;
+        showAdd = true;
+    }
+
+    private async Task AddAsync()
+    {
+        if (pendingAddId is null) return;
+        error = null;
+        try
+        {
+            await Api.PostAsync($"/api/monsters/{MonsterId}/tags/{pendingAddId}");
+            var newTag = allTags.FirstOrDefault(t => t.Id == pendingAddId);
+            if (newTag is not null)
+            {
+                selectedTags.Add(newTag);
+                Recompute();
+            }
+            pendingAddId = null;
+            showAdd = false;
+            if (Changed.HasDelegate) await Changed.InvokeAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task RemoveAsync(TagDto tag)
+    {
+        error = null;
+        try
+        {
+            await Api.DeleteAsync($"/api/monsters/{MonsterId}/tags/{tag.Id}");
+            selectedTags.Remove(tag);
+            Recompute();
+            if (Changed.HasDelegate) await Changed.InvokeAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+}

--- a/src/OvcinaHra.Client/Components/TagChipPicker.razor
+++ b/src/OvcinaHra.Client/Components/TagChipPicker.razor
@@ -21,7 +21,6 @@
                     ValueFieldName="Id"
                     NullText="(vyberte tag)"
                     SearchMode="ListSearchMode.AutoSearch"
-                    CssClass="oh-mon-d-tag-combo"
                     SizeMode="SizeMode.Small" />
         <button type="button" class="btn btn-sm btn-primary"
                 disabled="@(pendingAddId is null)" @onclick="AddAsync">Přidat</button>
@@ -118,7 +117,12 @@
         error = null;
         try
         {
-            await Api.DeleteAsync($"/api/monsters/{MonsterId}/tags/{tag.Id}");
+            var ok = await Api.DeleteAsync($"/api/monsters/{MonsterId}/tags/{tag.Id}");
+            if (!ok)
+            {
+                error = $"Odebrání tagu „{tag.Name}\u201c selhalo.";
+                return;
+            }
             selectedTags.Remove(tag);
             Recompute();
             if (Changed.HasDelegate) await Changed.InvokeAsync();

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.14.0</Version>
+    <Version>0.14.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterDetail.razor
@@ -1,0 +1,733 @@
+@page "/monsters/{Id:int}"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject GameContextService GameContext
+@inject NavigationManager Nav
+
+@if (loading)
+{
+    <p class="oh-mon-d-loading">Načítám…</p>
+}
+else if (monster is null)
+{
+    <div class="oh-mon-d-empty">
+        <i class="bi bi-exclamation-circle"></i>
+        <p>Příšera nenalezena.</p>
+        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/monsters")'>← Zpět na seznam</button>
+    </div>
+}
+else
+{
+    <div class="oh-mon-d-ts">
+        <button class="oh-mon-d-back" type="button"
+                @onclick='() => Nav.NavigateTo("/monsters")'>
+            <i class="bi bi-arrow-left"></i> Zpět
+        </button>
+        <div class="oh-mon-d-ts-title">
+            <h1>@monster.Name</h1>
+            <div class="oh-mon-d-ts-sub">
+                <span class="oh-mon-d-mtype">
+                    <i class="bi @MonsterTypeIcon(monster.MonsterType)"></i>@monster.MonsterType.GetDisplayName()
+                </span>
+                <span class="oh-mon-d-dotsep">·</span>
+                <span class="oh-mon-d-kbadge"><i class="bi bi-bar-chart-steps"></i>K@monster.Category</span>
+                <span class="oh-mon-d-dotsep">·</span>
+                <span class="oh-mon-d-id">#M@monster.Id.ToString("D3")</span>
+            </div>
+        </div>
+        <div class="oh-mon-d-ts-actions">
+            @if (activeTab == "upravit")
+            {
+                <button class="btn btn-secondary" @onclick="CancelEdit" disabled="@isSaving">Zrušit</button>
+                <button class="btn btn-primary" @onclick="SaveAsync"
+                        disabled="@(isSaving || string.IsNullOrWhiteSpace(editName))">Uložit</button>
+            }
+            else
+            {
+                <button class="btn btn-outline-primary" @onclick='() => SetTab("upravit")'><i class="bi bi-pencil"></i> Upravit</button>
+                <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true"><i class="bi bi-trash"></i> Smazat</button>
+            }
+        </div>
+    </div>
+
+    <div class="oh-mon-d-tabs">
+        <button class="oh-mon-d-tab @(activeTab == "karta" ? "oh-mon-d-active" : null)" @onclick='() => SetTab("karta")'>
+            <i class="bi bi-bookmark-fill"></i> Karta
+        </button>
+        <button class="oh-mon-d-tab @(activeTab == "upravit" ? "oh-mon-d-active" : null)" @onclick='() => SetTab("upravit")'>
+            <i class="bi bi-pencil"></i> Upravit
+        </button>
+        <button class="oh-mon-d-tab @(activeTab == "bojovka" ? "oh-mon-d-active" : null)" @onclick='() => SetTab("bojovka")'>
+            <i class="bi bi-shield-shaded"></i> Bojovka
+        </button>
+        <button class="oh-mon-d-tab @(activeTab == "korist" ? "oh-mon-d-active" : null)" @onclick='() => SetTab("korist")'>
+            <i class="bi bi-gem"></i> Kořist
+            @if (lootCount > 0)
+            {
+                <span class="oh-mon-d-tab-count">@lootCount</span>
+            }
+        </button>
+        <button class="oh-mon-d-tab @(activeTab == "vyskyt" ? "oh-mon-d-active" : null)" @onclick='() => SetTab("vyskyt")'>
+            <i class="bi bi-geo-alt"></i> Výskyt
+            @if (occurrenceCount > 0)
+            {
+                <span class="oh-mon-d-tab-count">@occurrenceCount</span>
+            }
+        </button>
+    </div>
+
+    <div class="oh-mon-d-body">
+        @if (activeTab == "karta")
+        {
+            <div class="oh-mon-d-bestiary">
+                <div class="oh-mon-d-karta">
+                    <div>
+                        <div class="oh-mon-d-illust">
+                            @if (!string.IsNullOrEmpty(heroImageUrl) && !heroImageFailed)
+                            {
+                                <img src="@heroImageUrl" alt="@monster.Name"
+                                     @onerror="() => heroImageFailed = true" />
+                            }
+                            else
+                            {
+                                <div class="oh-mon-d-illust-empty">
+                                    <i class="bi bi-bug-fill"></i>
+                                    <span>Iluustrace čeká</span>
+                                </div>
+                            }
+                        </div>
+                        <div class="oh-mon-d-illust-cap">
+                            <span>@monster.MonsterType.GetDisplayName() · Kategorie @monster.Category</span>
+                        </div>
+                    </div>
+                    <div class="oh-mon-d-stats">
+                        <div class="oh-mon-d-statrow">
+                            <i class="oh-mon-d-stat-icon bi bi-lightning-charge"></i>
+                            <span class="oh-mon-d-stat-lab">Útok</span>
+                            <span class="oh-mon-d-stat-val">@monster.Attack</span>
+                        </div>
+                        <div class="oh-mon-d-statrow">
+                            <i class="oh-mon-d-stat-icon bi bi-shield-shaded"></i>
+                            <span class="oh-mon-d-stat-lab">Obrana</span>
+                            <span class="oh-mon-d-stat-val">@monster.Defense</span>
+                        </div>
+                        <div class="oh-mon-d-statrow">
+                            <i class="oh-mon-d-stat-icon bi bi-heart-pulse"></i>
+                            <span class="oh-mon-d-stat-lab">Životy</span>
+                            <span class="oh-mon-d-stat-val">@monster.Health</span>
+                        </div>
+                        <div class="oh-mon-d-statrow">
+                            <i class="oh-mon-d-stat-icon bi bi-star-fill"></i>
+                            <span class="oh-mon-d-stat-lab">XP</span>
+                            <span class="oh-mon-d-stat-val">@(monster.RewardXp ?? 0)</span>
+                        </div>
+                        <div class="oh-mon-d-statrow">
+                            <i class="oh-mon-d-stat-icon bi bi-coin"></i>
+                            <span class="oh-mon-d-stat-lab">Groše</span>
+                            <span class="oh-mon-d-stat-val">@(monster.RewardMoney ?? 0)</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="oh-mon-d-sect">
+                    <div class="oh-mon-d-sect-label"><i class="bi bi-magic"></i>Schopnosti</div>
+                    <div class="oh-mon-d-sect-body">
+                        @if (string.IsNullOrWhiteSpace(monster.Abilities))
+                        {
+                            <span class="oh-mon-d-sect-empty">Žádné zvláštní schopnosti zaznamenány.</span>
+                        }
+                        else
+                        {
+                            @monster.Abilities
+                        }
+                    </div>
+                </div>
+                <div class="oh-mon-d-sect">
+                    <div class="oh-mon-d-sect-label"><i class="bi bi-cpu"></i>AI chování</div>
+                    <div class="oh-mon-d-sect-body">
+                        @if (string.IsNullOrWhiteSpace(monster.AiBehavior))
+                        {
+                            <span class="oh-mon-d-sect-empty">Bez popisu chování.</span>
+                        }
+                        else
+                        {
+                            @monster.AiBehavior
+                        }
+                    </div>
+                </div>
+                <div class="oh-mon-d-sect">
+                    <div class="oh-mon-d-sect-label"><i class="bi bi-tags"></i>Tagy</div>
+                    @if (monster.Tags.Count == 0)
+                    {
+                        <span class="oh-mon-d-sect-empty">Bez tagů.</span>
+                    }
+                    else
+                    {
+                        <div class="oh-mon-d-tags">
+                            @foreach (var tag in monster.Tags)
+                            {
+                                <span class="oh-mon-d-tag" @key="tag.Id">@tag.Name</span>
+                            }
+                        </div>
+                    }
+                </div>
+                @if (!string.IsNullOrWhiteSpace(monster.Notes))
+                {
+                    <div class="oh-mon-d-notes">
+                        <div class="oh-mon-d-notes-label">Poznámka organizátorů</div>
+                        <div class="oh-mon-d-notes-body">@monster.Notes</div>
+                    </div>
+                }
+            </div>
+        }
+        else if (activeTab == "upravit")
+        {
+            <DxFormLayout>
+                <DxFormLayoutGroup Caption="Identita" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="Název" ColSpanMd="8">
+                        <DxTextBox @bind-Text="@editName" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Kategorie" ColSpanMd="4">
+                        <DxSpinEdit @bind-Value="@editCategory" MinValue="0" MaxValue="10" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Typ" ColSpanMd="12">
+                        <DxComboBox Data="@monsterTypeValues" @bind-Value="@editType"
+                                    TextFieldName="Display" ValueFieldName="Value" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+                <DxFormLayoutGroup Caption="Vizuál" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="Obrázek" ColSpanMd="12">
+                        <ImagePicker EntityType="monsters" EntityId="monster.Id" Alt="Obrázek příšery" AspectRatio="4:3" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+                <DxFormLayoutGroup Caption="Bojovka" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="Útok" ColSpanMd="4">
+                        <DxSpinEdit @bind-Value="@editAttack" MinValue="0" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Obrana" ColSpanMd="4">
+                        <DxSpinEdit @bind-Value="@editDefense" MinValue="0" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Životy" ColSpanMd="4">
+                        <DxSpinEdit @bind-Value="@editHealth" MinValue="1" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Schopnosti" ColSpanMd="12">
+                        <DxMemo @bind-Text="@editAbilities" Rows="4" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="AI chování" ColSpanMd="12">
+                        <DxMemo @bind-Text="@editAiBehavior" Rows="3" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+                <DxFormLayoutGroup Caption="Odměna" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="XP" ColSpanMd="6">
+                        <DxSpinEdit @bind-Value="@editRewardXp" MinValue="0" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Groše" ColSpanMd="6">
+                        <DxSpinEdit @bind-Value="@editRewardMoney" MinValue="0" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Poznámky k odměně" ColSpanMd="12">
+                        <DxMemo @bind-Text="@editRewardNotes" Rows="2" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+                <DxFormLayoutGroup Caption="Tagy" ColSpanMd="12">
+                    <DxFormLayoutItem ColSpanMd="12">
+                        <TagChipPicker MonsterId="monster.Id" InitialTags="monster.Tags" Changed="OnTagsChangedAsync" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+                <DxFormLayoutGroup Caption="Poznámky" ColSpanMd="12">
+                    <DxFormLayoutItem ColSpanMd="12">
+                        <DxMemo @bind-Text="@editNotes" Rows="3" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+            </DxFormLayout>
+            @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
+            <div class="oh-mon-d-edit-footer">
+                <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true" disabled="@isSaving">
+                    <i class="bi bi-trash"></i> Smazat
+                </button>
+                <div class="oh-mon-d-spacer"></div>
+                <button class="btn btn-secondary" @onclick="CancelEdit" disabled="@isSaving">Zrušit</button>
+                <button class="btn btn-primary" @onclick="SaveAsync"
+                        disabled="@(isSaving || string.IsNullOrWhiteSpace(editName))">Uložit</button>
+            </div>
+        }
+        else if (activeTab == "bojovka")
+        {
+            <div class="oh-mon-d-bestiary">
+                <div class="oh-mon-d-bojovka">
+                    <div class="oh-mon-d-hp">
+                        <span class="oh-mon-d-hp-current">Životy: @tempHp / @monster.Health</span>
+                        <button type="button" @onclick="() => tempHp -= 1">−1 Život</button>
+                        <button type="button" @onclick="() => tempHp += 1">+1 Život</button>
+                        <button type="button" @onclick="() => tempHp = monster!.Health">resetovat</button>
+                    </div>
+                    <div class="oh-mon-d-bigstats">
+                        <div class="oh-mon-d-bigstat">
+                            <span class="oh-mon-d-bigstat-lab">Útok</span>
+                            <span class="oh-mon-d-bigstat-val">@monster.Attack</span>
+                        </div>
+                        <div class="oh-mon-d-bigstat">
+                            <span class="oh-mon-d-bigstat-lab">Obrana</span>
+                            <span class="oh-mon-d-bigstat-val">@monster.Defense</span>
+                        </div>
+                        <div class="oh-mon-d-bigstat">
+                            <span class="oh-mon-d-bigstat-lab">Životy</span>
+                            <span class="oh-mon-d-bigstat-val">@monster.Health</span>
+                        </div>
+                    </div>
+                    @if (!string.IsNullOrWhiteSpace(monster.Abilities))
+                    {
+                        <div>
+                            <div class="oh-mon-d-sect-label"><i class="bi bi-magic"></i>Schopnosti</div>
+                            <ol class="oh-mon-d-abilities-list">
+                                @foreach (var line in SplitLines(monster.Abilities))
+                                {
+                                    <li>@line</li>
+                                }
+                            </ol>
+                        </div>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(monster.AiBehavior))
+                    {
+                        <div>
+                            <div class="oh-mon-d-sect-label"><i class="bi bi-cpu"></i>AI chování</div>
+                            <blockquote class="oh-mon-d-ai-quote">@monster.AiBehavior</blockquote>
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+        else if (activeTab == "korist")
+        {
+            @if (lootGroups is null)
+            {
+                <p class="oh-mon-d-loading">Načítám kořist…</p>
+            }
+            else if (lootGroups.Count == 0)
+            {
+                <div class="oh-mon-d-empty">
+                    <i class="bi bi-gem"></i>
+                    <p>Tato příšera není přiřazena k žádné hře a nemá kořist.</p>
+                </div>
+            }
+            else
+            {
+                <div class="oh-mon-d-loot">
+                    @foreach (var grp in lootGroups)
+                    {
+                        var gid = grp.GameId;
+                        <div class="oh-mon-d-loot-game" @key="gid">
+                            <div class="oh-mon-d-loot-game-head">
+                                <h4>@grp.GameName</h4>
+                                <span class="oh-mon-d-loot-game-edition">ED. @grp.Edition</span>
+                                @if (GameContext.SelectedGameId == gid)
+                                {
+                                    <span class="oh-mon-d-loot-game-current">Aktuální hra</span>
+                                }
+                            </div>
+                            @if (grp.Loot.Count == 0)
+                            {
+                                <div class="oh-mon-d-loot-empty">Bez kořisti — v této hře příšera drop neměla.</div>
+                            }
+                            else
+                            {
+                                <div class="oh-mon-d-loot-tiles">
+                                    @foreach (var loot in grp.Loot)
+                                    {
+                                        var capLoot = loot;
+                                        <MonsterLootTile @key="capLoot.ItemId"
+                                                         Loot="capLoot"
+                                                         ImageUrl="@(itemImageUrls.TryGetValue(capLoot.ItemId, out var url) ? url : null)"
+                                                         OnClick="@(() => RequestRemoveLoot(capLoot))" />
+                                    }
+                                </div>
+                            }
+                            <button type="button" class="oh-mon-d-loot-add mt-2"
+                                    @onclick="@(() => OpenAddLoot(gid))">
+                                <i class="bi bi-plus-lg"></i> Přidat kořist
+                            </button>
+                        </div>
+                    }
+                </div>
+            }
+        }
+        else if (activeTab == "vyskyt")
+        {
+            @if (occurrences is null)
+            {
+                <p class="oh-mon-d-loading">Načítám výskyty…</p>
+            }
+            else if (occurrences.Count == 0)
+            {
+                <div class="oh-mon-d-empty">
+                    <i class="bi bi-geo-alt"></i>
+                    <p>Příšera se zatím v žádných questech neobjevuje.</p>
+                </div>
+            }
+            else
+            {
+                <div class="oh-mon-d-occur-summary">
+                    <span>Přiřazené hry: <strong>@occurrences.Count</strong></span>
+                    <span class="oh-mon-d-dotsep">·</span>
+                    <span><strong>@occurrences.Sum(o => o.QuestCount)</strong> questů</span>
+                    <span class="oh-mon-d-dotsep">·</span>
+                    <span><strong>@occurrences.Sum(o => o.EncounterCount)</strong> encounterů</span>
+                </div>
+                <table class="oh-mon-d-occur-table">
+                    <thead>
+                        <tr>
+                            <th>Hra</th>
+                            <th class="oh-mon-d-num">Questy</th>
+                            <th class="oh-mon-d-num">Encountery</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var o in occurrences)
+                        {
+                            var capOcc = o;
+                            <tr @key="capOcc.GameId" class="@(GameContext.SelectedGameId == capOcc.GameId ? "oh-mon-d-current" : null)">
+                                <td>@capOcc.GameName <span class="oh-mon-d-loot-game-edition">ED. @capOcc.Edition</span></td>
+                                <td class="oh-mon-d-num">@capOcc.QuestCount</td>
+                                <td class="oh-mon-d-num">@capOcc.EncounterCount</td>
+                                <td>
+                                    <button type="button" class="oh-mon-d-occur-remove"
+                                            @onclick="@(() => RequestRemoveFromGame(capOcc))">Odebrat</button>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            }
+        }
+    </div>
+}
+
+@* Delete-monster confirm *@
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Smazat příšeru?" Width="420px">
+    <BodyContentTemplate Context="ctx">
+        <p>Opravdu chcete trvale smazat příšeru <strong>@monster?.Name</strong>? Smaže se z bestiáře včetně všech přiřazení ke hrám, kořistí a encounterů.</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@* Remove-from-game confirm (Výskyt tab) *@
+<DxPopup @bind-Visible="@isRemoveFromGameVisible"
+         HeaderText="@($"Odebrat z hry {removeFromGame?.GameName}?")"
+         Width="500px">
+    <BodyContentTemplate Context="ctx">
+        @if (removeFromGame is not null)
+        {
+            <p>Příšera „@monster?.Name" se odstraní z přiřazení ke hře <strong>@removeFromGame.GameName</strong>.
+            Samotný záznam v bestiáři zůstane zachován, ale @removeFromGame.QuestCount questů a @removeFromGame.EncounterCount encounterů této hry s ní přestane počítat.</p>
+        }
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isRemoveFromGameVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmRemoveFromGameAsync">Odebrat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@* Remove-loot confirm (destructive — DxPopup per MEMORY rule) *@
+<DxPopup @bind-Visible="@isRemoveLootVisible" HeaderText="Smazat kořist?" Width="420px">
+    <BodyContentTemplate Context="ctx">
+        @if (removeLoot is not null)
+        {
+            <p>Opravdu chcete odebrat kořist <strong>@removeLoot.ItemName</strong> (× @removeLoot.Quantity) z této hry?</p>
+        }
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isRemoveLootVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmRemoveLootAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@* Add-loot popup *@
+<DxPopup @bind-Visible="@isAddLootVisible" HeaderText="Přidat kořist" Width="500px">
+    <BodyContentTemplate Context="ctx">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Předmět" ColSpanMd="8">
+                <DxComboBox Data="@allItems" @bind-Value="@addLootItemId"
+                            TextFieldName="Name" ValueFieldName="Id"
+                            NullText="(vyberte předmět)" SearchMode="ListSearchMode.AutoSearch" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Počet" ColSpanMd="4">
+                <DxSpinEdit @bind-Value="@addLootQuantity" MinValue="1" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        @if (addLootError is not null) { <div class="alert alert-danger mt-2 small">@addLootError</div> }
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" @onclick="() => isAddLootVisible = false">Zrušit</button>
+            <button class="btn btn-primary" disabled="@(addLootItemId is null)" @onclick="ConfirmAddLootAsync">Přidat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public int Id { get; set; }
+
+    private MonsterDetailDto? monster;
+    private bool loading = true;
+    private string? error;
+    private string? heroImageUrl;
+    private bool heroImageFailed;
+
+    private string activeTab = "karta";
+    private bool isDeleteVisible;
+    private bool isSaving;
+
+    // Edit form state
+    private string editName = "";
+    private int editCategory = 1;
+    private MonsterType editType = MonsterType.Beast;
+    private int editAttack, editDefense, editHealth = 1;
+    private string? editAbilities, editAiBehavior, editRewardNotes, editNotes;
+    private int editRewardXp, editRewardMoney;
+
+    // Bojovka local-only HP counter
+    private int tempHp;
+
+    // Kořist tab data
+    private List<MonsterLootByGameDto>? lootGroups;
+    private Dictionary<int, string?> itemImageUrls = new();
+    private List<ItemListDto> allItems = [];
+    private bool isAddLootVisible;
+    private int? addLootGameId;
+    private int? addLootItemId;
+    private int addLootQuantity = 1;
+    private string? addLootError;
+
+    // Výskyt tab data
+    private List<MonsterOccurrenceDto>? occurrences;
+    private bool isRemoveFromGameVisible;
+    private MonsterOccurrenceDto? removeFromGame;
+
+    // Tab badge counts (loaded eagerly so badges show immediately)
+    private int lootCount;
+    private int occurrenceCount;
+
+    private static readonly List<EnumItem<MonsterType>> monsterTypeValues = Enum.GetValues<MonsterType>()
+        .Select(v => new EnumItem<MonsterType>(v, v.GetDisplayName())).ToList();
+    record EnumItem<T>(T Value, string Display);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        await LoadMonsterAsync();
+        if (monster is not null)
+        {
+            // Eagerly load badge counts (single small calls)
+            await LoadLootGroupsAsync();
+            await LoadOccurrencesAsync();
+        }
+    }
+
+    private async Task LoadMonsterAsync()
+    {
+        loading = true;
+        try
+        {
+            monster = await Api.GetAsync<MonsterDetailDto>($"/api/monsters/{Id}");
+            if (monster is not null)
+            {
+                ResetEditFromMonster();
+                tempHp = monster.Health;
+                heroImageFailed = false;
+                heroImageUrl = null;
+                if (!string.IsNullOrWhiteSpace(monster.ImagePath))
+                {
+                    var urls = await Api.GetAsync<ImageUrlsDto>($"/api/images/monsters/{Id}");
+                    heroImageUrl = urls?.ImageUrl;
+                }
+            }
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { loading = false; }
+    }
+
+    private void ResetEditFromMonster()
+    {
+        if (monster is null) return;
+        editName = monster.Name;
+        editCategory = monster.Category;
+        editType = monster.MonsterType;
+        editAttack = monster.Attack;
+        editDefense = monster.Defense;
+        editHealth = monster.Health;
+        editAbilities = monster.Abilities;
+        editAiBehavior = monster.AiBehavior;
+        editRewardXp = monster.RewardXp ?? 0;
+        editRewardMoney = monster.RewardMoney ?? 0;
+        editRewardNotes = monster.RewardNotes;
+        editNotes = monster.Notes;
+    }
+
+    private async Task SetTab(string tab)
+    {
+        activeTab = tab;
+        if (tab == "bojovka" && monster is not null)
+        {
+            tempHp = monster.Health;
+        }
+        else if (tab == "korist")
+        {
+            if (lootGroups is null) await LoadLootGroupsAsync();
+            if (allItems.Count == 0) allItems = await Api.GetListAsync<ItemListDto>("/api/items");
+        }
+        else if (tab == "vyskyt")
+        {
+            if (occurrences is null) await LoadOccurrencesAsync();
+        }
+    }
+
+    private async Task LoadLootGroupsAsync()
+    {
+        try
+        {
+            lootGroups = await Api.GetListAsync<MonsterLootByGameDto>($"/api/monsters/{Id}/loot/all-games");
+            lootCount = lootGroups.Sum(g => g.Loot.Count);
+
+            // Build item->image map (one /api/items fetch covers all tiles)
+            if (lootCount > 0 && allItems.Count == 0)
+            {
+                allItems = await Api.GetListAsync<ItemListDto>("/api/items");
+            }
+            itemImageUrls = allItems.ToDictionary(i => i.Id, i => i.ImageUrl);
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task LoadOccurrencesAsync()
+    {
+        try
+        {
+            occurrences = await Api.GetListAsync<MonsterOccurrenceDto>($"/api/monsters/{Id}/occurrences");
+            occurrenceCount = occurrences.Count;
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private void CancelEdit()
+    {
+        ResetEditFromMonster();
+        activeTab = "karta";
+    }
+
+    private async Task SaveAsync()
+    {
+        if (monster is null || string.IsNullOrWhiteSpace(editName)) return;
+        error = null;
+        isSaving = true;
+        try
+        {
+            int? xp = editRewardXp > 0 ? editRewardXp : null;
+            int? money = editRewardMoney > 0 ? editRewardMoney : null;
+            await Api.PutAsync($"/api/monsters/{monster.Id}",
+                new UpdateMonsterDto(editName, editCategory, editType, editAttack, editDefense, editHealth,
+                    editAbilities, editAiBehavior, xp, money, editRewardNotes, editNotes));
+            await LoadMonsterAsync();
+            activeTab = "karta";
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        if (monster is null) return;
+        try
+        {
+            await Api.DeleteAsync($"/api/monsters/{monster.Id}");
+            isDeleteVisible = false;
+            Nav.NavigateTo("/monsters");
+        }
+        catch (Exception ex) { error = ex.Message; isDeleteVisible = false; }
+    }
+
+    private async Task OnTagsChangedAsync()
+    {
+        // Reload monster so the Karta tab + count badges reflect the new tag set.
+        await LoadMonsterAsync();
+    }
+
+    private void OpenAddLoot(int gameId)
+    {
+        addLootGameId = gameId;
+        addLootItemId = null;
+        addLootQuantity = 1;
+        addLootError = null;
+        isAddLootVisible = true;
+    }
+
+    private async Task ConfirmAddLootAsync()
+    {
+        if (monster is null || addLootGameId is null || addLootItemId is null) return;
+        addLootError = null;
+        try
+        {
+            await Api.PostAsync<CreateMonsterLootDto, object>("/api/monsters/loot",
+                new CreateMonsterLootDto(monster.Id, addLootItemId.Value, addLootGameId.Value, addLootQuantity));
+            isAddLootVisible = false;
+            await LoadLootGroupsAsync();
+        }
+        catch (Exception ex) { addLootError = ex.Message; }
+    }
+
+    private bool isRemoveLootVisible;
+    private MonsterLootDto? removeLoot;
+
+    private void RequestRemoveLoot(MonsterLootDto loot)
+    {
+        removeLoot = loot;
+        isRemoveLootVisible = true;
+    }
+
+    private async Task ConfirmRemoveLootAsync()
+    {
+        if (removeLoot is null) return;
+        try
+        {
+            await Api.DeleteAsync($"/api/monsters/loot/{removeLoot.MonsterId}/{removeLoot.ItemId}/{removeLoot.GameId}");
+            isRemoveLootVisible = false;
+            removeLoot = null;
+            await LoadLootGroupsAsync();
+        }
+        catch (Exception ex) { error = ex.Message; isRemoveLootVisible = false; }
+    }
+
+    private void RequestRemoveFromGame(MonsterOccurrenceDto o)
+    {
+        removeFromGame = o;
+        isRemoveFromGameVisible = true;
+    }
+
+    private async Task ConfirmRemoveFromGameAsync()
+    {
+        if (monster is null || removeFromGame is null) return;
+        try
+        {
+            await Api.DeleteAsync($"/api/monsters/game-monster/{removeFromGame.GameId}/{monster.Id}");
+            isRemoveFromGameVisible = false;
+            removeFromGame = null;
+            await LoadOccurrencesAsync();
+            await LoadLootGroupsAsync();
+        }
+        catch (Exception ex) { error = ex.Message; isRemoveFromGameVisible = false; }
+    }
+
+    private static IEnumerable<string> SplitLines(string s)
+        => s.Split('\n', StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()).Where(line => line.Length > 0);
+
+    private static string MonsterTypeIcon(MonsterType t) => t switch
+    {
+        MonsterType.Undead => "bi-x-octagon",
+        MonsterType.Beast => "bi-bug",
+        MonsterType.Goblin => "bi-person-walking",
+        MonsterType.Benevolent => "bi-heart",
+        MonsterType.Legend => "bi-stars",
+        MonsterType.Miscellaneous => "bi-question-circle",
+        _ => "bi-question-circle"
+    };
+}

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterDetail.razor
@@ -8,6 +8,15 @@
 {
     <p class="oh-mon-d-loading">Načítám…</p>
 }
+else if (monster is null && error is not null)
+{
+    <div class="oh-mon-d-empty">
+        <i class="bi bi-wifi-off"></i>
+        <p>Nepodařilo se načíst příšeru.</p>
+        <p class="text-danger small">@error</p>
+        <button class="btn btn-outline-primary" @onclick="LoadMonsterAsync">Zkusit znovu</button>
+    </div>
+}
 else if (monster is null)
 {
     <div class="oh-mon-d-empty">
@@ -92,7 +101,7 @@ else
                             {
                                 <div class="oh-mon-d-illust-empty">
                                     <i class="bi bi-bug-fill"></i>
-                                    <span>Iluustrace čeká</span>
+                                    <span>Ilustrace čeká</span>
                                 </div>
                             }
                         </div>
@@ -420,7 +429,7 @@ else
     <BodyContentTemplate Context="ctx">
         @if (removeFromGame is not null)
         {
-            <p>Příšera „@monster?.Name" se odstraní z přiřazení ke hře <strong>@removeFromGame.GameName</strong>.
+            <p>Příšera „@monster?.Name“ se odstraní z přiřazení ke hře <strong>@removeFromGame.GameName</strong>.
             Samotný záznam v bestiáři zůstane zachován, ale @removeFromGame.QuestCount questů a @removeFromGame.EncounterCount encounterů této hry s ní přestane počítat.</p>
         }
         <div class="d-flex gap-2 justify-content-end">
@@ -596,7 +605,13 @@ else
             }
             itemImageUrls = allItems.ToDictionary(i => i.Id, i => i.ImageUrl);
         }
-        catch (Exception ex) { error = ex.Message; }
+        catch (Exception ex)
+        {
+            // Surface the error and fall through to an empty list so the UI
+            // doesn't get stuck on the "Načítám…" branch (lootGroups is null).
+            error = $"Nepodařilo se načíst kořist: {ex.Message}";
+            lootGroups = [];
+        }
     }
 
     private async Task LoadOccurrencesAsync()
@@ -606,7 +621,11 @@ else
             occurrences = await Api.GetListAsync<MonsterOccurrenceDto>($"/api/monsters/{Id}/occurrences");
             occurrenceCount = occurrences.Count;
         }
-        catch (Exception ex) { error = ex.Message; }
+        catch (Exception ex)
+        {
+            error = $"Nepodařilo se načíst výskyty: {ex.Message}";
+            occurrences = [];
+        }
     }
 
     private void CancelEdit()
@@ -639,7 +658,13 @@ else
         if (monster is null) return;
         try
         {
-            await Api.DeleteAsync($"/api/monsters/{monster.Id}");
+            var ok = await Api.DeleteAsync($"/api/monsters/{monster.Id}");
+            if (!ok)
+            {
+                error = "Smazání příšery selhalo.";
+                isDeleteVisible = false;
+                return;
+            }
             isDeleteVisible = false;
             Nav.NavigateTo("/monsters");
         }
@@ -689,8 +714,13 @@ else
         if (removeLoot is null) return;
         try
         {
-            await Api.DeleteAsync($"/api/monsters/loot/{removeLoot.MonsterId}/{removeLoot.ItemId}/{removeLoot.GameId}");
+            var ok = await Api.DeleteAsync($"/api/monsters/loot/{removeLoot.MonsterId}/{removeLoot.ItemId}/{removeLoot.GameId}");
             isRemoveLootVisible = false;
+            if (!ok)
+            {
+                error = "Odebrání kořisti selhalo.";
+                return;
+            }
             removeLoot = null;
             await LoadLootGroupsAsync();
         }
@@ -708,8 +738,13 @@ else
         if (monster is null || removeFromGame is null) return;
         try
         {
-            await Api.DeleteAsync($"/api/monsters/game-monster/{removeFromGame.GameId}/{monster.Id}");
+            var ok = await Api.DeleteAsync($"/api/monsters/game-monster/{removeFromGame.GameId}/{monster.Id}");
             isRemoveFromGameVisible = false;
+            if (!ok)
+            {
+                error = $"Odebrání z hry {removeFromGame.GameName} selhalo.";
+                return;
+            }
             removeFromGame = null;
             await LoadOccurrencesAsync();
             await LoadLootGroupsAsync();

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -1828,3 +1828,135 @@
 .oh-ssg-popup-foot .oh-ssg-foot-note{font-size:.75rem;color:var(--oh-text-secondary);font-style:italic;margin-right:auto}
 .oh-ssg-popup-pic{display:flex;align-items:flex-start;gap:14px;flex-wrap:wrap}
 .oh-ssg-popup-err{margin:0 0 8px;padding:8px 10px;border-radius:var(--oh-radius-sm);background:rgba(211,47,47,.08);border:1px solid rgba(211,47,47,.3);color:var(--oh-error);font-size:.8125rem}
+
+/* ============================================================
+   Monster detail page (/monsters/{id}) — .oh-mon-d-*
+   Illuminated bestiary: title strip + sticky 5-tab strip,
+   Karta 62fr/38fr, Bojovka presenter, Kořist 5:7 MTG tiles,
+   Výskyt compact table.
+   Ported from docs/design/dialogs/monster-detail.mockup.unbundled.html
+   ============================================================ */
+
+/* Title strip */
+.oh-mon-d-ts{display:flex;align-items:flex-start;gap:18px;padding:18px 28px 12px;border-bottom:1px solid var(--oh-border);background:var(--oh-surface)}
+.oh-mon-d-ts-title{flex:1;min-width:0;display:flex;flex-direction:column;gap:6px}
+.oh-mon-d-ts-title h1{margin:0;font:900 2rem var(--oh-font-heading);color:var(--oh-primary);letter-spacing:-.01em;line-height:1.1}
+.oh-mon-d-ts-sub{display:flex;align-items:center;gap:10px;flex-wrap:wrap;color:var(--oh-text-secondary);font-size:.8125rem}
+.oh-mon-d-ts-sub .oh-mon-d-dotsep{opacity:.5;font-weight:600}
+.oh-mon-d-ts-actions{display:flex;align-items:center;gap:8px;flex-shrink:0}
+.oh-mon-d-back{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:var(--oh-radius-sm);background:transparent;border:1px solid var(--oh-border);color:var(--oh-text-secondary);font:500 .8125rem var(--oh-font-body);text-decoration:none;cursor:pointer}
+.oh-mon-d-back:hover{background:var(--oh-surface-alt);color:var(--oh-primary)}
+
+/* Reuse the neutral palette MonsterType chip + Kategorie kbadge from list page */
+.oh-mon-d-mtype{display:inline-flex;align-items:center;gap:5px;padding:3px 10px;border-radius:99px;font:600 .75rem var(--oh-font-body);letter-spacing:.02em;white-space:nowrap;background:#e9e4dc;border:1px solid #bfb4a2;color:#5a4a30}
+.oh-mon-d-mtype i{font-size:.8125rem}
+.oh-mon-d-kbadge{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:4px;background:rgba(178,98,35,.10);border:1px solid rgba(178,98,35,.32);color:#7a4315;font:600 .75rem var(--oh-font-mono)}
+.oh-mon-d-id{font:600 .75rem var(--oh-font-mono);color:var(--oh-text-secondary);letter-spacing:.04em}
+
+/* Tab strip — sticky under title */
+.oh-mon-d-tabs{display:flex;align-items:center;gap:2px;padding:0 28px;border-bottom:1px solid var(--oh-border);background:var(--oh-surface);position:sticky;top:0;z-index:5;overflow-x:auto}
+.oh-mon-d-tab{display:inline-flex;align-items:center;gap:7px;padding:12px 18px;min-height:44px;border:none;border-bottom:3px solid transparent;background:transparent;color:var(--oh-text-secondary);font:600 .875rem var(--oh-font-body);cursor:pointer;white-space:nowrap;transition:.15s}
+.oh-mon-d-tab i{font-size:.9375rem;opacity:.7}
+.oh-mon-d-tab:hover{color:var(--oh-primary)}
+.oh-mon-d-tab.oh-mon-d-active{color:var(--oh-primary);border-bottom-color:var(--oh-primary)}
+.oh-mon-d-tab.oh-mon-d-active i{opacity:1;color:var(--oh-primary-light)}
+.oh-mon-d-tab-count{font-family:var(--oh-font-mono);font-size:.75rem;color:var(--oh-text-secondary);background:var(--oh-surface-alt);border:1px solid var(--oh-border);border-radius:99px;padding:1px 7px;min-width:22px;text-align:center}
+.oh-mon-d-tab.oh-mon-d-active .oh-mon-d-tab-count{color:var(--oh-primary);border-color:rgba(74,124,52,.3);background:var(--oh-primary-surface)}
+
+/* Tab body container */
+.oh-mon-d-body{padding:24px 28px}
+
+/* Bestiary parchment card (used as Karta + Bojovka frame) */
+.oh-mon-d-bestiary{background:linear-gradient(145deg,#f5f0e8 0%,#ebe4d4 40%,#e8dcc8 100%);border:1px solid #d4c5a9;border-radius:6px;padding:32px 36px 28px;position:relative;overflow:hidden;box-shadow:0 2px 8px rgba(45,80,22,.10)}
+
+/* Karta layout — 2 columns, illustration vs stats */
+.oh-mon-d-karta{display:grid;grid-template-columns:62fr 38fr;gap:28px;align-items:start}
+@media (max-width:900px){.oh-mon-d-karta{grid-template-columns:1fr}}
+
+/* 4:3 hero illustration with parchment frame (per brief) */
+.oh-mon-d-illust{position:relative;width:100%;aspect-ratio:4/3;border:2px solid #c4b494;border-radius:4px;overflow:hidden;background:var(--oh-surface-alt);box-shadow:0 3px 14px rgba(45,80,22,.18),inset 0 0 0 1px rgba(255,248,230,.4)}
+.oh-mon-d-illust img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-mon-d-illust::after{content:"";position:absolute;inset:0;pointer-events:none;background:radial-gradient(ellipse at 28% 30%,rgba(255,240,200,.16) 0%,transparent 55%),linear-gradient(180deg,transparent 70%,rgba(139,119,80,.18) 100%)}
+.oh-mon-d-illust-empty{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:8px;color:rgba(139,90,43,.5);font:italic 700 .95rem Georgia,serif}
+.oh-mon-d-illust-empty i{font-size:3.5rem;opacity:.55}
+.oh-mon-d-illust-cap{display:flex;align-items:center;justify-content:space-between;font-family:Georgia,serif;font-size:.8125rem;color:#8b7750;font-style:italic;padding:8px 4px 0;gap:12px}
+
+/* Stat block — book-leger style: icon + label + mono value */
+.oh-mon-d-stats{display:flex;flex-direction:column;background:rgba(255,248,240,.45);box-shadow:inset 0 1px 0 rgba(178,98,35,.18);border-radius:4px;padding:6px 12px}
+.oh-mon-d-statrow{display:grid;grid-template-columns:22px 1fr auto;align-items:center;gap:10px;padding:10px 0;border-bottom:1px dotted rgba(178,98,35,.30)}
+.oh-mon-d-statrow:last-child{border-bottom:none}
+.oh-mon-d-stat-icon{color:var(--oh-primary-light);font-size:1rem;text-align:center}
+.oh-mon-d-stat-lab{font-family:Georgia,serif;font-style:italic;color:#5a4f3f;font-size:.875rem;letter-spacing:.02em}
+.oh-mon-d-stat-val{font-family:var(--oh-font-mono);font-weight:700;font-size:1.125rem;color:var(--oh-primary);font-variant-numeric:tabular-nums;text-align:right}
+
+/* Section heading + body (Schopnosti, AI chování, Tagy, Poznámka) */
+.oh-mon-d-sect{margin-top:24px}
+.oh-mon-d-sect-label{font-family:var(--oh-font-body);font-size:.75rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--oh-text-secondary);padding-bottom:6px;margin:0 0 12px;border-bottom:1px solid rgba(178,98,35,.22)}
+.oh-mon-d-sect-label i{color:var(--oh-primary-light);font-size:.875rem;margin-right:6px}
+.oh-mon-d-sect-body{font:400 .9375rem/1.55 Georgia,serif;color:var(--oh-text)}
+.oh-mon-d-sect-empty{font-style:italic;color:var(--oh-text-secondary);font-size:.875rem}
+.oh-mon-d-tags{display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.oh-mon-d-tag{display:inline-flex;align-items:center;gap:4px;padding:3px 10px;border-radius:99px;background:var(--oh-surface-alt);border:1px solid rgba(178,98,35,.32);color:#7a4315;font:500 .75rem var(--oh-font-body)}
+
+/* Notes callout (organizer-only Poznámka) */
+.oh-mon-d-notes{margin-top:24px;padding:14px 18px;background:rgba(255,248,240,.55);border:1px solid rgba(178,98,35,.22);border-left:3px solid var(--oh-card-border);border-radius:4px}
+.oh-mon-d-notes-label{font-size:.75rem;text-transform:uppercase;letter-spacing:.1em;font-weight:700;color:var(--oh-text-secondary);margin-bottom:4px}
+.oh-mon-d-notes-body{font:italic 400 .9125rem Georgia,serif;color:#5a4f3f}
+
+/* Bojovka — presenter view with three big stat boxes */
+.oh-mon-d-bojovka{display:flex;flex-direction:column;gap:18px}
+.oh-mon-d-hp{display:flex;align-items:center;gap:10px;padding:10px 14px;background:var(--oh-surface);border:1px solid var(--oh-border);border-radius:var(--oh-radius-sm);position:sticky;top:48px;z-index:4;flex-wrap:wrap}
+.oh-mon-d-hp-current{font-family:var(--oh-font-mono);font-weight:700;font-size:1.25rem;color:var(--oh-primary);font-variant-numeric:tabular-nums;margin-right:auto}
+.oh-mon-d-hp button{padding:6px 12px;border-radius:var(--oh-radius-sm);border:1px solid var(--oh-border);background:var(--oh-surface);color:var(--oh-primary);font:600 .8125rem var(--oh-font-body);cursor:pointer}
+.oh-mon-d-hp button:hover{background:var(--oh-primary-surface);border-color:var(--oh-primary-light)}
+.oh-mon-d-bigstats{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
+.oh-mon-d-bigstat{display:flex;flex-direction:column;align-items:center;gap:6px;padding:18px 14px;background:rgba(255,248,240,.65);border:1px solid #d4c5a9;border-radius:6px;border-top:4px solid var(--oh-card-border);box-shadow:0 1px 3px rgba(45,80,22,.10)}
+.oh-mon-d-bigstat-lab{font:700 .75rem var(--oh-font-body);text-transform:uppercase;letter-spacing:.1em;color:var(--oh-text-secondary)}
+.oh-mon-d-bigstat-val{font:900 3rem/1 var(--oh-font-mono);color:var(--oh-primary);font-variant-numeric:tabular-nums}
+.oh-mon-d-abilities-list{margin:0;padding:0 0 0 22px;font:400 1.0625rem/1.5 Georgia,serif;color:var(--oh-text)}
+.oh-mon-d-abilities-list li{margin-bottom:6px}
+.oh-mon-d-ai-quote{margin:0;padding:14px 18px;border-left:4px solid var(--oh-primary-light);background:rgba(74,124,52,.05);font:italic 400 1.0625rem/1.5 Georgia,serif;color:#3d3a32}
+
+/* Kořist — per-game grouping */
+.oh-mon-d-loot{display:flex;flex-direction:column;gap:24px}
+.oh-mon-d-loot-game{padding:14px 0;border-top:1px solid var(--oh-border)}
+.oh-mon-d-loot-game:first-child{border-top:none;padding-top:0}
+.oh-mon-d-loot-game-head{display:flex;align-items:center;gap:10px;margin-bottom:14px;flex-wrap:wrap}
+.oh-mon-d-loot-game-head h4{margin:0;font:700 1rem var(--oh-font-heading);color:var(--oh-primary)}
+.oh-mon-d-loot-game-edition{font:600 .6875rem var(--oh-font-mono);color:var(--oh-text-secondary);background:var(--oh-surface-alt);border:1px solid var(--oh-border);border-radius:99px;padding:1px 7px;letter-spacing:.04em}
+.oh-mon-d-loot-game-current{font:600 .6875rem var(--oh-font-body);text-transform:uppercase;letter-spacing:.08em;color:var(--oh-primary);background:var(--oh-primary-surface);border:1px solid rgba(74,124,52,.35);border-radius:99px;padding:2px 8px;margin-left:auto}
+.oh-mon-d-loot-tiles{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:14px}
+.oh-mon-d-loot-add{display:inline-flex;align-items:center;justify-content:center;gap:6px;border:2px dashed var(--oh-border);background:transparent;border-radius:var(--oh-radius-sm);color:var(--oh-text-secondary);font:600 .8125rem var(--oh-font-body);cursor:pointer;padding:12px;min-height:60px;width:100%;transition:.15s}
+.oh-mon-d-loot-add:hover{border-color:var(--oh-primary-light);color:var(--oh-primary);background:var(--oh-primary-surface)}
+.oh-mon-d-loot-empty{font-style:italic;color:var(--oh-text-secondary);font-size:.875rem;padding:8px 0}
+
+/* Loot tile — 5:7 MTG */
+.oh-mon-d-loot-tile{display:flex;flex-direction:column;border:1px solid var(--oh-border);border-radius:var(--oh-radius-sm);overflow:hidden;background:var(--oh-surface);box-shadow:0 1px 3px rgba(45,80,22,.08);transition:.15s;text-decoration:none;color:inherit;position:relative;cursor:pointer}
+.oh-mon-d-loot-tile:hover{border-color:var(--oh-primary-light);box-shadow:0 3px 10px rgba(45,80,22,.14);transform:translateY(-1px)}
+.oh-mon-d-loot-tile-img{width:100%;aspect-ratio:5/7;background:var(--oh-surface-alt);position:relative;display:flex;align-items:center;justify-content:center;overflow:hidden}
+.oh-mon-d-loot-tile-img img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-mon-d-loot-tile-img-empty{font-size:1.5rem;color:rgba(139,90,43,.5)}
+.oh-mon-d-loot-tile-qty{position:absolute;right:6px;bottom:6px;font:700 .75rem var(--oh-font-mono);background:rgba(44,24,16,.78);color:#fff;padding:2px 7px;border-radius:99px;letter-spacing:.04em}
+.oh-mon-d-loot-tile-name{padding:8px 10px;font:600 .8125rem var(--oh-font-heading);color:var(--oh-text);text-align:center;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+
+/* Výskyt — compact occurrences table */
+.oh-mon-d-occur-summary{display:flex;align-items:center;gap:18px;padding:12px 16px;background:var(--oh-primary-surface);border:1px solid rgba(74,124,52,.35);border-radius:var(--oh-radius-sm);margin-bottom:18px;font:600 .9375rem var(--oh-font-body);color:var(--oh-primary);flex-wrap:wrap}
+.oh-mon-d-occur-summary .oh-mon-d-dotsep{opacity:.5;font-weight:600}
+.oh-mon-d-occur-table{width:100%;border-collapse:collapse}
+.oh-mon-d-occur-table th{text-align:left;font:700 .6875rem var(--oh-font-body);text-transform:uppercase;letter-spacing:.08em;color:var(--oh-text-secondary);padding:8px 12px;border-bottom:1px solid var(--oh-border)}
+.oh-mon-d-occur-table th.oh-mon-d-num,.oh-mon-d-occur-table td.oh-mon-d-num{text-align:right;font-family:var(--oh-font-mono);font-variant-numeric:tabular-nums}
+.oh-mon-d-occur-table tbody tr{border-bottom:1px solid var(--oh-border);cursor:pointer;transition:.12s}
+.oh-mon-d-occur-table tbody tr:hover{background:var(--oh-primary-surface)}
+.oh-mon-d-occur-table tbody tr.oh-mon-d-current{border-left:3px solid var(--oh-primary)}
+.oh-mon-d-occur-table td{padding:10px 12px;font-size:.875rem;color:var(--oh-text)}
+.oh-mon-d-occur-remove{padding:4px 10px;border-radius:var(--oh-radius-sm);background:transparent;border:1px solid rgba(140,36,35,.35);color:#8c2423;font:600 .75rem var(--oh-font-body);cursor:pointer;transition:.15s}
+.oh-mon-d-occur-remove:hover{background:rgba(140,36,35,.08)}
+
+/* Empty / loading states */
+.oh-mon-d-loading{padding:48px 16px;text-align:center;color:var(--oh-text-secondary);font-style:italic}
+.oh-mon-d-empty{padding:48px 16px;text-align:center;color:var(--oh-text-secondary)}
+.oh-mon-d-empty i{font-size:3rem;color:var(--oh-primary-light);opacity:.6;display:block;margin-bottom:10px}
+
+/* Upravit — sticky form footer */
+.oh-mon-d-edit-footer{position:sticky;bottom:0;display:flex;align-items:center;gap:8px;padding:14px 28px;background:var(--oh-surface);border-top:1px solid var(--oh-border);box-shadow:0 -2px 8px rgba(45,80,22,.06);margin:24px -28px -24px;z-index:3}
+.oh-mon-d-edit-footer .oh-mon-d-spacer{flex:1}

--- a/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MonsterDtos.cs
@@ -73,3 +73,13 @@ public record CreateGameMonsterDto(int GameId, int MonsterId);
 public record MonsterLootDto(int MonsterId, int ItemId, string ItemName, int GameId, int Quantity);
 
 public record CreateMonsterLootDto(int MonsterId, int ItemId, int GameId, int Quantity = 1);
+
+// Loot grouped by game — feeds the MonsterDetail "Kořist" tab.
+// One row per game where the monster is either assigned (GameMonster) or already has loot rows.
+// Loot list is empty when the monster is assigned to the game but no items dropped yet.
+public record MonsterLootByGameDto(int GameId, string GameName, int Edition, List<MonsterLootDto> Loot);
+
+// Per-game occurrence summary — feeds the MonsterDetail "Výskyt" tab.
+// QuestCount = distinct Quest count (one QuestEncounter row per quest per monster — composite PK).
+// EncounterCount = SUM(Quantity) across those rows = total creature appearances in that game.
+public record MonsterOccurrenceDto(int GameId, string GameName, int Edition, int QuestCount, int EncounterCount);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MonsterEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MonsterEndpointTests.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
 
@@ -243,5 +246,129 @@ public class MonsterEndpointTests(PostgresFixture postgres) : IntegrationTestBas
         var response = await Client.DeleteAsync($"/api/monsters/loot/{monster.Id}/{item.Id}/{game.Id}");
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetLootAllGames_NoData_ReturnsEmpty()
+    {
+        var monster = await (await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto("Pavouk", 1, MonsterType.Beast, 2, 1, 4)))
+            .Content.ReadFromJsonAsync<MonsterDetailDto>();
+
+        var groups = await Client.GetFromJsonAsync<List<MonsterLootByGameDto>>(
+            $"/api/monsters/{monster!.Id}/loot/all-games");
+
+        Assert.NotNull(groups);
+        Assert.Empty(groups);
+    }
+
+    [Fact]
+    public async Task GetLootAllGames_AssignedGameWithLoot_GroupsCorrectly()
+    {
+        var game = await (await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Stíny Rhovanionu", 30, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3))))
+            .Content.ReadFromJsonAsync<GameDetailDto>();
+        var item1 = await (await Client.PostAsJsonAsync("/api/items",
+            new CreateItemDto("Stříbrný šíp", ItemType.Weapon)))
+            .Content.ReadFromJsonAsync<ItemDetailDto>();
+        var item2 = await (await Client.PostAsJsonAsync("/api/items",
+            new CreateItemDto("Bylinka", ItemType.Potion)))
+            .Content.ReadFromJsonAsync<ItemDetailDto>();
+        var monster = await (await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto("Skřetí lukostřelec", 2, MonsterType.Goblin, 12, 8, 45)))
+            .Content.ReadFromJsonAsync<MonsterDetailDto>();
+
+        await Client.PostAsJsonAsync("/api/monsters/game-monster",
+            new CreateGameMonsterDto(game!.Id, monster!.Id));
+        await Client.PostAsJsonAsync("/api/monsters/loot",
+            new CreateMonsterLootDto(monster.Id, item1!.Id, game.Id, 2));
+        await Client.PostAsJsonAsync("/api/monsters/loot",
+            new CreateMonsterLootDto(monster.Id, item2!.Id, game.Id, 1));
+
+        var groups = await Client.GetFromJsonAsync<List<MonsterLootByGameDto>>(
+            $"/api/monsters/{monster.Id}/loot/all-games");
+
+        Assert.NotNull(groups);
+        Assert.Single(groups);
+        var g = groups[0];
+        Assert.Equal(game.Id, g.GameId);
+        Assert.Equal("Stíny Rhovanionu", g.GameName);
+        Assert.Equal(30, g.Edition);
+        Assert.Equal(2, g.Loot.Count);
+        Assert.Contains(g.Loot, l => l.ItemName == "Stříbrný šíp" && l.Quantity == 2);
+        Assert.Contains(g.Loot, l => l.ItemName == "Bylinka" && l.Quantity == 1);
+    }
+
+    [Fact]
+    public async Task GetLootAllGames_AssignedWithoutLoot_StillIncludesGameWithEmptyList()
+    {
+        var game = await (await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Bez kořisti", 31, new DateOnly(2027, 5, 1), new DateOnly(2027, 5, 3))))
+            .Content.ReadFromJsonAsync<GameDetailDto>();
+        var monster = await (await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto("Krysa", 1, MonsterType.Beast, 2, 1, 4)))
+            .Content.ReadFromJsonAsync<MonsterDetailDto>();
+
+        await Client.PostAsJsonAsync("/api/monsters/game-monster",
+            new CreateGameMonsterDto(game!.Id, monster!.Id));
+
+        var groups = await Client.GetFromJsonAsync<List<MonsterLootByGameDto>>(
+            $"/api/monsters/{monster.Id}/loot/all-games");
+
+        Assert.NotNull(groups);
+        Assert.Single(groups);
+        Assert.Equal(game.Id, groups[0].GameId);
+        Assert.Empty(groups[0].Loot);
+    }
+
+    [Fact]
+    public async Task GetOccurrences_NoEncounters_ReturnsEmpty()
+    {
+        var monster = await (await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto("Stín", 4, MonsterType.Undead, 8, 6, 25)))
+            .Content.ReadFromJsonAsync<MonsterDetailDto>();
+
+        var occurrences = await Client.GetFromJsonAsync<List<MonsterOccurrenceDto>>(
+            $"/api/monsters/{monster!.Id}/occurrences");
+
+        Assert.NotNull(occurrences);
+        Assert.Empty(occurrences);
+    }
+
+    [Fact]
+    public async Task GetOccurrences_TwoQuestsInOneGame_AggregatesCounts()
+    {
+        var game = await (await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Hra s questy", 32, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 3))))
+            .Content.ReadFromJsonAsync<GameDetailDto>();
+        var monster = await (await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto("Vlk", 2, MonsterType.Beast, 8, 4, 18)))
+            .Content.ReadFromJsonAsync<MonsterDetailDto>();
+
+        // Seed quests + encounters directly via DbContext (no public encounter endpoint).
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var q1 = new Quest { Name = "Quest A", QuestType = QuestType.General, GameId = game!.Id };
+            var q2 = new Quest { Name = "Quest B", QuestType = QuestType.General, GameId = game.Id };
+            db.Quests.AddRange(q1, q2);
+            await db.SaveChangesAsync();
+
+            db.QuestEncounters.AddRange(
+                new QuestEncounter { QuestId = q1.Id, MonsterId = monster!.Id, Quantity = 5 },
+                new QuestEncounter { QuestId = q2.Id, MonsterId = monster.Id, Quantity = 3 });
+            await db.SaveChangesAsync();
+        }
+
+        var occurrences = await Client.GetFromJsonAsync<List<MonsterOccurrenceDto>>(
+            $"/api/monsters/{monster!.Id}/occurrences");
+
+        Assert.NotNull(occurrences);
+        Assert.Single(occurrences);
+        var o = occurrences[0];
+        Assert.Equal(game!.Id, o.GameId);
+        Assert.Equal("Hra s questy", o.GameName);
+        Assert.Equal(2, o.QuestCount);          // 2 distinct quests
+        Assert.Equal(8, o.EncounterCount);      // SUM(Quantity) = 5 + 3
     }
 }


### PR DESCRIPTION
## Summary

New `/monsters/{id:int}` detail page with 5 tabs — illuminated bestiary, not a stat block. See `docs/design/dialogs/monster-detail.md` and `.claude/restart-prompts/hra-ovcina-monster-detail-port.md` for the full design intent.

### Tabs

- **Karta** — 62fr/38fr layout: 4:3 hero illustration (parchment frame) + book-leger stat rows (icon · italic Georgia label · mono right-aligned value), then Schopnosti / AI chování / Tagy / Poznámka organizátorů sections.
- **Upravit** — 6-section DxFormLayout (Identita · Vizuál · Bojovka · Odměna · Tagy · Poznámky) with sticky footer (Smazat ghost-bordeaux far-left, Uložit disabled until name set). Tag picker is the new `TagChipPicker` component.
- **Bojovka** — presenter view for live encounters: three big 3rem mono stat boxes for ÚT / OBR / ŽIV, sticky HP counter (`−1 / +1 / resetovat`) that is **purely local state**, abilities as numbered bullets, AI chování as Georgia italic pull-quote.
- **Kořist** — per-game grouped 5:7 MTG loot tiles via new `MonsterLootTile` component. Quantity pill (`× N`) when > 1. "+ Přidat kořist" per game opens a small DxPopup picker. "Bez kořisti" muted italic when a game has no drops. Tile click opens a destructive-confirm popup before delete (per MEMORY destructive-confirm rule).
- **Výskyt** — compact table: Hra · Questy (N) · Encountery (N) · Odebrat. Summary row above. Odebrat routes through DxPopup confirm with `Odebrat z hry {GameName}?` header.

### Server changes

Two new aggregate endpoints (no breaking changes):

| Method | Route | Returns |
|---|---|---|
| GET | `/api/monsters/{id}/loot/all-games` | `List<MonsterLootByGameDto>` — one row per assigned game, even with empty loot |
| GET | `/api/monsters/{id}/occurrences` | `List<MonsterOccurrenceDto>` — per-game distinct quest count + SUM(Quantity) encounter count |

Plus two new DTOs: `MonsterLootByGameDto`, `MonsterOccurrenceDto`.

### Tests

+5 integration tests (`MonsterEndpointTests`):
- `GetLootAllGames_NoData_ReturnsEmpty`
- `GetLootAllGames_AssignedGameWithLoot_GroupsCorrectly`
- `GetLootAllGames_AssignedWithoutLoot_StillIncludesGameWithEmptyList`
- `GetOccurrences_NoEncounters_ReturnsEmpty`
- `GetOccurrences_TwoQuestsInOneGame_AggregatesCounts`

Full suite: **265/265 pass**.

### Caveats / follow-ups

1. **List-port branch (`feat/monster-list-port`) is not merged** — when it lands, MonsterList row click → quick-peek "Otevřít detail →" will navigate here. For now, the current MonsterList opens its edit popup on row click; the `/monsters/{id}` URL is reachable directly (e.g. via deep link) and works against this PR alone. List-port branch is parked in `.worktrees/monster-list-port` and will need rebase to v0.13.4 if landed after this.
2. **Playwright E2E deferred** — same root cause as list-port: `E2ETestBase` uses `WebApplicationFactory` in-memory server which Playwright's real browser cannot reach (`ERR_CONNECTION_REFUSED`). No existing test extends `E2ETestBase`, so the broken infra was unnoticed. Needs a separate infra task (real Kestrel + UseUrls). Monster API contracts are covered by the 5 new integration tests above.
3. **Drozd mascot SVG still missing** — empty illustration uses `bi-bug-fill` placeholder + Czech "Iluustrace čeká" caption. Drozd asset is a separate creative ask.
4. **MonsterType chip kept neutral** per `feedback_ovcina_kingdom_seal_palette` — mockup had per-type pastels but those are explicitly NOT used here.

## Test plan

- [ ] Build clean (`dotnet build OvcinaHra.slnx`) — TreatWarningsAsErrors, must stay zero warnings
- [ ] All tests pass (`dotnet test`) — 265/265
- [ ] `/monsters/{id}` renders with sticky 5-tab strip + title strip showing `{Type} · Kategorie {N} · #M{Id:D3}`
- [ ] Karta tab: 4:3 hero illustration with parchment frame, 5 stat rows in book-leger style, Schopnosti/AI/Tagy/Poznámka sections render
- [ ] Upravit tab: 6 sections in DxFormLayout, Uložit disabled until Name set, save returns to Karta tab with refreshed data
- [ ] Bojovka tab: three 3rem stat boxes + HP counter (−1 / +1 / resetovat) — counter never hits API
- [ ] Kořist tab: per-game grouping, MTG 5:7 tiles, "+ Přidat kořist" opens popup, tile click → confirm popup → delete works
- [ ] Výskyt tab: summary row + table, "Odebrat" → confirm popup with game name in header, removal updates the list
- [ ] Czech diacritics render in tabs, headings, popup headers
- [ ] DevTools console clean (no DxGrid attribute errors per `feedback_ovcinahra_devexpress_runtime_attrs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)