### PR TITLE
test(images): integration coverage for backfill-thumbs endpoint [v0.15.0]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -242,71 +242,80 @@ public static class ImageEndpoints
     {
         // (entityType, id, blobKey) triples — pulled up front so we're not
         // holding a long-lived DB cursor across network-bound thumbnail work.
+        //
+        // Projection note: we select anonymous { Id, BlobKey } per query and
+        // attach the constant entityType in-memory. An earlier version used
+        // `.Select(x => ValueTuple.Create("...", x.Id, x.ImagePath!))`, which
+        // EF Core translates into a PostgreSQL composite ROW literal
+        // (`SELECT ('locations', l."Id", l."ImagePath")`) that Npgsql then
+        // fails to deserialise into a .NET ValueTuple without an opt-in
+        // `EnableRecordsAsTuples` on the data source builder. Selecting
+        // scalar columns is the safe, cross-provider shape.
         var targets = new List<(string EntityType, int Id, string BlobKey)>();
 
-        foreach (var (entityType, id, blobKey) in await db.Locations
+        foreach (var row in await db.Locations
             .Where(l => l.ImagePath != null && l.ImagePath != "")
-            .Select(l => ValueTuple.Create("locations", l.Id, l.ImagePath!))
+            .Select(l => new { l.Id, BlobKey = l.ImagePath! })
             .ToListAsync(ct))
-            targets.Add((entityType, id, blobKey));
+            targets.Add(("locations", row.Id, row.BlobKey));
 
         // Rubber-stamp image on Location is surfaced as the "locationstamps"
         // entity-type alias; see the comment on ValidEntityTypes.
-        foreach (var (entityType, id, blobKey) in await db.Locations
+        foreach (var row in await db.Locations
             .Where(l => l.StampImagePath != null && l.StampImagePath != "")
-            .Select(l => ValueTuple.Create("locationstamps", l.Id, l.StampImagePath!))
+            .Select(l => new { l.Id, BlobKey = l.StampImagePath! })
             .ToListAsync(ct))
-            targets.Add((entityType, id, blobKey));
+            targets.Add(("locationstamps", row.Id, row.BlobKey));
 
-        foreach (var (entityType, id, blobKey) in await db.Items
+        foreach (var row in await db.Items
             .Where(i => i.ImagePath != null && i.ImagePath != "")
-            .Select(i => ValueTuple.Create("items", i.Id, i.ImagePath!))
+            .Select(i => new { i.Id, BlobKey = i.ImagePath! })
             .ToListAsync(ct))
-            targets.Add((entityType, id, blobKey));
+            targets.Add(("items", row.Id, row.BlobKey));
 
-        foreach (var (entityType, id, blobKey) in await db.Monsters
+        foreach (var row in await db.Monsters
             .Where(m => m.ImagePath != null && m.ImagePath != "")
-            .Select(m => ValueTuple.Create("monsters", m.Id, m.ImagePath!))
+            .Select(m => new { m.Id, BlobKey = m.ImagePath! })
             .ToListAsync(ct))
-            targets.Add((entityType, id, blobKey));
+            targets.Add(("monsters", row.Id, row.BlobKey));
 
-        foreach (var (entityType, id, blobKey) in await db.SecretStashes
+        foreach (var row in await db.SecretStashes
             .Where(s => s.ImagePath != null && s.ImagePath != "")
-            .Select(s => ValueTuple.Create("secretstashes", s.Id, s.ImagePath!))
+            .Select(s => new { s.Id, BlobKey = s.ImagePath! })
             .ToListAsync(ct))
-            targets.Add((entityType, id, blobKey));
+            targets.Add(("secretstashes", row.Id, row.BlobKey));
 
-        foreach (var (entityType, id, blobKey) in await db.Npcs
+        foreach (var row in await db.Npcs
             .Where(n => n.ImagePath != null && n.ImagePath != "")
-            .Select(n => ValueTuple.Create("npcs", n.Id, n.ImagePath!))
+            .Select(n => new { n.Id, BlobKey = n.ImagePath! })
             .ToListAsync(ct))
-            targets.Add((entityType, id, blobKey));
+            targets.Add(("npcs", row.Id, row.BlobKey));
 
-        foreach (var (entityType, id, blobKey) in await db.Buildings
+        foreach (var row in await db.Buildings
             .Where(b => b.ImagePath != null && b.ImagePath != "")
-            .Select(b => ValueTuple.Create("buildings", b.Id, b.ImagePath!))
+            .Select(b => new { b.Id, BlobKey = b.ImagePath! })
             .ToListAsync(ct))
-            targets.Add((entityType, id, blobKey));
+            targets.Add(("buildings", row.Id, row.BlobKey));
 
-        foreach (var (entityType, id, blobKey) in await db.Characters
+        foreach (var row in await db.Characters
             .Where(c => c.ImagePath != null && c.ImagePath != "")
-            .Select(c => ValueTuple.Create("characters", c.Id, c.ImagePath!))
+            .Select(c => new { c.Id, BlobKey = c.ImagePath! })
             .ToListAsync(ct))
-            targets.Add((entityType, id, blobKey));
+            targets.Add(("characters", row.Id, row.BlobKey));
 
         // Kingdom.BadgeImageUrl is the blob-key field — the column name is
         // legacy tech debt (see MEMORY feedback_ovcinahra_kingdom_badgeimageurl_is_blob_key).
-        foreach (var (entityType, id, blobKey) in await db.Kingdoms
+        foreach (var row in await db.Kingdoms
             .Where(k => k.BadgeImageUrl != null && k.BadgeImageUrl != "")
-            .Select(k => ValueTuple.Create("kingdoms", k.Id, k.BadgeImageUrl!))
+            .Select(k => new { k.Id, BlobKey = k.BadgeImageUrl! })
             .ToListAsync(ct))
-            targets.Add((entityType, id, blobKey));
+            targets.Add(("kingdoms", row.Id, row.BlobKey));
 
-        foreach (var (entityType, id, blobKey) in await db.Spells
+        foreach (var row in await db.Spells
             .Where(s => s.ImagePath != null && s.ImagePath != "")
-            .Select(s => ValueTuple.Create("spells", s.Id, s.ImagePath!))
+            .Select(s => new { s.Id, BlobKey = s.ImagePath! })
             .ToListAsync(ct))
-            targets.Add((entityType, id, blobKey));
+            targets.Add(("spells", row.Id, row.BlobKey));
 
         var presets = Enum.GetValues<ThumbnailPreset>();
         var attempted = 0;

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
@@ -1,7 +1,12 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
 
@@ -12,6 +17,13 @@ public class ImageEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
     // 1x1 transparent PNG
     private static readonly byte[] ValidPng = Convert.FromBase64String(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
+
+    // Minimal valid JPEG (1x1 pixel). SixLabors.ImageSharp needs a real JPEG
+    // header to decode — a raw byte array won't do. Kept separate from
+    // ValidPng because the backfill happy-path tests need JPEGs at the
+    // seeded ImagePath (which conventionally ends in .jpg).
+    private static readonly byte[] ValidJpeg = Convert.FromBase64String(
+        "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAICAgICAgICAgICAgIDAwYEAwMDAwcFBQQGCAcJCQgHCAgKCw4MCgoNCwgIDBEMDQ4PEBAQCQwSExIPEw4PEBD/2wBDAQICAgMDAwYEBAYQCggKEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AL+AH//Z");
 
     [Fact]
     public async Task Upload_ValidImage_ReturnsOkWithBlobKey()
@@ -101,4 +113,99 @@ public class ImageEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
+
+    // --- /api/images/backfill-thumbs ---
+
+    [Fact]
+    public async Task BackfillThumbs_GeneratesThumbsForAllImageBearingEntities()
+    {
+        // Arrange — seed one SecretStash and one Location directly via the
+        // DbContext. Bypassing the upload endpoint lets us set ImagePath to a
+        // predictable key, which is also the key we plant the source blob at.
+        int stashId;
+        int locationId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+
+            var stash = new SecretStash
+            {
+                Name = "Skrýš pro backfill test",
+                Description = "Seeded",
+            };
+            db.SecretStashes.Add(stash);
+            await db.SaveChangesAsync();
+            stash.ImagePath = $"secretstashes/{stash.Id}/image.jpg";
+
+            var location = new Location
+            {
+                Name = "Lokace pro backfill test",
+                LocationKind = LocationKind.Village,
+            };
+            db.Locations.Add(location);
+            await db.SaveChangesAsync();
+            location.ImagePath = $"locations/{location.Id}/image.jpg";
+
+            await db.SaveChangesAsync();
+
+            stashId = stash.Id;
+            locationId = location.Id;
+        }
+
+        // Plant the source blobs at the keys the ThumbnailService will
+        // download from. Uses the IBlobStorageService abstraction so the
+        // in-memory stub stores the bytes under the exact key.
+        var blob = (InMemoryBlobService)Factory.Services.GetRequiredService<IBlobStorageService>();
+        await blob.UploadAsync($"secretstashes/{stashId}/image.jpg",
+            new MemoryStream(ValidJpeg), "image/jpeg");
+        await blob.UploadAsync($"locations/{locationId}/image.jpg",
+            new MemoryStream(ValidJpeg), "image/jpeg");
+
+        // Act
+        var response = await Client.PostAsync("/api/images/backfill-thumbs", content: null);
+
+        // Assert — response
+        response.EnsureSuccessStatusCode();
+        var payload = await response.Content.ReadFromJsonAsync<ProcessedResponse>();
+        Assert.NotNull(payload);
+        // 2 seeded entities × 4 presets = 8. Using >= so the assertion stays
+        // correct if other fixtures later seed extra image-bearing rows.
+        Assert.True(payload.Processed >= 8,
+            $"Expected at least 8 processed pairs, got {payload.Processed}");
+
+        // Assert — every expected cache blob exists under the
+        // {entity}-thumbs/{id}-{w}x{h}.webp layout.
+        (int W, int H)[] expectedPresets =
+        [
+            (120, 120),
+            (240, 336),
+            (240, 300),
+            (480, 672),
+        ];
+        foreach (var (w, h) in expectedPresets)
+        {
+            Assert.True(blob.Contains($"secretstashes-thumbs/{stashId}-{w}x{h}.webp"),
+                $"expected stash thumb at secretstashes-thumbs/{stashId}-{w}x{h}.webp");
+            Assert.True(blob.Contains($"locations-thumbs/{locationId}-{w}x{h}.webp"),
+                $"expected location thumb at locations-thumbs/{locationId}-{w}x{h}.webp");
+        }
+    }
+
+    [Fact]
+    public async Task BackfillThumbs_Unauthenticated_Returns401()
+    {
+        // Arrange — a fresh client with no bearer token. IntegrationTestBase
+        // sets the Authorization header on Client; we want a clean one here
+        // so the group's RequireAuthorization() rejects us at the gate.
+        using var anon = Factory.CreateClient();
+        anon.DefaultRequestHeaders.Authorization = null;
+
+        // Act
+        var response = await anon.PostAsync("/api/images/backfill-thumbs", content: null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private sealed record ProcessedResponse(int Processed);
 }

--- a/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Services;
 
@@ -36,6 +37,16 @@ public class ApiWebApplicationFactory : WebApplicationFactory<Program>
                 services.Remove(blobDescriptor);
 
             services.AddSingleton<IBlobStorageService, InMemoryBlobService>();
+
+            // Remove the startup thumbnail backfill hosted service — tests that
+            // exercise the /api/images/backfill-thumbs endpoint seed their own
+            // data and assert on the result of an explicit call. Letting the
+            // hosted service run in parallel would race against the test's
+            // arrange phase and flake assertions.
+            var hostedDescriptor = services.SingleOrDefault(
+                d => d.ImplementationType == typeof(ThumbnailBackfillHostedService));
+            if (hostedDescriptor != null)
+                services.Remove(hostedDescriptor);
         });
     }
 }
@@ -76,4 +87,12 @@ public class InMemoryBlobService : IBlobStorageService
 
     public Task<bool> ExistsAsync(string blobKey, CancellationToken ct = default)
         => Task.FromResult(_blobs.ContainsKey(blobKey));
+
+    /// <summary>
+    /// Synchronous cache probe for tests — lets assertions like
+    /// <c>blob.Contains("locations-thumbs/1-120x120.webp")</c> verify the
+    /// backfill sweep generated the expected cache entries without paying
+    /// the async ceremony of <see cref="ExistsAsync"/>.
+    /// </summary>
+    public bool Contains(string blobKey) => _blobs.ContainsKey(blobKey);
 }


### PR DESCRIPTION
## Summary

Fills the integration-test gap for the `POST /api/images/backfill-thumbs` endpoint shipped in #84.

- **Happy path** — seed a `SecretStash` + `Location` with `ImagePath`, plant the source blobs in `InMemoryBlobService` at the same keys, POST the endpoint, assert the 4-preset thumb blobs land at `{entity}-thumbs/{id}-{w}x{h}.webp` for each entity. Asserts `processed >= 8` (2 entities × 4 presets: 120×120, 240×336, 240×300, 480×672).
- **Auth** — unauthenticated client gets `401 Unauthorized` (no role gate today, just the group's `RequireAuthorization()`).

The test factory removes `ThumbnailBackfillHostedService` from the service collection so the startup sweep doesn't race the explicit test arrange phase. `InMemoryBlobService` grew a public `Contains(key)` helper so assertions can probe the in-memory cache directly — test-fixture-only, no production surface.

## Production fix surfaced by the new test

The new happy-path test fired 500s against the real Postgres Testcontainer. The `BackfillAllThumbsAsync` projections used `.Select(x => ValueTuple.Create("entity", x.Id, x.ImagePath!))`, which EF Core 10 translates into a PostgreSQL composite `ROW(...)` literal (`SELECT ('locations', l."Id", l."ImagePath") FROM "Locations"`). Npgsql then fails to deserialise the returned `record` field into a .NET `ValueTuple` without opting in via `EnableRecordsAsTuples` on the data source builder — so the shipped endpoint 500'd on the first row against real Postgres.

Switched every projection to the standard `Select(x => new { x.Id, BlobKey = x.ImagePath! })` anonymous shape and attached the `entityType` constant in memory. Same semantics, SQL is now a plain scalar-column select, and the endpoint actually works.

## Test plan

- [x] `dotnet build OvcinaHra.slnx` — 0 warnings, 0 errors
- [x] New tests pass: `ImageEndpointTests.BackfillThumbs_GeneratesThumbsForAllImageBearingEntities`, `ImageEndpointTests.BackfillThumbs_Unauthenticated_Returns401`
- [x] Full test project green: **271 passed / 0 failed / 0 skipped** against Testcontainers Postgres
- [ ] CI `build` + `build-and-test` green
- [ ] Copilot review addressed

No version bump — behaviour change is a narrow production bug fix, not a new feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)