### PR TITLE
fix(nav): contain Katalog tab inside sidebar width [v0.14.3]

### DIFF
--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -238,7 +238,19 @@
     // We bind this to the whole nav container; tab buttons stop propagation via their click handlers being separate.
     private void CollapseOnMobile() => collapseNavMenu = true;
 
-    private string HraTabHint => GameContext.GameName ?? "Žádná hra";
+    // Tab is half the sidebar (~120 px); after icon + padding roughly ~85 px
+    // of text room, so cap the hint at ~20 chars with an ellipsis. CSS
+    // truncation in NavMenu.razor.css catches anything that still spills.
+    // The full game name is always reachable on /games and the hra overview.
+    private string HraTabHint
+    {
+        get
+        {
+            var name = GameContext.GameName;
+            if (string.IsNullOrWhiteSpace(name)) return "Žádná hra";
+            return name.Length > 20 ? name[..19] + "…" : name;
+        }
+    }
 
     protected override void OnInitialized()
     {

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor.css
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor.css
@@ -79,6 +79,12 @@
     cursor: pointer;
     font-family: var(--oh-font-body);
     transition: background 0.15s, color 0.15s, transform 0.15s;
+    /* Grid columns default to min-content — without min-width:0 the tab
+       refuses to shrink below its intrinsic content, pushing the second
+       tab off-screen. overflow:hidden is the visual safety net so a
+       stubborn child never bleeds past the column. */
+    min-width: 0;
+    overflow: hidden;
 }
 
     .oh-nav-tab .bi {

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.14.4</Version>
+    <Version>0.14.5</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hotfix for PR #76: the second sidebar tab (Katalog) pushed off-screen because the long Hra hint \"Balinova pozvánka (#30)\" refused to shrink inside its grid column.

## Fixes
- **CSS**: \`.oh-nav-tab\` gains \`min-width: 0\` + \`overflow: hidden\`. Grid children default to \`min-width: auto\` — they refuse to shrink below intrinsic content. Setting \`0\` lets the 1fr column actually share space, and the already-present \`text-overflow: ellipsis\` on the hint finally activates.
- **C#**: \`HraTabHint\` truncates \`GameName\` to 20 chars + ellipsis. Belt-and-suspenders — CSS is the final line of defence.

No markup change. No menu-width change. Design stays as shipped in PR #73/#76.

## Test plan
- [ ] \`dotnet build\` clean (0/0 — verified)
- [ ] Both tabs fit inside the sidebar at 240 px
- [ ] Long game names (\"Balinova pozvánka (#30)\") render as \"Balinova pozvánka …\" or similar, not overflowing
- [ ] Null / empty GameName → \"Žádná hra\" fallback still shown

Version 0.14.2 → 0.14.3.