### PR TITLE
[v0.15.8] Locations list — image height, actions column, detail link (closes #94)

### DIFF
--- a/src/OvcinaHra.Client/Components/LocationGridImageTile.razor
+++ b/src/OvcinaHra.Client/Components/LocationGridImageTile.razor
@@ -16,6 +16,7 @@
         <img class="oh-lg-loc-tile-img"
              src="@Location.ImageUrl"
              alt="@Location.Name"
+             loading="lazy"
              @onload="() => imageLoaded = true"
              @onerror="() => imageFailed = true" />
         <div class="oh-lg-loc-tile-img-veil"></div>

--- a/src/OvcinaHra.Client/Components/LocationGridImageTile.razor
+++ b/src/OvcinaHra.Client/Components/LocationGridImageTile.razor
@@ -1,0 +1,44 @@
+@* LocationGridImageTile — primary-image cell inside LocationList's Obrázek
+   column. Mirrors LocationGridStashTile sizing (aspect-ratio 5/7 + the
+   .oh-lg-loc-tile styling) so the row height of a location with images
+   lines up with its neighbouring stash tiles. No name label — the grid's
+   Name column owns the caption. *@
+
+@using OvcinaHra.Shared.Dtos
+
+<div class="oh-lg-loc-tile" title="@Location.Name">
+    @if (!imageLoaded || imageFailed)
+    {
+        <i class="oh-lg-glyph bi bi-image-fill" aria-hidden="true"></i>
+    }
+    @if (!string.IsNullOrEmpty(Location.ImageUrl) && !imageFailed)
+    {
+        <img class="oh-lg-loc-tile-img"
+             src="@Location.ImageUrl"
+             alt="@Location.Name"
+             @onload="() => imageLoaded = true"
+             @onerror="() => imageFailed = true" />
+        <div class="oh-lg-loc-tile-img-veil"></div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public LocationListDto Location { get; set; } = null!;
+
+    private bool imageLoaded;
+    private bool imageFailed;
+    private string? _lastUrl;
+
+    protected override void OnParametersSet()
+    {
+        // Reset state when the component is reused for a different location —
+        // otherwise a previously-loaded flag would suppress the glyph while
+        // the new src is still fetching.
+        if (_lastUrl != Location.ImageUrl)
+        {
+            _lastUrl = Location.ImageUrl;
+            imageLoaded = false;
+            imageFailed = false;
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Components/LocationGridStashTile.razor
+++ b/src/OvcinaHra.Client/Components/LocationGridStashTile.razor
@@ -26,7 +26,6 @@
     <span class="oh-lg-qcount @(Stash.TreasureQuests.Count == 0 ? "oh-lg-zero" : "")">
         <i class="bi bi-journal-text"></i>@Stash.TreasureQuests.Count
     </span>
-    <div class="oh-lg-nm">@Stash.Name</div>
     @if (Stash.TreasureQuests.Count > 0)
     {
         <div class="oh-lg-flyout">

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.6</Version>
+    <Version>0.15.8</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -84,9 +84,50 @@ else
 {
     <OvcinaGrid Data="@visibleRows"
                 KeyFieldName="Id"
-                LayoutKey="grid-layout-locations-v4"
+                LayoutKey="grid-layout-locations-v5"
                 RowClick="@OnGridRowClick">
         <Columns>
+            @* Actions — moved to first column per issue #94. Destructive
+               delete lives on the detail page now; list keeps non-destructive
+               actions + Otevřít detail as the explicit navigation affordance. *@
+            <DxGridDataColumn Caption="Akce" Width="170px"
+                              AllowSort="false" AllowGroup="false"
+                              FixedPosition="GridColumnFixedPosition.Left">
+                <CellDisplayTemplate>
+                    @{
+                        var loc = (LocationListDto)context.DataItem;
+                    }
+                    <div class="oh-lg-actions-cell">
+                        <div class="oh-lg-actions">
+                            <button type="button"
+                                    title="Otevřít detail"
+                                    @onclick="() => OpenDetail(loc)"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-box-arrow-up-right"></i>
+                            </button>
+                            <button type="button"
+                                    title="Nastavit GPS"
+                                    @onclick="() => OpenGpsDialog(loc)"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-geo-alt-fill"></i>
+                            </button>
+                            <button type="button"
+                                    title="Přiřadit quest (propojit)"
+                                    @onclick="() => OpenLinkDialog(loc)"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-link-45deg"></i>
+                            </button>
+                            <button type="button"
+                                    title="Otevřít na mapě"
+                                    @onclick="() => OpenOnMap(loc)"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-map-fill"></i>
+                            </button>
+                        </div>
+                    </div>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
             @* Marker dot — 40px, fixed left *@
             <DxGridDataColumn FieldName="LocationKind" Caption="" Width="40px"
                               AllowSort="false" AllowGroup="false"
@@ -195,6 +236,29 @@ else
                             <span class="oh-lg-parent-ref text-muted">—</span>
                         }
                     }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            @* Primary location image — mirrors stash-tile sizing so a row
+               with no stashes but with an image keeps the same height as a
+               row with tiles. Hidden by default outside the column chooser
+               only if the organizer opts out. *@
+            <DxGridDataColumn FieldName="ImageUrl" Caption="Obrázek" Width="120px"
+                              AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{
+                        var loc = (LocationListDto)context.DataItem;
+                    }
+                    <div class="oh-lg-loc-cell @(string.IsNullOrEmpty(loc.ImageUrl) ? "oh-lg-none" : "")">
+                        @if (!string.IsNullOrEmpty(loc.ImageUrl))
+                        {
+                            <LocationGridImageTile @key="loc.Id" Location="loc" />
+                        }
+                        else
+                        {
+                            <span>—</span>
+                        }
+                    </div>
                 </CellDisplayTemplate>
             </DxGridDataColumn>
 
@@ -311,47 +375,6 @@ else
                 </CellDisplayTemplate>
             </DxGridDataColumn>
 
-            @* Hover-reveal action icons (replaces 3-dot menu) *@
-            <DxGridDataColumn Caption="Akce" Width="150px"
-                              AllowSort="false" AllowGroup="false"
-                              TextAlignment="GridTextAlignment.Right"
-                              FixedPosition="GridColumnFixedPosition.Right">
-                <CellDisplayTemplate>
-                    @{
-                        var loc = (LocationListDto)context.DataItem;
-                    }
-                    <div class="oh-lg-actions-cell">
-                        <div class="oh-lg-actions">
-                            <button type="button"
-                                    title="Nastavit GPS"
-                                    @onclick="() => OpenGpsDialog(loc)"
-                                    @onclick:stopPropagation="true">
-                                <i class="bi bi-geo-alt-fill"></i>
-                            </button>
-                            <button type="button"
-                                    title="Přiřadit quest (propojit)"
-                                    @onclick="() => OpenLinkDialog(loc)"
-                                    @onclick:stopPropagation="true">
-                                <i class="bi bi-link-45deg"></i>
-                            </button>
-                            <button type="button"
-                                    title="Otevřít na mapě"
-                                    @onclick="() => OpenOnMap(loc)"
-                                    @onclick:stopPropagation="true">
-                                <i class="bi bi-map-fill"></i>
-                            </button>
-                            <button type="button"
-                                    class="oh-lg-danger"
-                                    title="Smazat"
-                                    @onclick="() => RequestDelete(loc)"
-                                    @onclick:stopPropagation="true">
-                                <i class="bi bi-trash-fill"></i>
-                            </button>
-                        </div>
-                    </div>
-                </CellDisplayTemplate>
-            </DxGridDataColumn>
-
             @* Hidden-by-default columns (preserved for column chooser) *@
             <DxGridDataColumn FieldName="Id" Caption="#" Width="50px" Visible="false" />
             <DxGridDataColumn FieldName="Description" Caption="Popis" Width="300px" Visible="false" />
@@ -458,29 +481,10 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
-@* Smazat — destructive action confirmation popup (required per MEMORY) *@
-<DxPopup @bind-Visible="@isDeleteConfirmVisible" HeaderText="Smazat lokaci?" Width="420px">
-    <BodyContentTemplate Context="popupContext">
-        <p class="mb-3">
-            Opravdu chcete smazat lokaci <strong>@deleteTarget?.Name</strong>?
-            Tento krok nelze vrátit zpět.
-        </p>
-        @if (deleteError is not null)
-        {
-            <div class="alert alert-danger py-2">@deleteError</div>
-        }
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="() => isDeleteConfirmVisible = false" disabled="@isSaving">Zrušit</button>
-            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync" disabled="@isSaving">
-                @if (isSaving)
-                {
-                    <span class="spinner-border spinner-border-sm me-1"></span>
-                }
-                Smazat
-            </button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
+@* Destructive delete now lives on the Location detail page — per issue #94
+   the list no longer ships a delete button, and this confirmation popup is
+   gone with it. If reintroduced, remember the MEMORY destructive-action-
+   confirm rule and keep the Api.DeleteAsync bool-return check. *@
 
 @code {
     [SupplyParameterFromQuery]
@@ -494,7 +498,6 @@ else
     private bool loading = true;
     private bool isGpsVisible;
     private bool isLinkVisible;
-    private bool isDeleteConfirmVisible;
     private bool isSaving;
 
     // Toolbar filter state
@@ -510,10 +513,6 @@ else
     // Precomputed variant counts — cell template runs per rendered row, so
     // pulling `locations.Count(...)` there was O(n²). Filled in LoadDataAsync.
     private Dictionary<int, int> variantCountByParent = new();
-
-    // Delete target
-    private LocationListDto? deleteTarget;
-    private string? deleteError;
 
     // GPS dialog state
     private LocationListDto? gpsTarget;
@@ -608,32 +607,9 @@ else
         Nav.NavigateTo($"/locations/{loc.Id}");
     }
 
-    // Delete flow — confirmation popup first, then Api.DeleteAsync with bool-return check.
-    private void RequestDelete(LocationListDto loc)
+    private void OpenDetail(LocationListDto loc)
     {
-        deleteTarget = loc;
-        deleteError = null;
-        isDeleteConfirmVisible = true;
-    }
-
-    private async Task ConfirmDeleteAsync()
-    {
-        if (deleteTarget is null) return;
-        deleteError = null;
-        isSaving = true;
-        try
-        {
-            var ok = await Api.DeleteAsync($"/api/locations/{deleteTarget.Id}");
-            if (!ok)
-            {
-                deleteError = "Nepodařilo se smazat lokaci. Možná je použita v některé hře.";
-                return;
-            }
-            isDeleteConfirmVisible = false;
-            deleteTarget = null;
-            await LoadDataAsync();
-        }
-        finally { isSaving = false; }
+        Nav.NavigateTo($"/locations/{loc.Id}");
     }
 
     private void OpenOnMap(LocationListDto loc)

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -241,8 +241,8 @@ else
 
             @* Primary location image — mirrors stash-tile sizing so a row
                with no stashes but with an image keeps the same height as a
-               row with tiles. Hidden by default outside the column chooser
-               only if the organizer opts out. *@
+               row with tiles. Shown by default; organizer can hide via
+               the column chooser. *@
             <DxGridDataColumn FieldName="ImageUrl" Caption="Obrázek" Width="120px"
                               AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -1581,6 +1581,36 @@
 .oh-lg-stash-cell.oh-lg-none{align-items:center !important}
 .oh-lg-stash-cell.oh-lg-none span{color:var(--oh-text-secondary);font-style:italic;font-size:.75rem}
 
+/* Location primary-image tile — sibling of .oh-lg-stash-tile for the
+   Obrázek column in /locations. Same aspect-ratio (5/7) so rows with a
+   location image line up in height with rows that only show stash tiles. */
+.oh-lg-loc-tile{
+  aspect-ratio:5/7;width:100%;max-width:100px;
+  border:1px solid #7a5a3d;border-radius:5px;
+  box-shadow:0 1px 3px rgba(45,80,22,.18), inset 0 0 0 1px rgba(255,248,230,.15);
+  transition:.18s;position:relative;overflow:hidden;min-width:0;
+  background:linear-gradient(145deg,#c8d4a8 0%,#8fab6a 60%,#5a7a3d 100%);
+}
+.oh-lg-loc-tile:hover{transform:translateY(-2px);box-shadow:0 4px 12px rgba(45,80,22,.3);z-index:5}
+.oh-lg-loc-tile > img.oh-lg-loc-tile-img{
+  position:absolute;inset:0;width:100%;height:100%;
+  object-fit:cover;z-index:1;display:block;
+}
+.oh-lg-loc-tile > .oh-lg-loc-tile-img-veil{
+  position:absolute;inset:0;pointer-events:none;z-index:2;
+  background:
+    radial-gradient(ellipse at 30% 35%,rgba(255,248,230,.18) 0%,transparent 55%),
+    linear-gradient(180deg,transparent 55%,rgba(20,12,4,.45) 100%);
+}
+.oh-lg-loc-tile > i.oh-lg-glyph{
+  position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);
+  color:rgba(255,248,230,.85);font-size:1.6rem;z-index:1;
+  text-shadow:0 1px 3px rgba(0,0,0,.5);
+}
+.oh-lg-loc-cell{padding:8px 10px !important;align-items:flex-start !important}
+.oh-lg-loc-cell.oh-lg-none{align-items:center !important}
+.oh-lg-loc-cell.oh-lg-none span{color:var(--oh-text-secondary);font-style:italic;font-size:.75rem}
+
 /* ============================================================
    EMPTY STATE
    ============================================================ */


### PR DESCRIPTION
## Summary
Addresses all 5 asks in #94.

- **Primary-image column** — new `LocationGridImageTile` component (aspect-ratio 5/7, 100px wide) keeps image-only rows matching the height of rows packed with stash tiles.
- **Stash-name caption dropped** from `LocationGridStashTile` — flyout still names the stash on hover; the Name column already carries the label.
- **Akce column moved** from fixed-right to fixed-left, now the first column.
- **"Otevřít detail" action** added to the actions cluster with `bi-box-arrow-up-right`. Navigates to `/locations/{id}` (the same route `RowClick` used to hit implicitly).
- **Smazat action removed** from the list. Destructive delete now lives only on `/locations/{id}`. The entire delete-confirmation popup, `RequestDelete`/`ConfirmDeleteAsync` handlers, and `deleteTarget`/`deleteError`/`isDeleteConfirmVisible` state are gone from `LocationList.razor`.

## LayoutKey bump — `grid-layout-locations-v4` → `grid-layout-locations-v5`
Column reorder + new Obrázek column. Existing users' saved layouts would otherwise replay against a schema that no longer matches.

## Verification
- [x] `dotnet build` clean with `TreatWarningsAsErrors=true`
- [x] LayoutKey bumped (per `feedback_ovcinagrid_layoutkey_bump`)
- [x] csproj `<Version>` 0.15.6 → 0.15.8 (skipping 0.15.7, claimed by PR #105)
- [x] `RowClick` still navigates to detail page
- [ ] Manual smoke test post-deploy: open /locations, verify Akce column is first, image column aligns with stash rows, detail action works, no Smazat button

## Files
- `src/OvcinaHra.Client/Components/LocationGridImageTile.razor` (new)
- `src/OvcinaHra.Client/Components/LocationGridStashTile.razor`
- `src/OvcinaHra.Client/Pages/Locations/LocationList.razor`
- `src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css`
- `src/OvcinaHra.Client/OvcinaHra.Client.csproj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)