### PR TITLE
feat(locations): aerial map + tighter zoom + orientation pins on detail [v0.15.1]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.0</Version>
+    <Version>0.15.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -384,6 +384,10 @@ else
     private bool miniMapInited;
     private decimal? lastMiniMapLat, lastMiniMapLon;
     private LocationKind? lastMiniMapKind;
+    // Tracks which elementId the live JS instance belongs to, so navigating between
+    // /locations/{id} pages without leaving the Upravit tab disposes the stale instance
+    // before re-initing under the new Id (per Copilot review on PR #85).
+    private string? lastMiniMapElementId;
 
     private bool HasGps => ParseGps(out _, out _);
 
@@ -577,6 +581,18 @@ else
 
     private async Task ReconcileMiniMapAsync()
     {
+        // If the route Id changed (user navigated to a different /locations/{id} while
+        // staying on Upravit), the old elementId no longer exists in the DOM. Dispose
+        // the stale JS instance before doing anything else.
+        if (miniMapInited && lastMiniMapElementId is not null && lastMiniMapElementId != MiniMapElementId)
+        {
+            try { await JS.InvokeVoidAsync("ovcinaMiniMap.dispose", lastMiniMapElementId); } catch { }
+            miniMapInited = false;
+            lastMiniMapLat = null; lastMiniMapLon = null;
+            lastMiniMapKind = null;
+            lastMiniMapElementId = null;
+        }
+
         decimal lat = 0, lon = 0;
         var shouldShow = activeTab == "upravit" && loc is not null && ParseGps(out lat, out lon);
 
@@ -588,6 +604,7 @@ else
                 miniMapInited = false;
                 lastMiniMapLat = null; lastMiniMapLon = null;
                 lastMiniMapKind = null;
+                lastMiniMapElementId = null;
             }
             return;
         }
@@ -616,6 +633,7 @@ else
                 miniMapInited = true;
                 lastMiniMapLat = lat; lastMiniMapLon = lon;
                 lastMiniMapKind = locationKind;
+                lastMiniMapElementId = MiniMapElementId;
                 await PaintContextMarkersAsync();
             }
             catch { /* element may not be in DOM yet; retried on next render */ }

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -350,6 +350,9 @@ else
     private LocationListDto? parent;
     private List<LocationListDto> variants = [];
     private List<LocationListDto> parentCandidates = [];
+    // Cached so the mini-map can paint surrounding orientation pins (issue #74)
+    // without re-fetching the catalog on every render.
+    private List<LocationListDto> allLocations = [];
     private string? mainImageUrl;
 
     private string activeTab = "karta";
@@ -445,13 +448,13 @@ else
 
             PopulateFormFromDto(detail);
 
-            // Parent + variants
-            var all = await Api.GetListAsync<LocationListDto>("/api/locations");
-            parentCandidates = all.Where(l => l.Id != Id).ToList();
+            // Parent + variants (and cached for the mini-map orientation pins, issue #74).
+            allLocations = await Api.GetListAsync<LocationListDto>("/api/locations");
+            parentCandidates = allLocations.Where(l => l.Id != Id).ToList();
             parent = detail.ParentLocationId.HasValue
-                ? all.FirstOrDefault(l => l.Id == detail.ParentLocationId.Value)
+                ? allLocations.FirstOrDefault(l => l.Id == detail.ParentLocationId.Value)
                 : null;
-            variants = all.Where(l => l.ParentLocationId == Id).ToList();
+            variants = allLocations.Where(l => l.ParentLocationId == Id).ToList();
 
             // Main image (ImagePicker has its own fetch, but we also render img on Karta)
             try
@@ -607,11 +610,13 @@ else
         {
             try
             {
+                // Issue #74: aerial photo style + tighter zoom (16, town-scale).
                 await JS.InvokeVoidAsync("ovcinaMiniMap.init",
-                    MiniMapElementId, (double)lat, (double)lon, 12, kindColor, apiKey);
+                    MiniMapElementId, (double)lat, (double)lon, 16, kindColor, apiKey, "aerial");
                 miniMapInited = true;
                 lastMiniMapLat = lat; lastMiniMapLon = lon;
                 lastMiniMapKind = locationKind;
+                await PaintContextMarkersAsync();
             }
             catch { /* element may not be in DOM yet; retried on next render */ }
             return;
@@ -627,6 +632,28 @@ else
             }
             catch { /* ignore transient errors */ }
         }
+    }
+
+    // Paint every other location with GPS as a small kind-colored dot for
+    // orientation. Issue #74 — organizers want context, not a single isolated pin.
+    private async Task PaintContextMarkersAsync()
+    {
+        if (!miniMapInited) return;
+        var ctx = allLocations
+            .Where(l => l.Id != Id && l.Latitude.HasValue && l.Longitude.HasValue)
+            .Select(l => new
+            {
+                lat = (double)l.Latitude!.Value,
+                lon = (double)l.Longitude!.Value,
+                name = l.Name,
+                color = KindMarkerColors.GetValueOrDefault(l.LocationKind, "#666")
+            })
+            .ToArray();
+        try
+        {
+            await JS.InvokeVoidAsync("ovcinaMiniMap.setContextMarkers", MiniMapElementId, ctx);
+        }
+        catch { /* ignore — surrounding pins are nice-to-have */ }
     }
 
     public async ValueTask DisposeAsync()

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -228,14 +228,18 @@ window.ovcinaMap = {
 window.ovcinaMiniMap = {
     _instances: {},
 
-    _rasterStyle: function (apiKey) {
-        if (apiKey && apiKey.length > 5) {
+    // styleKey:
+    //   'aerial'  → Mapy.cz aerial (photo) — default for the LocationDetail orientation map (issue #74)
+    //   'outdoor' → Mapy.cz tourist raster (previous default)
+    //   anything else (or no apiKey) → OSM raster fallback
+    _styleFor: function (styleKey, apiKey) {
+        if (apiKey && apiKey.length > 5 && (styleKey === 'aerial' || styleKey === 'outdoor' || styleKey === 'basic')) {
             return {
                 version: 8,
                 sources: {
                     'mapy-cz': {
                         type: 'raster',
-                        tiles: ['https://api.mapy.cz/v1/maptiles/outdoor/256/{z}/{x}/{y}?apikey=' + apiKey],
+                        tiles: ['https://api.mapy.cz/v1/maptiles/' + styleKey + '/256/{z}/{x}/{y}?apikey=' + apiKey],
                         tileSize: 256,
                         maxzoom: 19,
                         attribution: '&copy; Mapy.cz'
@@ -259,10 +263,12 @@ window.ovcinaMiniMap = {
         };
     },
 
-    init: function (elementId, lat, lon, zoom, kindColor, mapyCzApiKey) {
+    // styleKey is optional — defaults to 'aerial' (photo map) for the LocationDetail
+    // orientation map (issue #74). Bumped default zoom from 12 to 16 so the user lands
+    // on a town-scale view, not a continent-scale one.
+    init: function (elementId, lat, lon, zoom, kindColor, mapyCzApiKey, styleKey) {
         var el = document.getElementById(elementId);
         if (!el || typeof maplibregl === 'undefined') return;
-        // If already initialized with same coords, no-op.
         var existing = this._instances[elementId];
         if (existing) {
             this.update(elementId, lat, lon);
@@ -271,19 +277,19 @@ window.ovcinaMiniMap = {
 
         var map = new maplibregl.Map({
             container: el,
-            style: this._rasterStyle(mapyCzApiKey),
+            style: this._styleFor(styleKey || 'aerial', mapyCzApiKey),
             center: [lon, lat],
-            zoom: zoom || 12,
-            interactive: false,       // read-only mini preview
+            zoom: zoom || 16,
+            interactive: false,
             attributionControl: false
         });
 
         var el2 = document.createElement('div');
-        el2.style.cssText = 'width:16px;height:16px;border-radius:50%;background:' +
-            (kindColor || '#2D5016') + ';border:2px solid #fff;box-shadow:0 1px 3px rgba(0,0,0,.35);';
+        el2.style.cssText = 'width:18px;height:18px;border-radius:50%;background:' +
+            (kindColor || '#2D5016') + ';border:2px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,.5);';
         var marker = new maplibregl.Marker({ element: el2 }).setLngLat([lon, lat]).addTo(map);
 
-        this._instances[elementId] = { map: map, marker: marker };
+        this._instances[elementId] = { map: map, marker: marker, contextMarkers: [] };
     },
 
     update: function (elementId, lat, lon) {
@@ -293,9 +299,41 @@ window.ovcinaMiniMap = {
         inst.map.jumpTo({ center: [lon, lat] });
     },
 
+    // Paint a set of small dots around the current location for orientation (issue #74).
+    // Each item: { lat, lon, name, color }.
+    // Replaces the previous context markers (so caller can rebuild on game switch).
+    setContextMarkers: function (elementId, markers) {
+        var inst = this._instances[elementId];
+        if (!inst) return;
+        // Clear previous context markers
+        if (inst.contextMarkers) {
+            for (var i = 0; i < inst.contextMarkers.length; i++) {
+                try { inst.contextMarkers[i].remove(); } catch (e) { /* ignore */ }
+            }
+        }
+        inst.contextMarkers = [];
+        if (!markers || !markers.length) return;
+        for (var j = 0; j < markers.length; j++) {
+            var m = markers[j];
+            if (m.lat == null || m.lon == null) continue;
+            var dot = document.createElement('div');
+            dot.title = m.name || '';
+            dot.style.cssText = 'width:10px;height:10px;border-radius:50%;background:' +
+                (m.color || '#666') +
+                ';border:1.5px solid rgba(255,255,255,.85);box-shadow:0 1px 2px rgba(0,0,0,.4);opacity:.85;';
+            var ctx = new maplibregl.Marker({ element: dot }).setLngLat([m.lon, m.lat]).addTo(inst.map);
+            inst.contextMarkers.push(ctx);
+        }
+    },
+
     dispose: function (elementId) {
         var inst = this._instances[elementId];
         if (!inst) return;
+        if (inst.contextMarkers) {
+            for (var i = 0; i < inst.contextMarkers.length; i++) {
+                try { inst.contextMarkers[i].remove(); } catch (e) { /* ignore */ }
+            }
+        }
         try { inst.map.remove(); } catch (e) { /* ignore */ }
         delete this._instances[elementId];
     }

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -231,6 +231,7 @@ window.ovcinaMiniMap = {
     // styleKey:
     //   'aerial'  → Mapy.cz aerial (photo) — default for the LocationDetail orientation map (issue #74)
     //   'outdoor' → Mapy.cz tourist raster (previous default)
+    //   'basic'   → Mapy.cz basic raster
     //   anything else (or no apiKey) → OSM raster fallback
     _styleFor: function (styleKey, apiKey) {
         if (apiKey && apiKey.length > 5 && (styleKey === 'aerial' || styleKey === 'outdoor' || styleKey === 'basic')) {


### PR DESCRIPTION
## Summary

Closes #74.

The LocationDetail mini-map (Upravit tab) was a single isolated pin on the Mapy.cz tourist raster at zoom 12 — too zoomed out, no spatial context. Per the issue: *"The map should ideally be a photo map, zoomed much more in, and should show all the town locations so the user is oriented."*

### Changes

1. **Photo tile style.** Default switched to `aerial` (Mapy.cz aerial raster). `ovcinaMiniMap.init` now takes an optional 7th `styleKey` argument; the helper builds the right Mapy.cz raster URL for `aerial` / `outdoor` / `basic` and falls back to OSM when no API key is configured.
2. **Tighter default zoom.** 12 → 16. Town-scale view instead of continent.
3. **Orientation pins.** New `ovcinaMiniMap.setContextMarkers(elementId, markers)` JS helper. After init, the page paints every other location with GPS as a small 10 px kind-colored dot (with a `title` tooltip). The current location keeps its larger highlighted pin. Reuses the `allLocations` catalog the page already fetches for parent / variant pickers — no new API call.

### Files

- `src/OvcinaHra.Client/wwwroot/js/map-interop.js` — `ovcinaMiniMap`: new `_styleFor(styleKey, apiKey)`, optional `styleKey` on `init`, default zoom 16, new `setContextMarkers`, dispose now clears context markers too.
- `src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor` — `allLocations` field cached from the existing `/api/locations` fetch, init call passes `16` + `"aerial"`, new `PaintContextMarkersAsync()` runs after init succeeds.
- `OvcinaHra.Client.csproj` — `0.14.7` → `0.14.8`.

### Caveats

- **No new API endpoint.** Pure client + JS interop change.
- **Aerial tiles need the Mapy.cz API key.** When `Maps:MapyCzApiKey` is unset, both old behavior (tourist raster) and new behavior (aerial) fall back to OSM — same fallback path as before, just at the new default zoom.
- **Click-through on context dots is intentionally NOT wired** in this PR — the issue asks for orientation, not navigation. Easy to add later if desired (`Marker.getElement().addEventListener('click', ...)`).
- **Tooltip on context dots uses native `title` attr** — minimal, no new tooltip framework.

## Test plan

- [ ] `dotnet build OvcinaHra.slnx` clean (TreatWarningsAsErrors, zero warnings)
- [ ] `dotnet test` green (LocationEndpointTests 10/10 verified locally — no API change)
- [ ] Open `/locations/{id}` → Upravit tab on a location with GPS → mini-map renders as aerial, zoomed in, with current location's pin + small dots for every other location with GPS (hover for name)
- [ ] Same on a location WITHOUT a Mapy.cz API key configured → falls back to OSM raster (still zoomed in)
- [ ] Switch tabs / change Druh / change GPS → mini-map disposes & re-inits cleanly, context dots repaint
- [ ] DevTools console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)