### PR TITLE
feat(locations): render stash thumbnails in location grid tile [v0.15.2]

### DIFF
--- a/src/OvcinaHra.Client/Components/LocationGridStashTile.razor
+++ b/src/OvcinaHra.Client/Components/LocationGridStashTile.razor
@@ -1,0 +1,86 @@
+@* LocationGridStashTile — one stash cell inside LocationList's Skrýše column.
+   Mirrors SecretStashGridTile's state pattern: render the themed gradient +
+   glyph as fallback, overlay the image when present. Blazor @onload/@onerror
+   flip imageLoaded / imageFailed so a stale key or dropped blob reveals the
+   glyph gracefully (and survives list re-renders when the component is
+   reused for a different stash). *@
+
+@using OvcinaHra.Shared.Dtos
+
+<div class="oh-lg-stash-tile @ThemeClass"
+     @onclick="OnTileClick"
+     @onclick:stopPropagation="true">
+    @if (!imageLoaded || imageFailed)
+    {
+        <i class="oh-lg-glyph bi @GlyphClass" aria-hidden="true"></i>
+    }
+    @if (!string.IsNullOrEmpty(Stash.ImageUrl) && !imageFailed)
+    {
+        <img class="oh-lg-stash-tile-img"
+             src="@Stash.ImageUrl"
+             alt="@Stash.Name"
+             @onload="() => imageLoaded = true"
+             @onerror="() => imageFailed = true" />
+        <div class="oh-lg-stash-tile-img-veil"></div>
+    }
+    <span class="oh-lg-qcount @(Stash.TreasureQuests.Count == 0 ? "oh-lg-zero" : "")">
+        <i class="bi bi-journal-text"></i>@Stash.TreasureQuests.Count
+    </span>
+    <div class="oh-lg-nm">@Stash.Name</div>
+    @if (Stash.TreasureQuests.Count > 0)
+    {
+        <div class="oh-lg-flyout">
+            <div class="oh-lg-fh">Honby za pokladem</div>
+            @foreach (var tq in Stash.TreasureQuests.Take(5))
+            {
+                <div class="oh-lg-q">
+                    <span class="oh-lg-dot-q"></span>
+                    <span class="oh-lg-qn">@tq.Title</span>
+                    <span class="oh-lg-pill">Poklad</span>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public LocationStashDto Stash { get; set; } = null!;
+    [Parameter] public EventCallback<int> OnClick { get; set; }
+
+    private bool imageLoaded;
+    private bool imageFailed;
+    private string? _lastUrl;
+
+    protected override void OnParametersSet()
+    {
+        // Reset state when the component is reused for a different stash —
+        // otherwise a "loaded" flag from the previous row would suppress the
+        // glyph while the new src is still fetching.
+        if (_lastUrl != Stash.ImageUrl)
+        {
+            _lastUrl = Stash.ImageUrl;
+            imageLoaded = false;
+            imageFailed = false;
+        }
+    }
+
+    private Task OnTileClick() => OnClick.InvokeAsync(Stash.Id);
+
+    private string ThemeClass => (Stash.Id % 5) switch
+    {
+        0 => "oh-lg-chest",
+        1 => "oh-lg-hollow",
+        2 => "oh-lg-stone",
+        3 => "oh-lg-creek",
+        _ => "oh-lg-cave",
+    };
+
+    private string GlyphClass => (Stash.Id % 5) switch
+    {
+        0 => "bi-box2-heart-fill",
+        1 => "bi-archive-fill",
+        2 => "bi-gem",
+        3 => "bi-tree-fill",
+        _ => "bi-moon-stars-fill",
+    };
+}

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.3</Version>
+    <Version>0.15.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -228,29 +228,9 @@ else
                                      data-over="@overflow">
                                     @foreach (var stash in visible)
                                     {
-                                        <div class="oh-lg-stash-tile @StashTileTheme(stash.Id)"
-                                             @onclick="e => OnStashTileClick(stash.Id)"
-                                             @onclick:stopPropagation="true">
-                                            <i class="oh-lg-glyph bi @StashTileGlyph(stash.Id)"></i>
-                                            <span class="oh-lg-qcount @(stash.TreasureQuests.Count == 0 ? "oh-lg-zero" : "")">
-                                                <i class="bi bi-journal-text"></i>@stash.TreasureQuests.Count
-                                            </span>
-                                            <div class="oh-lg-nm">@stash.Name</div>
-                                            @if (stash.TreasureQuests.Count > 0)
-                                            {
-                                                <div class="oh-lg-flyout">
-                                                    <div class="oh-lg-fh">Honby za pokladem</div>
-                                                    @foreach (var tq in stash.TreasureQuests.Take(5))
-                                                    {
-                                                        <div class="oh-lg-q">
-                                                            <span class="oh-lg-dot-q"></span>
-                                                            <span class="oh-lg-qn">@tq.Title</span>
-                                                            <span class="oh-lg-pill">Poklad</span>
-                                                        </div>
-                                                    }
-                                                </div>
-                                            }
-                                        </div>
+                                        <LocationGridStashTile @key="stash.Id"
+                                                               Stash="stash"
+                                                               OnClick="OnStashTileClick" />
                                     }
                                 </div>
                             </div>
@@ -675,28 +655,6 @@ else
         LocationKind.Hobbit => "oh-lg-hobbit",
         LocationKind.Wilderness => "oh-lg-wilderness",
         _ => "oh-lg-wilderness",
-    };
-
-    private static string StashTileTheme(int stashId)
-    {
-        // Rotate through the 5 themed backgrounds defined in the ported CSS.
-        return (stashId % 5) switch
-        {
-            0 => "oh-lg-chest",
-            1 => "oh-lg-hollow",
-            2 => "oh-lg-stone",
-            3 => "oh-lg-creek",
-            _ => "oh-lg-cave",
-        };
-    }
-
-    private static string StashTileGlyph(int stashId) => (stashId % 5) switch
-    {
-        0 => "bi-box2-heart-fill",
-        1 => "bi-archive-fill",
-        2 => "bi-gem",
-        3 => "bi-tree-fill",
-        _ => "bi-moon-stars-fill",
     };
 
     private static string PluralCz(int n, string one, string few, string many)

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -1500,6 +1500,18 @@
 .oh-lg-stash-tile:hover{transform:translateY(-2px);box-shadow:0 4px 12px rgba(45,80,22,.3);z-index:5}
 /* Rubber-stamp thumb rendered in the hidden Razítko column of /locations. */
 .oh-lg-stamp-thumb{width:128px;height:128px;object-fit:contain;display:block}
+/* Thumbnail image overlays the themed gradient; its own veil provides the
+   bottom scrim so the name bar stays readable over photographic art. */
+.oh-lg-stash-tile > img.oh-lg-stash-tile-img{
+  position:absolute;inset:0;width:100%;height:100%;
+  object-fit:cover;z-index:1;display:block;
+}
+.oh-lg-stash-tile > .oh-lg-stash-tile-img-veil{
+  position:absolute;inset:0;pointer-events:none;z-index:2;
+  background:
+    radial-gradient(ellipse at 30% 35%,rgba(255,248,230,.18) 0%,transparent 55%),
+    linear-gradient(180deg,transparent 45%,rgba(20,12,4,.55) 85%,rgba(20,12,4,.75) 100%);
+}
 /* subtle interior vignette */
 .oh-lg-stash-tile::before{
   content:"";position:absolute;inset:0;pointer-events:none;


### PR DESCRIPTION
## Summary
- Stash tiles in `/locations`'s Skrýše column now display the stash image (same thumbnail endpoint used on `/secret-stashes`), preserving the themed gradient + glyph as fallback when no image or a load failure
- New `LocationGridStashTile.razor` encapsulates the @onload / @onerror state so a broken thumb gracefully reveals the glyph; keyed by `stash.Id` so component state doesn't leak across rows
- `LocationStashDto` already carried `ImageUrl` via `LocationEndpoints.GetByGame` — this PR is purely client-side, no API surface change
- Version bumped 0.15.1 → 0.15.2

## Test plan
- [ ] CI green (client build)
- [ ] `/locations` with `Catalog=false` renders stash tiles with images
- [ ] Tile with no ImagePath still shows themed gradient + glyph + count
- [ ] Click on tile navigates to `/secret-stashes/{id}`
- [ ] Hover flyout still shows treasure-quest list
- [ ] Stale / 404 thumb gracefully falls back to glyph (Blazor @onerror)