### PR TITLE
[v0.15.9] Monster detail — Soubojová karta rename, drop bojovka tab, fix Category chip (closes #100)

### DIFF
--- a/src/OvcinaHra.Client/Components/MonsterRow.razor
+++ b/src/OvcinaHra.Client/Components/MonsterRow.razor
@@ -43,7 +43,7 @@
     <div class="oh-mon-actions" @onclick:stopPropagation="true">
         <button type="button" title="Upravit" @onclick="HandleEdit"><i class="bi bi-pencil"></i></button>
         <button type="button" title="Přidat kořist" @onclick="HandleAddLoot"><i class="bi bi-plus-square"></i></button>
-        <button type="button" title="Zkoušet (Bojovka)" @onclick="HandleBattle"><i class="bi bi-play-fill"></i></button>
+        <button type="button" title="Zkoušet (Soubojová karta)" @onclick="HandleBattle"><i class="bi bi-play-fill"></i></button>
         <button type="button" class="oh-mon-danger" title="Smazat" @onclick="HandleDelete"><i class="bi bi-trash"></i></button>
     </div>
 

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.8</Version>
+    <Version>0.15.9</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterDetail.razor
@@ -39,9 +39,9 @@ else
                     <i class="bi @MonsterTypeIcon(monster.MonsterType)"></i>@monster.MonsterType.GetDisplayName()
                 </span>
                 <span class="oh-mon-d-dotsep">·</span>
-                <span class="oh-mon-d-kbadge"><i class="bi bi-bar-chart-steps"></i>K@monster.Category</span>
+                <span class="oh-mon-d-kbadge"><i class="bi bi-bar-chart-steps"></i>K@(monster.Category)</span>
                 <span class="oh-mon-d-dotsep">·</span>
-                <span class="oh-mon-d-id">#M@monster.Id.ToString("D3")</span>
+                <span class="oh-mon-d-id">#M@(monster.Id.ToString("D3"))</span>
             </div>
         </div>
         <div class="oh-mon-d-ts-actions">
@@ -65,9 +65,6 @@ else
         </button>
         <button class="oh-mon-d-tab @(activeTab == "upravit" ? "oh-mon-d-active" : null)" @onclick='() => SetTab("upravit")'>
             <i class="bi bi-pencil"></i> Upravit
-        </button>
-        <button class="oh-mon-d-tab @(activeTab == "bojovka" ? "oh-mon-d-active" : null)" @onclick='() => SetTab("bojovka")'>
-            <i class="bi bi-shield-shaded"></i> Bojovka
         </button>
         <button class="oh-mon-d-tab @(activeTab == "korist" ? "oh-mon-d-active" : null)" @onclick='() => SetTab("korist")'>
             <i class="bi bi-gem"></i> Kořist
@@ -209,7 +206,7 @@ else
                         <ImagePicker EntityType="monsters" EntityId="monster.Id" Alt="Obrázek příšery" AspectRatio="4:3" />
                     </DxFormLayoutItem>
                 </DxFormLayoutGroup>
-                <DxFormLayoutGroup Caption="Bojovka" ColSpanMd="12">
+                <DxFormLayoutGroup Caption="Soubojová karta" ColSpanMd="12">
                     <DxFormLayoutItem Caption="Útok" ColSpanMd="4">
                         <DxSpinEdit @bind-Value="@editAttack" MinValue="0" />
                     </DxFormLayoutItem>
@@ -257,52 +254,6 @@ else
                 <button class="btn btn-secondary" @onclick="CancelEdit" disabled="@isSaving">Zrušit</button>
                 <button class="btn btn-primary" @onclick="SaveAsync"
                         disabled="@(isSaving || string.IsNullOrWhiteSpace(editName))">Uložit</button>
-            </div>
-        }
-        else if (activeTab == "bojovka")
-        {
-            <div class="oh-mon-d-bestiary">
-                <div class="oh-mon-d-bojovka">
-                    <div class="oh-mon-d-hp">
-                        <span class="oh-mon-d-hp-current">Životy: @tempHp / @monster.Health</span>
-                        <button type="button" @onclick="() => tempHp -= 1">−1 Život</button>
-                        <button type="button" @onclick="() => tempHp += 1">+1 Život</button>
-                        <button type="button" @onclick="() => tempHp = monster!.Health">resetovat</button>
-                    </div>
-                    <div class="oh-mon-d-bigstats">
-                        <div class="oh-mon-d-bigstat">
-                            <span class="oh-mon-d-bigstat-lab">Útok</span>
-                            <span class="oh-mon-d-bigstat-val">@monster.Attack</span>
-                        </div>
-                        <div class="oh-mon-d-bigstat">
-                            <span class="oh-mon-d-bigstat-lab">Obrana</span>
-                            <span class="oh-mon-d-bigstat-val">@monster.Defense</span>
-                        </div>
-                        <div class="oh-mon-d-bigstat">
-                            <span class="oh-mon-d-bigstat-lab">Životy</span>
-                            <span class="oh-mon-d-bigstat-val">@monster.Health</span>
-                        </div>
-                    </div>
-                    @if (!string.IsNullOrWhiteSpace(monster.Abilities))
-                    {
-                        <div>
-                            <div class="oh-mon-d-sect-label"><i class="bi bi-magic"></i>Schopnosti</div>
-                            <ol class="oh-mon-d-abilities-list">
-                                @foreach (var line in SplitLines(monster.Abilities))
-                                {
-                                    <li>@line</li>
-                                }
-                            </ol>
-                        </div>
-                    }
-                    @if (!string.IsNullOrWhiteSpace(monster.AiBehavior))
-                    {
-                        <div>
-                            <div class="oh-mon-d-sect-label"><i class="bi bi-cpu"></i>AI chování</div>
-                            <blockquote class="oh-mon-d-ai-quote">@monster.AiBehavior</blockquote>
-                        </div>
-                    }
-                </div>
             </div>
         }
         else if (activeTab == "korist")
@@ -495,9 +446,6 @@ else
     private string? editAbilities, editAiBehavior, editRewardNotes, editNotes;
     private int editRewardXp, editRewardMoney;
 
-    // Bojovka local-only HP counter
-    private int tempHp;
-
     // Kořist tab data
     private List<MonsterLootByGameDto>? lootGroups;
     private Dictionary<int, string?> itemImageUrls = new();
@@ -542,7 +490,6 @@ else
             if (monster is not null)
             {
                 ResetEditFromMonster();
-                tempHp = monster.Health;
                 heroImageFailed = false;
                 heroImageUrl = null;
                 if (!string.IsNullOrWhiteSpace(monster.ImagePath))
@@ -576,11 +523,7 @@ else
     private async Task SetTab(string tab)
     {
         activeTab = tab;
-        if (tab == "bojovka" && monster is not null)
-        {
-            tempHp = monster.Health;
-        }
-        else if (tab == "korist")
+        if (tab == "korist")
         {
             if (lootGroups is null) await LoadLootGroupsAsync();
             if (allItems.Count == 0) allItems = await Api.GetListAsync<ItemListDto>("/api/items");
@@ -751,9 +694,6 @@ else
         }
         catch (Exception ex) { error = ex.Message; isRemoveFromGameVisible = false; }
     }
-
-    private static IEnumerable<string> SplitLines(string s)
-        => s.Split('\n', StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()).Where(line => line.Length > 0);
 
     private static string MonsterTypeIcon(MonsterType t) => t switch
     {

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
@@ -95,7 +95,7 @@ else
                             OnRowClick="@(() => OpenQuickPeekAsync(captured))"
                             OnEdit="@(() => OpenEditModal(captured))"
                             OnAddLoot="@(() => OpenEditModal(captured))"
-                            OnBattle="@(() => Nav.NavigateTo($"/monsters/{captured.Id}?tab=bojovka"))"
+                            OnBattle="@(() => Nav.NavigateTo($"/monsters/{captured.Id}"))"
                             OnDelete="@(() => RequestDeleteFromRow(captured))"
                             OnAssign="@(() => AssignMonsterAsync(captured.Id))" />
             }


### PR DESCRIPTION
## Summary
Closes #100. Three distinct changes in the Monster detail area:

1. **Rename "Bojovka" → "Soubojová karta"** in user-facing text only.
2. **Drop the Bojovka tab** from `MonsterDetail.razor` — the mini-game it fronted no longer exists. 5 tabs → 4 (Karta, Upravit, Kořist, Výskyt).
3. **Fix broken `.Category` + `.Id` chip rendering** in the title strip.

## The `.Category` bug — Razor email-detector

The chip strip was rendering raw template text (`"K@monster.Category"`, `"#M@monster.Id.ToString(\"D3\")"`) instead of evaluated values. Root cause: Razor treats `letter@letter` as a literal `name@domain` email pattern and skips expression evaluation.

```razor
<!-- Broken: Razor sees K@M and treats the whole token as literal text -->
<span class="oh-mon-d-kbadge">…K@monster.Category</span>
<span class="oh-mon-d-id">#M@monster.Id.ToString("D3")</span>

<!-- Fixed: explicit-expression parens force evaluation -->
<span class="oh-mon-d-kbadge">…K@(monster.Category)</span>
<span class="oh-mon-d-id">#M@(monster.Id.ToString("D3"))</span>
```

**Note on briefing over-reach:** the original briefing suggested the `ItemTypeDisplay` / `GetDisplayName()` enum pattern. `Monster.Category` is **not** an enum — it's a plain `int` (tier 0–10, edited via `DxSpinEdit`). No enum display getter added. Chip now renders `K3` (or whatever the tier int is) as intended. If `Category` becomes an enum later, that's a separate model + migration + DTO change.

## Orphan cleanup (from the tab drop)
- Removed `else if (activeTab == "bojovka")` content block
- Removed `private int tempHp` field + both `tempHp = monster.Health` assignments
- Removed `SplitLines` helper (only used by bojovka tab)
- Removed the `if (tab == "bojovka")` branch from `SetTab`
- `MonsterList.razor:98` dropped `?tab=bojovka` query param since target tab is gone — `OnBattle` now navigates to `/monsters/{id}` (lands on default Karta).

## Kept on purpose (code identifiers stay English)
- `.oh-mon-d-bojovka` CSS class is now orphan but harmless — the "Only user-visible text changes" memory rule keeps it as-is.
- A couple of comments in `ovcinahra-theme.css` still say "Bojovka presenter" — intentionally kept as historical markers.

## Verification
- [x] `dotnet build` clean with `TreatWarningsAsErrors=true`
- [x] `grep -rI 'Bojovka'` finds only CSS comments + the orphan class — no user-visible regressions
- [x] `grep -rI 'Soubojová karta'` shows the two intended replacements (form group caption + row button tooltip)
- [x] No grid column changes → no `LayoutKey` bump required
- [x] No DTO/enum/aggregate endpoint changes
- [ ] Manual smoke post-deploy: open any monster detail, verify title chips read "K{tier} · #M{id}" and there are only 4 tabs

## Version
`<Version>` 0.15.8 → 0.15.9. Parallel PR Hra2 takes 0.15.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)