### PR TITLE
feat(items): redesigned /items grid with photo, type-dot, class pips, flags box [v0.15.2]

### DIFF
--- a/src/OvcinaHra.Client/Components/ItemClassPips.razor
+++ b/src/OvcinaHra.Client/Components/ItemClassPips.razor
@@ -1,0 +1,42 @@
+@* Four-mono-pip row — lights up Válečník/Lučištník/Mág/Zloděj when their Req >= 1.
+   Intensity rises with Req (r1 baseline, r2/r3/r4+ darker). Tooltip shows exact level.
+   Brief hint: extract as .oh-class-pips-* later if reused on Quest rewards. *@
+
+<div class="oh-it-pips" title="@TitleSummary()">
+    <span class="oh-it-pip @PipClass(Warrior)" title="Válečník: @Warrior">
+        <i class="bi bi-shield-shaded"></i>
+        @if (Warrior > 1) { <span class="oh-it-pip-n">@Warrior</span> }
+    </span>
+    <span class="oh-it-pip @PipClass(Archer)" title="Lučištník: @Archer">
+        <i class="bi bi-bullseye"></i>
+        @if (Archer > 1) { <span class="oh-it-pip-n">@Archer</span> }
+    </span>
+    <span class="oh-it-pip @PipClass(Mage)" title="Mág: @Mage">
+        <i class="bi bi-magic"></i>
+        @if (Mage > 1) { <span class="oh-it-pip-n">@Mage</span> }
+    </span>
+    <span class="oh-it-pip @PipClass(Thief)" title="Zloděj: @Thief">
+        <i class="bi bi-incognito"></i>
+        @if (Thief > 1) { <span class="oh-it-pip-n">@Thief</span> }
+    </span>
+</div>
+
+@code {
+    [Parameter] public int Warrior { get; set; }
+    [Parameter] public int Archer { get; set; }
+    [Parameter] public int Mage { get; set; }
+    [Parameter] public int Thief { get; set; }
+
+    private static string PipClass(int req) => req switch
+    {
+        <= 0 => "",
+        1 => "oh-it-pip--lit",
+        2 => "oh-it-pip--lit oh-it-pip--lit-r2",
+        3 => "oh-it-pip--lit oh-it-pip--lit-r3",
+        4 => "oh-it-pip--lit oh-it-pip--lit-r4",
+        _ => "oh-it-pip--lit oh-it-pip--lit-r5",
+    };
+
+    private string TitleSummary() =>
+        $"Válečník {Warrior} · Lučištník {Archer} · Mág {Mage} · Zloděj {Thief}";
+}

--- a/src/OvcinaHra.Client/Components/ItemClassPips.razor
+++ b/src/OvcinaHra.Client/Components/ItemClassPips.razor
@@ -3,19 +3,19 @@
    Brief hint: extract as .oh-class-pips-* later if reused on Quest rewards. *@
 
 <div class="oh-it-pips" title="@TitleSummary()">
-    <span class="oh-it-pip @PipClass(Warrior)" title="Válečník: @Warrior">
+    <span class="oh-it-pip @ItemClassPipsHelpers.PipClass(Warrior)" title="Válečník: @Warrior">
         <i class="bi bi-shield-shaded"></i>
         @if (Warrior > 1) { <span class="oh-it-pip-n">@Warrior</span> }
     </span>
-    <span class="oh-it-pip @PipClass(Archer)" title="Lučištník: @Archer">
+    <span class="oh-it-pip @ItemClassPipsHelpers.PipClass(Archer)" title="Lučištník: @Archer">
         <i class="bi bi-bullseye"></i>
         @if (Archer > 1) { <span class="oh-it-pip-n">@Archer</span> }
     </span>
-    <span class="oh-it-pip @PipClass(Mage)" title="Mág: @Mage">
+    <span class="oh-it-pip @ItemClassPipsHelpers.PipClass(Mage)" title="Mág: @Mage">
         <i class="bi bi-magic"></i>
         @if (Mage > 1) { <span class="oh-it-pip-n">@Mage</span> }
     </span>
-    <span class="oh-it-pip @PipClass(Thief)" title="Zloděj: @Thief">
+    <span class="oh-it-pip @ItemClassPipsHelpers.PipClass(Thief)" title="Zloděj: @Thief">
         <i class="bi bi-incognito"></i>
         @if (Thief > 1) { <span class="oh-it-pip-n">@Thief</span> }
     </span>
@@ -26,16 +26,6 @@
     [Parameter] public int Archer { get; set; }
     [Parameter] public int Mage { get; set; }
     [Parameter] public int Thief { get; set; }
-
-    private static string PipClass(int req) => req switch
-    {
-        <= 0 => "",
-        1 => "oh-it-pip--lit",
-        2 => "oh-it-pip--lit oh-it-pip--lit-r2",
-        3 => "oh-it-pip--lit oh-it-pip--lit-r3",
-        4 => "oh-it-pip--lit oh-it-pip--lit-r4",
-        _ => "oh-it-pip--lit oh-it-pip--lit-r5",
-    };
 
     private string TitleSummary() =>
         $"Válečník {Warrior} · Lučištník {Archer} · Mág {Mage} · Zloděj {Thief}";

--- a/src/OvcinaHra.Client/Components/ItemClassPipsHelpers.cs
+++ b/src/OvcinaHra.Client/Components/ItemClassPipsHelpers.cs
@@ -1,0 +1,24 @@
+namespace OvcinaHra.Client.Components;
+
+/// <summary>
+/// Shared CSS-class mapping for the Items class-pip cells (Vál/Luč/Mág/Zlo).
+/// Used by both the inline grid CellTemplates in <c>ItemList.razor</c> and the
+/// 4-pip <c>ItemClassPips</c> component, so the lit/intensity ramp stays in
+/// one place. Extracted per Copilot review on PR #88.
+/// </summary>
+public static class ItemClassPipsHelpers
+{
+    /// <summary>
+    /// Returns the CSS class suffix for a class-requirement cell:
+    /// empty when not required, lit when req &gt;= 1 with intensity ramp r2-r5.
+    /// </summary>
+    public static string PipClass(int req) => req switch
+    {
+        <= 0 => "",
+        1 => "oh-it-pip--lit",
+        2 => "oh-it-pip--lit oh-it-pip--lit-r2",
+        3 => "oh-it-pip--lit oh-it-pip--lit-r3",
+        4 => "oh-it-pip--lit oh-it-pip--lit-r4",
+        _ => "oh-it-pip--lit oh-it-pip--lit-r5",
+    };
+}

--- a/src/OvcinaHra.Client/Components/ItemFlagsBox.razor
+++ b/src/OvcinaHra.Client/Components/ItemFlagsBox.razor
@@ -23,7 +23,7 @@
             <i class="bi bi-hourglass-split"></i>
         </span>
     }
-    <span class="oh-it-fcell @(IsCraftable ? "oh-it-fcell--lit" : "")" title="Craftable: @(IsCraftable ? "ano" : "ne")">
+    <span class="oh-it-fcell @(IsCraftable ? "oh-it-fcell--lit" : "")" title="Vyrobitelný: @(IsCraftable ? "ano" : "ne")">
         <i class="bi bi-tools"></i>
     </span>
 </div>
@@ -42,9 +42,9 @@
     {
         if (PerGame)
         {
-            return $"Prodává: {YN(IsSold)} · Nalezitelný: {YN(IsFindable)} · Craftable: {YN(IsCraftable)}";
+            return $"Prodává: {YN(IsSold)} · Nalezitelný: {YN(IsFindable)} · Vyrobitelný: {YN(IsCraftable)}";
         }
-        return $"Unikát: {YN(IsUnique)} · Limit: {YN(IsLimited)} · Craftable: {YN(IsCraftable)}";
+        return $"Unikát: {YN(IsUnique)} · Limit: {YN(IsLimited)} · Vyrobitelný: {YN(IsCraftable)}";
     }
 
     private static string YN(bool b) => b ? "ano" : "ne";

--- a/src/OvcinaHra.Client/Components/ItemFlagsBox.razor
+++ b/src/OvcinaHra.Client/Components/ItemFlagsBox.razor
@@ -1,0 +1,51 @@
+@* Compact 3-cell flags box. Two modes:
+   - Catalog (default):  Unikát · Limit · Craftable
+   - Per-hra (PerGame):  Prodává · Nalezitelný · Craftable
+   Each cell is always present (consistent column width); lit/dim by flag.
+   Designer kept the box at 96px wide regardless of which flags are set. *@
+
+<div class="oh-it-flags" title="@Summary()">
+    @if (PerGame)
+    {
+        <span class="oh-it-fcell @(IsSold ? "oh-it-fcell--lit-gold" : "")" title="Prodává: @(IsSold ? "ano" : "ne")">
+            <i class="bi bi-tag-fill"></i>
+        </span>
+        <span class="oh-it-fcell @(IsFindable ? "oh-it-fcell--lit" : "")" title="Nalezitelný: @(IsFindable ? "ano" : "ne")">
+            <i class="bi bi-search"></i>
+        </span>
+    }
+    else
+    {
+        <span class="oh-it-fcell @(IsUnique ? "oh-it-fcell--lit-gold" : "")" title="Unikát: @(IsUnique ? "ano" : "ne")">
+            <i class="bi bi-gem"></i>
+        </span>
+        <span class="oh-it-fcell @(IsLimited ? "oh-it-fcell--lit-bordeaux" : "")" title="Limit: @(IsLimited ? "ano" : "ne")">
+            <i class="bi bi-hourglass-split"></i>
+        </span>
+    }
+    <span class="oh-it-fcell @(IsCraftable ? "oh-it-fcell--lit" : "")" title="Craftable: @(IsCraftable ? "ano" : "ne")">
+        <i class="bi bi-tools"></i>
+    </span>
+</div>
+
+@code {
+    /// <summary>True for per-hra grid (Prodává/Nalezitelný/Craftable), false for catalog (Unikát/Limit/Craftable).</summary>
+    [Parameter] public bool PerGame { get; set; }
+
+    [Parameter] public bool IsUnique { get; set; }
+    [Parameter] public bool IsLimited { get; set; }
+    [Parameter] public bool IsSold { get; set; }
+    [Parameter] public bool IsFindable { get; set; }
+    [Parameter] public bool IsCraftable { get; set; }
+
+    private string Summary()
+    {
+        if (PerGame)
+        {
+            return $"Prodává: {YN(IsSold)} · Nalezitelný: {YN(IsFindable)} · Craftable: {YN(IsCraftable)}";
+        }
+        return $"Unikát: {YN(IsUnique)} · Limit: {YN(IsLimited)} · Craftable: {YN(IsCraftable)}";
+    }
+
+    private static string YN(bool b) => b ? "ano" : "ne";
+}

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.1</Version>
+    <Version>0.15.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -40,30 +40,66 @@ else if (!Catalog && gameItems.Count == 0)
 }
 else if (Catalog)
 {
-    <OvcinaGrid Data="@catalogItems" KeyFieldName="Id" LayoutKey="grid-layout-items-catalog-v2"
-                RowClick="@(e => OpenModal((ItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+    <OvcinaGrid Data="@catalogItems" KeyFieldName="Id" LayoutKey="grid-layout-items-v3"
+                RowClick="@(e => OpenQuickPeek((ItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Id" Caption="#" Width="60px" Visible="false" />
-            <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="150px" />
-            <DxGridDataColumn FieldName="Effect" Caption="Efekt" />
-            <DxGridDataColumn FieldName="PhysicalFormDisplay" Caption="Fyzická forma" Width="150px" Visible="false" />
-            <DxGridDataColumn FieldName="ReqWarrior" Caption="Váleč." Width="80px" Visible="false" />
-            <DxGridDataColumn FieldName="ReqArcher" Caption="Střelec" Width="80px" Visible="false" />
-            <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="80px" Visible="false" />
-            <DxGridDataColumn FieldName="ReqThief" Caption="Zloděj" Width="80px" Visible="false" />
-            <DxGridDataColumn FieldName="IsCraftable" Caption="Vyrobitelný" Width="120px">
-                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+
+            @* Foto — 78px column, 64x48 4:3 photo inside (issue #74-style: photo IS the artifact) *@
+            <DxGridDataColumn Caption="Foto" Width="78px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var it = (ItemListDto)context.DataItem; }
+                    <span class="oh-it-photo">
+                        @if (!string.IsNullOrEmpty(it.ImageUrl))
+                        {
+                            <img src="@it.ImageUrl" alt="@it.Name" />
+                        }
+                        else
+                        {
+                            <i class="bi bi-image oh-it-photo-empty" aria-hidden="true"></i>
+                        }
+                    </span>
+                </CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="IsUnique" Caption="Unikátní" Width="100px" Visible="false">
-                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+
+            @* Type-dot 24px — neutral palette per ItemType (NOT kingdom colors) *@
+            <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="•" Width="24px" AllowGroup="true">
+                <CellDisplayTemplate>
+                    @{ var it = (ItemListDto)context.DataItem; }
+                    <span class="oh-it-tdot @TdotClass(it.ItemType)" title="@it.ItemTypeDisplay"></span>
+                </CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="IsLimited" Caption="Limitovaný" Width="110px" Visible="false">
-                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+
+            <DxGridDataColumn FieldName="Name" Caption="Název" MinWidth="220" />
+            <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="130px" />
+            <DxGridDataColumn FieldName="PhysicalFormDisplay" Caption="Podoba" Width="150px" />
+
+            @* 4 class pip cols 64/64/64/88 *@
+            <DxGridDataColumn FieldName="ReqWarrior" Caption="Vál." Width="64px">
+                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Válečník: @context.Value"><i class="bi bi-shield-shaded"></i></span></CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="HasImage" Caption="Obrázek" Width="100px">
-                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+            <DxGridDataColumn FieldName="ReqArcher" Caption="Luč." Width="64px">
+                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Lučištník: @context.Value"><i class="bi bi-bullseye"></i></span></CellDisplayTemplate>
             </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="64px">
+                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Mág: @context.Value"><i class="bi bi-magic"></i></span></CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ReqThief" Caption="Zlo." Width="88px">
+                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Zloděj: @context.Value"><i class="bi bi-incognito"></i></span></CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            @* Cena + Sklad columns — hidden in catalog (no GameItem data; brief acceptance §4) *@
+            <DxGridDataColumn FieldName="Effect" Caption="Efekt" Width="240px" Visible="false" />
+
+            @* Flagy 3-cell box — Unikát/Limit/Craftable in catalog *@
+            <DxGridDataColumn Caption="Flagy" Width="96px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var it = (ItemListDto)context.DataItem; }
+                    <ItemFlagsBox PerGame="false" IsUnique="it.IsUnique" IsLimited="it.IsLimited" IsCraftable="it.IsCraftable" />
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            @* Catalog-only assign-to-current-game pill *@
             <DxGridDataColumn FieldName="Id" Caption="Hra" Width="130px" AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>
                     @{
@@ -86,50 +122,107 @@ else if (Catalog)
 }
 else
 {
-    <OvcinaGrid Data="@gameItems" KeyFieldName="Id" LayoutKey="grid-layout-items-game-v2"
-                RowClick="@(e => OpenModal((GameItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+    <OvcinaGrid Data="@gameItems" KeyFieldName="Id" LayoutKey="grid-layout-items-game-v3"
+                RowClick="@(e => OpenQuickPeek((GameItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
+            @* Context-menu column at fixed left edge — preserves Upravit / Odebrat / Smazat / Recept actions *@
             <DxGridDataColumn FieldName="" Caption="" Width="40px" AllowSort="false" AllowGroup="false" FixedPosition="GridColumnFixedPosition.Left">
                 <CellDisplayTemplate>
-                    @{
-                        var gi = (GameItemListDto)context.DataItem;
-                    }
+                    @{ var gi = (GameItemListDto)context.DataItem; }
                     <button class="btn btn-sm btn-link p-0 text-muted" @onclick="async e => await ShowContextMenu(e, gi)" @onclick:stopPropagation="true">
                         <i class="bi bi-three-dots-vertical"></i>
                     </button>
                 </CellDisplayTemplate>
             </DxGridDataColumn>
+
             <DxGridDataColumn FieldName="Id" Caption="#" Width="60px" Visible="false" />
-            <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="150px" />
-            <DxGridDataColumn FieldName="Effect" Caption="Efekt" />
-            <DxGridDataColumn FieldName="RecipeSummary" Caption="Recept" Width="340px" />
-            <DxGridDataColumn FieldName="Price" Caption="Cena" Width="90px" />
-            <DxGridDataColumn FieldName="StockCount" Caption="Skladem" Width="110px" />
-            <DxGridDataColumn FieldName="IsSold" Caption="Prodávaný" Width="110px">
-                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+
+            @* Foto 78px column, 64x48 4:3 photo *@
+            <DxGridDataColumn Caption="Foto" Width="78px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var gi = (GameItemListDto)context.DataItem; }
+                    <span class="oh-it-photo">
+                        @if (!string.IsNullOrEmpty(gi.ImageUrl))
+                        {
+                            <img src="@gi.ImageUrl" alt="@gi.Name" />
+                        }
+                        else
+                        {
+                            <i class="bi bi-image oh-it-photo-empty" aria-hidden="true"></i>
+                        }
+                    </span>
+                </CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="IsFindable" Caption="Nalezitelný" Width="110px">
-                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
+
+            @* Type-dot 24px *@
+            <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="•" Width="24px" AllowGroup="true">
+                <CellDisplayTemplate>
+                    @{ var gi = (GameItemListDto)context.DataItem; }
+                    <span class="oh-it-tdot @TdotClass(gi.ItemType)" title="@gi.ItemTypeDisplay"></span>
+                </CellDisplayTemplate>
             </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="Name" Caption="Název" MinWidth="220" />
+            <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="130px" />
+            <DxGridDataColumn FieldName="PhysicalFormDisplay" Caption="Podoba" Width="150px" />
+
+            @* 4 class pip cols *@
+            <DxGridDataColumn FieldName="ReqWarrior" Caption="Vál." Width="64px">
+                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Válečník: @context.Value"><i class="bi bi-shield-shaded"></i></span></CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ReqArcher" Caption="Luč." Width="64px">
+                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Lučištník: @context.Value"><i class="bi bi-bullseye"></i></span></CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="64px">
+                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Mág: @context.Value"><i class="bi bi-magic"></i></span></CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ReqThief" Caption="Zlo." Width="88px">
+                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Zloděj: @context.Value"><i class="bi bi-incognito"></i></span></CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            @* Cena coin gold accent — strikethrough when IsSold=false *@
+            <DxGridDataColumn FieldName="Price" Caption="Cena" Width="92px">
+                <CellDisplayTemplate>
+                    @{ var gi = (GameItemListDto)context.DataItem; }
+                    @if (gi.Price.HasValue && gi.Price.Value > 0)
+                    {
+                        <span class="oh-it-coin @(!gi.IsSold ? "oh-it-coin--struck" : "")">
+                            <i class="bi bi-coin"></i>@gi.Price.Value
+                        </span>
+                    }
+                    else
+                    {
+                        <span class="oh-it-coin oh-it-coin--empty">—</span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            @* Sklad — count or ∞ for nil; meter-style is a follow-up (no max field on DTO) *@
+            <DxGridDataColumn FieldName="StockCount" Caption="Sklad" Width="132px">
+                <CellDisplayTemplate>
+                    @{ var gi = (GameItemListDto)context.DataItem; }
+                    @if (gi.StockCount.HasValue)
+                    {
+                        <span class="oh-it-sklad">@gi.StockCount.Value</span>
+                    }
+                    else
+                    {
+                        <span class="oh-it-sklad oh-it-sklad--inf" title="Neomezený sklad">∞</span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            @* Flagy — per-hra meaning: Prodává/Nalezitelný/Craftable *@
+            <DxGridDataColumn Caption="Flagy" Width="96px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var gi = (GameItemListDto)context.DataItem; }
+                    <ItemFlagsBox PerGame="true" IsSold="gi.IsSold" IsFindable="gi.IsFindable" IsCraftable="gi.IsCraftable" />
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="Effect" Caption="Efekt" Width="240px" Visible="false" />
+            <DxGridDataColumn FieldName="RecipeSummary" Caption="Recept" Width="340px" Visible="false" />
             <DxGridDataColumn FieldName="SaleCondition" Caption="Podmínka prodeje" Width="240px" Visible="false" />
-            <DxGridDataColumn FieldName="PhysicalFormDisplay" Caption="Fyzická forma" Width="150px" Visible="false" />
-            <DxGridDataColumn FieldName="ReqWarrior" Caption="Váleč." Width="80px" Visible="false" />
-            <DxGridDataColumn FieldName="ReqArcher" Caption="Střelec" Width="80px" Visible="false" />
-            <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="80px" Visible="false" />
-            <DxGridDataColumn FieldName="ReqThief" Caption="Zloděj" Width="80px" Visible="false" />
-            <DxGridDataColumn FieldName="IsCraftable" Caption="Vyrobitelný" Width="120px" Visible="false">
-                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
-            </DxGridDataColumn>
-            <DxGridDataColumn FieldName="IsUnique" Caption="Unikátní" Width="100px" Visible="false">
-                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
-            </DxGridDataColumn>
-            <DxGridDataColumn FieldName="IsLimited" Caption="Limitovaný" Width="110px" Visible="false">
-                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
-            </DxGridDataColumn>
-            <DxGridDataColumn FieldName="HasImage" Caption="Obrázek" Width="100px">
-                <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
-            </DxGridDataColumn>
         </Columns>
     </OvcinaGrid>
 
@@ -142,6 +235,81 @@ else
         </Items>
     </DxContextMenu>
 }
+
+@* Quick-peek popup — 720x480, 360px hero photo left + fields right.
+   Opens on row click; "Otevřít detail →" navigates to /items/{id} (will 404
+   until the detail page ships in a follow-up — flagged in the PR body). *@
+<DxPopup @bind-Visible="@isQuickPeekVisible" HeaderText="@(quickPeekItem?.Name ?? "Předmět")" Width="720px">
+    <BodyContentTemplate Context="qpCtx">
+        @if (quickPeekItem is null)
+        {
+            <p>Načítám…</p>
+        }
+        else
+        {
+            <div class="oh-it-qp-grid">
+                <div class="oh-it-qp-hero">
+                    @if (!string.IsNullOrEmpty(quickPeekItem.ImageUrl))
+                    {
+                        <img src="@quickPeekItem.ImageUrl" alt="@quickPeekItem.Name" />
+                    }
+                    else
+                    {
+                        <i class="bi bi-image oh-it-photo-empty" aria-hidden="true"></i>
+                    }
+                </div>
+                <div class="oh-it-qp-fields">
+                    <h3 class="oh-it-qp-name">@quickPeekItem.Name</h3>
+                    <div class="oh-it-qp-meta">
+                        <span class="oh-it-tdot @TdotClass(quickPeekItem.ItemType)" title="@quickPeekItem.ItemTypeDisplay"></span>
+                        <span class="oh-it-ichip">@quickPeekItem.ItemTypeDisplay</span>
+                        @if (!string.IsNullOrWhiteSpace(quickPeekItem.PhysicalFormDisplay))
+                        {
+                            <span class="oh-it-ichip">@quickPeekItem.PhysicalFormDisplay</span>
+                        }
+                    </div>
+                    <ItemClassPips Warrior="quickPeekItem.ReqWarrior"
+                                   Archer="quickPeekItem.ReqArcher"
+                                   Mage="quickPeekItem.ReqMage"
+                                   Thief="quickPeekItem.ReqThief" />
+                    @if (!string.IsNullOrWhiteSpace(quickPeekItem.Effect))
+                    {
+                        <div class="oh-it-qp-section">
+                            <div class="oh-it-qp-section-title">Efekt</div>
+                            <div class="oh-it-qp-section-body">@quickPeekItem.Effect</div>
+                        </div>
+                    }
+                    <ItemFlagsBox PerGame="quickPeekIsPerGame"
+                                  IsUnique="quickPeekItem.IsUnique"
+                                  IsLimited="quickPeekItem.IsLimited"
+                                  IsCraftable="quickPeekItem.IsCraftable"
+                                  IsSold="quickPeekIsSold"
+                                  IsFindable="quickPeekIsFindable" />
+                    @if (quickPeekIsPerGame && quickPeekPrice.HasValue)
+                    {
+                        <div>
+                            <span class="oh-it-coin @(!quickPeekIsSold ? "oh-it-coin--struck" : "")">
+                                <i class="bi bi-coin"></i>@quickPeekPrice.Value Groše
+                            </span>
+                        </div>
+                    }
+                </div>
+            </div>
+            <div class="oh-it-qp-foot">
+                <button class="btn btn-secondary" @onclick="() => isQuickPeekVisible = false">Zavřít</button>
+                <div class="d-flex gap-2">
+                    <button class="btn btn-outline-primary" @onclick="OpenEditFromQuickPeek">
+                        <i class="bi bi-pencil"></i> Upravit
+                    </button>
+                    <button class="btn btn-primary"
+                            @onclick="@(() => Nav.NavigateTo($"/items/{quickPeekItem!.Id}"))">
+                        Otevřít detail <i class="bi bi-arrow-right"></i>
+                    </button>
+                </div>
+            </div>
+        }
+    </BodyContentTemplate>
+</DxPopup>
 
 <DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="900px">
     <BodyContentTemplate Context="popupContext">
@@ -360,6 +528,14 @@ else
     private List<ItemListDto> catalogItems = [];
     private List<GameItemListDto> gameItems = [];
     private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
+
+    // Quick-peek popup state (issue: replaces edit-modal-on-row-click per the brief).
+    private bool isQuickPeekVisible;
+    private ItemListDto? quickPeekItem;
+    private bool quickPeekIsPerGame;
+    private bool quickPeekIsSold;
+    private bool quickPeekIsFindable;
+    private int? quickPeekPrice;
 
     // Context menu state (in-game view only)
     private DxContextMenu? contextMenu;
@@ -787,5 +963,55 @@ else
     {
         try { await Api.DeleteAsync($"/api/items/{editingId}"); isDeleteVisible = false; isModalVisible = false; await LoadAsync(); }
         catch (Exception ex) { error = ex.Message; }
+    }
+
+    // ---- Visual helpers (issue: items-list-port) ----
+
+    // CSS suffix for the .oh-it-tdot--xxx neutral palette per ItemType.
+    private static string TdotClass(ItemType t) => "oh-it-tdot--" + t.ToString().ToLowerInvariant();
+
+    // CSS class for a single class-pip cell — lit + intensity ramp by req level.
+    private static string PipClass(int req) => req switch
+    {
+        <= 0 => "",
+        1 => "oh-it-pip--lit",
+        2 => "oh-it-pip--lit oh-it-pip--lit-r2",
+        3 => "oh-it-pip--lit oh-it-pip--lit-r3",
+        4 => "oh-it-pip--lit oh-it-pip--lit-r4",
+        _ => "oh-it-pip--lit oh-it-pip--lit-r5",
+    };
+
+    // ---- Quick-peek popup ----
+
+    private void OpenQuickPeek(ItemListDto item)
+    {
+        quickPeekItem = item;
+        quickPeekIsPerGame = false;
+        quickPeekIsSold = false;
+        quickPeekIsFindable = false;
+        quickPeekPrice = null;
+        isQuickPeekVisible = true;
+    }
+
+    private void OpenQuickPeek(GameItemListDto gi)
+    {
+        // Reuse ItemListDto shape for the popup body — they share all the catalog fields.
+        quickPeekItem = new ItemListDto(
+            gi.Id, gi.Name, gi.ItemType, gi.Effect, gi.PhysicalForm, gi.IsCraftable,
+            gi.ReqWarrior, gi.ReqArcher, gi.ReqMage, gi.ReqThief,
+            gi.IsUnique, gi.IsLimited, gi.ImagePath, gi.ImageUrl);
+        quickPeekIsPerGame = true;
+        quickPeekIsSold = gi.IsSold;
+        quickPeekIsFindable = gi.IsFindable;
+        quickPeekPrice = gi.Price;
+        isQuickPeekVisible = true;
+    }
+
+    private void OpenEditFromQuickPeek()
+    {
+        if (quickPeekItem is null) return;
+        isQuickPeekVisible = false;
+        // Reuse the existing edit-modal entry that already knows how to map ItemListDto.
+        OpenModal(quickPeekItem);
     }
 }

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -62,8 +62,10 @@ else if (Catalog)
                 </CellDisplayTemplate>
             </DxGridDataColumn>
 
-            @* Type-dot 24px — neutral palette per ItemType (NOT kingdom colors) *@
-            <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="•" Width="24px" AllowGroup="true">
+            @* Type-dot 24px — neutral palette per ItemType (NOT kingdom colors).
+               Unbound (no FieldName) so it doesn't collide with the text "Typ" column
+               under DxGrid's layout-persistence keying-by-FieldName. *@
+            <DxGridDataColumn Caption="•" Width="24px" AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>
                     @{ var it = (ItemListDto)context.DataItem; }
                     <span class="oh-it-tdot @TdotClass(it.ItemType)" title="@it.ItemTypeDisplay"></span>
@@ -76,16 +78,16 @@ else if (Catalog)
 
             @* 4 class pip cols 64/64/64/88 *@
             <DxGridDataColumn FieldName="ReqWarrior" Caption="Vál." Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Válečník: @context.Value"><i class="bi bi-shield-shaded"></i></span></CellDisplayTemplate>
+                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Válečník: @context.Value"><i class="bi bi-shield-shaded"></i></span></CellDisplayTemplate>
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="ReqArcher" Caption="Luč." Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Lučištník: @context.Value"><i class="bi bi-bullseye"></i></span></CellDisplayTemplate>
+                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Lučištník: @context.Value"><i class="bi bi-bullseye"></i></span></CellDisplayTemplate>
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Mág: @context.Value"><i class="bi bi-magic"></i></span></CellDisplayTemplate>
+                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Mág: @context.Value"><i class="bi bi-magic"></i></span></CellDisplayTemplate>
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="ReqThief" Caption="Zlo." Width="88px">
-                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Zloděj: @context.Value"><i class="bi bi-incognito"></i></span></CellDisplayTemplate>
+                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Zloděj: @context.Value"><i class="bi bi-incognito"></i></span></CellDisplayTemplate>
             </DxGridDataColumn>
 
             @* Cena + Sklad columns — hidden in catalog (no GameItem data; brief acceptance §4) *@
@@ -154,8 +156,10 @@ else
                 </CellDisplayTemplate>
             </DxGridDataColumn>
 
-            @* Type-dot 24px *@
-            <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="•" Width="24px" AllowGroup="true">
+            @* Type-dot 24px — unbound (no FieldName) per Copilot review on PR #88
+               so it doesn't collide with the text "Typ" column under DxGrid's
+               layout-persistence keying-by-FieldName. *@
+            <DxGridDataColumn Caption="•" Width="24px" AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>
                     @{ var gi = (GameItemListDto)context.DataItem; }
                     <span class="oh-it-tdot @TdotClass(gi.ItemType)" title="@gi.ItemTypeDisplay"></span>
@@ -168,16 +172,16 @@ else
 
             @* 4 class pip cols *@
             <DxGridDataColumn FieldName="ReqWarrior" Caption="Vál." Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Válečník: @context.Value"><i class="bi bi-shield-shaded"></i></span></CellDisplayTemplate>
+                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Válečník: @context.Value"><i class="bi bi-shield-shaded"></i></span></CellDisplayTemplate>
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="ReqArcher" Caption="Luč." Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Lučištník: @context.Value"><i class="bi bi-bullseye"></i></span></CellDisplayTemplate>
+                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Lučištník: @context.Value"><i class="bi bi-bullseye"></i></span></CellDisplayTemplate>
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Mág: @context.Value"><i class="bi bi-magic"></i></span></CellDisplayTemplate>
+                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Mág: @context.Value"><i class="bi bi-magic"></i></span></CellDisplayTemplate>
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="ReqThief" Caption="Zlo." Width="88px">
-                <CellDisplayTemplate><span class="oh-it-pip @PipClass((int)context.Value)" title="Zloděj: @context.Value"><i class="bi bi-incognito"></i></span></CellDisplayTemplate>
+                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Zloděj: @context.Value"><i class="bi bi-incognito"></i></span></CellDisplayTemplate>
             </DxGridDataColumn>
 
             @* Cena coin gold accent — strikethrough when IsSold=false *@
@@ -301,8 +305,9 @@ else
                     <button class="btn btn-outline-primary" @onclick="OpenEditFromQuickPeek">
                         <i class="bi bi-pencil"></i> Upravit
                     </button>
-                    <button class="btn btn-primary"
-                            @onclick="@(() => Nav.NavigateTo($"/items/{quickPeekItem!.Id}"))">
+                    @* Disabled until /items/{id} ships in a follow-up port — would 404 today. *@
+                    <button class="btn btn-primary" disabled
+                            title="Detail předmětu zatím není hotový — sleduj follow-up.">
                         Otevřít detail <i class="bi bi-arrow-right"></i>
                     </button>
                 </div>
@@ -970,16 +975,8 @@ else
     // CSS suffix for the .oh-it-tdot--xxx neutral palette per ItemType.
     private static string TdotClass(ItemType t) => "oh-it-tdot--" + t.ToString().ToLowerInvariant();
 
-    // CSS class for a single class-pip cell — lit + intensity ramp by req level.
-    private static string PipClass(int req) => req switch
-    {
-        <= 0 => "",
-        1 => "oh-it-pip--lit",
-        2 => "oh-it-pip--lit oh-it-pip--lit-r2",
-        3 => "oh-it-pip--lit oh-it-pip--lit-r3",
-        4 => "oh-it-pip--lit oh-it-pip--lit-r4",
-        _ => "oh-it-pip--lit oh-it-pip--lit-r5",
-    };
+    // PipClass mapping moved to ItemClassPipsHelpers.PipClass (per Copilot review on
+    // PR #88) so the lit/intensity ramp lives in one place.
 
     // ---- Quick-peek popup ----
 

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2105,11 +2105,9 @@
 .oh-it-coin--struck{text-decoration:line-through;opacity:.55}
 .oh-it-coin--empty{background:transparent;border-color:transparent;color:var(--oh-text-secondary);opacity:.6;font-weight:500}
 
-/* Sklad meter — mono "current/max" + 60px bar; red below 25%; infinite glyph */
+/* Sklad — mono current count or infinite glyph. Meter bar deferred until
+   GameItemListDto carries a max field (see PR body follow-up #4). */
 .oh-it-sklad{display:inline-flex;align-items:center;gap:8px;font-family:var(--oh-font-mono);font-size:.8125rem;font-variant-numeric:tabular-nums;color:var(--oh-text)}
-.oh-it-sklad-meter{position:relative;width:60px;height:6px;background:var(--oh-surface-alt);border:1px solid var(--oh-border);border-radius:99px;overflow:hidden}
-.oh-it-sklad-meter-fill{position:absolute;top:0;left:0;bottom:0;background:var(--oh-primary);border-radius:99px;transition:width .15s}
-.oh-it-sklad-meter-fill--low{background:#c0392b}
 .oh-it-sklad--inf{font-size:1rem;color:var(--oh-primary)}
 .oh-it-sklad--empty{color:var(--oh-text-secondary)}
 

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2046,3 +2046,90 @@
 .oh-mon-karta-block-title{font:700 .75rem var(--oh-font-body);color:var(--oh-text-secondary);text-transform:uppercase;letter-spacing:.06em;margin-bottom:4px}
 .oh-mon-karta-block-body{font:400 .875rem var(--oh-font-body);color:var(--oh-text);white-space:pre-wrap;line-height:1.5}
 .oh-mon-karta-foot{display:flex;justify-content:space-between;gap:10px;padding-top:8px;border-top:1px solid var(--oh-border);margin-top:6px}
+
+/* ============================================================
+   Items grid (/items) — .oh-it-*
+   Keeps the DxGrid chassis. CellTemplates use these classes for:
+   photo thumb · type-dot · type chip · 4 class pips · coin price ·
+   sklad meter · 3-cell flags box · quick-peek popup hero+fields.
+   Ported from docs/design/dialogs/item-list.mockup.unbundled.html
+   ============================================================ */
+
+/* Photo thumbnail in the Foto column (78px wide, 64x48 photo inside, 4:3) */
+.oh-it-photo{width:64px;height:48px;border-radius:3px;overflow:hidden;background:var(--oh-surface-alt);display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--oh-border)}
+.oh-it-photo img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-it-photo-empty{font-size:1.25rem;color:rgba(139,90,43,.4)}
+
+/* Type-dot — 10px circle, neutral palette per ItemType (NOT kingdom colors) */
+.oh-it-tdot{display:inline-block;width:10px;height:10px;border-radius:50%;box-shadow:0 0 0 1px rgba(0,0,0,.1),inset 0 -1px 1px rgba(0,0,0,.2);vertical-align:middle}
+.oh-it-tdot--weapon{background:#8a7148}
+.oh-it-tdot--shield{background:#a87038}
+.oh-it-tdot--armor{background:#6a4820}
+.oh-it-tdot--helmet{background:#8a8370}
+.oh-it-tdot--firearm{background:#b89060}
+.oh-it-tdot--horse{background:#7a5230}
+.oh-it-tdot--controlledcreature{background:#603020}
+.oh-it-tdot--lives{background:#a82828}
+.oh-it-tdot--scroll{background:#b89a68}
+.oh-it-tdot--potion{background:#2a6030}
+.oh-it-tdot--resource{background:#5a7a3d}
+.oh-it-tdot--money{background:#e8b830}
+.oh-it-tdot--gameanimal{background:#506838}
+.oh-it-tdot--minorartifact{background:#3870a8}
+.oh-it-tdot--jewelry{background:#b8963a}
+.oh-it-tdot--artifact{background:#6020a0}
+.oh-it-tdot--ingredient{background:#5a7a3d}
+.oh-it-tdot--commodity{background:#7a5a3d}
+.oh-it-tdot--miscellaneous{background:#9e9e9e}
+
+/* ItemType chip (text label) */
+.oh-it-ichip{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:99px;background:var(--oh-surface-alt);border:1px solid var(--oh-border);color:var(--oh-text-secondary);font:600 .6875rem var(--oh-font-body);letter-spacing:.02em;white-space:nowrap}
+.oh-it-ichip i{font-size:.6875rem;opacity:.85}
+
+/* Class pips — 4 mono pips, lit when Req>=1 with intensity by level */
+.oh-it-pips{display:inline-flex;align-items:center;gap:3px}
+.oh-it-pip{width:22px;height:20px;border-radius:3px;display:inline-flex;align-items:center;justify-content:center;gap:2px;background:transparent;border:1px solid var(--oh-border);color:#c4b494;font:600 .6875rem var(--oh-font-mono);cursor:help;line-height:1;position:relative}
+.oh-it-pip i{font-size:.6875rem}
+.oh-it-pip-n{font-size:.5625rem;line-height:1;opacity:.7}
+.oh-it-pip--lit{background:var(--oh-primary-surface);border-color:rgba(74,124,52,.5);color:var(--oh-primary)}
+.oh-it-pip--lit .oh-it-pip-n{color:var(--oh-primary);opacity:1}
+.oh-it-pip--lit-r2{background:#cfe0c2;border-color:rgba(74,124,52,.7)}
+.oh-it-pip--lit-r3{background:var(--oh-primary-light);border-color:var(--oh-primary);color:#fff}
+.oh-it-pip--lit-r3 .oh-it-pip-n{color:#fff}
+.oh-it-pip--lit-r4,.oh-it-pip--lit-r5{background:var(--oh-primary);border-color:var(--oh-primary-dark);color:#fff}
+.oh-it-pip--lit-r4 .oh-it-pip-n,.oh-it-pip--lit-r5 .oh-it-pip-n{color:#fff}
+
+/* Coin/Cena pill — gold accent (semantic, NOT kingdom Arnor color) */
+.oh-it-coin{display:inline-flex;align-items:center;gap:5px;padding:3px 9px;border-radius:99px;background:rgba(249,168,37,.18);border:1px solid rgba(249,168,37,.55);color:#8a6b0d;font:700 .8125rem var(--oh-font-mono);font-variant-numeric:tabular-nums;line-height:1}
+.oh-it-coin i{font-size:.75rem}
+.oh-it-coin--struck{text-decoration:line-through;opacity:.55}
+.oh-it-coin--empty{background:transparent;border-color:transparent;color:var(--oh-text-secondary);opacity:.6;font-weight:500}
+
+/* Sklad meter — mono "current/max" + 60px bar; red below 25%; infinite glyph */
+.oh-it-sklad{display:inline-flex;align-items:center;gap:8px;font-family:var(--oh-font-mono);font-size:.8125rem;font-variant-numeric:tabular-nums;color:var(--oh-text)}
+.oh-it-sklad-meter{position:relative;width:60px;height:6px;background:var(--oh-surface-alt);border:1px solid var(--oh-border);border-radius:99px;overflow:hidden}
+.oh-it-sklad-meter-fill{position:absolute;top:0;left:0;bottom:0;background:var(--oh-primary);border-radius:99px;transition:width .15s}
+.oh-it-sklad-meter-fill--low{background:#c0392b}
+.oh-it-sklad--inf{font-size:1rem;color:var(--oh-primary)}
+.oh-it-sklad--empty{color:var(--oh-text-secondary)}
+
+/* Flags box — 3 cells (28x22 each), lit/dim, mode-aware coloring */
+.oh-it-flags{display:inline-flex;gap:2px;align-items:center}
+.oh-it-fcell{width:28px;height:22px;display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--oh-border);background:var(--oh-surface-alt);color:#c4b494;border-radius:3px;font-size:.75rem;cursor:help}
+.oh-it-fcell--lit{background:var(--oh-primary-surface);border-color:rgba(74,124,52,.5);color:var(--oh-primary)}
+.oh-it-fcell--lit-gold{background:rgba(249,168,37,.18);border-color:rgba(249,168,37,.55);color:#8a6b0d}
+.oh-it-fcell--lit-bordeaux{background:rgba(140,36,35,.10);border-color:rgba(140,36,35,.40);color:#8c2423}
+
+/* Quick-peek popup — 720x480, 360px hero photo left + fields right */
+.oh-it-qp-grid{display:grid;grid-template-columns:360px 1fr;gap:20px;padding:4px 4px 14px;align-items:start}
+@media (max-width:768px){.oh-it-qp-grid{grid-template-columns:1fr}}
+.oh-it-qp-hero{width:100%;aspect-ratio:4/3;border-radius:var(--oh-radius);overflow:hidden;background:var(--oh-surface-alt);border:1px solid var(--oh-border);display:flex;align-items:center;justify-content:center}
+.oh-it-qp-hero img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-it-qp-hero .oh-it-photo-empty{font-size:4rem}
+.oh-it-qp-fields{display:flex;flex-direction:column;gap:12px;min-width:0}
+.oh-it-qp-name{font:700 1.25rem var(--oh-font-heading);color:var(--oh-primary);margin:0}
+.oh-it-qp-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.oh-it-qp-section{padding:8px 12px;background:var(--oh-surface-alt);border-radius:var(--oh-radius-sm);border:1px solid var(--oh-border)}
+.oh-it-qp-section-title{font:700 .6875rem var(--oh-font-body);color:var(--oh-text-secondary);text-transform:uppercase;letter-spacing:.08em;margin-bottom:4px}
+.oh-it-qp-section-body{font:400 .875rem var(--oh-font-body);color:var(--oh-text);line-height:1.5;white-space:pre-wrap}
+.oh-it-qp-foot{display:flex;justify-content:space-between;gap:10px;padding-top:10px;border-top:1px solid var(--oh-border);margin-top:6px}


### PR DESCRIPTION
## Summary

Implements the Items grid from the Claude Design mockup. **Designer pivoted from the original brief and KEPT the DxGrid chassis** — operators scan dozens of items looking for the right drop / reward / shop fit, and a dense tabular view beats a gallery for that workflow. `OvcinaGrid` wrapper, `LayoutKey` persistence, column chooser, filter menu, sticky header all preserved.

See `docs/design/dialogs/item-list.md` and `.claude/restart-prompts/hra-ovcina-item-list-port.md` for the full design intent.

### Catalog grid (`grid-layout-items-v3`)

| # | Width | Column | Notes |
|---|---|---|---|
| 1 | `78px` | **Foto** | 4:3 thumbnail using `ItemListDto.ImageUrl` directly (no per-row fetch) |
| 2 | `24px` | **Typ-dot** | 10 px circle, neutral palette per ItemType (NEVER kingdom colors) |
| 3 | `minmax(220, *)` | **Název** | Flexible |
| 4 | `130px` | **Typ** | Text chip |
| 5 | `150px` | **Podoba** | PhysicalForm |
| 6-9 | `64/64/64/88` | **4 class pips** | Vál · Luč · Mág · Zlo — lit when `Req≥1`, intensity ramp `r2-r5` |
| 10 | `96px` | **Flagy** | 3-cell box: Unikát / Limit / Craftable |
| 11 | `130px` | **Hra** | Existing assign/remove pill (catalog only) |

### Per-game grid (`grid-layout-items-game-v3`)

Same as catalog plus:
- **Cena** 92 px — coin gold pill (semantic accent, NOT kingdom Arnor); strikethrough when `IsSold=false`
- **Sklad** 132 px — mono count or `∞` glyph for null
- **Flagy** box switches meaning to Prodává / Nalezitelný / Craftable
- Context-menu column at fixed left edge — preserves Upravit / Otevřít recept / Odebrat z hry / Smazat actions

### New components

- `Components/ItemClassPips.razor` — 4 mono pips with intensity ramp. Used in the quick-peek popup; individual cells inlined in grid columns so each pip remains a sortable / groupable column per the brief.
- `Components/ItemFlagsBox.razor` — 3-cell box, mode-aware (`PerGame` parameter flips Unikát/Limit ↔ Prodává/Nalezitelný; Craftable always cell #3).

### Quick-peek popup (replaces edit-modal on row click)

- 720 px wide, `360px` hero photo left + name / type / pips / effect / flags right.
- Footer: **[Zavřít]** · **[Upravit]** (opens the existing edit modal) · **[Otevřít detail →]**.
- `Otevřít detail →` routes to `/items/{id}` which doesn't exist yet — **editing remains accessible via the popup's Upravit button until a detail page ships**.

## Caveats / follow-ups

1. **`/items/{id}` detail page does not exist yet** — the "Otevřít detail →" footer button will 404. Editing stays usable via the Upravit button in the same popup. When the detail page ships in a follow-up port, drop the Upravit button and let the detail page own that flow.
2. **Group-by-Typ hides Foto column dynamically** — designer note + brief acceptance criterion. Deferred — DxGrid grouping state needs a callback to toggle column `Visible` reactively. Easy follow-up.
3. **Custom filter strip** (Hledat / Typ / Třída / jen-nalezitelné / jen-prodejné toggles on the toolbar) — deferred. DxGrid's built-in column filter menu covers the same use cases for v1.
4. **Sklad meter bar** — `GameItemListDto.StockCount` is `int?` with no max field. Mockup's "current/max + 60 px meter" needs a max to be meaningful. Currently shows count or `∞`; meter visualization is a follow-up that requires a DTO change.
5. **`.oh-class-pips-*` extraction** — brief recommends extracting as a shared base for Quest reward UI. Deferred until QuestDetail ships.
6. **Playwright E2E deferred** — same root cause as prior ports: `E2ETestBase` uses `WebApplicationFactory` in-memory server which Playwright's real browser cannot reach. Item API contracts covered by existing `ItemEndpointTests` (10/10 pass).

## Test plan

- [ ] Build clean (`dotnet build OvcinaHra.slnx`) — TreatWarningsAsErrors, zero warnings
- [ ] `dotnet test` green — `ItemEndpointTests` 10/10 verified locally, no API surface changed
- [ ] `/items` (per-hra) renders the new 13-col layout with Foto + Typ-dot + Name + Typ + Podoba + 4 pips + Cena + Sklad + Flagy + context menu
- [ ] `/items?catalog=true` renders the catalog variant (Cena/Sklad hidden, Hra assign/remove column at end)
- [ ] LayoutKey bumped — verify by clearing localStorage then reloading
- [ ] Class pips light up by `ReqWarrior/Archer/Mage/Thief` (intensity ramp visible at high reqs)
- [ ] Flags box reads correct flags per mode (catalog: Unikát/Limit/Craftable, per-hra: Prodává/Nalezitelný/Craftable)
- [ ] Cena coin gold pill visible; strikethrough for items where `IsSold=false`
- [ ] Typ-dot column shows colored dots per ItemType (neutral palette, no kingdom colors)
- [ ] Row click opens 720 px quick-peek popup with hero photo + fields; "Upravit" opens existing edit modal; "Otevřít detail →" navigates to `/items/{id}` (404 until detail page ships)
- [ ] DevTools console clean (no DxGrid attribute errors per `feedback_ovcinahra_devexpress_runtime_attrs`)
- [ ] Czech diacritics render in headers, chips, popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)