### PR TITLE
[v0.15.7] SecretStashDetail hero loads full SAS URL

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.6</Version>
+    <Version>0.15.7</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashDetail.razor
+++ b/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashDetail.razor
@@ -203,7 +203,7 @@ else
         try
         {
             stash = await Api.GetAsync<SecretStashDetailDto>($"/api/secret-stashes/{Id}");
-            if (stash is not null)
+            if (stash is not null && !string.IsNullOrWhiteSpace(stash.ImagePath))
             {
                 try
                 {

--- a/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashDetail.razor
+++ b/src/OvcinaHra.Client/Pages/SecretStashes/SecretStashDetail.razor
@@ -38,9 +38,9 @@ else
 {
     <div class="row g-4">
         <div class="col-md-4">
-            @if (!string.IsNullOrEmpty(stash.ImageUrl) && !imageFailed)
+            @if (!string.IsNullOrEmpty(mainImageUrl) && !imageFailed)
             {
-                <img src="@stash.ImageUrl" alt="@stash.Name"
+                <img src="@mainImageUrl" alt="@stash.Name"
                      class="img-fluid rounded border w-100"
                      style="aspect-ratio:5/7;object-fit:cover"
                      @onerror="() => imageFailed = true" />
@@ -158,6 +158,7 @@ else
     private SecretStashDetailDto? stash;
     private SecretStashGameDetailDto? gameDetail;
     private string? gameDetailError;
+    private string? mainImageUrl;
     private bool loading = true;
     private string? error;
     private bool imageFailed;
@@ -196,11 +197,21 @@ else
         error = null;
         gameDetailError = null;
         imageFailed = false;
+        mainImageUrl = null;
         _lastId = Id;
         _lastGameId = GameContext.SelectedGameId;
         try
         {
             stash = await Api.GetAsync<SecretStashDetailDto>($"/api/secret-stashes/{Id}");
+            if (stash is not null)
+            {
+                try
+                {
+                    var urls = await Api.GetAsync<ImageUrlsDto>($"/api/images/secretstashes/{Id}");
+                    mainImageUrl = urls?.ImageUrl;
+                }
+                catch { mainImageUrl = null; }
+            }
             if (stash is not null && GameContext.SelectedGameId is int gid)
             {
                 try


### PR DESCRIPTION
## Summary
- SecretStashDetail hero now fetches the full-resolution blob SAS URL via `GET /api/images/secretstashes/{Id}` instead of binding the thumbnail URL that ships in `SecretStashDetailDto.ImageUrl`.
- Matches the **grid = thumb / detail = full SAS** rule established in the v0.13.0 image-sourcing pass (memory: `feedback_ovcinahra_image_sourcing_rule`).
- Pattern mirrors `LocationDetail.razor:466-469`.

## Changes
- `src/OvcinaHra.Client/Pages/SecretStashes/SecretStashDetail.razor` — new `mainImageUrl` field fetched post-stash-load, rendered by the hero `<img>`, reset on re-navigation; `<img @onerror>` state flag + `bi-box-seam` fallback glyph preserved.
- `src/OvcinaHra.Client/OvcinaHra.Client.csproj` — `<Version>` 0.15.6 → 0.15.7.

## Verification
- [x] `dotnet build` clean with `TreatWarningsAsErrors=true`.
- [x] Null-safe: `ApiClient.GetAsync<ImageUrlsDto>` 404 → `null` → hero shows the existing fallback glyph.
- [x] Catches any exception from the image-urls call so a transient blob failure doesn't take the whole page down.
- [ ] Manual smoke test post-deploy: open a secret stash with an image, confirm hero loads the full SAS (not thumb).

## Notes
- Leaves `Pages/Items/ItemList.razor:258` quick-peek as an open follow-up — same rule, different surface, tracked separately.
- No migration, no DB changes, no grid `LayoutKey` bump (not a grid change).
- Deploy verification: after merge, `curl https://api.hra.ovcina.cz/api/version` should report the squash-merge commit within ~8 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)