### PR TITLE
feat(treasures): planning dashboard — stage pipeline + pie-pin map + drag-drop [v0.15.6]

### DIFF
--- a/src/OvcinaHra.Client/Components/MapClickEventArgs.cs
+++ b/src/OvcinaHra.Client/Components/MapClickEventArgs.cs
@@ -3,3 +3,5 @@ namespace OvcinaHra.Client.Components;
 public record OvcinaMapClickEventArgs(double Latitude, double Longitude);
 
 public record OvcinaMarkerDragEventArgs(int Id, double Latitude, double Longitude, double OrigLatitude, double OrigLongitude);
+
+public record PiePayloadEventArgs(int LocationId, string Payload);

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -14,6 +14,8 @@
     [Parameter] public EventCallback<int> OnMarkerClick { get; set; }
     [Parameter] public EventCallback<OvcinaMarkerDragEventArgs> OnMarkerDrag { get; set; }
     [Parameter] public EventCallback OnStyleLoaded { get; set; }
+    [Parameter] public EventCallback<int> OnPieMarkerClick { get; set; }
+    [Parameter] public EventCallback<PiePayloadEventArgs> OnPieMarkerDrop { get; set; }
 
     private readonly string _elementId = $"map-{Guid.NewGuid():N}";
     private DotNetObjectReference<MapView>? _dotnetRef;
@@ -52,9 +54,38 @@
     public async Task UpdateMarkerPositionAsync(int id, double lat, double lon)
         => await JS.InvokeVoidAsync("ovcinaMap.updateMarkerPosition", id, lat, lon);
 
+    public async Task AddPieMarkerAsync(int id, double lat, double lon, int[] counts, int maxCount)
+        => await JS.InvokeVoidAsync("ovcinaMap.addPieMarker", id, lat, lon, counts, maxCount);
+
+    public async Task UpdatePieMarkerCountsAsync(int id, int[] counts, int maxCount)
+        => await JS.InvokeVoidAsync("ovcinaMap.updatePieMarkerCounts", id, counts, maxCount);
+
+    public async Task RemovePieMarkerAsync(int id)
+        => await JS.InvokeVoidAsync("ovcinaMap.removePieMarker", id);
+
+    public async Task AddZeroMarkerAsync(int id, double lat, double lon, string name, string kind)
+        => await JS.InvokeVoidAsync("ovcinaMap.addZeroMarker", id, lat, lon, name, kind);
+
+    public async Task RemoveZeroMarkerAsync(int id)
+        => await JS.InvokeVoidAsync("ovcinaMap.removeZeroMarker", id);
+
+    public async Task ClearPieMarkersAsync()
+        => await JS.InvokeVoidAsync("ovcinaMap.clearPieMarkers");
+
+    public async Task SetStageFilterAsync(IReadOnlyCollection<string>? stages)
+        => await JS.InvokeVoidAsync("ovcinaMap.setStageFilter", (object?)(stages?.ToArray()));
+
     [JSInvokable]
     public async Task OnMapClicked(double lat, double lng)
         => await OnMapClick.InvokeAsync(new OvcinaMapClickEventArgs(lat, lng));
+
+    [JSInvokable]
+    public async Task OnPieMarkerClicked(int id)
+        => await OnPieMarkerClick.InvokeAsync(id);
+
+    [JSInvokable]
+    public async Task OnPieMarkerDropped(int locationId, string payload)
+        => await OnPieMarkerDrop.InvokeAsync(new PiePayloadEventArgs(locationId, payload));
 
     [JSInvokable]
     public async Task OnMarkerClicked(int id)

--- a/src/OvcinaHra.Client/Components/StageChip.razor
+++ b/src/OvcinaHra.Client/Components/StageChip.razor
@@ -1,0 +1,18 @@
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+<span class="oh-stage-chip @CssClass(Difficulty)">@(Text ?? Difficulty.GetDisplayName())</span>
+
+@code {
+    [Parameter, EditorRequired] public TreasureQuestDifficulty Difficulty { get; set; }
+    [Parameter] public string? Text { get; set; }
+
+    private static string CssClass(TreasureQuestDifficulty d) => d switch
+    {
+        TreasureQuestDifficulty.Start => "oh-stage-chip-start",
+        TreasureQuestDifficulty.Early => "oh-stage-chip-early",
+        TreasureQuestDifficulty.Midgame => "oh-stage-chip-mid",
+        TreasureQuestDifficulty.Lategame => "oh-stage-chip-late",
+        _ => "oh-stage-chip-start"
+    };
+}

--- a/src/OvcinaHra.Client/Components/StagePipelineCard.razor
+++ b/src/OvcinaHra.Client/Components/StagePipelineCard.razor
@@ -1,0 +1,43 @@
+<div class="oh-tp-stage-card @(Count == 0 ? "oh-tp-empty-state" : "")" data-stage="@StageKey">
+    <div class="oh-tp-stage-card-hdr">
+        <div class="oh-tp-stage-card-nm">@Label</div>
+        @if (Goal is > 0)
+        {
+            <div class="oh-tp-stage-card-goal">cíl @Goal</div>
+        }
+    </div>
+    <div class="oh-tp-stage-card-numline">
+        <span class="oh-tp-stage-card-num">@Count</span>
+        <span class="oh-tp-stage-card-unit">@Pluralize(Count)</span>
+    </div>
+    @if (Goal is > 0)
+    {
+        <div class="oh-tp-stage-card-progress" title="@Count / @Goal">
+            <div class="oh-tp-stage-card-progress-fill" style="width:@(Math.Min(100, Count * 100 / Goal.Value))%"></div>
+        </div>
+    }
+    <div class="oh-tp-stage-card-strip">
+        @for (int i = 0; i < Count && i < 40; i++)
+        {
+            <div class="oh-tp-stage-card-cell"></div>
+        }
+        @if (Count > 40)
+        {
+            <div class="oh-tp-stage-card-cell" title="+@(Count - 40) dalších">…</div>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string StageKey { get; set; } = "start";
+    [Parameter, EditorRequired] public string Label { get; set; } = "";
+    [Parameter, EditorRequired] public int Count { get; set; }
+    [Parameter] public int? Goal { get; set; }
+
+    private static string Pluralize(int n) => n switch
+    {
+        1 => "poklad",
+        >= 2 and <= 4 => "poklady",
+        _ => "pokladů"
+    };
+}

--- a/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
+++ b/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
@@ -1,0 +1,251 @@
+@using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Domain.Enums
+
+<div class="oh-tp-form">
+    <div class="oh-tp-form-row">
+        <label class="oh-tp-form-label">Název</label>
+        <DxTextBox @bind-Text="@title" NullText="např. Poklad v Mlžných horách" />
+    </div>
+
+    <div class="oh-tp-form-row">
+        <label class="oh-tp-form-label">Fáze hry</label>
+        <div class="oh-tp-stage-picker">
+            @foreach (var s in stageKeys)
+            {
+                <label data-stage="@s.Key">
+                    <input type="radio" name="stage" value="@s.Value"
+                           checked="@(difficulty == s.Value)"
+                           @onchange="() => difficulty = s.Value" />
+                    <span>@s.Label</span>
+                </label>
+            }
+        </div>
+    </div>
+
+    <div class="oh-tp-form-row">
+        <label class="oh-tp-form-label">Umístění</label>
+        <div class="oh-tp-target-radios">
+            <label>
+                <input type="radio" name="target" checked="@(!toStash)"
+                       @onchange="() => toStash = false" />
+                <span>Na lokaci</span>
+            </label>
+            <label>
+                <input type="radio" name="target" checked="@toStash"
+                       disabled="@(Stashes.Count == 0)"
+                       @onchange="() => toStash = true" />
+                <span>Do skrýše@(Stashes.Count == 0 ? " (žádná skrýš)" : "")</span>
+            </label>
+        </div>
+        @if (toStash && Stashes.Count > 0)
+        {
+            <div class="mt-2">
+                <DxComboBox Data="@Stashes"
+                            @bind-Value="@stashId"
+                            TextFieldName="Name" ValueFieldName="Id"
+                            NullText="Vyberte skrýš…" />
+            </div>
+        }
+    </div>
+
+    @if (SelectedPool.Count > 0)
+    {
+        <div class="oh-tp-form-row">
+            <label class="oh-tp-form-label">Z zásobníku (@SelectedPool.Count)</label>
+            <div class="oh-tp-chosen-items">
+                @foreach (var p in SelectedPool)
+                {
+                    <div class="oh-tp-chosen-row">
+                        <i class="bi bi-check-circle text-success"></i>
+                        <span class="flex-grow-1">@p.ItemName</span>
+                        <span class="oh-tp-focus-quest-meta">×@p.Count</span>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+
+    <div class="oh-tp-unlimited-toggle">
+        <i class="bi bi-infinity"></i>
+        <div class="flex-grow-1">
+            <div style="font-weight:600">Nekonečné předměty</div>
+            <div class="oh-tp-focus-quest-meta">Nespotřebují se ze zásobníku — vhodné pro lektvary, mince, šifry.</div>
+        </div>
+    </div>
+    <div class="oh-tp-unlimited-pick">
+        <DxComboBox Data="@Unlimited" @bind-Value="@newUnlimitedItemId"
+                    TextFieldName="ItemName" ValueFieldName="ItemId"
+                    NullText="Přidat nekonečný předmět…"
+                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
+                    style="flex:1" />
+        <DxSpinEdit @bind-Value="@newUnlimitedCount" MinValue="1" MaxValue="99" style="width:80px" />
+        <button class="btn btn-sm btn-outline-primary"
+                @onclick="AddUnlimited"
+                disabled="@(newUnlimitedItemId is null)">
+            <i class="bi bi-plus-circle"></i>
+        </button>
+    </div>
+    @if (unlimitedItems.Count > 0)
+    {
+        <div class="oh-tp-chosen-items">
+            @foreach (var u in unlimitedItems)
+            {
+                <div class="oh-tp-chosen-row">
+                    <i class="bi bi-infinity" style="color:var(--oh-stage-early)"></i>
+                    <span class="flex-grow-1">@u.Name</span>
+                    <span class="oh-tp-focus-quest-meta">×@u.Count</span>
+                    <button type="button" class="remove" @onclick="() => unlimitedItems.Remove(u)"
+                            aria-label="Odebrat"><i class="bi bi-x-circle"></i></button>
+                </div>
+            }
+        </div>
+    }
+
+    <div class="oh-tp-form-row mt-3">
+        <label class="oh-tp-form-label">Nápověda (volitelné)</label>
+        <DxMemo @bind-Text="@clue" Rows="2" />
+    </div>
+
+    @if (error is not null)
+    {
+        <div class="alert alert-danger mt-2">@error</div>
+    }
+
+    <div class="oh-tp-form-footer">
+        <div class="spacer"></div>
+        <button type="button" class="btn btn-secondary" @onclick="CancelAsync" disabled="@saving">
+            Zrušit
+        </button>
+        <button type="button" class="btn btn-primary" @onclick="SaveAsync" disabled="@(saving || !CanSave())">
+            @if (saving)
+            {
+                <span class="spinner-border spinner-border-sm me-1"></span>
+            }
+            Schovat poklad
+        </button>
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public int GameId { get; set; }
+    [Parameter] public int? LocationId { get; set; }
+    [Parameter] public string? LocationName { get; set; }
+    [Parameter] public List<StashSummaryDto> Stashes { get; set; } = [];
+    [Parameter] public List<TreasurePoolItemDto> SelectedPool { get; set; } = [];
+    [Parameter] public List<UnlimitedItemDto> Unlimited { get; set; } = [];
+    [Parameter] public TreasureQuestDifficulty InitialDifficulty { get; set; } = TreasureQuestDifficulty.Start;
+    [Parameter] public string? InitialTitle { get; set; }
+    [Parameter] public EventCallback<AssignTreasureDto> OnSave { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+
+    private string title = "";
+    private string? clue;
+    private TreasureQuestDifficulty difficulty;
+    private bool toStash;
+    private int? stashId;
+    private int? newUnlimitedItemId;
+    private int newUnlimitedCount = 1;
+    private readonly List<UnlimitedChoice> unlimitedItems = [];
+    private bool saving;
+    private string? error;
+
+    private record UnlimitedChoice(int ItemId, string Name, int Count);
+
+    private record StagePick(string Key, TreasureQuestDifficulty Value, string Label);
+
+    private static readonly List<StagePick> stageKeys =
+    [
+        new("start", TreasureQuestDifficulty.Start, "Start"),
+        new("early", TreasureQuestDifficulty.Early, "Rozvoj hry"),
+        new("mid", TreasureQuestDifficulty.Midgame, "Střed hry"),
+        new("late", TreasureQuestDifficulty.Lategame, "Závěr hry")
+    ];
+
+    private bool _initialised;
+    private int? _lastLocationId;
+    private string? _lastInitialTitle;
+
+    protected override void OnParametersSet()
+    {
+        if (!_initialised || _lastLocationId != LocationId || _lastInitialTitle != InitialTitle)
+        {
+            _initialised = true;
+            _lastLocationId = LocationId;
+            _lastInitialTitle = InitialTitle;
+
+            title = InitialTitle ?? BuildDefaultTitle();
+            difficulty = InitialDifficulty;
+            toStash = false;
+            stashId = null;
+            clue = null;
+            newUnlimitedItemId = null;
+            newUnlimitedCount = 1;
+            unlimitedItems.Clear();
+            error = null;
+        }
+    }
+
+    private string BuildDefaultTitle()
+    {
+        var loc = LocationName ?? "lokace";
+        var itemPart = SelectedPool.Count switch
+        {
+            0 => "Poklad",
+            1 => SelectedPool[0].ItemName,
+            _ => $"{SelectedPool.Count} předmětů"
+        };
+        return $"{itemPart} @ {loc}";
+    }
+
+    private void AddUnlimited()
+    {
+        if (newUnlimitedItemId is null) return;
+        var item = Unlimited.FirstOrDefault(u => u.ItemId == newUnlimitedItemId.Value);
+        if (item is null) return;
+        var existing = unlimitedItems.FirstOrDefault(u => u.ItemId == item.ItemId);
+        if (existing is not null) unlimitedItems.Remove(existing);
+        unlimitedItems.Add(new UnlimitedChoice(item.ItemId, item.ItemName, newUnlimitedCount));
+        newUnlimitedItemId = null;
+        newUnlimitedCount = 1;
+    }
+
+    private bool CanSave() =>
+        !string.IsNullOrWhiteSpace(title)
+        && (toStash ? stashId.HasValue : LocationId.HasValue)
+        && (SelectedPool.Count > 0 || unlimitedItems.Count > 0);
+
+    private async Task SaveAsync()
+    {
+        error = null;
+        if (!CanSave())
+        {
+            error = "Vyplň název, cíl a alespoň jeden předmět.";
+            return;
+        }
+        saving = true;
+        try
+        {
+            var dto = new AssignTreasureDto(
+                title.Trim(),
+                difficulty,
+                GameId,
+                string.IsNullOrWhiteSpace(clue) ? null : clue.Trim(),
+                toStash ? null : LocationId,
+                toStash ? stashId : null,
+                SelectedPool.Select(p => p.Id).ToList(),
+                unlimitedItems.Select(u => new UnlimitedItemAssignDto(u.ItemId, u.Count)).ToList());
+
+            await OnSave.InvokeAsync(dto);
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private Task CancelAsync() => OnCancel.InvokeAsync();
+}

--- a/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
+++ b/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
@@ -51,7 +51,7 @@
     @if (SelectedPool.Count > 0)
     {
         <div class="oh-tp-form-row">
-            <label class="oh-tp-form-label">Z zásobníku (@SelectedPool.Count)</label>
+            <label class="oh-tp-form-label">Ze zásobníku (@SelectedPool.Count)</label>
             <div class="oh-tp-chosen-items">
                 @foreach (var p in SelectedPool)
                 {

--- a/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
+++ b/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
@@ -1,0 +1,62 @@
+@using System.Text.Json
+@using OvcinaHra.Shared.Dtos
+@inject IJSRuntime JS
+
+<div @ref="elementRef"
+     class="oh-tp-pool-tile @(Selected ? "selected" : "")"
+     title="@($"{Item.ItemName} (×{Item.Count})")"
+     @onclick="OnClickInternal">
+    @if (!imageFailed)
+    {
+        <img class="oh-tp-pool-tile-img"
+             src="@($"/api/images/items/{Item.ItemId}/thumb?size=small")"
+             alt="@Item.ItemName"
+             @onerror="() => imageFailed = true"
+             draggable="false" />
+    }
+    else
+    {
+        <div class="oh-tp-pool-tile-fallback"><i class="bi bi-gem"></i></div>
+    }
+    @if (Item.Count > 1)
+    {
+        <div class="oh-tp-pool-tile-badge">×@Item.Count</div>
+    }
+    <div class="oh-tp-pool-tile-name">@Item.ItemName</div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public TreasurePoolItemDto Item { get; set; } = default!;
+    [Parameter] public bool Selected { get; set; }
+    [Parameter] public EventCallback<TreasurePoolItemDto> OnToggle { get; set; }
+
+    private ElementReference elementRef;
+    private bool imageFailed;
+    private int _wiredForItemId = -1;
+
+    protected override void OnParametersSet()
+    {
+        if (_wiredForItemId != Item.ItemId)
+        {
+            imageFailed = false;
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_wiredForItemId != Item.Id)
+        {
+            _wiredForItemId = Item.Id;
+            var payload = JsonSerializer.Serialize(new
+            {
+                PoolItemId = Item.Id,
+                ItemId = Item.ItemId,
+                ItemName = Item.ItemName,
+                Count = Item.Count
+            });
+            await JS.InvokeVoidAsync("ovcinaDnd.setDraggable", elementRef, payload);
+        }
+    }
+
+    private Task OnClickInternal() => OnToggle.InvokeAsync(Item);
+}

--- a/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
+++ b/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
@@ -32,21 +32,25 @@
 
     private ElementReference elementRef;
     private bool imageFailed;
-    private int _wiredForItemId = -1;
+    private int _imageStateForItemId = -1;
+    private int _wiredForPoolItemId = -1;
 
     protected override void OnParametersSet()
     {
-        if (_wiredForItemId != Item.ItemId)
+        // Reset image-failure state only when the underlying catalog item changes
+        // (image URL is keyed by Item.ItemId, not the pool entry's Id).
+        if (_imageStateForItemId != Item.ItemId)
         {
+            _imageStateForItemId = Item.ItemId;
             imageFailed = false;
         }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (_wiredForItemId != Item.Id)
+        if (_wiredForPoolItemId != Item.Id)
         {
-            _wiredForItemId = Item.Id;
+            _wiredForPoolItemId = Item.Id;
             var payload = JsonSerializer.Serialize(new
             {
                 PoolItemId = Item.Id,

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.5</Version>
+    <Version>0.15.6</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -6,6 +6,7 @@
 @using OvcinaHra.Shared.Extensions
 @inject ApiClient Api
 @inject GameContextService GameContext
+@inject IJSRuntime JS
 @implements IDisposable
 
 <div class="d-flex justify-content-between align-items-center mb-2">
@@ -40,7 +41,7 @@ else
             <StagePipelineCard StageKey="mid"   Label="Střed hry"  Count="@(summary?.MidgameCount ?? 0)" />
             <StagePipelineCard StageKey="late"  Label="Závěr hry"  Count="@(summary?.LategameCount ?? 0)" />
             <div class="oh-tp-pool-mini @(summary?.PoolRemaining == 0 ? "oh-tp-empty-state" : "")"
-                 @onclick="ScrollToPool">
+                 @onclick="ScrollToPoolAsync">
                 <div class="oh-tp-pool-mini-lbl"><i class="bi bi-bag"></i> Zásobník</div>
                 <div class="oh-tp-pool-mini-num">@(summary?.PoolRemaining ?? 0)</div>
                 <div class="oh-tp-pool-mini-sub">předmětů čeká</div>
@@ -358,7 +359,7 @@ else
 @* ================== DELETE CONFIRM POPUP ================== *@
 <DxPopup @bind-Visible="@isDeleteQuestVisible" HeaderText="Smazat poklad?" Width="420px">
     <BodyContentTemplate Context="popupContext">
-        <p>Opravdu smazat poklad <strong>@editTitle</strong>? Předměty z zásobníku se uvolní zpět.</p>
+        <p>Opravdu smazat poklad <strong>@editTitle</strong>? Předměty ze zásobníku se uvolní zpět.</p>
         <div class="d-flex gap-2 justify-content-end">
             <button class="btn btn-secondary" @onclick="() => isDeleteQuestVisible = false">Zrušit</button>
             <button class="btn btn-danger" @onclick="DeleteQuestAsync">Smazat</button>
@@ -401,7 +402,9 @@ else
     {
         activeStages ??= new HashSet<string>(stageKeys.Select(s => s.Key));
         if (!activeStages.Add(key)) activeStages.Remove(key);
-        if (activeStages.Count == stageKeys.Count) activeStages = null;
+        // Empty and full sets both collapse to null ("all active") so the
+        // filter chip UI and the JS opacity state never disagree.
+        if (activeStages.Count == 0 || activeStages.Count == stageKeys.Count) activeStages = null;
         if (mapView is not null) await mapView.SetStageFilterAsync(activeStages);
     }
 
@@ -582,10 +585,11 @@ else
     {
         LocationKind.Town => "town",
         LocationKind.Village => "village",
-        LocationKind.Wilderness => "wilderness",
         LocationKind.Magical => "magical",
-        LocationKind.PointOfInterest => "hobbit",
-        LocationKind.Dungeon => "magical",
+        LocationKind.Hobbit => "hobbit",
+        LocationKind.Wilderness => "wilderness",
+        LocationKind.Dungeon => "dungeon",
+        LocationKind.PointOfInterest => "pointofinterest",
         _ => "wilderness"
     };
 
@@ -700,7 +704,13 @@ else
 
     private async Task RemoveEditItemAsync(TreasureItemDto item)
     {
-        await Api.DeleteAsync($"/api/treasure-quests/{editQuestId}/items/{item.Id}");
+        var ok = await Api.DeleteAsync($"/api/treasure-quests/{editQuestId}/items/{item.Id}");
+        if (!ok)
+        {
+            editError = "Nepodařilo se odebrat předmět.";
+            StateHasChanged();
+            return;
+        }
         editQuestItems.Remove(item);
         StateHasChanged();
     }
@@ -728,7 +738,14 @@ else
     {
         try
         {
-            await Api.DeleteAsync($"/api/treasure-quests/{editQuestId}");
+            var ok = await Api.DeleteAsync($"/api/treasure-quests/{editQuestId}");
+            if (!ok)
+            {
+                editError = "Smazání pokladu selhalo.";
+                isDeleteQuestVisible = false;
+                StateHasChanged();
+                return;
+            }
             isDeleteQuestVisible = false;
             isEditQuestVisible = false;
             markersPlaced = false;
@@ -755,9 +772,14 @@ else
             .FirstOrDefault(s => s.Id == stashId)?.Name ?? $"skrýš #{stashId}";
     }
 
-    private void ScrollToPool()
+    private async Task ScrollToPoolAsync()
     {
         focusedLocationId = null;
         StateHasChanged();
+        try
+        {
+            await JS.InvokeVoidAsync("ovcinaDnd.scrollIntoViewById", "oh-tp-pool-anchor");
+        }
+        catch { /* best-effort scroll — ignore if JS host missing */ }
     }
 }

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -1,217 +1,250 @@
 @page "/treasures"
 @attribute [Authorize]
+@using OvcinaHra.Client.Components
+@using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
 @inject ApiClient Api
 @inject GameContextService GameContext
 @implements IDisposable
 
-<h1 class="mb-3">Rozmístění pokladů</h1>
-
-@* Summary bar *@
-@if (summary is not null)
-{
-    <div class="d-flex gap-3 mb-3 flex-wrap">
-        <div class="badge bg-secondary fs-6 p-2">V zásobě: <strong>@summary.PoolRemaining</strong></div>
-        <div class="badge bg-success fs-6 p-2">Umístěno: <strong>@summary.Placed</strong></div>
-        <div class="badge bg-info text-dark fs-6 p-2">Start: @summary.StartCount</div>
-        <div class="badge bg-info text-dark fs-6 p-2">Raná: @summary.EarlyCount</div>
-        <div class="badge bg-warning text-dark fs-6 p-2">Střed: @summary.MidgameCount</div>
-        <div class="badge bg-danger fs-6 p-2">Závěr: @summary.LategameCount</div>
-    </div>
-}
+<div class="d-flex justify-content-between align-items-center mb-2">
+    <h1 class="mb-0">Rozmístění pokladů</h1>
+    <button class="btn btn-primary btn-sm" @onclick="OpenAddToPoolModal">
+        <i class="bi bi-plus-circle me-1"></i> Přidat do zásobníku
+    </button>
+</div>
 
 @if (loading)
 {
-    <p>Načítám...</p>
+    <div class="oh-tp-loading">Načítám…</div>
 }
-else if (poolItems.Count == 0 && locationCards.Count == 0)
+else if (poolItems.Count == 0 && locationCards.Count == 0 && allQuests.Count == 0)
 {
-    <div class="text-center text-muted py-5">
-        <i class="bi bi-gem fs-1 d-block mb-2"></i>
+    <div class="oh-tp-empty">
+        <i class="bi bi-gem"></i>
         <p>Žádné poklady pro tuto hru.</p>
-        <button class="btn btn-primary" @onclick="OpenAddToPoolModal">+ Přidat do zásobníku</button>
+        <button class="btn btn-primary" @onclick="OpenAddToPoolModal">
+            <i class="bi bi-plus-circle me-1"></i> Přidat do zásobníku
+        </button>
     </div>
 }
 else
 {
-    <div class="row">
-        @* LEFT: Item pool *@
-        <div class="col-md-5">
-            <div class="d-flex justify-content-between align-items-center mb-2">
-                <h5 class="mb-0">Zásobník předmětů</h5>
-                <button class="btn btn-sm btn-primary" @onclick="OpenAddToPoolModal">+ Přidat</button>
+    <div class="oh-tp-page">
+
+        @* ================== ZONE 1 — Pipeline ================== *@
+        <div class="oh-tp-pipeline">
+            <StagePipelineCard StageKey="start" Label="Start" Count="@(summary?.StartCount ?? 0)" />
+            <StagePipelineCard StageKey="early" Label="Rozvoj hry" Count="@(summary?.EarlyCount ?? 0)" />
+            <StagePipelineCard StageKey="mid"   Label="Střed hry"  Count="@(summary?.MidgameCount ?? 0)" />
+            <StagePipelineCard StageKey="late"  Label="Závěr hry"  Count="@(summary?.LategameCount ?? 0)" />
+            <div class="oh-tp-pool-mini @(summary?.PoolRemaining == 0 ? "oh-tp-empty-state" : "")"
+                 @onclick="ScrollToPool">
+                <div class="oh-tp-pool-mini-lbl"><i class="bi bi-bag"></i> Zásobník</div>
+                <div class="oh-tp-pool-mini-num">@(summary?.PoolRemaining ?? 0)</div>
+                <div class="oh-tp-pool-mini-sub">předmětů čeká</div>
+                <div class="oh-tp-pool-mini-jump">Ukázat <i class="bi bi-arrow-right"></i></div>
             </div>
-            <OvcinaGrid Data="@poolItems" KeyFieldName="Id" LayoutKey="grid-layout-treasure-pool"
-                        SelectionMode="GridSelectionMode.Multiple"
-                        SelectedDataItems="@selectedPoolItems"
-                        SelectedDataItemsChanged="@OnPoolSelectionChanged"
-                        ShowGroupPanel="true">
-                <Columns>
-                    <DxGridDataColumn FieldName="ItemName" Caption="Předmět" />
-                    <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="120px" />
-                    <DxGridDataColumn FieldName="Count" Caption="Počet" Width="70px" />
-                </Columns>
-            </OvcinaGrid>
         </div>
 
-        @* RIGHT: Location cards *@
-        <div class="col-md-7">
-            <h5 class="mb-2">Lokace</h5>
-            <div class="d-flex flex-wrap gap-2" style="max-height: 65vh; overflow-y: auto;">
-                @foreach (var loc in locationCards)
+        @* ================== ZONE 2 — Workspace ================== *@
+        <div class="oh-tp-workspace">
+
+            @* LEFT: map *@
+            <div class="oh-tp-map-panel">
+                <div class="oh-tp-stage-filter">
+                    <span class="oh-tp-stage-filter-lbl">Fáze:</span>
+                    <button class="oh-tp-filter-chip @(activeStages is null ? "active" : "")"
+                            data-stage="all"
+                            @onclick="SelectAllStages">Všechny</button>
+                    @foreach (var s in stageKeys)
+                    {
+                        <button class="oh-tp-filter-chip @(IsStageActive(s.Key) ? "active" : "")"
+                                data-stage="@s.Key"
+                                @onclick="() => ToggleStage(s.Key)">@s.Label</button>
+                    }
+                </div>
+                <div class="oh-tp-map-host" id="oh-tp-map-host">
+                    <MapView @ref="mapView"
+                             Height="100%"
+                             CenterLat="49.4532461" CenterLon="18.0203242" Zoom="12"
+                             OnPieMarkerClick="HandlePieClick"
+                             OnPieMarkerDrop="HandlePieDrop"
+                             OnStyleLoaded="HandleStyleLoaded" />
+                </div>
+                <div class="oh-tp-map-toolbar">
+                    <span>Legenda:</span>
+                    @foreach (var s in stageKeys)
+                    {
+                        <span class="oh-tp-focus-stats"><span class="sw" style="background:var(--oh-stage-@s.SoftKey)"></span>@s.Label</span>
+                    }
+                    <div class="oh-tp-map-toolbar-spacer"></div>
+                    <span class="oh-tp-map-count">@locationCards.Count lokací · @(summary?.Placed ?? 0) umístěno</span>
+                </div>
+            </div>
+
+            @* RIGHT: assignment panel *@
+            <div class="oh-tp-assign-panel">
+                @if (focusedLocationId is null)
                 {
-                    <div class="card treasure-location-card @(loc.TotalItems == 0 ? "border-secondary" : "border-primary")"
-                         style="width: 220px; cursor: pointer;"
-                         @onclick="() => OpenAssignPopup(loc)">
-                        <div class="card-body p-2">
-                            <h6 class="card-title mb-1 text-truncate" title="@loc.LocationName">
-                                @GetLocationIcon(loc.LocationKind) @loc.LocationName
-                            </h6>
-                            <div class="d-flex gap-1 flex-wrap mb-1">
-                                <span class="badge bg-info text-dark" title="Start">S:@loc.StartCount</span>
-                                <span class="badge bg-info text-dark" title="Rozvoj hry">R:@loc.EarlyCount</span>
-                                <span class="badge bg-warning text-dark" title="Střed hry">M:@loc.MidgameCount</span>
-                                <span class="badge bg-danger" title="Závěr hry">L:@loc.LategameCount</span>
+                    @* --- Default: pool grid --- *@
+                    <div class="oh-tp-assign-hdr">
+                        <h5>Zásobník (@poolItems.Count)</h5>
+                        <span class="oh-tp-focus-quest-meta">@selectedPool.Count vybráno</span>
+                    </div>
+                    <div class="oh-tp-assign-body" id="oh-tp-pool-anchor">
+                        @if (selectedPool.Count > 0)
+                        {
+                            <div class="oh-tp-drag-hint">
+                                <i class="bi bi-arrow-left-right"></i>
+                                Přetáhni vybrané kachličky na špendlík na mapě, nebo klikni na lokaci pro přidání.
                             </div>
-                            <div class="d-flex justify-content-between">
-                                <small class="text-muted">Celkem: @loc.TotalItems</small>
-                                <small class="text-muted">Skrýše: @loc.StashCount/@loc.MaxStashes</small>
+                        }
+                        @if (poolItems.Count == 0)
+                        {
+                            <div class="oh-tp-empty">
+                                <i class="bi bi-bag"></i>
+                                <p>Zásobník je prázdný.</p>
+                                <button class="btn btn-sm btn-outline-primary" @onclick="OpenAddToPoolModal">Přidat předmět</button>
                             </div>
-                        </div>
+                        }
+                        else
+                        {
+                            <div class="oh-tp-pool-grid">
+                                @foreach (var p in poolItems)
+                                {
+                                    <TreasurePoolTile @key="p.Id"
+                                                      Item="p"
+                                                      Selected="@IsSelected(p)"
+                                                      OnToggle="TogglePoolSelection" />
+                                }
+                            </div>
+                        }
                     </div>
                 }
-                @if (locationCards.Count == 0)
+                else
                 {
-                    <p class="text-muted">Žádné lokace přiřazené k hře.</p>
+                    @* --- Location focus --- *@
+                    var loc = locationCards.FirstOrDefault(l => l.LocationId == focusedLocationId);
+                    <div class="oh-tp-assign-hdr">
+                        <h5>@(loc?.LocationName ?? "Lokace")</h5>
+                        <button class="oh-tp-close" @onclick="CloseFocus" title="Zavřít">
+                            <i class="bi bi-x-lg"></i>
+                        </button>
+                    </div>
+                    <div class="oh-tp-assign-tabs">
+                        <button class="oh-tp-assign-tab @(focusTab == "prehled" ? "active" : "")"
+                                @onclick='() => focusTab = "prehled"'>Přehled</button>
+                        <button class="oh-tp-assign-tab @(focusTab == "pridat" ? "active" : "")"
+                                @onclick='() => focusTab = "pridat"'>Přidat poklad</button>
+                    </div>
+                    <div class="oh-tp-assign-body">
+                        @if (focusTab == "prehled" && loc is not null)
+                        {
+                            <div class="oh-tp-focus-summary">
+                                <div class="oh-tp-focus-stats">
+                                    <span><span class="sw" style="background:var(--oh-stage-start)"></span>Start @loc.StartCount</span>
+                                    <span><span class="sw" style="background:var(--oh-stage-early)"></span>Rozvoj @loc.EarlyCount</span>
+                                    <span><span class="sw" style="background:var(--oh-stage-midgame)"></span>Střed @loc.MidgameCount</span>
+                                    <span><span class="sw" style="background:var(--oh-stage-lategame)"></span>Závěr @loc.LategameCount</span>
+                                </div>
+                            </div>
+
+                            var locQuests = allQuests.Where(q => q.LocationId == focusedLocationId).ToList();
+                            var stashIds = loc.Stashes.Select(s => s.Id).ToHashSet();
+                            var stashQuests = allQuests.Where(q => q.SecretStashId.HasValue && stashIds.Contains(q.SecretStashId.Value)).ToList();
+                            var allLocQuests = locQuests.Concat(stashQuests).ToList();
+
+                            @if (allLocQuests.Count == 0)
+                            {
+                                <p class="text-muted">Žádné poklady. Klikni na <strong>Přidat poklad</strong>.</p>
+                            }
+                            else
+                            {
+                                foreach (var stage in stageKeys)
+                                {
+                                    var qs = allLocQuests.Where(q => q.Difficulty == stage.Value).ToList();
+                                    if (qs.Count == 0) continue;
+                                    <div class="oh-tp-focus-group-hdr">
+                                        <span class="sw" style="background:var(--oh-stage-@stage.SoftKey)"></span>
+                                        @stage.Label · @qs.Count @Pluralize(qs.Count)
+                                    </div>
+                                    foreach (var q in qs)
+                                    {
+                                        <div class="oh-tp-focus-quest" @onclick="() => OpenEditQuestPopup(q)">
+                                            <StageChip Difficulty="@q.Difficulty" />
+                                            <span class="oh-tp-focus-quest-title">@q.Title</span>
+                                            @if (q.SecretStashId.HasValue)
+                                            {
+                                                <span class="oh-tp-focus-quest-meta">
+                                                    <i class="bi bi-gem"></i>
+                                                    @(loc.Stashes.FirstOrDefault(s => s.Id == q.SecretStashId.Value)?.Name ?? $"skrýš #{q.SecretStashId}")
+                                                </span>
+                                            }
+                                            <i class="bi bi-pencil oh-tp-focus-quest-meta"></i>
+                                        </div>
+                                    }
+                                }
+                            }
+                        }
+                        else if (focusTab == "pridat" && loc is not null)
+                        {
+                            <TreasureAssignForm GameId="@gameId"
+                                                LocationId="@focusedLocationId"
+                                                LocationName="@loc.LocationName"
+                                                Stashes="@loc.Stashes.ToList()"
+                                                SelectedPool="@selectedPool"
+                                                Unlimited="@unlimitedItems"
+                                                InitialDifficulty="@lastUsedDifficulty"
+                                                OnSave="HandleAssignSaveAsync"
+                                                OnCancel='() => focusTab = "prehled"' />
+                        }
+                    </div>
                 }
             </div>
         </div>
-    </div>
 
-    @* BOTTOM: Overview *@
-    <div class="mt-4">
-        <h5 class="mb-2 d-flex align-items-center gap-2">
-            Přehled pokladů
-            <button class="btn btn-sm btn-outline-secondary" @onclick="() => overviewVisible = !overviewVisible">
-                @(overviewVisible ? "Skrýt" : "Zobrazit")
-            </button>
-        </h5>
-        @if (overviewVisible)
-        {
-            <OvcinaGrid Data="@allQuests" KeyFieldName="Id" LayoutKey="grid-layout-treasure-overview"
-                        RowClick="@(e => OpenEditQuestPopup((TreasureQuestListDto)e.Grid.GetDataItem(e.VisibleIndex)))"
-                        ShowGroupPanel="true">
-                <Columns>
-                    <DxGridDataColumn FieldName="Title" Caption="Název" />
-                    <DxGridDataColumn FieldName="DifficultyDisplay" Caption="Obtížnost" Width="130px" />
-                    <DxGridDataColumn FieldName="LocationId" Caption="Lokace" Width="150px">
-                        <CellDisplayTemplate>@GetLocationName((int?)context.Value)</CellDisplayTemplate>
-                    </DxGridDataColumn>
-                    <DxGridDataColumn FieldName="SecretStashId" Caption="Skrýš" Width="150px" Visible="false" />
-                    <DxGridDataColumn FieldName="GameId" Caption="Hra" Width="60px" Visible="false" />
-                </Columns>
-            </OvcinaGrid>
-        }
+        @* ================== ZONE 3 — Overview ================== *@
+        <div class="oh-tp-z3 @(overviewVisible ? "" : "collapsed")">
+            <div class="oh-tp-z3-bar" @onclick="() => overviewVisible = !overviewVisible">
+                <i class="bi bi-chevron-down"></i>
+                <h5>Všechny poklady (@allQuests.Count)</h5>
+                <span class="oh-tp-focus-quest-meta">@(overviewVisible ? "Skrýt" : "Zobrazit")</span>
+            </div>
+            @if (overviewVisible)
+            {
+                <div class="oh-tp-z3-body">
+                    <OvcinaGrid Data="@allQuests" KeyFieldName="Id" LayoutKey="grid-layout-treasures-v2"
+                                RowClick="@(e => OpenEditQuestPopup((TreasureQuestListDto)e.Grid.GetDataItem(e.VisibleIndex)))"
+                                ShowGroupPanel="true">
+                        <Columns>
+                            <DxGridDataColumn FieldName="Title" Caption="Název" />
+                            <DxGridDataColumn FieldName="DifficultyDisplay" Caption="Fáze" Width="130px" GroupIndex="0" />
+                            <DxGridDataColumn FieldName="LocationId" Caption="Lokace" Width="200px">
+                                <CellDisplayTemplate>@GetLocationName((int?)context.Value)</CellDisplayTemplate>
+                            </DxGridDataColumn>
+                            <DxGridDataColumn FieldName="SecretStashId" Caption="Skrýš" Width="160px" Visible="false">
+                                <CellDisplayTemplate>@GetStashName((int?)context.Value)</CellDisplayTemplate>
+                            </DxGridDataColumn>
+                            <DxGridDataColumn FieldName="GameId" Caption="Hra" Width="60px" Visible="false" />
+                        </Columns>
+                    </OvcinaGrid>
+                </div>
+            }
+        </div>
     </div>
 }
 
-@* === ASSIGN POPUP === *@
-<DxPopup AllowResize="true" @bind-Visible="@isAssignVisible" HeaderText="@assignTitle" Width="650px">
-    <BodyContentTemplate Context="popupContext">
-        @if (assignSelectedPool.Count > 0)
-        {
-            <div class="mb-3">
-                <h6>Vybrané z zásobníku:</h6>
-                <ul class="list-unstyled mb-0">
-                    @foreach (var p in assignSelectedPool)
-                    {
-                        <li><i class="bi bi-check-circle text-success me-1"></i> @p.ItemName (@(p.Count)x)</li>
-                    }
-                </ul>
-            </div>
-        }
-
-        @* Unlimited items *@
-        <div class="mb-3 p-2 border rounded" style="background: var(--oh-primary-surface, #f8f9fa);">
-            <h6 class="mb-2">Přidat neomezený předmět:</h6>
-            <div class="d-flex gap-2 align-items-end">
-                <DxComboBox Data="@unlimitedItems" @bind-Value="@newUnlimitedItemId"
-                            TextFieldName="ItemName" ValueFieldName="ItemId"
-                            NullText="Vyberte předmět..." ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
-                            style="flex: 1;" />
-                <DxSpinEdit @bind-Value="@newUnlimitedCount" MinValue="1" MaxValue="99" style="width: 80px;" />
-                <button class="btn btn-sm btn-outline-primary" @onclick="AddUnlimitedToAssign" disabled="@(newUnlimitedItemId is null)">
-                    <i class="bi bi-plus-circle"></i>
-                </button>
-            </div>
-            @if (assignUnlimitedItems.Count > 0)
-            {
-                <ul class="list-unstyled mt-2 mb-0">
-                    @foreach (var u in assignUnlimitedItems)
-                    {
-                        <li class="d-flex justify-content-between align-items-center">
-                            <span>@u.ItemName (@(u.Count)x)</span>
-                            <button class="btn btn-sm btn-link text-danger p-0" @onclick="() => assignUnlimitedItems.Remove(u)">
-                                <i class="bi bi-x-circle"></i>
-                            </button>
-                        </li>
-                    }
-                </ul>
-            }
-        </div>
-
-        <DxFormLayout>
-            <DxFormLayoutItem Caption="Umístění" ColSpanMd="12">
-                <div class="d-flex gap-3">
-                    <div class="form-check">
-                        <input class="form-check-input" type="radio" id="placeAtLocation" checked="@(!assignToStash)" @onchange="() => assignToStash = false" />
-                        <label class="form-check-label" for="placeAtLocation">Přímo na lokaci</label>
-                    </div>
-                    <div class="form-check">
-                        <input class="form-check-input" type="radio" id="placeAtStash" checked="@assignToStash"
-                               @onchange="() => assignToStash = true" disabled="@(assignLocationStashes.Count == 0)" />
-                        <label class="form-check-label" for="placeAtStash">Do skrýše</label>
-                    </div>
-                </div>
-            </DxFormLayoutItem>
-            @if (assignToStash)
-            {
-                <DxFormLayoutItem Caption="Skrýš" ColSpanMd="12">
-                    <DxComboBox Data="@assignLocationStashes" @bind-Value="@assignStashId"
-                                TextFieldName="Name" ValueFieldName="Id" NullText="Vyberte skrýš..." />
-                </DxFormLayoutItem>
-            }
-            <DxFormLayoutItem Caption="Obtížnost" ColSpanMd="6">
-                <DxComboBox Data="@difficultyValues" @bind-Value="@assignDifficulty" TextFieldName="Display" ValueFieldName="Value" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
-                <DxTextBox @bind-Text="@assignQuestTitle" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Nápověda" ColSpanMd="12">
-                <DxMemo @bind-Text="@assignClue" Rows="2" />
-            </DxFormLayoutItem>
-        </DxFormLayout>
-
-        @if (assignError is not null) { <div class="alert alert-danger mt-2">@assignError</div> }
-
-        <div class="d-flex gap-2 mt-3">
-            <div style="flex: 1"></div>
-            <button class="btn btn-secondary" @onclick="() => isAssignVisible = false">Zrušit</button>
-            <button class="btn btn-primary" @onclick="ConfirmAssignAsync" disabled="@assignSaving">
-                @if (assignSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
-                Schovat poklad
-            </button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
-
-@* === ADD TO POOL POPUP === *@
+@* ================== ADD-TO-POOL POPUP ================== *@
 <DxPopup @bind-Visible="@isAddPoolVisible" HeaderText="Přidat do zásobníku" Width="450px">
     <BodyContentTemplate Context="popupContext">
         <DxFormLayout>
             <DxFormLayoutItem Caption="Předmět" ColSpanMd="12">
                 <DxComboBox Data="@findableItems" @bind-Value="@poolItemId"
                             TextFieldName="DisplayName" ValueFieldName="ItemId"
-                            NullText="Vyberte předmět..." ListRenderMode="ListRenderMode.Virtual" />
+                            NullText="Vyberte předmět…"
+                            ListRenderMode="ListRenderMode.Virtual" />
             </DxFormLayoutItem>
             <DxFormLayoutItem Caption="Počet" ColSpanMd="6">
                 <DxSpinEdit @bind-Value="@poolItemCount" MinValue="1" MaxValue="99" />
@@ -220,58 +253,69 @@ else
         @if (poolError is not null) { <div class="alert alert-danger mt-2">@poolError</div> }
         <div class="d-flex gap-2 mt-3 justify-content-end">
             <button class="btn btn-secondary" @onclick="() => isAddPoolVisible = false">Zrušit</button>
-            <button class="btn btn-primary" @onclick="AddToPoolAsync" disabled="@poolSaving">Přidat</button>
+            <button class="btn btn-primary" @onclick="AddToPoolAsync" disabled="@(poolSaving || poolItemId is null)">
+                @if (poolSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Přidat
+            </button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
 
-@* === EDIT QUEST POPUP === *@
-<DxPopup AllowResize="true" @bind-Visible="@isEditQuestVisible" HeaderText="@editQuestTitle" Width="700px">
+@* ================== EDIT QUEST POPUP ================== *@
+<DxPopup AllowResize="true" @bind-Visible="@isEditQuestVisible" HeaderText="@editQuestTitle" Width="720px">
     <BodyContentTemplate Context="popupContext">
         <DxFormLayout>
             <DxFormLayoutItem Caption="Název" ColSpanMd="12">
                 <DxTextBox @bind-Text="@editTitle" />
             </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Obtížnost" ColSpanMd="6">
-                <DxComboBox Data="@difficultyValues" @bind-Value="@editDifficulty" TextFieldName="Display" ValueFieldName="Value" />
+            <DxFormLayoutItem Caption="Fáze" ColSpanMd="6">
+                <DxComboBox Data="@difficultyValues"
+                            @bind-Value="@editDifficulty"
+                            TextFieldName="Display" ValueFieldName="Value" />
             </DxFormLayoutItem>
             <DxFormLayoutItem Caption="Nápověda" ColSpanMd="12">
                 <DxMemo @bind-Text="@editClue" Rows="2" />
             </DxFormLayoutItem>
             <DxFormLayoutItem Caption="Umístění" ColSpanMd="12">
-                <div class="d-flex gap-3">
-                    <div class="form-check">
-                        <input class="form-check-input" type="radio" id="editPlaceAtLocation" checked="@(!editToStash)" @onchange="() => editToStash = false" />
-                        <label class="form-check-label" for="editPlaceAtLocation">Přímo na lokaci</label>
-                    </div>
-                    <div class="form-check">
-                        <input class="form-check-input" type="radio" id="editPlaceAtStash" checked="@editToStash"
-                               @onchange="() => editToStash = true" disabled="@(editStashes.Count == 0)" />
-                        <label class="form-check-label" for="editPlaceAtStash">Do skrýše</label>
-                    </div>
+                <div class="oh-tp-target-radios">
+                    <label>
+                        <input type="radio" name="editTarget" checked="@(!editToStash)"
+                               @onchange="() => editToStash = false" />
+                        <span>Na lokaci</span>
+                    </label>
+                    <label>
+                        <input type="radio" name="editTarget" checked="@editToStash"
+                               disabled="@(editStashes.Count == 0)"
+                               @onchange="() => editToStash = true" />
+                        <span>Do skrýše</span>
+                    </label>
                 </div>
             </DxFormLayoutItem>
             @if (!editToStash)
             {
                 <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
-                    <DxComboBox Data="@editLocations" @bind-Value="@editLocationId"
+                    <DxComboBox Data="@editLocations"
+                                @bind-Value="@editLocationId"
                                 TextFieldName="Name" ValueFieldName="Id"
-                                NullText="Vyberte lokaci..." ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                                NullText="Vyberte lokaci…"
+                                ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
                 </DxFormLayoutItem>
             }
-            @if (editToStash)
+            else
             {
                 <DxFormLayoutItem Caption="Skrýš" ColSpanMd="12">
-                    <DxComboBox Data="@editStashesFiltered" @bind-Value="@editStashId"
+                    <DxComboBox Data="@editStashesFiltered"
+                                @bind-Value="@editStashId"
                                 TextFieldName="StashName" ValueFieldName="SecretStashId"
-                                NullText="Vyberte skrýš..." ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                                NullText="Vyberte skrýš…"
+                                ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
                 </DxFormLayoutItem>
             }
         </DxFormLayout>
 
         @if (editQuestId.HasValue && editQuestItems.Count > 0)
         {
-            <div class="mt-3 p-3 border rounded" style="background: var(--oh-primary-surface, #f8f9fa);">
+            <div class="mt-3 p-3 border rounded" style="background:var(--oh-primary-surface,#f8f9fa);">
                 <h6 class="mb-2"><i class="bi bi-gem me-1"></i> Předměty v pokladu</h6>
                 <table class="table table-sm mb-0">
                     <thead><tr><th>Předmět</th><th style="width:80px">Počet</th><th style="width:40px"></th></tr></thead>
@@ -281,7 +325,13 @@ else
                             <tr>
                                 <td>@item.ItemName</td>
                                 <td>@item.Count</td>
-                                <td><button class="btn btn-sm btn-link text-danger p-0" @onclick="() => RemoveEditItemAsync(item)" @onclick:stopPropagation="true"><i class="bi bi-x-circle"></i></button></td>
+                                <td>
+                                    <button class="btn btn-sm btn-link text-danger p-0"
+                                            @onclick="() => RemoveEditItemAsync(item)"
+                                            @onclick:stopPropagation="true">
+                                        <i class="bi bi-x-circle"></i>
+                                    </button>
+                                </td>
                             </tr>
                         }
                     </tbody>
@@ -290,18 +340,25 @@ else
         }
 
         @if (editError is not null) { <div class="alert alert-danger mt-2">@editError</div> }
-        <div class="d-flex gap-2 mt-3">
-            <button class="btn btn-outline-danger" @onclick="() => isDeleteQuestVisible = true">Smazat</button>
-            <div style="flex: 1"></div>
+
+        <div class="oh-tp-form-footer">
+            <button class="btn btn-outline-danger" @onclick="() => isDeleteQuestVisible = true">
+                <i class="bi bi-trash me-1"></i> Smazat
+            </button>
+            <div class="spacer"></div>
             <button class="btn btn-secondary" @onclick="() => isEditQuestVisible = false">Zrušit</button>
-            <button class="btn btn-primary" @onclick="SaveEditQuestAsync" disabled="@editSaving">Uložit</button>
+            <button class="btn btn-primary" @onclick="SaveEditQuestAsync" disabled="@editSaving">
+                @if (editSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Uložit
+            </button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
 
-<DxPopup @bind-Visible="@isDeleteQuestVisible" HeaderText="Potvrdit smazání" Width="400px">
+@* ================== DELETE CONFIRM POPUP ================== *@
+<DxPopup @bind-Visible="@isDeleteQuestVisible" HeaderText="Smazat poklad?" Width="420px">
     <BodyContentTemplate Context="popupContext">
-        <p>Smazat poklad <strong>@editTitle</strong>? Předměty se vrátí do zásobníku.</p>
+        <p>Opravdu smazat poklad <strong>@editTitle</strong>? Předměty z zásobníku se uvolní zpět.</p>
         <div class="d-flex gap-2 justify-content-end">
             <button class="btn btn-secondary" @onclick="() => isDeleteQuestVisible = false">Zrušit</button>
             <button class="btn btn-danger" @onclick="DeleteQuestAsync">Smazat</button>
@@ -310,50 +367,68 @@ else
 </DxPopup>
 
 @code {
-    // Data
+    // ===== Data =====
     private List<TreasurePoolItemDto> poolItems = [];
     private List<TreasurePlanningLocationDto> locationCards = [];
+    private List<LocationListDto> locations = [];
     private List<TreasureQuestListDto> allQuests = [];
     private List<UnlimitedItemDto> unlimitedItems = [];
     private TreasureSummaryDto? summary;
-    private bool loading = true, overviewVisible;
+    private bool loading = true;
 
-    // Pool selection
-    private IReadOnlyList<object> selectedPoolItems = [];
-    private void OnPoolSelectionChanged(IReadOnlyList<object> items) => selectedPoolItems = items;
+    // ===== Pool selection =====
+    private readonly List<TreasurePoolItemDto> selectedPool = [];
+    private bool IsSelected(TreasurePoolItemDto p) => selectedPool.Any(s => s.Id == p.Id);
 
-    // Game context
-    private int gameId => GameContext.SelectedGameId ?? 1;
+    private void TogglePoolSelection(TreasurePoolItemDto p)
+    {
+        var existing = selectedPool.FirstOrDefault(s => s.Id == p.Id);
+        if (existing is not null) selectedPool.Remove(existing);
+        else selectedPool.Add(p);
+    }
 
-    // Difficulty enum helper
-    private static readonly List<EnumItem<TreasureQuestDifficulty>> difficultyValues = Enum.GetValues<TreasureQuestDifficulty>()
-        .Select(v => new EnumItem<TreasureQuestDifficulty>(v, v.GetDisplayName())).ToList();
-    record EnumItem<T>(T Value, string Display);
+    // ===== Stage filter =====
+    private HashSet<string>? activeStages;
+    private bool IsStageActive(string key) => activeStages is null || activeStages.Contains(key);
 
-    // === ASSIGN state ===
-    private bool isAssignVisible, assignSaving, assignToStash;
-    private string assignTitle = "", assignQuestTitle = "";
-    private string? assignClue, assignError;
-    private TreasureQuestDifficulty assignDifficulty = TreasureQuestDifficulty.Start;
-    private int? assignLocationId, assignStashId;
-    private List<StashSummaryDto> assignLocationStashes = [];
-    private List<TreasurePoolItemDto> assignSelectedPool = [];
-    private List<AssignUnlimitedItem> assignUnlimitedItems = [];
-    private int? newUnlimitedItemId;
-    private int newUnlimitedCount = 1;
-    record AssignUnlimitedItem(int ItemId, string ItemName, int Count);
+    private async Task SelectAllStages()
+    {
+        activeStages = null;
+        if (mapView is not null) await mapView.SetStageFilterAsync(null);
+    }
 
-    // Sticky difficulty
+    private async Task ToggleStage(string key)
+    {
+        activeStages ??= new HashSet<string>(stageKeys.Select(s => s.Key));
+        if (!activeStages.Add(key)) activeStages.Remove(key);
+        if (activeStages.Count == stageKeys.Count) activeStages = null;
+        if (mapView is not null) await mapView.SetStageFilterAsync(activeStages);
+    }
+
+    // ===== Focus state =====
+    private int? focusedLocationId;
+    private string focusTab = "prehled";
     private TreasureQuestDifficulty lastUsedDifficulty = TreasureQuestDifficulty.Start;
 
-    // === ADD TO POOL state ===
+    // ===== Game context =====
+    private int gameId => GameContext.SelectedGameId ?? 1;
+
+    // ===== Map =====
+    private MapView? mapView;
+    private bool styleLoaded;
+    private bool markersPlaced;
+
+    // ===== Overview =====
+    private bool overviewVisible;
+
+    // ===== Add-to-pool popup =====
     private bool isAddPoolVisible, poolSaving;
     private int? poolItemId;
     private int poolItemCount = 1;
     private string? poolError;
     private List<AvailablePoolItemDto> findableItems = [];
 
-    // === EDIT QUEST state ===
+    // ===== Edit-quest popup =====
     private bool isEditQuestVisible, isDeleteQuestVisible, editSaving;
     private int? editQuestId;
     private string editTitle = "", editQuestTitle = "";
@@ -369,7 +444,28 @@ else
             ? editStashes.Where(s => s.LocationId == editLocationId.Value).ToList()
             : editStashes;
 
-    // === LIFECYCLE ===
+    // ===== Stage metadata =====
+    private record StageInfo(string Key, string SoftKey, TreasureQuestDifficulty Value, string Label);
+    private static readonly List<StageInfo> stageKeys =
+    [
+        new("start", "start",    TreasureQuestDifficulty.Start,    "Start"),
+        new("early", "early",    TreasureQuestDifficulty.Early,    "Rozvoj hry"),
+        new("mid",   "midgame",  TreasureQuestDifficulty.Midgame,  "Střed hry"),
+        new("late",  "lategame", TreasureQuestDifficulty.Lategame, "Závěr hry"),
+    ];
+
+    private static readonly List<EnumItem<TreasureQuestDifficulty>> difficultyValues = Enum.GetValues<TreasureQuestDifficulty>()
+        .Select(v => new EnumItem<TreasureQuestDifficulty>(v, v.GetDisplayName())).ToList();
+    private record EnumItem<T>(T Value, string Display);
+
+    private static string Pluralize(int n) => n switch
+    {
+        1 => "quest",
+        >= 2 and <= 4 => "questy",
+        _ => "questů"
+    };
+
+    // ===== Lifecycle =====
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
@@ -377,114 +473,177 @@ else
         await LoadAllAsync();
     }
 
+    private async void OnGameChanged()
+    {
+        markersPlaced = false;
+        focusedLocationId = null;
+        selectedPool.Clear();
+        await LoadAllAsync();
+        await PlaceMarkersIfReadyAsync();
+        StateHasChanged();
+    }
+
+    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
+
     private async Task LoadAllAsync()
     {
         loading = true;
-        var poolTask = Api.GetListAsync<TreasurePoolItemDto>($"/api/treasure-planning/pool/{gameId}");
-        var locTask = Api.GetListAsync<TreasurePlanningLocationDto>($"/api/treasure-planning/locations/{gameId}");
-        var questTask = Api.GetListAsync<TreasureQuestListDto>($"/api/treasure-quests/by-game/{gameId}");
-        var summaryTask = Api.GetAsync<TreasureSummaryDto>($"/api/treasure-planning/summary/{gameId}");
-        var unlimitedTask = Api.GetListAsync<UnlimitedItemDto>($"/api/treasure-planning/unlimited/{gameId}");
+        var poolTask       = Api.GetListAsync<TreasurePoolItemDto>($"/api/treasure-planning/pool/{gameId}");
+        var cardsTask      = Api.GetListAsync<TreasurePlanningLocationDto>($"/api/treasure-planning/locations/{gameId}");
+        var locationsTask  = Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gameId}");
+        var questTask      = Api.GetListAsync<TreasureQuestListDto>($"/api/treasure-quests/by-game/{gameId}");
+        var summaryTask    = Api.GetAsync<TreasureSummaryDto>($"/api/treasure-planning/summary/{gameId}");
+        var unlimitedTask  = Api.GetListAsync<UnlimitedItemDto>($"/api/treasure-planning/unlimited/{gameId}");
 
-        await Task.WhenAll(poolTask, locTask, questTask, summaryTask, unlimitedTask);
+        await Task.WhenAll(poolTask, cardsTask, locationsTask, questTask, summaryTask, unlimitedTask);
 
-        poolItems = poolTask.Result;
-        locationCards = locTask.Result;
-        allQuests = questTask.Result;
-        summary = summaryTask.Result;
+        poolItems      = poolTask.Result;
+        locationCards  = cardsTask.Result;
+        locations      = locationsTask.Result;
+        allQuests      = questTask.Result;
+        summary        = summaryTask.Result;
         unlimitedItems = unlimitedTask.Result;
+
+        // Prune selection of items that left the pool.
+        var poolIds = poolItems.Select(p => p.Id).ToHashSet();
+        selectedPool.RemoveAll(s => !poolIds.Contains(s.Id));
+
         loading = false;
     }
 
-    private async void OnGameChanged() { await LoadAllAsync(); StateHasChanged(); }
-    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
-
-    // === LOCATION CARDS ===
-    private string GetLocationIcon(LocationKind kind) => kind switch
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        LocationKind.Town => "\ud83c\udfe0",
-        LocationKind.Village => "\ud83c\udfe1",
-        LocationKind.Wilderness => "\ud83c\udf32",
-        LocationKind.Magical => "\u2728",
-        LocationKind.PointOfInterest => "\ud83d\udccd",
-        LocationKind.Dungeon => "\ud83d\udd73\ufe0f",
-        _ => "\ud83d\udccd"
+        await PlaceMarkersIfReadyAsync();
+    }
+
+    private async Task PlaceMarkersIfReadyAsync()
+    {
+        if (mapView is null || !styleLoaded || loading || markersPlaced) return;
+        markersPlaced = true;
+        await RenderAllMarkersAsync();
+    }
+
+    private async Task HandleStyleLoaded()
+    {
+        styleLoaded = true;
+        markersPlaced = false;
+        await PlaceMarkersIfReadyAsync();
+    }
+
+    private async Task RenderAllMarkersAsync()
+    {
+        if (mapView is null) return;
+        await mapView.ClearPieMarkersAsync();
+
+        var maxCount = Math.Max(1, locationCards
+            .SelectMany(l => new[] { l.StartCount, l.EarlyCount, l.MidgameCount, l.LategameCount })
+            .DefaultIfEmpty(0).Max());
+
+        // Fit map to the game's locations.
+        var placed = locations.Where(l => l.Latitude.HasValue && l.Longitude.HasValue).ToList();
+        if (placed.Count > 0)
+        {
+            var minLat = (double)placed.Min(l => l.Latitude!.Value);
+            var maxLat = (double)placed.Max(l => l.Latitude!.Value);
+            var minLon = (double)placed.Min(l => l.Longitude!.Value);
+            var maxLon = (double)placed.Max(l => l.Longitude!.Value);
+            if (Math.Abs(maxLat - minLat) > 0.0005 || Math.Abs(maxLon - minLon) > 0.0005)
+            {
+                await mapView.FitBoundsAsync(minLat, minLon, maxLat, maxLon);
+            }
+            else
+            {
+                await mapView.SetCenterAsync(minLat, minLon, 15);
+            }
+        }
+
+        foreach (var loc in placed)
+        {
+            var card = locationCards.FirstOrDefault(c => c.LocationId == loc.Id);
+            if (card is null || card.TotalItems == 0)
+            {
+                await mapView.AddZeroMarkerAsync(loc.Id,
+                    (double)loc.Latitude!.Value, (double)loc.Longitude!.Value,
+                    loc.Name, KindSlug(loc.LocationKind));
+            }
+            else
+            {
+                var counts = new[] { card.StartCount, card.EarlyCount, card.MidgameCount, card.LategameCount };
+                await mapView.AddPieMarkerAsync(loc.Id,
+                    (double)loc.Latitude!.Value, (double)loc.Longitude!.Value,
+                    counts, maxCount);
+            }
+        }
+
+        await mapView.SetStageFilterAsync(activeStages);
+    }
+
+    private static string KindSlug(LocationKind k) => k switch
+    {
+        LocationKind.Town => "town",
+        LocationKind.Village => "village",
+        LocationKind.Wilderness => "wilderness",
+        LocationKind.Magical => "magical",
+        LocationKind.PointOfInterest => "hobbit",
+        LocationKind.Dungeon => "magical",
+        _ => "wilderness"
     };
 
-    private string GetLocationName(int? locationId)
+    // ===== Handlers from MapView =====
+    private Task HandlePieClick(int locationId)
     {
-        if (locationId is null) return "";
-        return locationCards.FirstOrDefault(l => l.LocationId == locationId)?.LocationName ?? $"#{locationId}";
+        focusedLocationId = locationId;
+        focusTab = "prehled";
+        StateHasChanged();
+        return Task.CompletedTask;
     }
 
-    // === ASSIGN POPUP ===
-    private void OpenAssignPopup(TreasurePlanningLocationDto loc)
+    private async Task HandlePieDrop(PiePayloadEventArgs args)
     {
-        assignError = null;
-        assignLocationId = loc.LocationId;
-        assignStashId = null;
-        assignToStash = false;
-        assignLocationStashes = loc.Stashes;
-        assignDifficulty = lastUsedDifficulty;
-        assignClue = null;
-        assignUnlimitedItems = [];
-        newUnlimitedItemId = null;
-        newUnlimitedCount = 1;
-
-        // Capture selected pool items
-        assignSelectedPool = selectedPoolItems.Cast<TreasurePoolItemDto>().ToList();
-
-        // Auto-generate title
-        var itemPart = assignSelectedPool.Count switch
-        {
-            0 => "Poklad",
-            1 => assignSelectedPool[0].ItemName,
-            _ => $"{assignSelectedPool.Count} předmětů"
-        };
-        assignQuestTitle = $"{itemPart} @ {loc.LocationName}";
-        assignTitle = $"Schovat poklad — {loc.LocationName}";
-
-        isAssignVisible = true;
-    }
-
-    private void AddUnlimitedToAssign()
-    {
-        if (newUnlimitedItemId is null) return;
-        var item = unlimitedItems.FirstOrDefault(u => u.ItemId == newUnlimitedItemId.Value);
-        if (item is null) return;
-        // Update existing or add new
-        var existing = assignUnlimitedItems.FirstOrDefault(u => u.ItemId == item.ItemId);
-        if (existing is not null)
-            assignUnlimitedItems.Remove(existing);
-        assignUnlimitedItems.Add(new AssignUnlimitedItem(item.ItemId, item.ItemName, newUnlimitedCount));
-        newUnlimitedItemId = null;
-        newUnlimitedCount = 1;
-    }
-
-    private async Task ConfirmAssignAsync()
-    {
-        assignError = null; assignSaving = true;
+        // Payload: { PoolItemId, ItemId, ItemName, Count }
         try
         {
-            var dto = new AssignTreasureDto(
-                assignQuestTitle, assignDifficulty, gameId, assignClue,
-                assignToStash ? null : assignLocationId,
-                assignToStash ? assignStashId : null,
-                assignSelectedPool.Select(p => p.Id).ToList(),
-                assignUnlimitedItems.Select(u => new UnlimitedItemAssignDto(u.ItemId, u.Count)).ToList());
+            using var doc = System.Text.Json.JsonDocument.Parse(args.Payload);
+            var poolItemId = doc.RootElement.GetProperty("PoolItemId").GetInt32();
+            var picked = poolItems.FirstOrDefault(p => p.Id == poolItemId);
+            if (picked is null) return;
 
-            await Api.PostAsync<AssignTreasureDto, TreasureQuestDetailDto>("/api/treasure-planning/assign", dto);
-            lastUsedDifficulty = assignDifficulty;
-            isAssignVisible = false;
-            selectedPoolItems = [];
-            await LoadAllAsync();
+            // Ensure the dragged item is selected; keep any prior selection intact
+            // so the user can batch-drop multiple onto the same pin.
+            if (!IsSelected(picked)) selectedPool.Add(picked);
+
+            focusedLocationId = args.LocationId;
+            focusTab = "pridat";
             StateHasChanged();
+            await Task.CompletedTask;
         }
-        catch (Exception ex) { assignError = ex.Message; }
-        finally { assignSaving = false; }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Pie drop payload error: {ex.Message}");
+        }
     }
 
-    // === ADD TO POOL ===
+    // ===== Focus close =====
+    private void CloseFocus()
+    {
+        focusedLocationId = null;
+        focusTab = "prehled";
+    }
+
+    // ===== Save assignment =====
+    private async Task HandleAssignSaveAsync(AssignTreasureDto dto)
+    {
+        await Api.PostAsync<AssignTreasureDto, TreasureQuestDetailDto>("/api/treasure-planning/assign", dto);
+        lastUsedDifficulty = dto.Difficulty;
+        selectedPool.Clear();
+        markersPlaced = false;
+        await LoadAllAsync();
+        await PlaceMarkersIfReadyAsync();
+        focusTab = "prehled";
+        StateHasChanged();
+    }
+
+    // ===== Add-to-pool =====
     private async Task OpenAddToPoolModal()
     {
         poolError = null; poolItemId = null; poolItemCount = 1;
@@ -499,7 +658,8 @@ else
         try
         {
             await Api.PostAsync<CreateTreasurePoolItemDto, TreasurePoolItemDto>(
-                "/api/treasure-planning/pool", new CreateTreasurePoolItemDto(poolItemId.Value, gameId, poolItemCount));
+                "/api/treasure-planning/pool",
+                new CreateTreasurePoolItemDto(poolItemId.Value, gameId, poolItemCount));
             isAddPoolVisible = false;
             await LoadAllAsync();
             StateHasChanged();
@@ -508,7 +668,7 @@ else
         finally { poolSaving = false; }
     }
 
-    // === EDIT QUEST ===
+    // ===== Overview edit =====
     private void OpenEditQuestPopup(TreasureQuestListDto q)
     {
         editError = null;
@@ -555,7 +715,9 @@ else
                     editToStash ? null : editLocationId,
                     editToStash ? editStashId : null));
             isEditQuestVisible = false;
+            markersPlaced = false;
             await LoadAllAsync();
+            await PlaceMarkersIfReadyAsync();
             StateHasChanged();
         }
         catch (Exception ex) { editError = ex.Message; }
@@ -567,10 +729,35 @@ else
         try
         {
             await Api.DeleteAsync($"/api/treasure-quests/{editQuestId}");
-            isDeleteQuestVisible = false; isEditQuestVisible = false;
+            isDeleteQuestVisible = false;
+            isEditQuestVisible = false;
+            markersPlaced = false;
             await LoadAllAsync();
+            await PlaceMarkersIfReadyAsync();
             StateHasChanged();
         }
         catch (Exception ex) { editError = ex.Message; }
+    }
+
+    // ===== Helpers =====
+    private string GetLocationName(int? locationId)
+    {
+        if (locationId is null) return "";
+        return locationCards.FirstOrDefault(l => l.LocationId == locationId)?.LocationName
+            ?? locations.FirstOrDefault(l => l.Id == locationId)?.Name
+            ?? $"#{locationId}";
+    }
+
+    private string GetStashName(int? stashId)
+    {
+        if (stashId is null) return "";
+        return locationCards.SelectMany(l => l.Stashes)
+            .FirstOrDefault(s => s.Id == stashId)?.Name ?? $"skrýš #{stashId}";
+    }
+
+    private void ScrollToPool()
+    {
+        focusedLocationId = null;
+        StateHasChanged();
     }
 }

--- a/src/OvcinaHra.Client/wwwroot/css/app.css
+++ b/src/OvcinaHra.Client/wwwroot/css/app.css
@@ -32,6 +32,23 @@
     --oh-kingdom-lake: #1565C0;
     --oh-kingdom-arnor: #F9A825;
 
+    /* === Stage palette (canon — treasure-quest difficulty) === */
+    --oh-stage-start:    #7FA657;
+    --oh-stage-early:    #D4A63C;
+    --oh-stage-midgame:  #C17B3D;
+    --oh-stage-lategame: #8C2423;
+    --oh-stage-start-soft:    rgba(127, 166,  87, 0.14);
+    --oh-stage-early-soft:    rgba(212, 166,  60, 0.14);
+    --oh-stage-midgame-soft:  rgba(193, 123,  61, 0.14);
+    --oh-stage-lategame-soft: rgba(140,  36,  35, 0.12);
+
+    /* === Location kind (map marker dots — canon) === */
+    --oh-kind-town:       #2c3e50;
+    --oh-kind-village:    #27ae60;
+    --oh-kind-magical:    #8e44ad;
+    --oh-kind-hobbit:     #f39c12;
+    --oh-kind-wilderness: #16a085;
+
     /* === Status === */
     --oh-status-draft: #8B4513;
     --oh-status-active: #2D5016;

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2250,3 +2250,189 @@
 .oh-it-d-loading{padding:48px 16px;text-align:center;color:var(--oh-text-secondary);font-style:italic}
 .oh-it-d-empty{padding:48px 16px;text-align:center;color:var(--oh-text-secondary)}
 .oh-it-d-empty i{font-size:3rem;color:var(--oh-primary-light);opacity:.6;display:block;margin-bottom:10px}
+
+/* ============================================================
+   Stage chip (reusable — difficulty pill for treasure quests).
+   Used on treasure pool tiles, assignment panel, overview grid.
+   ============================================================ */
+.oh-stage-chip{display:inline-block;font:600 .6875rem var(--oh-font-body);padding:2px 9px;border-radius:99px;color:#fff;letter-spacing:.02em;line-height:1.5;white-space:nowrap}
+.oh-stage-chip-start{background:var(--oh-stage-start)}
+.oh-stage-chip-early{background:var(--oh-stage-early);color:#3a2612}
+.oh-stage-chip-mid  {background:var(--oh-stage-midgame)}
+.oh-stage-chip-midgame{background:var(--oh-stage-midgame)}
+.oh-stage-chip-late {background:var(--oh-stage-lategame)}
+.oh-stage-chip-lategame{background:var(--oh-stage-lategame)}
+
+/* ============================================================
+   Treasures Planning dashboard — scoped .oh-tp-*
+   Zone 1: pipeline (4 stage cards + Zásobník mini)
+   Zone 2: map (60fr) + assignment panel (40fr)
+   Zone 3: collapsible overview grid
+   ============================================================ */
+.oh-tp-page{display:flex;flex-direction:column;gap:16px;padding:4px 0}
+.oh-tp-loading{padding:48px 16px;text-align:center;color:var(--oh-text-secondary);font-style:italic}
+.oh-tp-empty{padding:48px 16px;text-align:center;color:var(--oh-text-secondary)}
+.oh-tp-empty i{font-size:3rem;color:var(--oh-primary-light);opacity:.6;display:block;margin-bottom:10px}
+
+/* Zone 1 — pipeline ---------------------------------------- */
+.oh-tp-pipeline{display:grid;grid-template-columns:1fr 1fr 1fr 1fr 160px;gap:12px;min-height:160px}
+.oh-tp-stage-card{position:relative;display:flex;flex-direction:column;padding:14px 16px 14px 22px;background:var(--oh-surface);border:1px solid var(--oh-card-border,var(--oh-border));border-radius:var(--oh-radius);box-shadow:var(--oh-shadow)}
+.oh-tp-stage-card::before{content:"";position:absolute;top:0;bottom:0;left:0;width:6px;background:var(--c,#7FA657);border-radius:var(--oh-radius) 0 0 var(--oh-radius)}
+.oh-tp-stage-card[data-stage="start"]{--c:var(--oh-stage-start)}
+.oh-tp-stage-card[data-stage="early"]{--c:var(--oh-stage-early)}
+.oh-tp-stage-card[data-stage="mid"]{--c:var(--oh-stage-midgame)}
+.oh-tp-stage-card[data-stage="midgame"]{--c:var(--oh-stage-midgame)}
+.oh-tp-stage-card[data-stage="late"]{--c:var(--oh-stage-lategame)}
+.oh-tp-stage-card[data-stage="lategame"]{--c:var(--oh-stage-lategame)}
+.oh-tp-stage-card.oh-tp-empty-state{opacity:.62}
+.oh-tp-stage-card-hdr{display:flex;align-items:baseline;justify-content:space-between;gap:8px}
+.oh-tp-stage-card-nm{font:700 1rem var(--oh-font-heading);color:var(--oh-primary);letter-spacing:.005em}
+.oh-tp-stage-card-goal{font:italic 400 .75rem var(--oh-font-body);color:var(--oh-text-secondary)}
+.oh-tp-stage-card-numline{display:flex;align-items:baseline;gap:8px;margin-top:2px}
+.oh-tp-stage-card-num{font:500 2.4rem/1 var(--oh-font-mono);color:var(--oh-text,#2a2a2a);letter-spacing:-.02em}
+.oh-tp-stage-card.oh-tp-empty-state .oh-tp-stage-card-num{color:var(--oh-text-secondary)}
+.oh-tp-stage-card-unit{font:400 .8125rem var(--oh-font-body);color:var(--oh-text-secondary)}
+.oh-tp-stage-card-progress{margin-top:8px;height:4px;background:var(--oh-surface-alt);border-radius:99px;overflow:hidden;border:1px solid var(--oh-border)}
+.oh-tp-stage-card-progress-fill{height:100%;background:var(--c);transition:.3s ease width}
+.oh-tp-stage-card-strip{margin-top:auto;display:flex;flex-wrap:wrap;gap:3px;align-content:flex-start;min-height:22px;padding-top:8px}
+.oh-tp-stage-card-cell{width:12px;height:12px;border-radius:2px;background:var(--c);opacity:.9;box-shadow:inset 0 0 0 1px rgba(0,0,0,.08)}
+.oh-tp-stage-card-cell.k-elves{background:var(--oh-kingdom-elves)}
+.oh-tp-stage-card-cell.k-dwarves{background:var(--oh-kingdom-dwarves)}
+.oh-tp-stage-card-cell.k-lake{background:var(--oh-kingdom-lake)}
+.oh-tp-stage-card-cell.k-arnor{background:var(--oh-kingdom-arnor)}
+
+/* Zásobník mini-card ----------------------------------------- */
+.oh-tp-pool-mini{display:flex;flex-direction:column;padding:14px 16px;background:var(--oh-surface);border:1px solid var(--oh-card-border,var(--oh-border));border-radius:var(--oh-radius);box-shadow:var(--oh-shadow);cursor:pointer;transition:border-color .15s,box-shadow .15s}
+.oh-tp-pool-mini:hover{border-color:var(--oh-primary-light);box-shadow:var(--oh-shadow-lg)}
+.oh-tp-pool-mini.oh-tp-empty-state{opacity:.62}
+.oh-tp-pool-mini-lbl{font:600 .6875rem var(--oh-font-body);text-transform:uppercase;letter-spacing:.08em;color:var(--oh-text-secondary);display:flex;align-items:center;gap:4px}
+.oh-tp-pool-mini-lbl i{color:var(--oh-card-border,#8B6F47);font-size:.75rem}
+.oh-tp-pool-mini-num{font:500 2.4rem/1 var(--oh-font-mono);color:var(--oh-primary);margin-top:6px}
+.oh-tp-pool-mini.oh-tp-empty-state .oh-tp-pool-mini-num{color:var(--oh-text-secondary)}
+.oh-tp-pool-mini-sub{font:400 .8125rem var(--oh-font-body);color:var(--oh-text-secondary);margin-top:2px}
+.oh-tp-pool-mini-jump{margin-top:auto;font:600 .75rem var(--oh-font-body);color:var(--oh-primary-light);display:inline-flex;align-items:center;gap:4px}
+
+/* Zone 2 — workspace --------------------------------------- */
+.oh-tp-workspace{display:grid;grid-template-columns:60fr 40fr;gap:16px;min-height:520px}
+.oh-tp-map-panel{display:flex;flex-direction:column;background:var(--oh-surface);border:1px solid var(--oh-card-border,var(--oh-border));border-radius:var(--oh-radius);box-shadow:var(--oh-shadow);overflow:hidden}
+.oh-tp-stage-filter{display:flex;align-items:center;gap:8px;padding:10px 12px;border-bottom:1px solid var(--oh-border);background:var(--oh-surface-alt);flex-wrap:wrap}
+.oh-tp-stage-filter-lbl{font:600 .75rem var(--oh-font-body);color:var(--oh-text-secondary);text-transform:uppercase;letter-spacing:.06em;margin-right:4px}
+.oh-tp-filter-chip{font:600 .75rem var(--oh-font-body);padding:4px 12px;border-radius:99px;border:1px solid var(--oh-border);background:var(--oh-surface);color:var(--oh-text-secondary);cursor:pointer;user-select:none;transition:all .15s}
+.oh-tp-filter-chip:hover{border-color:var(--oh-primary-light);color:var(--oh-primary)}
+.oh-tp-filter-chip.active{background:var(--c,var(--oh-primary));border-color:var(--c,var(--oh-primary));color:#fff}
+.oh-tp-filter-chip[data-stage="start"]{--c:var(--oh-stage-start)}
+.oh-tp-filter-chip[data-stage="early"]{--c:var(--oh-stage-early);color:var(--oh-text)}
+.oh-tp-filter-chip[data-stage="early"].active{color:#3a2612}
+.oh-tp-filter-chip[data-stage="mid"],.oh-tp-filter-chip[data-stage="midgame"]{--c:var(--oh-stage-midgame)}
+.oh-tp-filter-chip[data-stage="late"],.oh-tp-filter-chip[data-stage="lategame"]{--c:var(--oh-stage-lategame)}
+.oh-tp-filter-chip[data-stage="all"]{--c:var(--oh-primary)}
+.oh-tp-map-host{flex:1;min-height:480px;position:relative;background:#e8e4d8}
+.oh-tp-map-toolbar{display:flex;align-items:center;gap:8px;padding:8px 12px;border-top:1px solid var(--oh-border);background:var(--oh-surface);font-size:.8125rem;color:var(--oh-text-secondary)}
+.oh-tp-map-toolbar-spacer{flex:1}
+.oh-tp-map-count{font-family:var(--oh-font-mono);color:var(--oh-text);font-size:.8125rem}
+
+/* Pie pins (SVG built in JS — only positioning + state CSS here) */
+.oh-tp-pin{cursor:pointer;transition:transform .15s ease,filter .15s ease}
+.oh-tp-pin-pie{width:64px;height:64px}
+.oh-tp-pin-pie:hover{transform:scale(1.06);filter:drop-shadow(0 4px 8px rgba(40,25,5,.5));z-index:8}
+.oh-tp-pin-svg{display:block}
+.oh-tp-pin-backing{fill:rgba(245,237,227,.92);stroke:none}
+.oh-tp-pin-ring{fill:none;stroke:var(--oh-card-border,#8B6F47);stroke-width:2.5}
+.oh-tp-pin-inner{fill:rgba(255,248,240,.95);stroke:#6b5a3a;stroke-width:1}
+.oh-tp-pin-num{font:700 .75rem var(--oh-font-mono);fill:var(--oh-text,#2a2a2a);pointer-events:none;dominant-baseline:middle}
+.oh-tp-wedge{transition:opacity .2s}
+.oh-tp-wedge-start{fill:var(--oh-stage-start)}
+.oh-tp-wedge-early{fill:var(--oh-stage-early)}
+.oh-tp-wedge-mid  {fill:var(--oh-stage-midgame)}
+.oh-tp-wedge-late {fill:var(--oh-stage-lategame)}
+.oh-tp-pin-zero{width:10px;height:10px;border-radius:50%;background:var(--c,#666);border:1.5px solid rgba(255,255,255,.85);box-shadow:0 1px 2px rgba(0,0,0,.4);opacity:.85}
+.oh-tp-pin-zero[data-kind="town"]{--c:var(--oh-kind-town)}
+.oh-tp-pin-zero[data-kind="village"]{--c:var(--oh-kind-village)}
+.oh-tp-pin-zero[data-kind="magical"]{--c:var(--oh-kind-magical)}
+.oh-tp-pin-zero[data-kind="hobbit"]{--c:var(--oh-kind-hobbit)}
+.oh-tp-pin-zero[data-kind="wilderness"]{--c:var(--oh-kind-wilderness)}
+.oh-tp-pin-zero[data-kind="pointofinterest"]{--c:var(--oh-kind-town)}
+.oh-tp-pin-zero[data-kind="dungeon"]{--c:var(--oh-kind-magical)}
+.oh-tp-pin-dragtarget{transform:scale(1.18);filter:drop-shadow(0 0 0 4px rgba(212,166,60,.55)) drop-shadow(0 4px 8px rgba(40,25,5,.5));z-index:9;position:relative}
+.oh-tp-pin-dragtarget::after{content:"+";position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);font:700 1.6rem var(--oh-font-mono);color:var(--oh-stage-early);text-shadow:0 1px 2px rgba(0,0,0,.5);pointer-events:none}
+
+/* Assignment panel ----------------------------------------- */
+.oh-tp-assign-panel{display:flex;flex-direction:column;background:var(--oh-surface);border:1px solid var(--oh-card-border,var(--oh-border));border-radius:var(--oh-radius);box-shadow:var(--oh-shadow);overflow:hidden;min-height:520px}
+.oh-tp-assign-hdr{display:flex;align-items:center;gap:10px;padding:12px 14px;border-bottom:1px solid var(--oh-border);background:var(--oh-surface-alt)}
+.oh-tp-assign-hdr h5{margin:0;font:700 1rem var(--oh-font-heading);color:var(--oh-primary);flex:1}
+.oh-tp-assign-hdr .oh-tp-close{background:none;border:none;font-size:1.1rem;cursor:pointer;color:var(--oh-text-secondary);padding:2px 6px;line-height:1}
+.oh-tp-assign-hdr .oh-tp-close:hover{color:var(--oh-primary)}
+.oh-tp-assign-body{flex:1;overflow-y:auto;padding:14px}
+.oh-tp-assign-filters{display:flex;gap:6px;margin-bottom:10px;flex-wrap:wrap}
+.oh-tp-assign-tabs{display:flex;gap:2px;padding:6px 10px 0;border-bottom:1px solid var(--oh-border);background:var(--oh-surface-alt)}
+.oh-tp-assign-tab{font:600 .8125rem var(--oh-font-body);padding:8px 14px;background:none;border:none;border-bottom:3px solid transparent;color:var(--oh-text-secondary);cursor:pointer}
+.oh-tp-assign-tab.active{color:var(--oh-primary);border-bottom-color:var(--oh-primary)}
+
+/* Pool grid (5:7 MTG tiles) -------------------------------- */
+.oh-tp-pool-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(110px,1fr));gap:8px}
+.oh-tp-pool-grid.oh-tp-pool-compact{grid-template-columns:repeat(auto-fill,minmax(84px,1fr))}
+.oh-tp-pool-tile{position:relative;aspect-ratio:5/7;border-radius:8px;border:1px solid var(--oh-card-border,var(--oh-border));background:var(--oh-surface-alt);cursor:grab;user-select:none;overflow:hidden;box-shadow:var(--oh-shadow);transition:transform .15s,box-shadow .15s}
+.oh-tp-pool-tile:hover{transform:translateY(-2px);box-shadow:0 6px 14px rgba(45,80,22,.25);z-index:3}
+.oh-tp-pool-tile:active{cursor:grabbing}
+.oh-tp-pool-tile.selected{border-color:var(--oh-primary);box-shadow:0 0 0 2px var(--oh-primary-light) inset,var(--oh-shadow-lg)}
+.oh-tp-pool-tile-dragging{opacity:.5;transform:rotate(-3deg) scale(.98)}
+.oh-tp-pool-tile-img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
+.oh-tp-pool-tile-fallback{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:1.5rem;color:var(--oh-primary-light);background:var(--oh-surface-alt)}
+.oh-tp-pool-tile-name{position:absolute;left:4px;right:4px;bottom:4px;font:600 .75rem var(--oh-font-body);color:#fff;text-shadow:0 1px 3px rgba(0,0,0,.8);line-height:1.15;max-height:2.3em;overflow:hidden}
+.oh-tp-pool-tile-badge{position:absolute;top:4px;right:4px;background:rgba(45,80,22,.92);color:#fff;border-radius:99px;padding:1px 6px;font:600 .6875rem var(--oh-font-mono);letter-spacing:.01em}
+
+/* Drag hint banner */
+.oh-tp-drag-hint{display:flex;align-items:center;gap:8px;padding:8px 12px;background:var(--oh-stage-early-soft);border:1px dashed var(--oh-stage-early);border-radius:var(--oh-radius-sm);color:var(--oh-text);font-size:.8125rem;margin-bottom:8px}
+.oh-tp-drag-hint i{color:var(--oh-stage-early)}
+
+/* Location focus — Přehled list */
+.oh-tp-focus-summary{display:flex;align-items:center;gap:12px;padding:10px;background:var(--oh-primary-surface);border-radius:var(--oh-radius-sm);margin-bottom:10px}
+.oh-tp-focus-stats{display:flex;flex-wrap:wrap;gap:10px;font-family:var(--oh-font-mono);font-size:.8125rem}
+.oh-tp-focus-stats .sw{display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:5px;vertical-align:middle}
+.oh-tp-focus-quest{display:flex;align-items:center;gap:8px;padding:8px 10px;background:var(--oh-surface);border:1px solid var(--oh-border);border-radius:var(--oh-radius-sm);margin-bottom:6px;cursor:pointer;transition:border-color .15s}
+.oh-tp-focus-quest:hover{border-color:var(--oh-primary-light)}
+.oh-tp-focus-quest-title{flex:1;font:600 .875rem var(--oh-font-body);color:var(--oh-text)}
+.oh-tp-focus-quest-meta{font-size:.75rem;color:var(--oh-text-secondary);font-family:var(--oh-font-mono)}
+.oh-tp-focus-stash-hdr{font:600 .75rem var(--oh-font-body);color:var(--oh-text-secondary);text-transform:uppercase;letter-spacing:.06em;margin:10px 0 6px}
+.oh-tp-focus-group-hdr{display:flex;align-items:center;gap:6px;font:700 .875rem var(--oh-font-heading);color:var(--oh-primary);margin:10px 0 6px}
+.oh-tp-focus-group-hdr .sw{width:10px;height:10px;border-radius:2px}
+
+/* Assignment form */
+.oh-tp-form-row{margin-bottom:12px}
+.oh-tp-form-label{font:600 .8125rem var(--oh-font-body);color:var(--oh-text-secondary);margin-bottom:4px;display:block}
+.oh-tp-stage-picker{display:grid;grid-template-columns:repeat(4,1fr);gap:6px}
+.oh-tp-stage-picker label{position:relative;display:flex;flex-direction:column;align-items:center;gap:4px;padding:8px 6px;border:1px solid var(--oh-border);border-radius:var(--oh-radius-sm);background:var(--oh-surface);cursor:pointer;transition:all .15s;font:600 .75rem var(--oh-font-body);color:var(--oh-text-secondary)}
+.oh-tp-stage-picker label:hover{border-color:var(--c);color:var(--oh-text)}
+.oh-tp-stage-picker label[data-stage="start"]{--c:var(--oh-stage-start)}
+.oh-tp-stage-picker label[data-stage="early"]{--c:var(--oh-stage-early)}
+.oh-tp-stage-picker label[data-stage="mid"],.oh-tp-stage-picker label[data-stage="midgame"]{--c:var(--oh-stage-midgame)}
+.oh-tp-stage-picker label[data-stage="late"],.oh-tp-stage-picker label[data-stage="lategame"]{--c:var(--oh-stage-lategame)}
+.oh-tp-stage-picker input{position:absolute;opacity:0;pointer-events:none}
+.oh-tp-stage-picker input:checked + .oh-tp-stage-picker-chip,
+.oh-tp-stage-picker label:has(input:checked){background:var(--c);color:#fff;border-color:var(--c)}
+.oh-tp-stage-picker label[data-stage="early"]:has(input:checked){color:#3a2612}
+.oh-tp-target-radios{display:flex;gap:10px;align-items:center;padding:8px;background:var(--oh-surface-alt);border-radius:var(--oh-radius-sm)}
+.oh-tp-target-radios label{display:inline-flex;align-items:center;gap:6px;font:600 .8125rem var(--oh-font-body);color:var(--oh-text);cursor:pointer}
+.oh-tp-target-radios input[disabled] + span{color:var(--oh-text-secondary);cursor:not-allowed}
+.oh-tp-unlimited-toggle{display:flex;align-items:center;gap:8px;padding:10px;background:var(--oh-stage-early-soft);border:1px dashed var(--oh-stage-early);border-radius:var(--oh-radius-sm);margin:8px 0}
+.oh-tp-unlimited-toggle i{color:var(--oh-stage-early)}
+.oh-tp-unlimited-pick{display:flex;gap:6px;align-items:end;margin-top:8px}
+.oh-tp-chosen-items{margin-top:10px}
+.oh-tp-chosen-row{display:flex;align-items:center;gap:8px;padding:4px 0;font-size:.8125rem}
+.oh-tp-chosen-row .remove{background:none;border:none;color:var(--oh-error);cursor:pointer;padding:0 4px}
+.oh-tp-form-footer{display:flex;gap:8px;justify-content:flex-end;align-items:center;padding-top:12px;border-top:1px solid var(--oh-border);margin-top:12px}
+.oh-tp-form-footer .spacer{flex:1}
+
+/* Zone 3 — overview ---------------------------------------- */
+.oh-tp-z3{background:var(--oh-surface);border:1px solid var(--oh-card-border,var(--oh-border));border-radius:var(--oh-radius);box-shadow:var(--oh-shadow);overflow:hidden}
+.oh-tp-z3-bar{display:flex;align-items:center;gap:10px;padding:10px 14px;background:var(--oh-surface-alt);border-bottom:1px solid var(--oh-border);cursor:pointer;user-select:none}
+.oh-tp-z3-bar h5{margin:0;flex:1;font:700 .9375rem var(--oh-font-heading);color:var(--oh-primary)}
+.oh-tp-z3-bar i{color:var(--oh-primary);transition:transform .2s}
+.oh-tp-z3.collapsed .oh-tp-z3-bar i{transform:rotate(-90deg)}
+.oh-tp-z3-body{padding:10px}
+
+/* Responsive ----------------------------------------------- */
+@media (max-width:1100px){
+    .oh-tp-pipeline{grid-template-columns:repeat(2,1fr);grid-auto-rows:auto}
+    .oh-tp-workspace{grid-template-columns:1fr;min-height:auto}
+}

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2408,7 +2408,6 @@
 .oh-tp-stage-picker label[data-stage="mid"],.oh-tp-stage-picker label[data-stage="midgame"]{--c:var(--oh-stage-midgame)}
 .oh-tp-stage-picker label[data-stage="late"],.oh-tp-stage-picker label[data-stage="lategame"]{--c:var(--oh-stage-lategame)}
 .oh-tp-stage-picker input{position:absolute;opacity:0;pointer-events:none}
-.oh-tp-stage-picker input:checked + .oh-tp-stage-picker-chip,
 .oh-tp-stage-picker label:has(input:checked){background:var(--c);color:#fff;border-color:var(--c)}
 .oh-tp-stage-picker label[data-stage="early"]:has(input:checked){color:#3a2612}
 .oh-tp-target-radios{display:flex;gap:10px;align-items:center;padding:8px;background:var(--oh-surface-alt);border-radius:var(--oh-radius-sm)}

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -339,3 +339,199 @@ window.ovcinaMiniMap = {
         delete this._instances[elementId];
     }
 };
+
+// ----------------------------------------------------------------------
+// Pie-wedge markers for /treasures planning.
+// Fixed-quadrant layout — Start=NE, Early=SE, Mid=SW, Late=NW — with
+// per-stage wedge radius scaled by count / maxCount. Unfilled portion
+// shows a muted parchment disc beneath the coloured wedges. Pie markers
+// are tracked separately from ovcinaMap._markers so the /map and
+// /treasures pages never collide.
+// ----------------------------------------------------------------------
+window.ovcinaMap._pieMarkers = {};
+window.ovcinaMap._zeroMarkers = {};
+window.ovcinaMap._activePieStages = null; // Set<string> | null (null = all active)
+
+window.ovcinaMap._buildPieSvg = function (counts, maxCount) {
+    var c0 = counts[0] | 0, c1 = counts[1] | 0, c2 = counts[2] | 0, c3 = counts[3] | 0;
+    var total = c0 + c1 + c2 + c3;
+    var cap = Math.max(1, maxCount || total);
+    var maxR = 28;
+    var stages = ['start', 'early', 'mid', 'late'];
+    // Each wedge occupies a fixed 90° quadrant. Path uses a small arc.
+    // Paths below are parameterised by `r` (scaled radius per stage).
+    var paths = [
+        function (r) { return 'M0,0 L0,' + (-r) + ' A' + r + ',' + r + ' 0 0 1 ' + r + ',0 Z'; }, // NE / Start
+        function (r) { return 'M0,0 L' + r + ',0 A' + r + ',' + r + ' 0 0 1 0,' + r + ' Z'; }, // SE / Early
+        function (r) { return 'M0,0 L0,' + r + ' A' + r + ',' + r + ' 0 0 1 ' + (-r) + ',0 Z'; }, // SW / Mid
+        function (r) { return 'M0,0 L' + (-r) + ',0 A' + r + ',' + r + ' 0 0 1 0,' + (-r) + ' Z'; } // NW / Late
+    ];
+    var svg = '<svg width="64" height="64" viewBox="-32 -32 64 64" class="oh-tp-pin-svg">';
+    // Parchment backing disc (shows through in unfilled portions).
+    svg += '<circle class="oh-tp-pin-backing" r="' + maxR + '" cx="0" cy="0" />';
+    // Coloured wedges at scaled radius (skip zero-count stages).
+    var cs = [c0, c1, c2, c3];
+    for (var i = 0; i < 4; i++) {
+        if (cs[i] <= 0) continue;
+        var r = Math.max(6, maxR * Math.min(1, cs[i] / cap));
+        svg += '<path class="oh-tp-wedge oh-tp-wedge-' + stages[i] + '" data-stage="' + stages[i] + '" d="' + paths[i](r.toFixed(2)) + '"/>';
+    }
+    // Outer ring + inner numeral disc.
+    svg += '<circle class="oh-tp-pin-ring" r="' + (maxR + 1) + '" cx="0" cy="0" />';
+    svg += '<circle class="oh-tp-pin-inner" r="10" cx="0" cy="0" />';
+    svg += '<text class="oh-tp-pin-num" x="0" y="4" text-anchor="middle">' + total + '</text>';
+    svg += '</svg>';
+    return svg;
+};
+
+window.ovcinaMap._wireDropTarget = function (element, locationId) {
+    var self = this;
+    element.addEventListener('dragover', function (e) {
+        e.preventDefault();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+        element.classList.add('oh-tp-pin-dragtarget');
+    });
+    element.addEventListener('dragleave', function () {
+        element.classList.remove('oh-tp-pin-dragtarget');
+    });
+    element.addEventListener('drop', function (e) {
+        e.preventDefault();
+        element.classList.remove('oh-tp-pin-dragtarget');
+        var payload = e.dataTransfer && e.dataTransfer.getData('application/x-oh-pool-item');
+        if (self._dotnetRef && payload) {
+            self._dotnetRef.invokeMethodAsync('OnPieMarkerDropped', locationId, payload);
+        }
+    });
+};
+
+window.ovcinaMap.addPieMarker = function (id, lat, lon, counts, maxCount) {
+    if (!this._map) return;
+    this.removePieMarker(id);
+    var wrap = document.createElement('div');
+    wrap.className = 'oh-tp-pin oh-tp-pin-pie';
+    wrap.setAttribute('data-pie-id', id);
+    wrap.innerHTML = this._buildPieSvg(counts, maxCount);
+
+    var self = this;
+    wrap.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnPieMarkerClicked', id);
+    });
+    this._wireDropTarget(wrap, id);
+
+    var marker = new maplibregl.Marker({ element: wrap, anchor: 'center' })
+        .setLngLat([lon, lat])
+        .addTo(this._map);
+
+    this._pieMarkers[id] = { marker: marker, element: wrap, counts: counts.slice() };
+    this._applyStageFilterToElement(wrap);
+};
+
+window.ovcinaMap.updatePieMarkerCounts = function (id, counts, maxCount) {
+    var rec = this._pieMarkers[id];
+    if (!rec) return;
+    rec.counts = counts.slice();
+    rec.element.innerHTML = this._buildPieSvg(counts, maxCount);
+    this._applyStageFilterToElement(rec.element);
+};
+
+window.ovcinaMap.removePieMarker = function (id) {
+    var rec = this._pieMarkers[id];
+    if (rec) {
+        try { rec.marker.remove(); } catch (e) { /* ignore */ }
+        delete this._pieMarkers[id];
+    }
+};
+
+window.ovcinaMap.addZeroMarker = function (id, lat, lon, name, kind) {
+    if (!this._map) return;
+    this.removeZeroMarker(id);
+    var dot = document.createElement('div');
+    dot.className = 'oh-tp-pin oh-tp-pin-zero';
+    dot.setAttribute('data-kind', (kind || 'wilderness').toLowerCase());
+    dot.title = name || '';
+    var self = this;
+    dot.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnPieMarkerClicked', id);
+    });
+    this._wireDropTarget(dot, id);
+    var marker = new maplibregl.Marker({ element: dot, anchor: 'center' })
+        .setLngLat([lon, lat])
+        .addTo(this._map);
+    this._zeroMarkers[id] = { marker: marker, element: dot };
+};
+
+window.ovcinaMap.removeZeroMarker = function (id) {
+    var rec = this._zeroMarkers[id];
+    if (rec) {
+        try { rec.marker.remove(); } catch (e) { /* ignore */ }
+        delete this._zeroMarkers[id];
+    }
+};
+
+window.ovcinaMap.clearPieMarkers = function () {
+    for (var id in this._pieMarkers) {
+        try { this._pieMarkers[id].marker.remove(); } catch (e) { /* ignore */ }
+    }
+    this._pieMarkers = {};
+    for (var zid in this._zeroMarkers) {
+        try { this._zeroMarkers[zid].marker.remove(); } catch (e) { /* ignore */ }
+    }
+    this._zeroMarkers = {};
+};
+
+window.ovcinaMap._applyStageFilterToElement = function (el) {
+    var active = this._activePieStages;
+    var wedges = el.querySelectorAll('[data-stage]');
+    for (var i = 0; i < wedges.length; i++) {
+        var s = wedges[i].getAttribute('data-stage');
+        wedges[i].style.opacity = (!active || active.has(s)) ? '1' : '0.15';
+    }
+};
+
+window.ovcinaMap.setStageFilter = function (stages) {
+    this._activePieStages = (stages && stages.length > 0) ? new Set(stages) : null;
+    for (var id in this._pieMarkers) {
+        this._applyStageFilterToElement(this._pieMarkers[id].element);
+    }
+};
+
+// ----------------------------------------------------------------------
+// Tiny HTML5-DnD helper — lets Blazor pool tiles set a payload without
+// round-tripping DataTransfer through C#. Registers a native dragstart
+// on the element; on drop, the pie-marker side reads
+// 'application/x-oh-pool-item'. setDraggable is idempotent.
+// ----------------------------------------------------------------------
+window.ovcinaDnd = {
+    _wired: new WeakMap(),
+
+    setDraggable: function (element, payload) {
+        if (!element) return;
+        if (this._wired.has(element)) {
+            this._wired.set(element, payload);
+            return;
+        }
+        this._wired.set(element, payload);
+        element.setAttribute('draggable', 'true');
+        var self = this;
+        element.addEventListener('dragstart', function (e) {
+            var p = self._wired.get(element);
+            if (!p) return;
+            if (e.dataTransfer) {
+                e.dataTransfer.setData('application/x-oh-pool-item', p);
+                e.dataTransfer.effectAllowed = 'move';
+            }
+            element.classList.add('oh-tp-pool-tile-dragging');
+        });
+        element.addEventListener('dragend', function () {
+            element.classList.remove('oh-tp-pool-tile-dragging');
+        });
+    },
+
+    clear: function (element) {
+        if (!element) return;
+        this._wired.delete(element);
+        element.removeAttribute('draggable');
+    }
+};

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -479,7 +479,28 @@ window.ovcinaMap.clearPieMarkers = function () {
         try { this._zeroMarkers[zid].marker.remove(); } catch (e) { /* ignore */ }
     }
     this._zeroMarkers = {};
+    this._activePieStages = null;
 };
+
+// Wrap switchStyle + dispose so style changes and teardown also wipe pie/zero
+// markers (the original methods only touched ._markers). Prevents DOM leaks
+// when the /treasures page switches map style or the user navigates away.
+(function () {
+    var originalSwitchStyle = window.ovcinaMap.switchStyle;
+    if (typeof originalSwitchStyle === 'function') {
+        window.ovcinaMap.switchStyle = function () {
+            try { this.clearPieMarkers(); } catch (e) { /* ignore */ }
+            return originalSwitchStyle.apply(this, arguments);
+        };
+    }
+    var originalDispose = window.ovcinaMap.dispose;
+    if (typeof originalDispose === 'function') {
+        window.ovcinaMap.dispose = function () {
+            try { this.clearPieMarkers(); } catch (e) { /* ignore */ }
+            return originalDispose.apply(this, arguments);
+        };
+    }
+})();
 
 window.ovcinaMap._applyStageFilterToElement = function (el) {
     var active = this._activePieStages;
@@ -533,5 +554,12 @@ window.ovcinaDnd = {
         if (!element) return;
         this._wired.delete(element);
         element.removeAttribute('draggable');
+    },
+
+    // Generic DOM helper used by pages that want a smooth scroll to a known
+    // anchor id without a full JS interop round-trip per handler.
+    scrollIntoViewById: function (elementId) {
+        var el = document.getElementById(elementId);
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
 };


### PR DESCRIPTION
## Summary

Three-zone `/treasures` rewrite per the Claude Design mockup (Variant A pie pins, Kanon stage palette, drag-and-drop from pool to map pin).

- **Zone 1**: 4 stage pipeline cards (Start / Rozvoj hry / Střed hry / Závěr hry) + Zásobník mini-card with PoolRemaining numeral.
- **Zone 2** (60fr / 40fr): MapLibre tile with **4-wedge pie pins** (fixed-quadrant + radius-scaling) left; assignment panel right in three states — Default (pool grid), Location-focus (Přehled + Přidat poklad tabs), Drag-target (pie-pin grows + `+` overlay).
- **Zone 3**: collapsible DxGrid overview grouped by stage. `LayoutKey` bumped `grid-layout-treasure-overview` → `grid-layout-treasures-v2`.

## Implementation notes

- **New components**: `StageChip.razor` (reusable pill), `StagePipelineCard.razor`, `TreasurePoolTile.razor` (draggable 5:7 MTG tile), `TreasureAssignForm.razor`.
- **`map-interop.js`** — extended `ovcinaMap` with `addPieMarker / updatePieMarkerCounts / removePieMarker / addZeroMarker / removeZeroMarker / clearPieMarkers / setStageFilter`. New `window.ovcinaDnd` bridges Blazor pool tiles to native HTML5 DnD (`application/x-oh-pool-item` MIME).
- **Pie-pin SVG** — 64×64 viewBox, outer ring r=29, parchment backing disc, colored wedges at scaled radii (`min(1, count/max) * 28`), inner disc + total-count numeral. Empty stages show parchment only.
- **`MapView.razor`** — gets `OnPieMarkerClick` / `OnPieMarkerDrop` event callbacks + async wrappers (`AddPieMarkerAsync`, `SetStageFilterAsync`, etc.). New `PiePayloadEventArgs` record.
- **Stage palette canon** (`app.css :root`) — `--oh-stage-start / early / midgame / lategame` + `*-soft` rgba variants. Also `--oh-kind-*` for LocationKind zero-marker dots.
- **`.oh-tp-*` block** appended to `ovcinahra-theme.css` (~180 lines). Reusable `.oh-stage-chip-*` also added.
- **Preserved** — XOR `LocationId` / `SecretStashId` invariant validated on the form + server. Nekonečný (`UnlimitedItems`) path kept alongside pool-consumption path. Delete routes through DxPopup confirm. Destructive action rule honored.

## Testing

- `dotnet build OvcinaHra.slnx -c Debug` — clean, **0 warnings** (`TreatWarningsAsErrors=true`).
- `dotnet test tests/OvcinaHra.Api.Tests` — **274/274 passed**.
- `tests/OvcinaHra.E2E` — 7/8 passed; the one failure (`LocationManagementTests.FullLocationLifecycle_CreateEditDelete`) is **pre-existing**, unrelated to `/treasures`, and E2E is not in CI (`api-ci.yml` runs only `OvcinaHra.Api.Tests`). Playwright E2E infra is known broken per skill notes — deferred.

## Test plan

- [ ] `/treasures` renders the 4 stage cards + Zásobník; counts match `TreasureSummaryDto`.
- [ ] Map shows pie-wedge pins per location with treasures; wedge radius scales with per-stage count. Zero-treasure locations render as small kind-colored dots.
- [ ] Stage filter chips above the map — click one to toggle, click "Všechny" to clear; inactive stages fade to 15% opacity.
- [ ] Click a pin → right panel switches to Location focus (Přehled lists existing quests grouped by stage).
- [ ] "Přidat poklad" tab → form submits both pool-consumption and Nekonečný paths; `LocationId XOR SecretStashId` validated.
- [ ] Drag a pool tile onto a pin → pin grows with `+` overlay; drop prefills Přidat poklad with dragged item + target location.
- [ ] Zone 3 collapsible — expands to DxGrid grouped by Difficulty. Row click opens edit popup. Delete routes through confirm popup.
- [ ] Czech diacritics render throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)