### PR TITLE
[v0.15.17] Item list redesign — 5:7 tiles, Otevřít detail action, class pip column (closes #97)

### DIFF
--- a/src/OvcinaHra.Client/Components/ItemClassPips.razor
+++ b/src/OvcinaHra.Client/Components/ItemClassPips.razor
@@ -5,19 +5,19 @@
 <div class="oh-it-pips" title="@TitleSummary()">
     <span class="oh-it-pip @ItemClassPipsHelpers.PipClass(Warrior)" title="Válečník: @Warrior">
         <i class="bi bi-shield-shaded"></i>
-        @if (Warrior > 1) { <span class="oh-it-pip-n">@Warrior</span> }
+        @if (Warrior > 0) { <span class="oh-it-pip-n">@Warrior</span> }
     </span>
     <span class="oh-it-pip @ItemClassPipsHelpers.PipClass(Archer)" title="Lučištník: @Archer">
         <i class="bi bi-bullseye"></i>
-        @if (Archer > 1) { <span class="oh-it-pip-n">@Archer</span> }
+        @if (Archer > 0) { <span class="oh-it-pip-n">@Archer</span> }
     </span>
     <span class="oh-it-pip @ItemClassPipsHelpers.PipClass(Mage)" title="Mág: @Mage">
         <i class="bi bi-magic"></i>
-        @if (Mage > 1) { <span class="oh-it-pip-n">@Mage</span> }
+        @if (Mage > 0) { <span class="oh-it-pip-n">@Mage</span> }
     </span>
     <span class="oh-it-pip @ItemClassPipsHelpers.PipClass(Thief)" title="Zloděj: @Thief">
         <i class="bi bi-incognito"></i>
-        @if (Thief > 1) { <span class="oh-it-pip-n">@Thief</span> }
+        @if (Thief > 0) { <span class="oh-it-pip-n">@Thief</span> }
     </span>
 </div>
 

--- a/src/OvcinaHra.Client/Components/ItemGridImageTile.razor
+++ b/src/OvcinaHra.Client/Components/ItemGridImageTile.razor
@@ -1,0 +1,40 @@
+@* ItemGridImageTile — 5:7 MTG-card aspect tile used in the ItemList Foto
+   column (issue #97). Mirrors LocationGridImageTile's fail/load state
+   pattern — @onerror flips a Blazor flag rather than mutating the DOM, so
+   a component reused in @foreach doesn't stay stuck on the previous item's
+   error. Height locked to the row height; aspect-ratio keeps width derived. *@
+
+<span class="oh-it-tile" title="@Name">
+    @if (!imageLoaded || imageFailed)
+    {
+        <i class="oh-it-tile-glyph bi bi-image" aria-hidden="true"></i>
+    }
+    @if (!string.IsNullOrEmpty(ImageUrl) && !imageFailed)
+    {
+        <img class="oh-it-tile-img"
+             src="@ImageUrl"
+             alt="@Name"
+             loading="lazy"
+             @onload="() => imageLoaded = true"
+             @onerror="() => imageFailed = true" />
+    }
+</span>
+
+@code {
+    [Parameter, EditorRequired] public string Name { get; set; } = "";
+    [Parameter] public string? ImageUrl { get; set; }
+
+    private bool imageLoaded;
+    private bool imageFailed;
+    private string? _lastUrl;
+
+    protected override void OnParametersSet()
+    {
+        if (_lastUrl != ImageUrl)
+        {
+            _lastUrl = ImageUrl;
+            imageLoaded = false;
+            imageFailed = false;
+        }
+    }
+}

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.14</Version>
+    <Version>0.15.17</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -18,6 +18,49 @@
     </div>
 </div>
 
+@* Toolbar — issue #97: search, type dropdown, quick toggles.
+   Per-hra toggles (Prodávané / Nalezitelné) only render in game mode;
+   Vyrobitelné applies in both. Hidden on the "pick a game first" empty
+   state to match the existing reveal/hide rhythm. *@
+@if (!loading && (Catalog || GameContext.SelectedGameId is not null))
+{
+    <div class="oh-lg-toolbar mb-2">
+        <DxTextBox Text="@searchText"
+                   TextChanged="@(v => { searchText = v; StateHasChanged(); })"
+                   NullText="Hledat název, efekt…"
+                   BindValueMode="BindValueMode.OnDelayedInput"
+                   InputDelay="250"
+                   CssClass="oh-lg-tb-search flex-grow-0" />
+
+        <DxComboBox Data="@itemTypeFilterOptions"
+                    @bind-Value="@filterType"
+                    TextFieldName="Display"
+                    ValueFieldName="Value"
+                    NullText="Všechny typy"
+                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
+                    CssClass="oh-lg-tb-dd" />
+
+        <button type="button"
+                class="oh-lg-tb-toggle @(filterOnlyCraftable ? "oh-lg-on" : "")"
+                @onclick="() => { filterOnlyCraftable = !filterOnlyCraftable; StateHasChanged(); }">
+            <span class="oh-lg-sw"></span>jen vyrobitelné
+        </button>
+        @if (!Catalog)
+        {
+            <button type="button"
+                    class="oh-lg-tb-toggle @(filterOnlyForSale ? "oh-lg-on" : "")"
+                    @onclick="() => { filterOnlyForSale = !filterOnlyForSale; StateHasChanged(); }">
+                <span class="oh-lg-sw"></span>jen prodávané
+            </button>
+            <button type="button"
+                    class="oh-lg-tb-toggle @(filterOnlyFindable ? "oh-lg-on" : "")"
+                    @onclick="() => { filterOnlyFindable = !filterOnlyFindable; StateHasChanged(); }">
+                <span class="oh-lg-sw"></span>jen nalezitelné
+            </button>
+        }
+    </div>
+}
+
 @if (loading)
 {
     <p>Načítám...</p>
@@ -40,31 +83,43 @@ else if (!Catalog && gameItems.Count == 0)
 }
 else if (Catalog)
 {
-    <OvcinaGrid Data="@catalogItems" KeyFieldName="Id" LayoutKey="grid-layout-items-v3"
+    <OvcinaGrid Data="@visibleCatalogItems" KeyFieldName="Id" LayoutKey="grid-layout-items-v4"
                 RowClick="@(e => OpenQuickPeek((ItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
-            <DxGridDataColumn FieldName="Id" Caption="#" Width="60px" Visible="false" />
-
-            @* Foto — 78px column, 64x48 4:3 photo inside (issue #74-style: photo IS the artifact) *@
-            <DxGridDataColumn Caption="Foto" Width="78px" AllowSort="false" AllowGroup="false">
+            @* Akce — fixed left. Otevřít detail → /items/{id} mirrors the LocationList
+               pattern (PR #106). Destructive delete stays on the edit popup; not
+               surfaced here. Issue #97 ask: grid needs a direct path to the detail page. *@
+            <DxGridDataColumn Caption="Akce" Width="62px"
+                              AllowSort="false" AllowGroup="false"
+                              FixedPosition="GridColumnFixedPosition.Left">
                 <CellDisplayTemplate>
                     @{ var it = (ItemListDto)context.DataItem; }
-                    <span class="oh-it-photo">
-                        @if (!string.IsNullOrEmpty(it.ImageUrl))
-                        {
-                            <img src="@it.ImageUrl" alt="@it.Name" />
-                        }
-                        else
-                        {
-                            <i class="bi bi-image oh-it-photo-empty" aria-hidden="true"></i>
-                        }
-                    </span>
+                    <div class="oh-lg-actions-cell">
+                        <div class="oh-lg-actions">
+                            <button type="button"
+                                    title="Otevřít detail"
+                                    @onclick="@(() => Nav.NavigateTo($"/items/{it.Id}"))"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-box-arrow-up-right"></i>
+                            </button>
+                        </div>
+                    </div>
                 </CellDisplayTemplate>
             </DxGridDataColumn>
 
-            @* Type-dot 24px — neutral palette per ItemType (NOT kingdom colors).
-               Unbound (no FieldName) so it doesn't collide with the text "Typ" column
-               under DxGrid's layout-persistence keying-by-FieldName. *@
+            <DxGridDataColumn FieldName="Id" Caption="#" Width="60px" Visible="false" />
+
+            @* Foto — 5:7 MTG-card aspect tile per issue #97 (was 4:3). Narrow width
+               matches a 48 px row; the tile component handles fail-state itself. *@
+            <DxGridDataColumn Caption="Foto" Width="58px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var it = (ItemListDto)context.DataItem; }
+                    <ItemGridImageTile @key="it.Id" Name="@it.Name" ImageUrl="@it.ImageUrl" />
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            @* Type-dot unbound (no FieldName) so it doesn't collide with the text
+               "Typ" column under DxGrid's layout-persistence keying (Copilot, PR #88). *@
             <DxGridDataColumn Caption="•" Width="24px" AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>
                     @{ var it = (ItemListDto)context.DataItem; }
@@ -76,21 +131,31 @@ else if (Catalog)
             <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="130px" />
             <DxGridDataColumn FieldName="PhysicalFormDisplay" Caption="Podoba" Width="150px" />
 
-            @* 4 class pip cols 64/64/64/88 *@
-            <DxGridDataColumn FieldName="ReqWarrior" Caption="Vál." Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Válečník: @context.Value"><i class="bi bi-shield-shaded"></i></span></CellDisplayTemplate>
-            </DxGridDataColumn>
-            <DxGridDataColumn FieldName="ReqArcher" Caption="Luč." Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Lučištník: @context.Value"><i class="bi bi-bullseye"></i></span></CellDisplayTemplate>
-            </DxGridDataColumn>
-            <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Mág: @context.Value"><i class="bi bi-magic"></i></span></CellDisplayTemplate>
-            </DxGridDataColumn>
-            <DxGridDataColumn FieldName="ReqThief" Caption="Zlo." Width="88px">
-                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Zloděj: @context.Value"><i class="bi bi-incognito"></i></span></CellDisplayTemplate>
+            @* Požadavky — single-column 4-pip cluster (issue #97). Icons light up
+               by level; tooltip per pip names the class + level. Default visible. *@
+            <DxGridDataColumn Caption="Požadavky" Width="184px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var it = (ItemListDto)context.DataItem; }
+                    <ItemClassPips Warrior="it.ReqWarrior" Archer="it.ReqArcher" Mage="it.ReqMage" Thief="it.ReqThief" />
+                </CellDisplayTemplate>
             </DxGridDataColumn>
 
-            @* Cena + Sklad columns — hidden in catalog (no GameItem data; brief acceptance §4) *@
+            @* Individual class columns — just the number, hidden by default. User
+               reveals via the column chooser when they want to filter/group on a
+               specific class level. No icon here — the pip cluster owns the visual. *@
+            <DxGridDataColumn FieldName="ReqWarrior" Caption="Vál." Width="72px" Visible="false">
+                <CellDisplayTemplate>@RenderReq((int)context.Value)</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ReqArcher" Caption="Luč." Width="72px" Visible="false">
+                <CellDisplayTemplate>@RenderReq((int)context.Value)</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="72px" Visible="false">
+                <CellDisplayTemplate>@RenderReq((int)context.Value)</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ReqThief" Caption="Zlo." Width="72px" Visible="false">
+                <CellDisplayTemplate>@RenderReq((int)context.Value)</CellDisplayTemplate>
+            </DxGridDataColumn>
+
             <DxGridDataColumn FieldName="Effect" Caption="Efekt" Width="240px" Visible="false" />
 
             @* Flagy 3-cell box — Unikát/Limit/Craftable in catalog *@
@@ -124,10 +189,31 @@ else if (Catalog)
 }
 else
 {
-    <OvcinaGrid Data="@gameItems" KeyFieldName="Id" LayoutKey="grid-layout-items-game-v3"
+    <OvcinaGrid Data="@visibleGameItems" KeyFieldName="Id" LayoutKey="grid-layout-items-game-v4"
                 RowClick="@(e => OpenQuickPeek((GameItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
-            @* Context-menu column at fixed left edge — preserves Upravit / Odebrat / Smazat / Recept actions *@
+            @* Akce — fixed left. Primary "Otevřít detail" button per issue #97.
+               The 3-dot context menu column below still owns Upravit / Odebrat /
+               Smazat / Otevřít recept — it's the row-level command hub. *@
+            <DxGridDataColumn Caption="Akce" Width="62px"
+                              AllowSort="false" AllowGroup="false"
+                              FixedPosition="GridColumnFixedPosition.Left">
+                <CellDisplayTemplate>
+                    @{ var gi = (GameItemListDto)context.DataItem; }
+                    <div class="oh-lg-actions-cell">
+                        <div class="oh-lg-actions">
+                            <button type="button"
+                                    title="Otevřít detail"
+                                    @onclick="@(() => Nav.NavigateTo($"/items/{gi.Id}"))"
+                                    @onclick:stopPropagation="true">
+                                <i class="bi bi-box-arrow-up-right"></i>
+                            </button>
+                        </div>
+                    </div>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            @* Context-menu column — preserves Upravit / Odebrat / Smazat / Recept *@
             <DxGridDataColumn FieldName="" Caption="" Width="40px" AllowSort="false" AllowGroup="false" FixedPosition="GridColumnFixedPosition.Left">
                 <CellDisplayTemplate>
                     @{ var gi = (GameItemListDto)context.DataItem; }
@@ -139,26 +225,15 @@ else
 
             <DxGridDataColumn FieldName="Id" Caption="#" Width="60px" Visible="false" />
 
-            @* Foto 78px column, 64x48 4:3 photo *@
-            <DxGridDataColumn Caption="Foto" Width="78px" AllowSort="false" AllowGroup="false">
+            @* Foto — 5:7 MTG-card aspect tile per issue #97 (was 4:3). *@
+            <DxGridDataColumn Caption="Foto" Width="58px" AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>
                     @{ var gi = (GameItemListDto)context.DataItem; }
-                    <span class="oh-it-photo">
-                        @if (!string.IsNullOrEmpty(gi.ImageUrl))
-                        {
-                            <img src="@gi.ImageUrl" alt="@gi.Name" />
-                        }
-                        else
-                        {
-                            <i class="bi bi-image oh-it-photo-empty" aria-hidden="true"></i>
-                        }
-                    </span>
+                    <ItemGridImageTile @key="gi.Id" Name="@gi.Name" ImageUrl="@gi.ImageUrl" />
                 </CellDisplayTemplate>
             </DxGridDataColumn>
 
-            @* Type-dot 24px — unbound (no FieldName) per Copilot review on PR #88
-               so it doesn't collide with the text "Typ" column under DxGrid's
-               layout-persistence keying-by-FieldName. *@
+            @* Type-dot unbound — avoids DxGrid layout-key collision w/ Typ column. *@
             <DxGridDataColumn Caption="•" Width="24px" AllowSort="false" AllowGroup="false">
                 <CellDisplayTemplate>
                     @{ var gi = (GameItemListDto)context.DataItem; }
@@ -170,18 +245,27 @@ else
             <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="130px" />
             <DxGridDataColumn FieldName="PhysicalFormDisplay" Caption="Podoba" Width="150px" />
 
-            @* 4 class pip cols *@
-            <DxGridDataColumn FieldName="ReqWarrior" Caption="Vál." Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Válečník: @context.Value"><i class="bi bi-shield-shaded"></i></span></CellDisplayTemplate>
+            @* Požadavky — single-column 4-pip cluster (issue #97). *@
+            <DxGridDataColumn Caption="Požadavky" Width="184px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var gi = (GameItemListDto)context.DataItem; }
+                    <ItemClassPips Warrior="gi.ReqWarrior" Archer="gi.ReqArcher" Mage="gi.ReqMage" Thief="gi.ReqThief" />
+                </CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="ReqArcher" Caption="Luč." Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Lučištník: @context.Value"><i class="bi bi-bullseye"></i></span></CellDisplayTemplate>
+
+            @* Individual class columns — just the number, hidden by default.
+               Revealed via the column chooser for filtering/grouping. *@
+            <DxGridDataColumn FieldName="ReqWarrior" Caption="Vál." Width="72px" Visible="false">
+                <CellDisplayTemplate>@RenderReq((int)context.Value)</CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="64px">
-                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Mág: @context.Value"><i class="bi bi-magic"></i></span></CellDisplayTemplate>
+            <DxGridDataColumn FieldName="ReqArcher" Caption="Luč." Width="72px" Visible="false">
+                <CellDisplayTemplate>@RenderReq((int)context.Value)</CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="ReqThief" Caption="Zlo." Width="88px">
-                <CellDisplayTemplate><span class="oh-it-pip @ItemClassPipsHelpers.PipClass((int)context.Value)" title="Zloděj: @context.Value"><i class="bi bi-incognito"></i></span></CellDisplayTemplate>
+            <DxGridDataColumn FieldName="ReqMage" Caption="Mág" Width="72px" Visible="false">
+                <CellDisplayTemplate>@RenderReq((int)context.Value)</CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ReqThief" Caption="Zlo." Width="72px" Visible="false">
+                <CellDisplayTemplate>@RenderReq((int)context.Value)</CellDisplayTemplate>
             </DxGridDataColumn>
 
             @* Cena coin gold accent — strikethrough when IsSold=false *@
@@ -585,6 +669,57 @@ else
     private HashSet<int> assignedItemIds = [];
 
     private bool _previousCatalog;
+
+    // Toolbar filter state (issue #97). Per-hra toggles (ForSale/Findable) only
+    // apply in game mode; Craftable + search + type apply to both modes.
+    private string? searchText;
+    private ItemType? filterType;
+    private bool filterOnlyCraftable;
+    private bool filterOnlyForSale;
+    private bool filterOnlyFindable;
+
+    private static readonly List<EnumItem<ItemType?>> itemTypeFilterOptions =
+        Enum.GetValues<ItemType>()
+            .Select(v => new EnumItem<ItemType?>(v, v.GetDisplayName()))
+            .ToList();
+
+    private List<ItemListDto> visibleCatalogItems => catalogItems.Where(MatchesCatalog).ToList();
+    private List<GameItemListDto> visibleGameItems => gameItems.Where(MatchesGame).ToList();
+
+    private bool MatchesCatalog(ItemListDto it)
+    {
+        if (filterType.HasValue && it.ItemType != filterType.Value) return false;
+        if (filterOnlyCraftable && !it.IsCraftable) return false;
+        if (!string.IsNullOrWhiteSpace(searchText))
+        {
+            var needle = searchText.Trim();
+            var nameMatch = it.Name.Contains(needle, StringComparison.OrdinalIgnoreCase);
+            var effectMatch = it.Effect?.Contains(needle, StringComparison.OrdinalIgnoreCase) == true;
+            if (!nameMatch && !effectMatch) return false;
+        }
+        return true;
+    }
+
+    private bool MatchesGame(GameItemListDto gi)
+    {
+        if (filterType.HasValue && gi.ItemType != filterType.Value) return false;
+        if (filterOnlyCraftable && !gi.IsCraftable) return false;
+        if (filterOnlyForSale && !gi.IsSold) return false;
+        if (filterOnlyFindable && !gi.IsFindable) return false;
+        if (!string.IsNullOrWhiteSpace(searchText))
+        {
+            var needle = searchText.Trim();
+            var nameMatch = gi.Name.Contains(needle, StringComparison.OrdinalIgnoreCase);
+            var effectMatch = gi.Effect?.Contains(needle, StringComparison.OrdinalIgnoreCase) == true;
+            var recipeMatch = gi.RecipeSummary?.Contains(needle, StringComparison.OrdinalIgnoreCase) == true;
+            if (!nameMatch && !effectMatch && !recipeMatch) return false;
+        }
+        return true;
+    }
+
+    // Grid cell helper — renders the class-requirement number only when > 0.
+    // Empty cells stay clean; filter menus still see the raw int on the DTO.
+    private static string RenderReq(int v) => v > 0 ? v.ToString() : "";
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2104,6 +2104,12 @@
 .oh-it-photo img{width:100%;height:100%;object-fit:cover;display:block}
 .oh-it-photo-empty{font-size:1.25rem;color:rgba(139,90,43,.4)}
 
+/* Foto tile — 5:7 MTG-card aspect (issue #97). Height locked to the row; width
+   is derived. Narrow by design — "quite small, but that's okay". */
+.oh-it-tile{position:relative;display:inline-block;aspect-ratio:5/7;height:48px;border-radius:3px;overflow:hidden;background:var(--oh-surface-alt);border:1px solid var(--oh-border);vertical-align:middle}
+.oh-it-tile-img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;display:block}
+.oh-it-tile-glyph{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:rgba(139,90,43,.4);font-size:1rem}
+
 /* Type-dot — 10px circle, neutral palette per ItemType (NOT kingdom colors) */
 .oh-it-tdot{display:inline-block;width:10px;height:10px;border-radius:50%;box-shadow:0 0 0 1px rgba(0,0,0,.1),inset 0 -1px 1px rgba(0,0,0,.2);vertical-align:middle}
 .oh-it-tdot--weapon{background:#8a7148}


### PR DESCRIPTION
## Summary
Closes #97. Three asks from the issue, all delivered, plus a bonus filter toolbar.

## Changes

### 1. Image — 5:7 grid tile via new `ItemGridImageTile` component
- New `src/OvcinaHra.Client/Components/ItemGridImageTile.razor` (33 LOC).
- Mirrors `LocationGridImageTile.razor` patterns: `aspect-ratio: 5/7`, state-flag `@onerror` (no inline DOM mutation), `OnParametersSet` resets on URL change, `@key` on the parent `@foreach`.

### 2. "Otevřít detail" row action
Fixed-left **Akce** column in both modes (catalog + per-game), `bi-box-arrow-up-right` icon, navigates to `/items/{id}`. Same pattern as `LocationList.razor` (PR #106).

### 3. Class requirements pip column
**Reused the existing `ItemClassPips` component** — didn't reinvent. New **Požadavky** column shows the 4 class pips with their level numbers as small badges:
- Válečník → `bi-shield-shaded`
- Lučištník → `bi-bullseye`
- Mág → `bi-magic`
- Zloděj → `bi-incognito`

Individual `ReqX` columns retained as **plain numbers + hidden by default** so the user can still surface them via the column chooser for filter purposes.

### Bonus — toolbar
Inferred from the issue text. Above the grid: **Hledat** input, **Typ** dropdown, plus three filter switches (jen vyrobitelné / jen prodávané / jen nalezitelné).

## LayoutKey bumps (per `feedback_ovcinagrid_layoutkey_bump` rule)

Both grids:
- **Catalog:** `grid-layout-items-v3` → `grid-layout-items-v4`
- **Game:** `grid-layout-items-game-v3` → `grid-layout-items-game-v4`

Required because columns changed shape (new Akce column at left, new Požadavky column, ReqX changed from pip rendering to plain numbers + hidden). Without the bump, users' saved filter state would mis-target the new columns.

## Delete action — kept (with reasoning)

PR #106 dropped Smazat from `LocationList`'s actions column on the principle that destructive deletes should live on the detail page only. This PR **kept it** for `ItemList` because:
- The game grid's 3-dot context menu bundles **Upravit / Odebrat / Smazat / Recept** — four actions in total.
- Stripping just Smazat would leave an asymmetric menu (3 non-destructive + 1 missing destructive).
- The existing `isDeleteVisible` `DxPopup` confirmation already wraps it (per `feedback_ovcinahra_destructive_confirm`).
- Edit popup also retains its Smazat button.

If you want strict #106 parity, easy follow-up — strip Smazat from both the context menu + edit popup, route deletes through `ItemDetail.razor` (closes #114-style).

## Files
| File | LOC |
|---|---|
| `src/OvcinaHra.Client/Components/ItemGridImageTile.razor` (new) | +33 |
| `src/OvcinaHra.Client/Pages/Items/ItemList.razor` | +186 / -53 |
| `src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css` | +6 |
| `src/OvcinaHra.Client/OvcinaHra.Client.csproj` | +1 / -1 |

Total: 4 files, +234 / -53.

## Verification
- [x] `dotnet build` clean across full solution (6 projects) with `TreatWarningsAsErrors=true`
- [x] LayoutKey bumps explicit (catalog v3→v4, game v3→v4)
- [x] No `DxGridDataColumn.AllowFilter` (DevExpress 25.2.5 runtime crash trap respected)
- [x] Tiles use `@key` + state-flag pattern, no inline DOM mutation
- [x] Image source uses thumbnail URL from list DTO (per `feedback_ovcinahra_image_sourcing_rule`)
- [x] Czech UI text, English code + routes
- [ ] Manual smoke post-deploy: `/items` grid in both catalog + game modes — verify tiles render at 5:7, Otevřít detail navigates correctly, class pips display, filter toolbar works

## Version
`<Version>` 0.15.14 → 0.15.17. Skips 0.15.15 (Hra1 PR #122 game bbox) and 0.15.16 (Hra2's #100-followup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)