### PR TITLE
[v0.15.13] Item peek popup — 5:7 aspect, adaptive image sizing (closes #95)

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.12</Version>
+    <Version>0.15.13</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2162,10 +2162,10 @@
 .oh-it-fcell--lit-gold{background:rgba(249,168,37,.18);border-color:rgba(249,168,37,.55);color:#8a6b0d}
 .oh-it-fcell--lit-bordeaux{background:rgba(140,36,35,.10);border-color:rgba(140,36,35,.40);color:#8c2423}
 
-/* Quick-peek popup — 720x480, 360px hero photo left + fields right */
+/* Quick-peek popup — 720px wide, 360px MTG-card (5:7) hero left + fields right */
 .oh-it-qp-grid{display:grid;grid-template-columns:360px 1fr;gap:20px;padding:4px 4px 14px;align-items:start}
 @media (max-width:768px){.oh-it-qp-grid{grid-template-columns:1fr}}
-.oh-it-qp-hero{width:100%;aspect-ratio:4/3;border-radius:var(--oh-radius);overflow:hidden;background:var(--oh-surface-alt);border:1px solid var(--oh-border);display:flex;align-items:center;justify-content:center}
+.oh-it-qp-hero{width:100%;aspect-ratio:5/7;border-radius:var(--oh-radius);overflow:hidden;background:var(--oh-surface-alt);border:1px solid var(--oh-border);display:flex;align-items:center;justify-content:center}
 .oh-it-qp-hero img{width:100%;height:100%;object-fit:cover;display:block}
 .oh-it-qp-hero .oh-it-photo-empty{font-size:4rem}
 .oh-it-qp-fields{display:flex;flex-direction:column;gap:12px;min-width:0}


### PR DESCRIPTION
## Summary
Closes #95. Item cards share MTG / Bicycle 5:7 proportions — the quick-peek popup hero was boxing them into 4:3 and cropping card tops/bottoms.

## Change
**Single CSS value flip** on `.oh-it-qp-hero`:
```css
/* aspect-ratio: 4/3 → aspect-ratio: 5/7 */
```

Hero column stays 360 px wide, grows from 270 px tall to 504 px tall. Popup width unchanged (720 px), popup grows vertically.

`object-fit: cover` was already in place on the inner `<img>` — that gives the "adaptive resize based on source image size" the issue asks for: any source aspect (portrait photo, square illustration, panoramic weapon shot) fills the 5:7 frame exactly, with crop coming from whichever dimension overhangs. **Chose cover over contain** per the briefing guardrail (matches the grid tile pattern + card look). Letterboxed `contain` is a trivial follow-up if you ever prefer no-crop.

Block comment on `.oh-it-qp-hero` refreshed from "720x480" to reflect the MTG-card hero shape.

## Files
- `src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css` — aspect-ratio + comment (4 lines changed)
- `src/OvcinaHra.Client/OvcinaHra.Client.csproj` — `<Version>` 0.15.12 → 0.15.13

**No `.razor` changes.** The popup markup already uses `.oh-it-qp-hero` correctly; only the CSS rule was wrong. `@onload`/`@onerror` state on the img stays. "Otevřít detail" button from PR #114 stays. No grid column changes → no `LayoutKey` bump.

## Verification
- [x] `dotnet build` clean with `TreatWarningsAsErrors=true`
- [x] Branch rebased onto latest `origin/main` (96519c3, v0.15.12) before commit — no merge commit, clean linear history
- [ ] Manual smoke post-deploy: open `/items` → click any row → peek popup → confirm hero is portrait MTG-card shape, item image fills the frame without distortion

## Version
`<Version>` 0.15.12 → 0.15.13. Parallel PR Hra2 takes 0.15.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)