### PR TITLE
[v0.15.11] Item peek popup — Otevřít detail action (closes #101)

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.10</Version>
+    <Version>0.15.11</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -241,8 +241,7 @@ else
 }
 
 @* Quick-peek popup — 720x480, 360px hero photo left + fields right.
-   Opens on row click; "Otevřít detail →" navigates to /items/{id} (will 404
-   until the detail page ships in a follow-up — flagged in the PR body). *@
+   Opens on row click; "Otevřít detail →" navigates to /items/{id}. *@
 <DxPopup @bind-Visible="@isQuickPeekVisible" HeaderText="@(quickPeekItem?.Name ?? "Předmět")" Width="720px">
     <BodyContentTemplate Context="qpCtx">
         @if (quickPeekItem is null)
@@ -305,9 +304,8 @@ else
                     <button class="btn btn-outline-primary" @onclick="OpenEditFromQuickPeek">
                         <i class="bi bi-pencil"></i> Upravit
                     </button>
-                    @* Disabled until /items/{id} ships in a follow-up port — would 404 today. *@
-                    <button class="btn btn-primary" disabled
-                            title="Detail předmětu zatím není hotový — sleduj follow-up.">
+                    <button class="btn btn-primary"
+                            @onclick="@(() => Nav.NavigateTo($"/items/{quickPeekItem!.Id}"))">
                         Otevřít detail <i class="bi bi-arrow-right"></i>
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
Closes #101. Enables the "Otevřít detail" action in the item peek popup footer — navigates to `/items/{id}` (the detail page from PR #90).

## The fix was smaller than it looked

An "Otevřít detail" button was **already** present in `ItemList.razor:309-312` as a **disabled placeholder** left behind by the original quick-peek port, back when `/items/{id}` didn't exist yet. PR #90 shipped the detail page in February but the placeholder was never un-disabled.

This PR just:
- Drops the `disabled` attribute + the `title="Detail předmětu zatím není hotový…"` placeholder tooltip.
- Wires the `@onclick` to `NavigationManager.NavigateTo($"/items/{quickPeekItem!.Id}")`.
- Removes the obsolete comment above `<DxPopup>` (lines 244-245) that warned about the 404 — no longer true.

Pattern mirrored from `MonsterList.razor:162-168` (peek popup footer "Otevřít detail"). `NavigationManager` was already injected as `Nav` at line 5.

## Changes
- `src/OvcinaHra.Client/Pages/Items/ItemList.razor` — -6 / +2 (net removal; more comment & `disabled` attr gone than handler added)
- `src/OvcinaHra.Client/OvcinaHra.Client.csproj` — `<Version>` 0.15.10 → 0.15.11

## Verification
- [x] `dotnet build` clean with `TreatWarningsAsErrors=true`
- [x] Pattern consistent with `MonsterList.razor` peek footer
- [x] `NavigationManager` already injected
- [ ] Manual smoke post-deploy: open `/items`, click any grid row → peek popup → Otevřít detail → should land on `/items/{id}`

## Version
`<Version>` 0.15.10 → 0.15.11. Parallel PR Hra2 takes 0.15.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)