### PR TITLE
[v0.15.28] service-worker — add /\.woff2$/ to offlineAssetsInclude so .woff2 fonts precache (closes #132)

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.27</Version>
+    <Version>0.15.28</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/wwwroot/service-worker.published.js
+++ b/src/OvcinaHra.Client/wwwroot/service-worker.published.js
@@ -8,7 +8,7 @@ self.addEventListener('fetch', event => event.respondWith(onFetch(event)));
 
 const cacheNamePrefix = 'offline-cache-';
 const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}`;
-const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.blat$/, /\.dat$/, /\.webmanifest$/ ];
+const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.woff2$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.blat$/, /\.dat$/, /\.webmanifest$/ ];
 const offlineAssetsExclude = [ /^service-worker\.js$/ ];
 
 // Replace with your base path if you are hosting on a subfolder. Ensure there is a trailing '/'.


### PR DESCRIPTION
## Summary
Closes #132. Adds `/\.woff2$/` to `offlineAssetsInclude` in `service-worker.published.js` so Blazor's install-time precache actually caches `.woff2` fonts — complements PR #131's query-string strip.

## Change
One regex added to the stock Blazor PWA precache filter:

```diff
 const offlineAssetsInclude = [
     /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/,
-    /\.css$/, /\.woff$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/,
+    /\.css$/, /\.woff$/, /\.woff2$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/,
     /\.blat$/, /\.dat$/, /\.webmanifest$/];
```

Dev `service-worker.js` left alone — it's a no-op fetch listener with no precache list.

## Effect
After merge + deploy, the published SW precaches **both** `.woff` and `.woff2` font variants at install time. Combined with #131's queryless font URLs, offline PWA users now hit `.woff2` directly (first choice per `@font-face`) instead of falling back to the heavier `.woff`.

## Verification
- [x] `dotnet build` clean
- [x] `dotnet publish -c Release` — `service-worker-assets.js` still includes `.woff2` entries with SRI hashes (manifest side was already correct; this PR fixes the runtime regex filter)
- [ ] Manual offline smoke post-deploy: Chrome DevTools → install PWA → Network tab offline → reload → expect `.woff2` font requests served from SW cache (200 from service worker)

## Context
Path B from #116's original triage. Path A shipped in PR #131 (stripped the cache-bust query strings so `.woff` matched its cached key). This PR completes the fix so `.woff2` also precaches.

## Note on version

Branch was rebased from original 0.15.25 → 0.15.28 after main moved from 0.15.22 → 0.15.27 via PR #131 and others. Version bump handled manually here because the auto-bump CI (coming in parallel PR #NN) wasn't active at the time of rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)