### PR TITLE
fix(images): 302 hot-cache redirect + throttle cold resizes [v0.14.4]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -60,23 +60,35 @@ public static class ImageEndpoints
             return TypedResults.NotFound();
 
         var preset = ThumbnailService.ParsePreset(size);
+
+        // Hot-cache path: the common case after the first visitor for a given
+        // (entity, preset). Return a 302 redirect to the cached thumb's SAS URL
+        // so the browser fetches the bytes straight from Azure Blob and the API
+        // is out of the bandwidth path entirely. Prevents the 503 storm when a
+        // page like /locations fires 80+ parallel thumbnail requests at once.
+        var cachedSasUrl = await thumbnailService.TryGetCachedSasUrlAsync(entityType, entityId, preset, ct);
+        if (cachedSasUrl is not null)
+            return TypedResults.Redirect(cachedSasUrl, permanent: false);
+
+        // Cold-cache path: resize + cache (throttled inside the service). On
+        // first-ever generation we stream the bytes inline — the cache will be
+        // populated for subsequent requests which then hit the hot path above.
         var result = await thumbnailService.GetOrCreateAsync(entityType, entityId, imagePath, preset, ct);
 
         if (result is null)
         {
-            // Graceful degrade — return a redirect to the full-res SAS so the
-            // user still sees something when resize fails (missing source
-            // blob, corrupt image, ImageSharp exception, etc.).
+            // Graceful degrade — redirect to the full-res SAS so the user still
+            // sees something when resize fails (missing source blob, corrupt
+            // image, ImageSharp exception, etc.).
             var fallback = blobService.GetSasUrl(imagePath);
             if (fallback is null)
                 return TypedResults.NotFound();
             return TypedResults.Redirect(fallback, permanent: false);
         }
 
-        // Let browsers cache aggressively — list pages revisit the same tile
-        // URLs constantly, and our cache-key includes the (entity, size) pair.
-        // Upload path invalidates the server cache, but user browsers will
-        // only refresh after 24 h or a hard reload. Acceptable for this UX.
+        // Cold-path: tell the browser to cache for 24 h so we don't churn the
+        // resize work on refreshes. Upload path invalidates the server cache;
+        // browser caches only refresh after max-age or a hard reload.
         http.Response.Headers.CacheControl = "public, max-age=86400";
         return TypedResults.File(result.Bytes, result.ContentType);
     }

--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -66,9 +66,18 @@ public static class ImageEndpoints
         // so the browser fetches the bytes straight from Azure Blob and the API
         // is out of the bandwidth path entirely. Prevents the 503 storm when a
         // page like /locations fires 80+ parallel thumbnail requests at once.
+        //
+        // Cache-Control on the redirect itself tells the browser to reuse the
+        // 302 response for an hour — without it the browser re-issues the same
+        // GET on every navigation, and the rolling 1 h SAS means the Location
+        // header differs each time, so the browser can't reuse the downstream
+        // blob bytes either. One hour keeps us safely under the SAS expiry.
         var cachedSasUrl = await thumbnailService.TryGetCachedSasUrlAsync(entityType, entityId, preset, ct);
         if (cachedSasUrl is not null)
+        {
+            http.Response.Headers.CacheControl = "public, max-age=3600";
             return TypedResults.Redirect(cachedSasUrl, permanent: false);
+        }
 
         // Cold-cache path: resize + cache (throttled inside the service). On
         // first-ever generation we stream the bytes inline — the cache will be

--- a/src/OvcinaHra.Api/Services/ThumbnailService.cs
+++ b/src/OvcinaHra.Api/Services/ThumbnailService.cs
@@ -93,24 +93,24 @@ public class ThumbnailService : IThumbnailService
         if (cached is not null)
             return new ThumbnailResult(cached, "image/webp");
 
-        // Cache miss — fetch source, resize, encode, cache. The resize block runs
-        // under a concurrency gate so a thumbnail stampede on a cold page doesn't
-        // overwhelm the container.
-        var source = await _blob.DownloadAsync(sourceBlobKey, ct);
-        if (source is null)
-        {
-            _logger.LogWarning("Thumbnail source blob missing: {SourceKey}", sourceBlobKey);
-            return null;
-        }
-
+        // Cache miss — acquire the gate FIRST, then download + resize. Doing the
+        // download outside the gate would let 80 concurrent 5 MB source blobs
+        // sit in memory while queued, which defeats half the point of throttling.
         await _resizeGate.WaitAsync(ct);
         try
         {
             // Re-check after acquiring the gate — another request may have populated
-            // the cache while we were waiting. Avoids duplicate work.
+            // the cache while we were waiting. Avoids duplicate download + resize.
             cached = await _blob.DownloadAsync(cacheKey, ct);
             if (cached is not null)
                 return new ThumbnailResult(cached, "image/webp");
+
+            var source = await _blob.DownloadAsync(sourceBlobKey, ct);
+            if (source is null)
+            {
+                _logger.LogWarning("Thumbnail source blob missing: {SourceKey}", sourceBlobKey);
+                return null;
+            }
 
             byte[] resized;
             using (var image = Image.Load(source))

--- a/src/OvcinaHra.Api/Services/ThumbnailService.cs
+++ b/src/OvcinaHra.Api/Services/ThumbnailService.cs
@@ -20,6 +20,14 @@ public interface IThumbnailService
     /// </summary>
     Task<ThumbnailResult?> GetOrCreateAsync(
         string entityType, int entityId, string sourceBlobKey, ThumbnailPreset preset, CancellationToken ct = default);
+
+    /// <summary>
+    /// Fast cache probe — returns a SAS URL to the cached thumbnail blob if it exists,
+    /// or <c>null</c> if the thumbnail has not been generated yet. Used by the endpoint
+    /// to short-circuit hot-cache lookups into a 302 redirect (no bytes through the API).
+    /// </summary>
+    Task<string?> TryGetCachedSasUrlAsync(
+        string entityType, int entityId, ThumbnailPreset preset, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -45,10 +53,31 @@ public class ThumbnailService : IThumbnailService
     private readonly IBlobStorageService _blob;
     private readonly ILogger<ThumbnailService> _logger;
 
+    // Cap concurrent resizes across the whole process. A list page fires ~50
+    // thumbnail requests in parallel; 50 simultaneous ImageSharp decode+resize+
+    // encode cycles tank a small Container App (503s from the platform). The
+    // limit lets early requests finish while later ones queue briefly. Static
+    // because ThumbnailService is DI-registered as singleton.
+    private static readonly SemaphoreSlim _resizeGate = new(4, 4);
+
     public ThumbnailService(IBlobStorageService blob, ILogger<ThumbnailService> logger)
     {
         _blob = blob;
         _logger = logger;
+    }
+
+    public async Task<string?> TryGetCachedSasUrlAsync(
+        string entityType, int entityId, ThumbnailPreset preset, CancellationToken ct = default)
+    {
+        var (width, height) = DimensionsFor(preset);
+        var cacheKey = $"{entityType}-thumbs/{entityId}-{width}x{height}.webp";
+        // ExistsAsync is a single HEAD request — cheap compared to DownloadAsync
+        // or a full resize. When the thumb is cached (the common case after the
+        // first visitor), the caller redirects to this SAS URL and the browser
+        // fetches the bytes straight from Azure Blob. Zero bytes through the API.
+        if (!await _blob.ExistsAsync(cacheKey, ct))
+            return null;
+        return _blob.GetSasUrl(cacheKey);
     }
 
     public async Task<ThumbnailResult?> GetOrCreateAsync(
@@ -57,12 +86,16 @@ public class ThumbnailService : IThumbnailService
         var (width, height) = DimensionsFor(preset);
         var cacheKey = $"{entityType}-thumbs/{entityId}-{width}x{height}.webp";
 
-        // Cache hit? Return cached bytes directly.
+        // Cache hit? Return cached bytes directly. (Endpoint should have short-
+        // circuited via TryGetCachedSasUrlAsync, but double-check in case the
+        // cache populated after that probe.)
         var cached = await _blob.DownloadAsync(cacheKey, ct);
         if (cached is not null)
             return new ThumbnailResult(cached, "image/webp");
 
-        // Cache miss — fetch source, resize, encode, cache.
+        // Cache miss — fetch source, resize, encode, cache. The resize block runs
+        // under a concurrency gate so a thumbnail stampede on a cold page doesn't
+        // overwhelm the container.
         var source = await _blob.DownloadAsync(sourceBlobKey, ct);
         if (source is null)
         {
@@ -70,8 +103,15 @@ public class ThumbnailService : IThumbnailService
             return null;
         }
 
+        await _resizeGate.WaitAsync(ct);
         try
         {
+            // Re-check after acquiring the gate — another request may have populated
+            // the cache while we were waiting. Avoids duplicate work.
+            cached = await _blob.DownloadAsync(cacheKey, ct);
+            if (cached is not null)
+                return new ThumbnailResult(cached, "image/webp");
+
             byte[] resized;
             using (var image = Image.Load(source))
             {
@@ -86,9 +126,6 @@ public class ThumbnailService : IThumbnailService
                 resized = ms.ToArray();
             }
 
-            // Write to cache (fire-and-forget style would be nicer but we want the
-            // write to complete so a concurrent second request picks it up; the
-            // extra ~20 ms is negligible).
             using (var uploadStream = new MemoryStream(resized))
             {
                 await _blob.UploadAsync(cacheKey, uploadStream, "image/webp", ct);
@@ -100,6 +137,10 @@ public class ThumbnailService : IThumbnailService
         {
             _logger.LogWarning(ex, "Thumbnail resize failed for {SourceKey} at preset {Preset}", sourceBlobKey, preset);
             return null;
+        }
+        finally
+        {
+            _resizeGate.Release();
         }
     }
 

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.14.2</Version>
+    <Version>0.14.4</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Kills the 503 storm on /locations (80+ tiles) and every other list page.

## Root cause
Thumbnail endpoint was streaming bytes through the API on every hit — cold OR warm. On a small Container App, 80 concurrent streams + (on cold cache) 80 simultaneous ImageSharp resizes → platform 503s whatever it can't serve.

## Fixes
1. **Hot cache → 302 redirect**. `TryGetCachedSasUrlAsync` does a single HEAD; if the thumb exists, endpoint issues a 302 to its SAS URL. Browser fetches directly from Blob. Zero bytes through API.
2. **Cold cache → `SemaphoreSlim(4, 4)` around the ImageSharp resize block**. 80 concurrent misses now queue; max 4 resizes in flight at a time. Second cache-check after gate acquisition so only one request actually does the work per (entity, preset).

Net expected effect on /locations after this deploys:
- First-ever visitor: ~4 × resize time (staggered), rest fast
- Everyone else: ~80 HTTP HEAD + 80 browser-direct Blob fetches, **0 bytes through API**, **0 503s**

## Test plan
- [ ] \`dotnet build\` clean (0/0 verified)
- [ ] Open /locations, F12 → Network. After first load (warm cache): requests to \`/api/images/.../thumb\` return **302** with \`Location: https://<storage>...blob.core.windows.net/...\` header
- [ ] Clear browser cache → open /locations. No 503s. A handful of tiles may take a second longer (throttled resize) but all eventually resolve with 200.
- [ ] Upload a new image via ImagePicker → existing thumbs invalidated, page refresh shows new thumb

Version 0.14.2 → 0.14.4 (0.14.3 in-flight on PR #80).