### PR TITLE
ci: scheduled scale-down for ovcinahra Container Apps (cron 22:00 UTC 24 April)

### DIFF
--- a/.github/workflows/ovcinahra-scale-down.yml
+++ b/.github/workflows/ovcinahra-scale-down.yml
@@ -1,0 +1,52 @@
+# Scale ovcinahra-api + ovcinahra-web Container Apps back down to the
+# cheap baseline after the 2026-04-24 performance-boost window.
+#
+# Cron fires at 22:00 UTC on 24 April = 00:00 CEST on 25 April — i.e.,
+# right after midnight local time. workflow_dispatch is also enabled so
+# the scale-down can be triggered manually if the cron slips (GitHub
+# sometimes delays scheduled jobs by up to 15 min under load).
+
+name: Ovcinahra — scale Container Apps back down
+
+on:
+  schedule:
+    - cron: '0 22 24 4 *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scale-down:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Sign in to Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Scale ovcinahra-api + ovcinahra-web down to baseline
+        run: |
+          for app in ovcinahra-api ovcinahra-web; do
+            echo "Scaling $app back to 0.25 vCPU / 0.5 GiB / 1-1 replicas"
+            az containerapp update -n "$app" -g ovcina \
+              --cpu 0.25 --memory 0.5Gi \
+              --min-replicas 1 --max-replicas 1
+          done
+
+      - name: Verify final sizing
+        run: |
+          az containerapp list \
+            --query "[?starts_with(name,'ovcinahra')].{name:name, cpu:properties.template.containers[0].resources.cpu, mem:properties.template.containers[0].resources.memory, min:properties.template.scale.minReplicas, max:properties.template.scale.maxReplicas}" \
+            -o table
+
+      - name: Ping /api/version to confirm the API is still healthy
+        run: |
+          for i in 1 2 3 4 5; do
+            body=$(curl -sS --max-time 10 https://api.hra.ovcina.cz/api/version || true)
+            echo "attempt $i: $body"
+            if [ -n "$body" ]; then exit 0; fi
+            sleep 15
+          done
+          echo "::warning::API did not respond after scale-down; check Azure portal"


### PR DESCRIPTION
## Summary

One-shot cron that fires at **22:00 UTC on 24 April** = **00:00 CEST on 25 April** (just past midnight local time). Scales `ovcinahra-api` + `ovcinahra-web` back to baseline (0.25 vCPU / 0.5 GiB / 1-1 replicas) after today's performance-boost window.

Also exposes `workflow_dispatch` so the scale-down can be triggered manually if the cron slips (GitHub Actions scheduled jobs can be delayed up to 15 min under load).

## Auth

Uses `AZURE_CREDENTIALS` secret (already set in the repo). Backed by service principal `sp-ovcinahra-scale-down`, **scoped to rg `ovcina` only** (least privilege).

## Current state of the apps (boosted)

```
Name             Cpu    Mem    MinRep    MaxRep
ovcinahra-api    1.0    2Gi    2         5
ovcinahra-web    1.0    2Gi    2         5
```

After the cron fires tonight, both return to:

```
ovcinahra-api    0.25   0.5Gi  1         1
ovcinahra-web    0.25   0.5Gi  1         1
```

## How to verify

- Watch https://github.com/timurlain/OvcinaHra/actions after 22:00 UTC
- Or trigger manually from the Actions tab (workflow_dispatch)
- Workflow also pings `/api/version` afterwards to confirm the API is still healthy

**Merge this before 22:00 UTC today** so the cron is registered in time. If the cron window is missed, trigger via workflow_dispatch instead.