### PR TITLE
feat(locations): rubber stamp image per catalog location [v0.15.3]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -8,7 +8,13 @@ namespace OvcinaHra.Api.Endpoints;
 
 public static class ImageEndpoints
 {
-    private static readonly HashSet<string> ValidEntityTypes = ["locations", "items", "monsters", "secretstashes", "npcs", "buildings", "characters", "kingdoms", "spells"];
+    // "locationstamps" is a logical alias keyed by Location.Id that reads /
+    // writes Location.StampImagePath. Exposed as its own entity type so that
+    // the thumbnail cache, pre-gen, and backfill pipelines treat the rubber
+    // stamp as an independent image (its cache keys don't collide with the
+    // main location image). See GetEntityImagePaths and the Upload DbContext
+    // switch for the dispatch.
+    private static readonly HashSet<string> ValidEntityTypes = ["locations", "locationstamps", "items", "monsters", "secretstashes", "npcs", "buildings", "characters", "kingdoms", "spells"];
     private static readonly HashSet<string> AllowedContentTypes = ["image/jpeg", "image/png", "image/webp"];
     private const long MaxFileSize = 5 * 1024 * 1024; // 5 MB
 
@@ -244,6 +250,14 @@ public static class ImageEndpoints
             .ToListAsync(ct))
             targets.Add((entityType, id, blobKey));
 
+        // Rubber-stamp image on Location is surfaced as the "locationstamps"
+        // entity-type alias; see the comment on ValidEntityTypes.
+        foreach (var (entityType, id, blobKey) in await db.Locations
+            .Where(l => l.StampImagePath != null && l.StampImagePath != "")
+            .Select(l => ValueTuple.Create("locationstamps", l.Id, l.StampImagePath!))
+            .ToListAsync(ct))
+            targets.Add((entityType, id, blobKey));
+
         foreach (var (entityType, id, blobKey) in await db.Items
             .Where(i => i.ImagePath != null && i.ImagePath != "")
             .Select(i => ValueTuple.Create("items", i.Id, i.ImagePath!))
@@ -400,6 +414,13 @@ public static class ImageEndpoints
                         location.ImagePath = blobKey;
                 }
                 break;
+            case "locationstamps":
+                // Logical alias for Location.StampImagePath; ignores isPlacement
+                // because the rubber stamp has no placement variant.
+                var locationForStamp = await db.Locations.FindAsync(entityId);
+                if (locationForStamp is not null)
+                    locationForStamp.StampImagePath = blobKey;
+                break;
             case "items":
                 var item = await db.Items.FindAsync(entityId);
                 if (item is not null) item.ImagePath = blobKey;
@@ -445,6 +466,9 @@ public static class ImageEndpoints
             "locations" => await db.Locations.Where(l => l.Id == entityId)
                 .Select(l => new ValueTuple<string?, string?>(l.ImagePath, l.PlacementPhotoPath))
                 .FirstOrDefaultAsync(),
+            "locationstamps" => await db.Locations.Where(l => l.Id == entityId)
+                .Select(l => new ValueTuple<string?, string?>(l.StampImagePath, null))
+                .FirstOrDefaultAsync(),
             "items" => await db.Items.Where(i => i.Id == entityId)
                 .Select(i => new ValueTuple<string?, string?>(i.ImagePath, null))
                 .FirstOrDefaultAsync(),
@@ -478,6 +502,7 @@ public static class ImageEndpoints
         return entityType switch
         {
             "locations" => await db.Locations.AnyAsync(l => l.Id == entityId),
+            "locationstamps" => await db.Locations.AnyAsync(l => l.Id == entityId),
             "items" => await db.Items.AnyAsync(i => i.Id == entityId),
             "monsters" => await db.Monsters.AnyAsync(m => m.Id == entityId),
             "secretstashes" => await db.SecretStashes.AnyAsync(s => s.Id == entityId),

--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -46,7 +46,8 @@ public static class LocationEndpoints
                 l.GamePotential,
                 l.NpcInfo,
                 l.SetupNotes,
-                l.ImagePath
+                l.ImagePath,
+                l.StampImagePath
             })
             .ToListAsync();
 
@@ -61,7 +62,9 @@ public static class LocationEndpoints
             Array.Empty<LocationQuestDto>(),
             Array.Empty<LocationTreasureQuestDto>(),
             ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"))).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
+            StampImagePath: r.StampImagePath,
+            StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"))).ToList();
 
         return TypedResults.Ok(locations);
     }
@@ -78,7 +81,7 @@ public static class LocationEndpoints
         return TypedResults.Ok(new LocationDetailDto(
             loc.Id, loc.Name, loc.Description, loc.Details, loc.GamePotential, loc.Prompt, loc.Region, loc.LocationKind,
             loc.Coordinates?.Latitude, loc.Coordinates?.Longitude,
-            loc.ImagePath, loc.PlacementPhotoPath, loc.NpcInfo, loc.SetupNotes,
+            loc.ImagePath, loc.PlacementPhotoPath, loc.StampImagePath, loc.NpcInfo, loc.SetupNotes,
             loc.ParentLocationId, variants));
     }
 
@@ -106,7 +109,7 @@ public static class LocationEndpoints
         var result = new LocationDetailDto(
             loc.Id, loc.Name, loc.Description, loc.Details, loc.GamePotential, loc.Prompt, loc.Region, loc.LocationKind,
             loc.Coordinates?.Latitude, loc.Coordinates?.Longitude,
-            loc.ImagePath, loc.PlacementPhotoPath, loc.NpcInfo, loc.SetupNotes,
+            loc.ImagePath, loc.PlacementPhotoPath, loc.StampImagePath, loc.NpcInfo, loc.SetupNotes,
             loc.ParentLocationId, []);
 
         return TypedResults.Created($"/api/locations/{loc.Id}", result);
@@ -166,6 +169,7 @@ public static class LocationEndpoints
                 l.NpcInfo,
                 l.SetupNotes,
                 l.ImagePath,
+                l.StampImagePath,
                 Stashes = l.GameSecretStashes
                     .Where(gss => gss.GameId == gameId)
                     .OrderBy(gss => gss.SecretStash.Name)
@@ -224,7 +228,9 @@ public static class LocationEndpoints
             Quests: r.Quests,
             LocationTreasureQuests: r.LocationTreasureQuests,
             ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"))).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
+            StampImagePath: r.StampImagePath,
+            StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"))).ToList();
 
         return TypedResults.Ok(dtos);
     }

--- a/src/OvcinaHra.Api/Migrations/20260423213803_AddLocationStampImagePath.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260423213803_AddLocationStampImagePath.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260423213803_AddLocationStampImagePath")]
+    partial class AddLocationStampImagePath
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260423213803_AddLocationStampImagePath.cs
+++ b/src/OvcinaHra.Api/Migrations/20260423213803_AddLocationStampImagePath.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLocationStampImagePath : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "StampImagePath",
+                table: "Locations",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StampImagePath",
+                table: "Locations");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Components/LocationEditPopup.razor
+++ b/src/OvcinaHra.Client/Components/LocationEditPopup.razor
@@ -124,6 +124,13 @@
                     <DxFormLayoutItem Caption="Foto umístění" ColSpanMd="12">
                         <ImagePicker EntityType="locations" EntityId="editingId.Value" Field="placement" Alt="Foto umístění" AspectRatio="3:2" />
                     </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Razítko" ColSpanMd="12">
+                        @* Separate entity-type alias (locationstamps) so the stamp's
+                           thumbnail cache, pre-gen, and backfill don't collide with
+                           the main location image. Same Location.Id, different blob
+                           path + DB column (Location.StampImagePath). *@
+                        <ImagePicker EntityType="locationstamps" EntityId="editingId.Value" Alt="Razítko lokace" AspectRatio="1:1" Width="180px" />
+                    </DxFormLayoutItem>
                 }
                 <DxFormLayoutItem Caption="Info pro CP (NPC)" ColSpanMd="12">
                     <DxMemo @bind-Text="@model.NpcInfo" Rows="4" data-testid="location-npc" />

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.2</Version>
+    <Version>0.15.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -84,7 +84,7 @@ else
 {
     <OvcinaGrid Data="@visibleRows"
                 KeyFieldName="Id"
-                LayoutKey="grid-layout-locations-v3"
+                LayoutKey="grid-layout-locations-v4"
                 RowClick="@OnGridRowClick">
         <Columns>
             @* Marker dot — 40px, fixed left *@
@@ -379,6 +379,22 @@ else
             <DxGridDataColumn FieldName="NpcInfo" Caption="NPC" Width="220px" Visible="false" />
             <DxGridDataColumn FieldName="Latitude" Caption="Šířka" Width="120px" DisplayFormat="F5" Visible="false" />
             <DxGridDataColumn FieldName="Longitude" Caption="Délka" Width="120px" DisplayFormat="F5" Visible="false" />
+            @* Rubber stamp thumbnail — hidden by default; organizers reveal via
+               the column chooser. Filter/sort on the URL is not meaningful, so
+               both are disabled. *@
+            <DxGridDataColumn FieldName="StampImageUrl" Caption="Razítko" Width="80px"
+                              Visible="false" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{
+                        var loc = (LocationListDto)context.DataItem;
+                    }
+                    @if (!string.IsNullOrWhiteSpace(loc.StampImageUrl))
+                    {
+                        <img src="@loc.StampImageUrl" alt="Razítko @loc.Name"
+                             class="oh-lg-stamp-thumb" loading="lazy" />
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
         </Columns>
     </OvcinaGrid>
 }

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -382,7 +382,7 @@ else
             @* Rubber stamp thumbnail — hidden by default; organizers reveal via
                the column chooser. Filter/sort on the URL is not meaningful, so
                both are disabled. *@
-            <DxGridDataColumn FieldName="StampImageUrl" Caption="Razítko" Width="80px"
+            <DxGridDataColumn FieldName="StampImageUrl" Caption="Razítko" Width="150px"
                               Visible="false" AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>
                     @{

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -1499,7 +1499,7 @@
 .oh-lg-stash-tile.oh-lg-cave{background:radial-gradient(circle at 50% 55%,#1a0f08 0%,#3a2818 50%,#5a4028 85%)}
 .oh-lg-stash-tile:hover{transform:translateY(-2px);box-shadow:0 4px 12px rgba(45,80,22,.3);z-index:5}
 /* Rubber-stamp thumb rendered in the hidden Razítko column of /locations. */
-.oh-lg-stamp-thumb{width:40px;height:40px;object-fit:contain;display:block}
+.oh-lg-stamp-thumb{width:128px;height:128px;object-fit:contain;display:block}
 /* subtle interior vignette */
 .oh-lg-stash-tile::before{
   content:"";position:absolute;inset:0;pointer-events:none;

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -1498,6 +1498,8 @@
 .oh-lg-stash-tile.oh-lg-creek{background:linear-gradient(180deg,#8fab6a 0%,#6b8ca8 55%,#3d5a78 100%)}
 .oh-lg-stash-tile.oh-lg-cave{background:radial-gradient(circle at 50% 55%,#1a0f08 0%,#3a2818 50%,#5a4028 85%)}
 .oh-lg-stash-tile:hover{transform:translateY(-2px);box-shadow:0 4px 12px rgba(45,80,22,.3);z-index:5}
+/* Rubber-stamp thumb rendered in the hidden Razítko column of /locations. */
+.oh-lg-stamp-thumb{width:40px;height:40px;object-fit:contain;display:block}
 /* subtle interior vignette */
 .oh-lg-stash-tile::before{
   content:"";position:absolute;inset:0;pointer-events:none;

--- a/src/OvcinaHra.Shared/Domain/Entities/Location.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Location.cs
@@ -12,6 +12,7 @@ public class Location
     public GpsCoordinates? Coordinates { get; set; }
     public string? ImagePath { get; set; }
     public string? PlacementPhotoPath { get; set; }
+    public string? StampImagePath { get; set; }
     public string? NpcInfo { get; set; }
     public string? SetupNotes { get; set; }
     public string? Details { get; set; }

--- a/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
@@ -21,7 +21,9 @@ public record LocationListDto(
     IReadOnlyList<LocationQuestDto> Quests,
     IReadOnlyList<LocationTreasureQuestDto> LocationTreasureQuests,
     string? ImagePath = null,
-    string? ImageUrl = null)
+    string? ImageUrl = null,
+    string? StampImagePath = null,
+    string? StampImageUrl = null)
 {
     [JsonIgnore]
     public string LocationKindDisplay => LocationKind.GetDisplayName();
@@ -77,6 +79,7 @@ public record LocationDetailDto(
     decimal? Longitude,
     string? ImagePath,
     string? PlacementPhotoPath,
+    string? StampImagePath,
     string? NpcInfo,
     string? SetupNotes,
     int? ParentLocationId,


### PR DESCRIPTION
## Summary
- Adds **Razítko** (rubber stamp) to each catalog location — a second blob-keyed image used in-game as proof-of-presence
- Uses the existing thumbnail pipeline (302 hot cache, pre-gen on upload, startup backfill) via a new entity-type alias \`locationstamps\` so cache keys don't collide with the main location image
- LocationEditPopup grows a third \`ImagePicker\` (1:1, 180px) labelled **Razítko**
- LocationList gains a hidden \"Razítko\" column showing a 40×40 thumbnail; organizers reveal via column chooser
- LayoutKey bumped \`grid-layout-locations-v3\` → \`v4\`
- New EF migration \`AddLocationStampImagePath\`

## Test plan
- [ ] CI green (API + Client build, integration tests)
- [ ] Upload stamp via LocationEditPopup → \`POST /api/images/locationstamps/{id}\` writes blob + sets \`StampImagePath\`
- [ ] \`GET /api/locations/by-game/{gameId}\` returns \`StampImageUrl\` populated when stamp exists, null otherwise
- [ ] Thumbnail endpoint \`GET /api/images/locationstamps/{id}/thumb?size=small\` serves the stamp
- [ ] LocationList column chooser reveals \"Razítko\" column; thumbnails render at 40×40
- [ ] Startup backfill sweeps stamps alongside other entity types