### PR TITLE
[v0.15.14] Block GameItem removal when referenced by TreasureItem or MonsterLoot (closes #99)

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -221,10 +221,52 @@ public static class ItemEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Results<NoContent, NotFound>> DeleteGameItem(int gameId, int itemId, WorldDbContext db)
+    // Removing the per-game link must not strand ghost TreasureItem /
+    // MonsterLoot rows that still reference this (GameId, ItemId) pair —
+    // see issue #99. Block the delete with a Czech ProblemDetails(400)
+    // listing the offending TreasureQuest titles / pool count / Monster
+    // names so the organizer knows what to detach first. QuestReward /
+    // PersonalQuestItemReward / CraftingIngredient are catalog-level (not
+    // per-game) and are left alone here; follow-ups can tighten those.
+    private static async Task<IResult> DeleteGameItem(int gameId, int itemId, WorldDbContext db)
     {
         var gi = await db.GameItems.FindAsync(gameId, itemId);
         if (gi is null) return TypedResults.NotFound();
+
+        var treasureQuestTitles = await db.TreasureItems
+            .Where(ti => ti.GameId == gameId && ti.ItemId == itemId && ti.TreasureQuestId != null)
+            .Select(ti => ti.TreasureQuest!.Title)
+            .Distinct()
+            .OrderBy(t => t)
+            .ToListAsync();
+
+        var poolCount = await db.TreasureItems
+            .Where(ti => ti.GameId == gameId && ti.ItemId == itemId && ti.TreasureQuestId == null)
+            .SumAsync(ti => (int?)ti.Count) ?? 0;
+
+        var monsterNames = await db.MonsterLoots
+            .Where(ml => ml.GameId == gameId && ml.ItemId == itemId)
+            .Select(ml => ml.Monster.Name)
+            .Distinct()
+            .OrderBy(n => n)
+            .ToListAsync();
+
+        if (treasureQuestTitles.Count > 0 || poolCount > 0 || monsterNames.Count > 0)
+        {
+            var parts = new List<string>();
+            if (treasureQuestTitles.Count > 0)
+                parts.Add($"je součástí pokladu: {string.Join(", ", treasureQuestTitles)}");
+            if (poolCount > 0)
+                parts.Add($"v zásobníku: {poolCount} ks");
+            if (monsterNames.Count > 0)
+                parts.Add($"kořist příšer: {string.Join(", ", monsterNames)}");
+
+            return TypedResults.Problem(
+                title: "Položku nelze odebrat",
+                detail: $"Tuto položku nelze odebrat — {string.Join("; ", parts)}.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
         db.GameItems.Remove(gi);
         await db.SaveChangesAsync();
         return TypedResults.NoContent();

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.12</Version>
+    <Version>0.15.14</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -885,10 +885,14 @@ else
         error = null; isSaving = true;
         try
         {
-            var deleted = await Api.DeleteAsync($"/api/items/game-item/{GameContext.SelectedGameId}/{editingId}");
+            var (deleted, problem) = await Api.DeleteWithProblemAsync(
+                $"/api/items/game-item/{GameContext.SelectedGameId}/{editingId}");
             if (!deleted)
             {
-                error = "Odebrání předmětu ze hry se nezdařilo.";
+                // Surface the server's Czech ProblemDetails.detail verbatim —
+                // e.g. the #99 block lists the offending treasures so the user
+                // knows what to detach before retrying.
+                error = problem ?? "Odebrání předmětu ze hry se nezdařilo.";
                 return;
             }
             gameItemExists = false;
@@ -917,10 +921,11 @@ else
         error = null;
         try
         {
-            var deleted = await Api.DeleteAsync($"/api/items/game-item/{GameContext.SelectedGameId}/{itemId}");
+            var (deleted, problem) = await Api.DeleteWithProblemAsync(
+                $"/api/items/game-item/{GameContext.SelectedGameId}/{itemId}");
             if (!deleted)
             {
-                error = "Odebrání předmětu ze hry se nezdařilo.";
+                error = problem ?? "Odebrání předmětu ze hry se nezdařilo.";
                 return;
             }
             await ReloadGameLinkAsync();

--- a/src/OvcinaHra.Client/Services/ApiClient.cs
+++ b/src/OvcinaHra.Client/Services/ApiClient.cs
@@ -88,20 +88,24 @@ public class ApiClient
         var response = await _http.DeleteAsync(url);
         if (response.IsSuccessStatusCode) return (true, null);
 
-        try
-        {
-            var problem = await response.Content.ReadFromJsonAsync<ProblemDetailsLite>(JsonOptions);
-            if (!string.IsNullOrWhiteSpace(problem?.Detail))
-                return (false, problem.Detail);
-            if (!string.IsNullOrWhiteSpace(problem?.Title))
-                return (false, problem.Title);
-        }
-        catch (JsonException)
-        {
-            // Non-JSON body — fall through to the raw-text path below.
-        }
-
+        // Read the body once, then attempt JSON parse — avoids the stream-consumed
+        // pitfall where ReadFromJsonAsync drains the stream before the raw fallback.
         var raw = await response.Content.ReadAsStringAsync();
+        if (!string.IsNullOrWhiteSpace(raw))
+        {
+            try
+            {
+                var problem = JsonSerializer.Deserialize<ProblemDetailsLite>(raw, JsonOptions);
+                if (!string.IsNullOrWhiteSpace(problem?.Detail))
+                    return (false, problem.Detail);
+                if (!string.IsNullOrWhiteSpace(problem?.Title))
+                    return (false, problem.Title);
+            }
+            catch (JsonException)
+            {
+                // Non-JSON body — fall through to the raw-text return below.
+            }
+        }
         return (false, string.IsNullOrWhiteSpace(raw) ? null : raw);
     }
 

--- a/src/OvcinaHra.Client/Services/ApiClient.cs
+++ b/src/OvcinaHra.Client/Services/ApiClient.cs
@@ -76,4 +76,34 @@ public class ApiClient
         var response = await _http.DeleteAsync(url);
         return response.IsSuccessStatusCode;
     }
+
+    // Variant of DeleteAsync that reads the server's ProblemDetails on
+    // non-success so the caller can surface the server's Czech `detail`
+    // verbatim in the UI instead of a generic fallback. On success returns
+    // (true, null); on failure returns (false, problemDetailOrNull) where
+    // problemDetailOrNull is the ProblemDetails.detail field or the raw body
+    // if the server did not return an application/problem+json response.
+    public async Task<(bool Ok, string? ProblemDetail)> DeleteWithProblemAsync(string url)
+    {
+        var response = await _http.DeleteAsync(url);
+        if (response.IsSuccessStatusCode) return (true, null);
+
+        try
+        {
+            var problem = await response.Content.ReadFromJsonAsync<ProblemDetailsLite>(JsonOptions);
+            if (!string.IsNullOrWhiteSpace(problem?.Detail))
+                return (false, problem.Detail);
+            if (!string.IsNullOrWhiteSpace(problem?.Title))
+                return (false, problem.Title);
+        }
+        catch (JsonException)
+        {
+            // Non-JSON body — fall through to the raw-text path below.
+        }
+
+        var raw = await response.Content.ReadAsStringAsync();
+        return (false, string.IsNullOrWhiteSpace(raw) ? null : raw);
+    }
+
+    private sealed record ProblemDetailsLite(string? Title, string? Detail, int? Status);
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ItemGameLinkTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ItemGameLinkTests.cs
@@ -20,6 +20,7 @@ public class ItemGameLinkTests(PostgresFixture postgres) : IntegrationTestBase(p
     {
         var response = await Client.PostAsJsonAsync("/api/games",
             new CreateGameDto("Hra #99", 1, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 3)));
+        response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
     }
 
@@ -27,6 +28,7 @@ public class ItemGameLinkTests(PostgresFixture postgres) : IntegrationTestBase(p
     {
         var response = await Client.PostAsJsonAsync("/api/locations",
             new CreateLocationDto("Skála", LocationKind.Wilderness, 49.5m, 17.1m));
+        response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<LocationDetailDto>())!;
     }
 
@@ -34,6 +36,7 @@ public class ItemGameLinkTests(PostgresFixture postgres) : IntegrationTestBase(p
     {
         var response = await Client.PostAsJsonAsync("/api/items",
             new CreateItemDto(name, ItemType.Potion));
+        response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<ItemDetailDto>())!;
     }
 
@@ -101,12 +104,12 @@ public class ItemGameLinkTests(PostgresFixture postgres) : IntegrationTestBase(p
         Assert.Contains("Drakův poklad", body);
         Assert.Contains("Položku nelze odebrat", body);
 
-        // Row must still exist — confirm via the usable-items query for the
-        // same game; a missing GameItem wouldn't appear here.
-        var usable = await Client.GetFromJsonAsync<List<ItemListDto>>(
-            $"/api/items/usable?playerClass={(int)PlayerClass.Warrior}&level=1&gameId={game.Id}");
-        Assert.NotNull(usable);
-        Assert.Contains(usable, i => i.Id == item.Id);
+        // Row must still exist — confirm via the by-game item list. Direct
+        // (GameId, ItemId) check, not dependent on class/level rules.
+        var byGame = await Client.GetFromJsonAsync<List<ItemListDto>>(
+            $"/api/items/by-game/{game.Id}");
+        Assert.NotNull(byGame);
+        Assert.Contains(byGame, i => i.Id == item.Id);
     }
 
     // ----- TreasureItem: pool only -----

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ItemGameLinkTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ItemGameLinkTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using System.Net.Http.Json;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+// Covers DELETE /api/items/game-item/{gameId}/{itemId} per issue #99.
+// The endpoint must refuse to delete a GameItem while a per-game entity
+// still references the same (GameId, ItemId) — otherwise TreasureItem /
+// MonsterLoot rows survive as silent ghosts. Tests span the three blocking
+// sources (assigned treasure, pool treasure, monster loot) plus a regression
+// happy-path that confirms an unreferenced GameItem still deletes cleanly.
+public class ItemGameLinkTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    // ----- helpers -----
+
+    private async Task<GameDetailDto> CreateGameAsync()
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Hra #99", 1, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 3)));
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    private async Task<LocationDetailDto> CreateLocationAsync()
+    {
+        var response = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Skála", LocationKind.Wilderness, 49.5m, 17.1m));
+        return (await response.Content.ReadFromJsonAsync<LocationDetailDto>())!;
+    }
+
+    private async Task<ItemDetailDto> CreateItemAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/items",
+            new CreateItemDto(name, ItemType.Potion));
+        return (await response.Content.ReadFromJsonAsync<ItemDetailDto>())!;
+    }
+
+    private async Task AssignItemToGameAsync(int gameId, int itemId)
+    {
+        var response = await Client.PostAsJsonAsync("/api/items/game-item",
+            new CreateGameItemDto(gameId, itemId));
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<int> CreateMonsterAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto(name, 1, MonsterType.Beast, 5, 5, 10));
+        response.EnsureSuccessStatusCode();
+        var monster = await response.Content.ReadFromJsonAsync<MonsterDetailDto>();
+        return monster!.Id;
+    }
+
+    // ----- 204 regression -----
+
+    [Fact]
+    public async Task DeleteGameItem_NoReferences_ReturnsNoContent()
+    {
+        var game = await CreateGameAsync();
+        var item = await CreateItemAsync("Neškodný meč");
+        await AssignItemToGameAsync(game.Id, item.Id);
+
+        var response = await Client.DeleteAsync($"/api/items/game-item/{game.Id}/{item.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    // ----- TreasureItem: assigned -----
+
+    [Fact]
+    public async Task DeleteGameItem_WhenReferencedByAssignedTreasureItem_ReturnsBadRequestWithTitle()
+    {
+        var game = await CreateGameAsync();
+        var location = await CreateLocationAsync();
+        var item = await CreateItemAsync("Prsten síly");
+        await AssignItemToGameAsync(game.Id, item.Id);
+
+        // Build a pool row, then attach it to a quest — this flips
+        // TreasureQuestId from null to the quest id, turning the item into
+        // an assigned reference rather than a pool one.
+        var poolResponse = await Client.PostAsJsonAsync("/api/treasure-planning/pool",
+            new CreateTreasurePoolItemDto(item.Id, game.Id, 1));
+        poolResponse.EnsureSuccessStatusCode();
+        var pool = await poolResponse.Content.ReadFromJsonAsync<TreasurePoolItemDto>();
+
+        var assignResponse = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto(
+                Title: "Drakův poklad",
+                Difficulty: TreasureQuestDifficulty.Lategame,
+                GameId: game.Id,
+                LocationId: location.Id,
+                TreasureItemIds: new List<int> { pool!.Id }));
+        assignResponse.EnsureSuccessStatusCode();
+
+        var response = await Client.DeleteAsync($"/api/items/game-item/{game.Id}/{item.Id}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Drakův poklad", body);
+        Assert.Contains("Položku nelze odebrat", body);
+
+        // Row must still exist — confirm via the usable-items query for the
+        // same game; a missing GameItem wouldn't appear here.
+        var usable = await Client.GetFromJsonAsync<List<ItemListDto>>(
+            $"/api/items/usable?playerClass={(int)PlayerClass.Warrior}&level=1&gameId={game.Id}");
+        Assert.NotNull(usable);
+        Assert.Contains(usable, i => i.Id == item.Id);
+    }
+
+    // ----- TreasureItem: pool only -----
+
+    [Fact]
+    public async Task DeleteGameItem_WhenReferencedByPoolTreasureItem_ReturnsBadRequest()
+    {
+        var game = await CreateGameAsync();
+        var item = await CreateItemAsync("Lektvar magie");
+        await AssignItemToGameAsync(game.Id, item.Id);
+
+        var poolResponse = await Client.PostAsJsonAsync("/api/treasure-planning/pool",
+            new CreateTreasurePoolItemDto(item.Id, game.Id, 2));
+        poolResponse.EnsureSuccessStatusCode();
+
+        var response = await Client.DeleteAsync($"/api/items/game-item/{game.Id}/{item.Id}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("zásobník", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ----- MonsterLoot -----
+
+    [Fact]
+    public async Task DeleteGameItem_WhenReferencedByMonsterLoot_ReturnsBadRequestWithMonsterName()
+    {
+        var game = await CreateGameAsync();
+        var item = await CreateItemAsync("Dračí šupina");
+        await AssignItemToGameAsync(game.Id, item.Id);
+        var monsterId = await CreateMonsterAsync("Bahenní červ");
+
+        var lootResponse = await Client.PostAsJsonAsync("/api/monsters/loot",
+            new CreateMonsterLootDto(monsterId, item.Id, game.Id, 1));
+        lootResponse.EnsureSuccessStatusCode();
+
+        var response = await Client.DeleteAsync($"/api/items/game-item/{game.Id}/{item.Id}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Bahenní červ", body);
+        Assert.Contains("kořist", body, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #99. Removing a `GameItem` (per-game item link) used to silently strand any `TreasureItem` referencing the same `(GameId, ItemId)` — exactly how *"Bahno z besedného močálu"* became a ghost in the Zásobník earlier today. This PR blocks the DELETE with a 400 + Czech ProblemDetails naming the offenders.

## Audit-driven scope — extended beyond TreasureItem to MonsterLoot

Full grep over `src/OvcinaHra.Shared/Domain/Entities/` for any type with `public int ItemId`:

| Entity | Shape | Per-game? | Decision |
|---|---|---|---|
| GameItem | (GameId, ItemId) | — (the link itself) | n/a |
| **TreasureItem** | (GameId, ItemId, TreasureQuestId?) | yes | **BLOCKED this PR** (assigned + pool both) |
| **MonsterLoot** | (MonsterId, ItemId, GameId) | yes | **BLOCKED this PR** (same footgun, same fix) |
| QuestReward | (QuestId, ItemId) | no — Quest is catalog | follow-up candidate |
| PersonalQuestItemReward | (PersonalQuestId, ItemId) | no — PersonalQuest is catalog | follow-up candidate |
| CraftingIngredient | (CraftingRecipeId, ItemId) | no — recipe is catalog | follow-up candidate |

Catalog-level references (Quest/PersonalQuest/Crafting) don't create a per-game ghost when `GameItem` is removed — they live on entities shared across games, so the only effect is the item won't surface in this game's item list. That's organizer misconfiguration, not silent DB rot. Different semantic, can be filed as a separate ticket if a stricter "item must be in game for reward to be reachable" rule is wanted later.

## Backend — `ItemEndpoints.cs:DeleteGameItem`

- Pre-check counts `TreasureItem` and `MonsterLoot` rows referencing `(GameId, ItemId)`.
- Returns `400 BadRequest` ProblemDetails with conditional sub-clauses:
  - `title`: `"Položku nelze odebrat"`
  - `detail`: `"Tuto položku nelze odebrat — je součástí pokladu: X, Y; v zásobníku: N ks; kořist příšer: M."`
  - Only applicable sub-clauses are included (e.g. pool-only case drops the treasure + monster clauses).
- **Signature change**: `Results<NoContent, NotFound>` → `IResult` to accommodate the `Problem(...)` branch. Minimal-API routing handles the new return type without metadata changes; no OpenAPI break.

## Tests — `tests/OvcinaHra.Api.Tests/Endpoints/ItemGameLinkTests.cs` (new file, 153 LOC)

All 4 cases passing (10 s total):
- `DeleteGameItem_NoReferences_ReturnsNoContent` ✅ (regression — no breakage on the happy path)
- `DeleteGameItem_WhenReferencedByAssignedTreasureItem_ReturnsBadRequestWithTitle` ✅
- `DeleteGameItem_WhenReferencedByPoolTreasureItem_ReturnsBadRequest` ✅
- `DeleteGameItem_WhenReferencedByMonsterLoot_ReturnsBadRequestWithMonsterName` ✅

Tests seed `MonsterLoot` via the real endpoint `POST /api/monsters/loot` rather than direct DbContext injection — keeps the suite consistent with how other tests seed data.

## Client UI — `ApiClient.cs` + `ItemList.razor`

- New narrow method: `ApiClient.DeleteWithProblemAsync(url)` returns `(bool ok, string? problemDetail)`. Existing `DeleteAsync(url) → bool` is **untouched** so no other callsite is affected.
- Only the two `DELETE /api/items/game-item/...` callsites in `ItemList.razor` opt into the ProblemDetails surface (`RemoveGameItemAsync` + `UnassignItemAsync`, both inside their own method bodies). On `false`, the Czech detail message renders in the existing error banner.
- Parsing fallback: if response body isn't `application/problem+json`, raw body text is returned (`JsonException` swallowed, `ReadAsStringAsync` runs).

## Verification
- [x] `dotnet build` clean with `TreatWarningsAsErrors=true`
- [x] `dotnet test` — 4 new cases all green (10 s)
- [x] EF Core 10 migration parity — no schema change needed (no entity field added)
- [x] No grid column changes → no `LayoutKey` bump
- [x] Czech UI + ProblemDetails messages
- [ ] Manual smoke post-deploy: try removing an item-game link for an item that's in a treasure → expect 400 banner naming the treasure

## Merge safety vs parallel work
- PR #117 (Hra1, item peek 5:7 redesign) — pure CSS in `ovcinahra-theme.css`. Zero overlap.
- Round 6 Hra1 task (game bbox) — different area entirely. Zero overlap.

## Version
`<Version>` 0.15.12 → 0.15.14 (skipping 0.15.13 claimed by PR #117).

🤖 Generated with [Claude Code](https://claude.com/claude-code)