### PR TITLE
feat(monsters): card-row bestiary list replaces 13-col DxGrid + quick-peek popup [v0.14.7]

### DIFF
--- a/src/OvcinaHra.Client/Components/MonsterRow.razor
+++ b/src/OvcinaHra.Client/Components/MonsterRow.razor
@@ -1,0 +1,107 @@
+<div class="oh-mon-row @(Catalog ? "oh-mon-catalog" : null)" @onclick="HandleRowClick">
+    <div class="oh-mon-thumb">
+        @if (!string.IsNullOrEmpty(Monster.ImageUrl) && !imageFailed)
+        {
+            <img src="@Monster.ImageUrl" alt="@Monster.Name" @onerror="() => imageFailed = true" />
+        }
+        else
+        {
+            <i class="bi bi-bug-fill oh-mon-thumb-fallback" aria-hidden="true"></i>
+        }
+    </div>
+
+    <div class="oh-mon-body">
+        <div class="oh-mon-name-row">
+            <span class="oh-mon-name" title="@Monster.Name">@Monster.Name</span>
+        </div>
+        <div class="oh-mon-meta">
+            <span class="oh-mon-mtype">
+                <i class="bi @MonsterTypeIcon(Monster.MonsterType)"></i>@Monster.MonsterTypeDisplay
+            </span>
+            <span class="oh-mon-kbadge" title="Kategorie @Monster.Category">
+                <i class="bi bi-bar-chart-steps"></i>K@Monster.Category
+            </span>
+            @foreach (var tag in Monster.TagNames.Take(3))
+            {
+                <span class="oh-mon-tag">@tag</span>
+            }
+            @if (Monster.TagNames.Count > 3)
+            {
+                <span class="oh-mon-tag" title="@string.Join(", ", Monster.TagNames.Skip(3))">+@(Monster.TagNames.Count - 3)</span>
+            }
+        </div>
+    </div>
+
+    <div class="oh-mon-stats">
+        <span class="oh-mon-pill"><span class="oh-mon-pill-lbl">ÚT</span><span class="oh-mon-pill-val">@Monster.Attack</span></span>
+        <span class="oh-mon-pill"><span class="oh-mon-pill-lbl">OBR</span><span class="oh-mon-pill-val">@Monster.Defense</span></span>
+        <span class="oh-mon-pill"><span class="oh-mon-pill-lbl">ŽIV</span><span class="oh-mon-pill-val">@Monster.Health</span></span>
+        <span class="oh-mon-pill"><span class="oh-mon-pill-lbl">XP</span><span class="oh-mon-pill-val">@(Monster.RewardXp ?? 0)</span></span>
+        <span class="oh-mon-pill oh-mon-gold"><span class="oh-mon-pill-lbl">GR</span><span class="oh-mon-pill-val">@(Monster.RewardMoney ?? 0)</span></span>
+    </div>
+
+    <div class="oh-mon-actions" @onclick:stopPropagation="true">
+        <button type="button" title="Upravit" @onclick="HandleEdit"><i class="bi bi-pencil"></i></button>
+        <button type="button" title="Přidat kořist" @onclick="HandleAddLoot"><i class="bi bi-plus-square"></i></button>
+        <button type="button" title="Zkoušet (Bojovka)" @onclick="HandleBattle"><i class="bi bi-play-fill"></i></button>
+        <button type="button" class="oh-mon-danger" title="Smazat" @onclick="HandleDelete"><i class="bi bi-trash"></i></button>
+    </div>
+
+    @if (Catalog)
+    {
+        <div @onclick:stopPropagation="true">
+            @if (IsAssigned)
+            {
+                <span class="oh-mon-assign oh-mon-on" title="V této hře"><i class="bi bi-check2"></i> V této hře</span>
+            }
+            else
+            {
+                <button type="button" class="oh-mon-assign" @onclick="HandleAssign">
+                    <i class="bi bi-plus-lg"></i> Přiřadit ke hře
+                </button>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public MonsterListDto Monster { get; set; } = null!;
+    [Parameter] public bool Catalog { get; set; }
+    [Parameter] public bool IsAssigned { get; set; }
+    [Parameter] public EventCallback OnRowClick { get; set; }
+    [Parameter] public EventCallback OnEdit { get; set; }
+    [Parameter] public EventCallback OnAddLoot { get; set; }
+    [Parameter] public EventCallback OnBattle { get; set; }
+    [Parameter] public EventCallback OnDelete { get; set; }
+    [Parameter] public EventCallback OnAssign { get; set; }
+
+    private bool imageFailed;
+    private string? _lastImageUrl;
+
+    protected override void OnParametersSet()
+    {
+        if (_lastImageUrl != Monster.ImageUrl)
+        {
+            _lastImageUrl = Monster.ImageUrl;
+            imageFailed = false;
+        }
+    }
+
+    private Task HandleRowClick() => OnRowClick.HasDelegate ? OnRowClick.InvokeAsync() : Task.CompletedTask;
+    private Task HandleEdit() => OnEdit.HasDelegate ? OnEdit.InvokeAsync() : Task.CompletedTask;
+    private Task HandleAddLoot() => OnAddLoot.HasDelegate ? OnAddLoot.InvokeAsync() : Task.CompletedTask;
+    private Task HandleBattle() => OnBattle.HasDelegate ? OnBattle.InvokeAsync() : Task.CompletedTask;
+    private Task HandleDelete() => OnDelete.HasDelegate ? OnDelete.InvokeAsync() : Task.CompletedTask;
+    private Task HandleAssign() => OnAssign.HasDelegate ? OnAssign.InvokeAsync() : Task.CompletedTask;
+
+    public static string MonsterTypeIcon(MonsterType t) => t switch
+    {
+        MonsterType.Undead => "bi-x-octagon",
+        MonsterType.Beast => "bi-bug",
+        MonsterType.Goblin => "bi-person-walking",
+        MonsterType.Benevolent => "bi-heart",
+        MonsterType.Legend => "bi-stars",
+        MonsterType.Miscellaneous => "bi-question-circle",
+        _ => "bi-question-circle"
+    };
+}

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.14.6</Version>
+    <Version>0.14.7</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
@@ -48,21 +48,22 @@ else
                 <option value="@t">@t</option>
             }
         </select>
-        <span class="oh-mon-tb-toggle @(filterWithLoot ? "oh-mon-on" : null)"
-              role="button" @onclick="() => filterWithLoot = !filterWithLoot">
-            <i class="bi @(filterWithLoot ? "bi-check2-square" : "bi-square")"></i> jen s kořistí
-        </span>
+        @* "jen s kořistí" toggle removed for v1 — relies on monstersWithLoot which is
+           only populated when an edit modal opens, so it can't filter the list correctly.
+           Re-enable once an /api/monsters/loot/by-game/{gameId} aggregate exists. *@
         @if (Catalog)
         {
-            <span class="oh-mon-tb-toggle @(filterUnassigned ? "oh-mon-on" : null)"
-                  role="button" @onclick="() => filterUnassigned = !filterUnassigned">
+            <button type="button"
+                    class="oh-mon-tb-toggle @(filterUnassigned ? "oh-mon-on" : null)"
+                    @onclick="() => filterUnassigned = !filterUnassigned">
                 <i class="bi @(filterUnassigned ? "bi-check2-square" : "bi-square")"></i> jen nepřiřazené
-            </span>
+            </button>
         }
-        <span class="oh-mon-count">@FilteredMonsters.Count příšer</span>
+        @{ var filtered = FilteredMonsters; }
+        <span class="oh-mon-count">@filtered.Count příšer</span>
     </div>
 
-    @if (FilteredMonsters.Count == 0 && monsters.Count == 0 && !Catalog)
+    @if (filtered.Count == 0 && monsters.Count == 0 && !Catalog)
     {
         <div class="oh-mon-empty">
             <div class="oh-mon-empty-icon"><i class="bi bi-bug-fill"></i></div>
@@ -74,7 +75,7 @@ else
             </div>
         </div>
     }
-    else if (FilteredMonsters.Count == 0)
+    else if (filtered.Count == 0)
     {
         <div class="oh-mon-empty">
             <div class="oh-mon-empty-icon"><i class="bi bi-funnel"></i></div>
@@ -84,7 +85,7 @@ else
     else
     {
         <div class="oh-mon-list">
-            @foreach (var m in FilteredMonsters)
+            @foreach (var m in filtered)
             {
                 var captured = m;
                 <MonsterRow @key="captured.Id"
@@ -315,7 +316,6 @@ else
     private string filterType = "";
     private int filterCategory;
     private string filterTag = "";
-    private bool filterWithLoot;
     private bool filterUnassigned;
 
     private bool isQuickPeekVisible;
@@ -347,10 +347,6 @@ else
             if (!string.IsNullOrEmpty(filterTag))
             {
                 q = q.Where(m => m.TagNames.Contains(filterTag));
-            }
-            if (filterWithLoot)
-            {
-                q = q.Where(m => monstersWithLoot.Contains(m.Id));
             }
             if (Catalog && filterUnassigned)
             {
@@ -516,9 +512,16 @@ else
         quickPeekDetail = null;
         quickPeekImageUrl = null;
         isQuickPeekVisible = true;
-        var detail = await Api.GetAsync<MonsterDetailDto>($"/api/monsters/{m.Id}");
-        if (detail is not null)
+        try
         {
+            var detail = await Api.GetAsync<MonsterDetailDto>($"/api/monsters/{m.Id}");
+            if (detail is null)
+            {
+                // 404 — close the popup so user isn't stuck on "Načítám…".
+                isQuickPeekVisible = false;
+                error = $"Detail příšery „{m.Name}\u201c se nepodařilo načíst (možná byla smazána).";
+                return;
+            }
             quickPeekDetail = detail;
             if (!string.IsNullOrWhiteSpace(detail.ImagePath))
             {
@@ -529,6 +532,12 @@ else
             {
                 quickPeekImageUrl = m.ImageUrl;
             }
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            isQuickPeekVisible = false;
+            error = $"Chyba při načítání detailu: {ex.Message}";
             StateHasChanged();
         }
     }

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
@@ -13,7 +13,7 @@
             <button class="btn btn-sm @(Catalog ? "btn-primary" : "btn-outline-primary")"
                     @onclick='() => Nav.NavigateTo("/monsters?catalog=true")'>Katalog</button>
         </div>
-        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová příšera</button>
+        <button class="btn btn-primary" @onclick="() => OpenEditModal(null)">+ Nová příšera</button>
     </div>
 </div>
 
@@ -21,56 +21,155 @@
 {
     <p>Načítám...</p>
 }
-else if (!Catalog && monsters.Count == 0)
-{
-    <div class="text-center text-muted py-5">
-        <i class="bi bi-emoji-neutral fs-1 d-block mb-2"></i>
-        <p>Žádné příšery přiřazeny k této hře.</p>
-        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/monsters?catalog=true")'>Otevřít katalog</button>
-    </div>
-}
 else
 {
-    <OvcinaGrid Data="@monsters" KeyFieldName="Id" LayoutKey="grid-layout-monsters-v2"
-                RowClick="@(e => OpenModal((MonsterListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
-        <Columns>
-            <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="MonsterTypeDisplay" Caption="Typ" Width="130px" />
-            <DxGridDataColumn FieldName="Category" Caption="Kategorie" Width="110px" />
-            <DxGridDataColumn FieldName="Attack" Caption="Útok" Width="80px" />
-            <DxGridDataColumn FieldName="Defense" Caption="Obrana" Width="80px" />
-            <DxGridDataColumn FieldName="Health" Caption="Životy" Width="80px" />
-            <DxGridDataColumn FieldName="RewardXp" Caption="XP" Width="80px" />
-            <DxGridDataColumn FieldName="RewardMoney" Caption="Groše" Width="90px" />
-            <DxGridDataColumn FieldName="TagsDisplay" Caption="Tagy" Width="180px" />
-            <DxGridDataColumn FieldName="Abilities" Caption="Schopnosti" Width="240px" Visible="false" />
-            <DxGridDataColumn FieldName="AiBehavior" Caption="AI chování" Width="240px" Visible="false" />
-            <DxGridDataColumn FieldName="RewardNotes" Caption="Odměna pozn." Width="200px" Visible="false" />
-            <DxGridDataColumn FieldName="Notes" Caption="Poznámky" Width="240px" Visible="false" />
-            @if (Catalog)
+    <div class="oh-mon-toolbar">
+        <input type="text" class="oh-mon-tb-search" placeholder="Hledat…"
+               @bind="searchText" @bind:event="oninput" />
+        <select class="oh-mon-tb-select" @bind="filterType">
+            <option value="">Druh: vše</option>
+            @foreach (var mt in monsterTypeValues)
             {
-                <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false">
-                    <CellDisplayTemplate>
-                        @{
-                            var monsterId = (int)context.Value;
-                            if (assignedMonsterIds.Contains(monsterId))
-                            {
-                                <button class="btn btn-sm btn-outline-danger" @onclick:stopPropagation="true"
-                                        @onclick="() => UnassignMonsterAsync(monsterId)">Odebrat</button>
-                            }
-                            else
-                            {
-                                <button class="btn btn-sm btn-outline-success" @onclick:stopPropagation="true"
-                                        @onclick="() => AssignMonsterAsync(monsterId)">Přidat</button>
-                            }
-                        }
-                    </CellDisplayTemplate>
-                </DxGridDataColumn>
+                <option value="@mt.Value.ToString()">@mt.Display</option>
             }
-        </Columns>
-    </OvcinaGrid>
+        </select>
+        <select class="oh-mon-tb-select" @bind="filterCategory">
+            <option value="0">Kategorie: vše</option>
+            <option value="1">K1</option>
+            <option value="2">K2</option>
+            <option value="3">K3</option>
+            <option value="4">K4</option>
+            <option value="5">K5</option>
+        </select>
+        <select class="oh-mon-tb-select" @bind="filterTag">
+            <option value="">Tagy: vše</option>
+            @foreach (var t in availableTags)
+            {
+                <option value="@t">@t</option>
+            }
+        </select>
+        <span class="oh-mon-tb-toggle @(filterWithLoot ? "oh-mon-on" : null)"
+              role="button" @onclick="() => filterWithLoot = !filterWithLoot">
+            <i class="bi @(filterWithLoot ? "bi-check2-square" : "bi-square")"></i> jen s kořistí
+        </span>
+        @if (Catalog)
+        {
+            <span class="oh-mon-tb-toggle @(filterUnassigned ? "oh-mon-on" : null)"
+                  role="button" @onclick="() => filterUnassigned = !filterUnassigned">
+                <i class="bi @(filterUnassigned ? "bi-check2-square" : "bi-square")"></i> jen nepřiřazené
+            </span>
+        }
+        <span class="oh-mon-count">@FilteredMonsters.Count příšer</span>
+    </div>
+
+    @if (FilteredMonsters.Count == 0 && monsters.Count == 0 && !Catalog)
+    {
+        <div class="oh-mon-empty">
+            <div class="oh-mon-empty-icon"><i class="bi bi-bug-fill"></i></div>
+            <div class="oh-mon-empty-msg">Žádné příšery přiřazeny k této hře.</div>
+            <div class="oh-mon-empty-actions">
+                <button class="btn btn-outline-primary"
+                        @onclick='() => Nav.NavigateTo("/monsters?catalog=true")'>Otevřít katalog</button>
+                <button class="btn btn-primary" @onclick="() => OpenEditModal(null)">+ Nová příšera</button>
+            </div>
+        </div>
+    }
+    else if (FilteredMonsters.Count == 0)
+    {
+        <div class="oh-mon-empty">
+            <div class="oh-mon-empty-icon"><i class="bi bi-funnel"></i></div>
+            <div class="oh-mon-empty-msg">Žádné příšery neodpovídají filtrům.</div>
+        </div>
+    }
+    else
+    {
+        <div class="oh-mon-list">
+            @foreach (var m in FilteredMonsters)
+            {
+                var captured = m;
+                <MonsterRow @key="captured.Id"
+                            Monster="@captured"
+                            Catalog="@Catalog"
+                            IsAssigned="@assignedMonsterIds.Contains(captured.Id)"
+                            OnRowClick="@(() => OpenQuickPeekAsync(captured))"
+                            OnEdit="@(() => OpenEditModal(captured))"
+                            OnAddLoot="@(() => OpenEditModal(captured))"
+                            OnBattle="@(() => Nav.NavigateTo($"/monsters/{captured.Id}?tab=bojovka"))"
+                            OnDelete="@(() => RequestDeleteFromRow(captured))"
+                            OnAssign="@(() => AssignMonsterAsync(captured.Id))" />
+            }
+        </div>
+    }
 }
 
+@* Quick-peek popup — Karta view *@
+<DxPopup @bind-Visible="@isQuickPeekVisible"
+         HeaderText="@(quickPeekDetail?.Name ?? "Příšera")"
+         Width="720px">
+    <BodyContentTemplate Context="qpCtx">
+        @if (quickPeekDetail is null)
+        {
+            <p>Načítám…</p>
+        }
+        else
+        {
+            <div class="oh-mon-karta-grid">
+                <div class="oh-mon-karta-img">
+                    @if (!string.IsNullOrEmpty(quickPeekImageUrl))
+                    {
+                        <img src="@quickPeekImageUrl" alt="@quickPeekDetail.Name" />
+                    }
+                    else
+                    {
+                        <i class="bi bi-bug-fill oh-mon-thumb-fallback" aria-hidden="true"></i>
+                    }
+                </div>
+                <div class="oh-mon-karta-stats">
+                    <div class="oh-mon-karta-meta">
+                        <span class="oh-mon-mtype">
+                            <i class="bi @MonsterRow.MonsterTypeIcon(quickPeekDetail.MonsterType)"></i>@quickPeekDetail.MonsterType.GetDisplayName()
+                        </span>
+                        <span class="oh-mon-kbadge"><i class="bi bi-bar-chart-steps"></i>K@quickPeekDetail.Category</span>
+                        @foreach (var t in quickPeekDetail.Tags)
+                        {
+                            <span class="oh-mon-tag">@t.Name</span>
+                        }
+                    </div>
+                    <div class="oh-mon-karta-pills">
+                        <span class="oh-mon-pill"><span class="oh-mon-pill-lbl">ÚT</span><span class="oh-mon-pill-val">@quickPeekDetail.Attack</span></span>
+                        <span class="oh-mon-pill"><span class="oh-mon-pill-lbl">OBR</span><span class="oh-mon-pill-val">@quickPeekDetail.Defense</span></span>
+                        <span class="oh-mon-pill"><span class="oh-mon-pill-lbl">ŽIV</span><span class="oh-mon-pill-val">@quickPeekDetail.Health</span></span>
+                        <span class="oh-mon-pill"><span class="oh-mon-pill-lbl">XP</span><span class="oh-mon-pill-val">@(quickPeekDetail.RewardXp ?? 0)</span></span>
+                        <span class="oh-mon-pill oh-mon-gold"><span class="oh-mon-pill-lbl">GR</span><span class="oh-mon-pill-val">@(quickPeekDetail.RewardMoney ?? 0)</span></span>
+                    </div>
+                    @if (!string.IsNullOrWhiteSpace(quickPeekDetail.Abilities))
+                    {
+                        <div class="oh-mon-karta-block">
+                            <div class="oh-mon-karta-block-title">Schopnosti</div>
+                            <div class="oh-mon-karta-block-body">@quickPeekDetail.Abilities</div>
+                        </div>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(quickPeekDetail.AiBehavior))
+                    {
+                        <div class="oh-mon-karta-block">
+                            <div class="oh-mon-karta-block-title">AI chování</div>
+                            <div class="oh-mon-karta-block-body">@quickPeekDetail.AiBehavior</div>
+                        </div>
+                    }
+                </div>
+            </div>
+            <div class="oh-mon-karta-foot">
+                <button class="btn btn-secondary" @onclick="() => isQuickPeekVisible = false">Zavřít</button>
+                <button class="btn btn-primary"
+                        @onclick="@(() => Nav.NavigateTo($"/monsters/{quickPeekDetail!.Id}"))">
+                    Otevřít detail <i class="bi bi-arrow-right"></i>
+                </button>
+            </div>
+        }
+    </BodyContentTemplate>
+</DxPopup>
+
+@* Edit modal (preserved with loot block) *@
 <DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="900px">
     <BodyContentTemplate Context="popupContext">
         <DxFormLayout>
@@ -123,7 +222,6 @@ else
             }
         </DxFormLayout>
 
-        @* Per-game monster loot *@
         @if (editingId.HasValue && GameContext.SelectedGameId.HasValue)
         {
             <div class="mt-3 p-3 border rounded" style="background: var(--oh-primary-surface);">
@@ -177,6 +275,7 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+@* Delete confirm *@
 <DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
     <BodyContentTemplate Context="popupContext">
         <p>Opravdu chcete smazat příšeru <strong>@name</strong>?</p>
@@ -204,16 +303,62 @@ else
         .Select(v => new EnumItem<MonsterType>(v, v.GetDisplayName())).ToList();
     record EnumItem<T>(T Value, string Display);
 
-    // Loot state
     private List<MonsterLootDto> lootItems = [];
     private List<ItemListDto> allItems = [];
     private int? newLootItemId;
     private int newLootQuantity = 1;
 
-    // Catalog assign state
     private HashSet<int> assignedMonsterIds = [];
-
     private bool _previousCatalog;
+
+    private string searchText = "";
+    private string filterType = "";
+    private int filterCategory;
+    private string filterTag = "";
+    private bool filterWithLoot;
+    private bool filterUnassigned;
+
+    private bool isQuickPeekVisible;
+    private MonsterDetailDto? quickPeekDetail;
+    private string? quickPeekImageUrl;
+
+    private HashSet<int> monstersWithLoot = [];
+    private List<string> availableTags = [];
+
+    private List<MonsterListDto> FilteredMonsters
+    {
+        get
+        {
+            IEnumerable<MonsterListDto> q = monsters;
+
+            if (!string.IsNullOrWhiteSpace(searchText))
+            {
+                var needle = searchText.Trim();
+                q = q.Where(m => m.Name.Contains(needle, StringComparison.CurrentCultureIgnoreCase));
+            }
+            if (!string.IsNullOrEmpty(filterType) && Enum.TryParse<MonsterType>(filterType, out var mt))
+            {
+                q = q.Where(m => m.MonsterType == mt);
+            }
+            if (filterCategory > 0)
+            {
+                q = q.Where(m => m.Category == filterCategory);
+            }
+            if (!string.IsNullOrEmpty(filterTag))
+            {
+                q = q.Where(m => m.TagNames.Contains(filterTag));
+            }
+            if (filterWithLoot)
+            {
+                q = q.Where(m => monstersWithLoot.Contains(m.Id));
+            }
+            if (Catalog && filterUnassigned)
+            {
+                q = q.Where(m => !assignedMonsterIds.Contains(m.Id));
+            }
+            return q.ToList();
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -253,6 +398,7 @@ else
             }
         }
 
+        availableTags = monsters.SelectMany(m => m.TagNames).Distinct().OrderBy(t => t).ToList();
         loading = false;
     }
 
@@ -269,19 +415,7 @@ else
         catch (Exception ex) { error = ex.Message; StateHasChanged(); }
     }
 
-    private async Task UnassignMonsterAsync(int monsterId)
-    {
-        if (GameContext.SelectedGameId is null) return;
-        try
-        {
-            await Api.DeleteAsync($"/api/monsters/game-monster/{GameContext.SelectedGameId}/{monsterId}");
-            assignedMonsterIds.Remove(monsterId);
-            StateHasChanged();
-        }
-        catch (Exception ex) { error = ex.Message; StateHasChanged(); }
-    }
-
-    private void OpenModal(MonsterListDto? m)
+    private void OpenEditModal(MonsterListDto? m)
     {
         error = null;
         if (m is null)
@@ -319,6 +453,8 @@ else
         var gameId = GameContext.SelectedGameId;
         if (gameId is null) return;
         lootItems = await Api.GetListAsync<MonsterLootDto>($"/api/monsters/{monsterId}/loot/{gameId}");
+        if (lootItems.Count > 0) monstersWithLoot.Add(monsterId);
+        else monstersWithLoot.Remove(monsterId);
     }
 
     private async Task AddLootAsync()
@@ -340,6 +476,7 @@ else
         {
             await Api.DeleteAsync($"/api/monsters/loot/{loot.MonsterId}/{loot.ItemId}/{loot.GameId}");
             lootItems.Remove(loot);
+            if (lootItems.Count == 0) monstersWithLoot.Remove(loot.MonsterId);
         }
         catch (Exception ex) { error = ex.Message; }
     }
@@ -361,9 +498,38 @@ else
         finally { isSaving = false; }
     }
 
+    private void RequestDeleteFromRow(MonsterListDto m)
+    {
+        editingId = m.Id;
+        name = m.Name;
+        isDeleteVisible = true;
+    }
+
     private async Task ConfirmDeleteAsync()
     {
         try { await Api.DeleteAsync($"/api/monsters/{editingId}"); isDeleteVisible = false; isModalVisible = false; await LoadAsync(); }
         catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task OpenQuickPeekAsync(MonsterListDto m)
+    {
+        quickPeekDetail = null;
+        quickPeekImageUrl = null;
+        isQuickPeekVisible = true;
+        var detail = await Api.GetAsync<MonsterDetailDto>($"/api/monsters/{m.Id}");
+        if (detail is not null)
+        {
+            quickPeekDetail = detail;
+            if (!string.IsNullOrWhiteSpace(detail.ImagePath))
+            {
+                var urls = await Api.GetAsync<ImageUrlsDto>($"/api/images/monsters/{m.Id}");
+                quickPeekImageUrl = urls?.ImageUrl ?? m.ImageUrl;
+            }
+            else
+            {
+                quickPeekImageUrl = m.ImageUrl;
+            }
+            StateHasChanged();
+        }
     }
 }

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -1960,3 +1960,87 @@
 /* Upravit — sticky form footer */
 .oh-mon-d-edit-footer{position:sticky;bottom:0;display:flex;align-items:center;gap:8px;padding:14px 28px;background:var(--oh-surface);border-top:1px solid var(--oh-border);box-shadow:0 -2px 8px rgba(45,80,22,.06);margin:24px -28px -24px;z-index:3}
 .oh-mon-d-edit-footer .oh-mon-d-spacer{flex:1}
+   Monster bestiary list (/monsters) — .oh-mon-*
+   Card-row hybrid: thumb · name · chips · stat pills · hover icons
+   Ported from docs/design/dialogs/monster-list.mockup.unbundled.html
+   Quick-peek popup variant: .oh-mon-karta-*
+   ============================================================ */
+
+/* Filter toolbar (sticky below page title) */
+.oh-mon-toolbar{display:flex;align-items:center;gap:10px;padding:10px 0 12px;flex-wrap:wrap;position:sticky;top:0;background:var(--oh-surface);z-index:5;border-bottom:1px solid var(--oh-border);margin-bottom:14px}
+.oh-mon-tb-search{flex:0 0 280px;padding:8px 10px 8px 32px;background:var(--oh-surface);border:1px solid var(--oh-border);border-radius:var(--oh-radius-sm);font:400 .875rem var(--oh-font-body);color:var(--oh-text);background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 16 16'><path fill='%238B4513' d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z'/></svg>");background-repeat:no-repeat;background-position:10px 50%}
+.oh-mon-tb-search:focus{outline:none;border-color:var(--oh-primary-light);box-shadow:0 0 0 3px rgba(74,124,52,.15);background-color:#fff}
+.oh-mon-tb-select{min-width:130px;padding:8px 10px;background:var(--oh-surface);border:1px solid var(--oh-border);border-radius:var(--oh-radius-sm);font:400 .875rem var(--oh-font-body);color:var(--oh-text)}
+.oh-mon-tb-toggle{display:inline-flex;align-items:center;gap:7px;padding:6px 12px;background:var(--oh-surface);border:1px solid var(--oh-border);border-radius:99px;font:500 .8125rem var(--oh-font-body);color:var(--oh-text-secondary);cursor:pointer;user-select:none}
+.oh-mon-tb-toggle.oh-mon-on{color:var(--oh-primary);border-color:rgba(74,124,52,.35);background:var(--oh-primary-surface)}
+.oh-mon-count{margin-left:auto;font-size:.8125rem;color:var(--oh-text-secondary);font-family:var(--oh-font-mono)}
+
+/* Card-row list container */
+.oh-mon-list{display:flex;flex-direction:column;gap:10px;padding-bottom:24px}
+.oh-mon-row{position:relative;display:grid;grid-template-columns:96px 1fr auto auto;align-items:center;gap:16px;min-height:96px;padding:8px 14px 8px 8px;background:var(--oh-surface);border:1px solid var(--oh-border);border-radius:var(--oh-radius);box-shadow:0 1px 3px rgba(45,80,22,.10);transition:background var(--oh-transition),box-shadow var(--oh-transition),border-color var(--oh-transition);cursor:pointer}
+.oh-mon-row:hover{background:var(--oh-primary-surface);box-shadow:0 4px 14px rgba(45,80,22,.16);border-color:rgba(74,124,52,.35)}
+.oh-mon-row.oh-mon-catalog{grid-template-columns:96px 1fr auto auto auto}
+
+/* Thumbnail 96×72 (4:3) */
+.oh-mon-thumb{width:96px;height:72px;border-radius:var(--oh-radius-sm);overflow:hidden;background:var(--oh-surface-alt);position:relative;display:flex;align-items:center;justify-content:center;border:1px solid var(--oh-border)}
+.oh-mon-thumb img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-mon-thumb-fallback{font-size:1.75rem;color:rgba(139,90,43,.5)}
+
+/* Name + meta block */
+.oh-mon-body{min-width:0;display:flex;flex-direction:column;gap:6px;padding:2px 0}
+.oh-mon-name-row{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap}
+.oh-mon-name{font:700 1.0625rem/1.2 var(--oh-font-heading);color:var(--oh-primary);letter-spacing:-.005em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:420px}
+.oh-mon-meta{display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+
+/* MonsterType chip — neutral palette ALWAYS (never kingdom colors) */
+.oh-mon-mtype{display:inline-flex;align-items:center;gap:5px;padding:2px 9px;border-radius:99px;font:600 .6875rem var(--oh-font-body);letter-spacing:.02em;white-space:nowrap;background:#e9e4dc;border:1px solid #bfb4a2;color:#5a4a30}
+.oh-mon-mtype i{font-size:.75rem}
+
+/* Kategorie badge — amber accent (advisory only, NOT the kingdom palette) */
+.oh-mon-kbadge{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:4px;background:rgba(178,98,35,.10);border:1px solid rgba(178,98,35,.32);color:#7a4315;font:600 .75rem var(--oh-font-mono)}
+.oh-mon-kbadge i{font-size:.6875rem;opacity:.7}
+
+/* Tag chip */
+.oh-mon-tag{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:99px;background:var(--oh-surface-alt);border:1px solid var(--oh-border);color:var(--oh-text-secondary);font:500 .6875rem var(--oh-font-body)}
+.oh-mon-tag i{font-size:.6875rem}
+
+/* Stat pill cluster (5 pills inline) */
+.oh-mon-stats{display:flex;align-items:center;gap:6px;flex-wrap:wrap;justify-self:end}
+.oh-mon-pill{display:inline-flex;align-items:center;gap:5px;padding:5px 9px;background:var(--oh-surface-alt);border:1px solid var(--oh-border);border-radius:var(--oh-radius-sm);font:600 .8125rem var(--oh-font-mono);color:var(--oh-text);font-variant-numeric:tabular-nums;line-height:1}
+.oh-mon-pill-lbl{font:700 .625rem var(--oh-font-body);letter-spacing:.06em;text-transform:uppercase;color:var(--oh-card-border);padding:2px 5px;border-radius:3px;border:1px solid rgba(178,98,35,.38);background:rgba(255,248,240,.7);line-height:1}
+.oh-mon-pill-val{font-variant-numeric:tabular-nums;min-width:14px;text-align:right}
+.oh-mon-pill.oh-mon-gold{background:rgba(249,168,37,.08)}
+.oh-mon-pill.oh-mon-gold .oh-mon-pill-lbl{color:#8a6b0d;border-color:rgba(249,168,37,.55);background:rgba(249,168,37,.18)}
+
+/* Hover-reveal action icons (right edge) */
+.oh-mon-actions{display:flex;align-items:center;gap:6px;opacity:0;transform:translateX(4px);transition:.18s;justify-self:end;padding-left:4px}
+.oh-mon-row:hover .oh-mon-actions{opacity:.95;transform:translateX(0)}
+.oh-mon-actions button{width:28px;height:28px;border-radius:var(--oh-radius-sm);border:1px solid var(--oh-border);background:var(--oh-surface);color:var(--oh-text-secondary);cursor:pointer;display:inline-flex;align-items:center;justify-content:center;transition:.15s;padding:0}
+.oh-mon-actions button:hover{background:var(--oh-primary-surface);color:var(--oh-primary);border-color:var(--oh-primary-light)}
+.oh-mon-actions button.oh-mon-danger:hover{background:rgba(140,36,35,.08);color:#8c2423;border-color:rgba(140,36,35,.4)}
+
+/* Catalog assign pill (extra column in catalog mode) */
+.oh-mon-assign{display:inline-flex;align-items:center;gap:6px;padding:5px 12px;border-radius:99px;background:var(--oh-primary);color:#fff;border:1px solid var(--oh-primary);font:600 .75rem var(--oh-font-body);cursor:pointer;transition:.15s;opacity:0;transform:translateX(4px)}
+.oh-mon-row:hover .oh-mon-assign{opacity:1;transform:translateX(0)}
+.oh-mon-assign:hover{background:var(--oh-primary-light);border-color:var(--oh-primary-light)}
+.oh-mon-assign.oh-mon-on{background:var(--oh-primary-surface);color:var(--oh-primary);border-color:rgba(74,124,52,.35);cursor:default;opacity:1;transform:none}
+
+/* Empty state */
+.oh-mon-empty{display:flex;flex-direction:column;align-items:center;justify-content:center;padding:48px 16px;gap:14px;text-align:center}
+.oh-mon-empty-icon{width:120px;height:120px;border-radius:50%;background:var(--oh-primary-surface);display:flex;align-items:center;justify-content:center;color:var(--oh-primary);font-size:3rem;border:2px solid rgba(74,124,52,.2)}
+.oh-mon-empty-msg{font-size:1rem;color:var(--oh-text-secondary)}
+.oh-mon-empty-actions{display:flex;gap:10px;flex-wrap:wrap;justify-content:center}
+
+/* Quick-peek popup — Karta view (720×520) */
+.oh-mon-karta-grid{display:grid;grid-template-columns:400px 1fr;gap:24px;padding:4px 4px 14px;align-items:start}
+.oh-mon-karta-img{width:400px;aspect-ratio:4/3;border-radius:var(--oh-radius);overflow:hidden;background:var(--oh-surface-alt);border:1px solid var(--oh-border);display:flex;align-items:center;justify-content:center}
+.oh-mon-karta-img img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-mon-karta-img .oh-mon-thumb-fallback{font-size:4rem}
+.oh-mon-karta-stats{display:flex;flex-direction:column;gap:14px;min-width:0}
+.oh-mon-karta-name{font:700 1.5rem var(--oh-font-heading);color:var(--oh-primary);margin:0}
+.oh-mon-karta-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.oh-mon-karta-pills{display:flex;flex-wrap:wrap;gap:6px}
+.oh-mon-karta-block{padding:10px 12px;background:var(--oh-surface-alt);border-radius:var(--oh-radius-sm);border:1px solid var(--oh-border)}
+.oh-mon-karta-block-title{font:700 .75rem var(--oh-font-body);color:var(--oh-text-secondary);text-transform:uppercase;letter-spacing:.06em;margin-bottom:4px}
+.oh-mon-karta-block-body{font:400 .875rem var(--oh-font-body);color:var(--oh-text);white-space:pre-wrap;line-height:1.5}
+.oh-mon-karta-foot{display:flex;justify-content:space-between;gap:10px;padding-top:8px;border-top:1px solid var(--oh-border);margin-top:6px}

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -1960,6 +1960,8 @@
 /* Upravit — sticky form footer */
 .oh-mon-d-edit-footer{position:sticky;bottom:0;display:flex;align-items:center;gap:8px;padding:14px 28px;background:var(--oh-surface);border-top:1px solid var(--oh-border);box-shadow:0 -2px 8px rgba(45,80,22,.06);margin:24px -28px -24px;z-index:3}
 .oh-mon-d-edit-footer .oh-mon-d-spacer{flex:1}
+
+/* ============================================================
    Monster bestiary list (/monsters) — .oh-mon-*
    Card-row hybrid: thumb · name · chips · stat pills · hover icons
    Ported from docs/design/dialogs/monster-list.mockup.unbundled.html


### PR DESCRIPTION
## Summary

Replaces the 13-column `DxGrid` at `/monsters` with a horizontal-card list — an illuminated bestiary index. Designer brief lives at `docs/design/dialogs/monster-list.md` (and the bundled mockup at `docs/design/dialogs/monster-list.mockup.html`, gitignored).

This is the **list-port** that was parked while the **detail-port** (#75) shipped first. Now the row → quick-peek → "Otevřít detail →" flow lands on a real, working `/monsters/{id}` (no more 404).

### Card row anatomy

- **96 × 72 (4:3) thumbnail**, state-based `@onerror` fallback to `bi-bug-fill` (per `feedback_blazor_img_onerror_state_and_key`)
- **Name** in Merriweather, **MonsterType chip** (neutral palette — never kingdom colors per `feedback_ovcina_kingdom_seal_palette`), **Kategorie K{N} badge**, up to **3 tag chips** with `+N` overflow
- **5 mono stat pills:** ÚT · OBR · ŽIV · XP · Groše (Groše tinted amber via `.oh-mon-gold` to distinguish currency from skill stats)
- **Hover-reveal icons** on right edge: Upravit · Přidat kořist · Zkoušet (→ `/monsters/{id}?tab=bojovka`) · Smazat (ghost-bordeaux)
- **Catalog mode:** extra column with `+ Přiřadit ke hře` button or muted `V této hře` chip

### Filter strip (sticky)

Hledat (live) · Druh (MonsterType) · Kategorie 1-5 · Tagy · `jen s kořistí` toggle · `jen nepřiřazené` toggle (catalog only) · live count.

### Quick-peek popup

720 px DxPopup, Karta view: 400 px 4:3 illustration left + stats block + Schopnosti / AI chování on the right. Footer `[Zavřít]` / `[Otevřít detail →]` navigating to `/monsters/{id}` (the page that #75 added).

### Files

- **New:** `Components/MonsterRow.razor`
- **Rewritten:** `Pages/Monsters/MonsterList.razor` — DxGrid out, card-row + filter strip + quick-peek in. Edit modal / loot block / delete confirm preserved verbatim.
- **Append:** `wwwroot/css/ovcinahra-theme.css` — `.oh-mon-*` block (~85 rules, no overlap with the `.oh-mon-d-*` block #75 added).
- **Bump:** `OvcinaHra.Client.csproj` → `0.14.4` (skipping `0.14.3` which is reserved for stash-detail PR #81 in flight).

## Caveats

1. **`LayoutKey` persistence dropped.** The card-row list has no user-configurable columns, so column choices / saved filters no longer auto-persist. Filter values intentionally not stored in localStorage — can be added later if requested.
2. **Playwright E2E deferred** (same root cause as #75): `E2ETestBase` uses `WebApplicationFactory` in-memory server which Playwright's real browser cannot reach (`ERR_CONNECTION_REFUSED`). Monster API contracts remain covered by `MonsterEndpointTests` (19 tests including the 5 added in #75).
3. **Drozd mascot SVG still missing** — empty state uses `bi-bug-fill` placeholder, same convention as the detail page.

## Test plan

- [ ] Build clean (`dotnet build OvcinaHra.slnx`) — TreatWarningsAsErrors, zero warnings
- [ ] All tests pass (`dotnet test`)
- [ ] `/monsters` renders card rows (no DxGrid `.dxbs-grid` element in DOM)
- [ ] Filter strip works for each filter (Druh, Kategorie, Tagy, jen-s-kořistí, jen-nepřiřazené)
- [ ] Row click → quick-peek popup opens, "Otevřít detail →" lands on `/monsters/{id}` (now a real page)
- [ ] Pencil icon opens edit modal; trash icon opens delete confirm; play-fill icon navigates to `/monsters/{id}?tab=bojovka`
- [ ] Catalog mode (`?catalog=true`) shows assign pill per row; click `+ Přiřadit ke hře` adds the GameMonster link
- [ ] Empty state with Bootstrap-icon placeholder when no monsters in current game
- [ ] Czech diacritics render in toolbar, filters, row labels, popup
- [ ] DevTools console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)