### PR TITLE
feat(map): overlay editor Phase 1+2 — data model + 6 primitives + save/load (closes #96 phase 1+2)

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -19,6 +21,10 @@ public static class GameEndpoints
         group.MapPut("/{id:int}", Update);
         group.MapPost("/{id:int}/link", LinkToRegistrace);
         group.MapDelete("/{id:int}/link", UnlinkFromRegistrace);
+
+        // Map overlay (issue #96) — free-draw shapes per game, stored as JSON blob.
+        group.MapGet("/{id:int}/overlay", GetOverlay);
+        group.MapPut("/{id:int}/overlay", UpdateOverlay);
 
         group.MapGet("/{gameId:int}/skills", GetGameSkills);
         group.MapGet("/{gameId:int}/skills/{gameSkillId:int}", GetGameSkillById);
@@ -133,6 +139,65 @@ public static class GameEndpoints
             return TypedResults.NotFound();
 
         game.ExternalGameId = null;
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    // ----- Map overlay (issue #96) ----------------------------------------
+
+    /// <summary>Max serialized overlay payload — 256 KiB, enough for ~3000 freehand points.</summary>
+    private const int OverlayMaxBytes = 256 * 1024;
+
+    /// <summary>
+    /// JsonSerializerOptions scoped to the overlay endpoints. Defaults are
+    /// fine — the <see cref="MapOverlayShape"/> hierarchy carries its own
+    /// JsonPolymorphic attributes so the discriminator is written/read
+    /// automatically. Shared instance avoids per-request allocation.
+    /// </summary>
+    private static readonly JsonSerializerOptions OverlayJsonOptions = new() { WriteIndented = false };
+
+    private static async Task<Results<Ok<MapOverlayDto>, NoContent, NotFound>> GetOverlay(int id, WorldDbContext db)
+    {
+        var game = await db.Games.FindAsync(id);
+        if (game is null)
+            return TypedResults.NotFound();
+
+        if (string.IsNullOrWhiteSpace(game.OverlayJson))
+            return TypedResults.NoContent();
+
+        // Best-effort deserialize: if a stored overlay is corrupt (e.g. schema
+        // drift from a future Phase 3 adding new shape types), treat as empty
+        // rather than 500 — the client can then re-save a valid overlay.
+        try
+        {
+            var dto = JsonSerializer.Deserialize<MapOverlayDto>(game.OverlayJson, OverlayJsonOptions);
+            return dto is null ? TypedResults.NoContent() : TypedResults.Ok(dto);
+        }
+        catch (JsonException)
+        {
+            return TypedResults.NoContent();
+        }
+    }
+
+    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> UpdateOverlay(
+        int id, MapOverlayDto dto, WorldDbContext db)
+    {
+        // § _review-instincts #1: resource lookup BEFORE validation.
+        var game = await db.Games.FindAsync(id);
+        if (game is null)
+            return TypedResults.NotFound();
+
+        var serialized = JsonSerializer.Serialize(dto, OverlayJsonOptions);
+        var byteCount = Encoding.UTF8.GetByteCount(serialized);
+        if (byteCount > OverlayMaxBytes)
+        {
+            return TypedResults.Problem(
+                title: "Překryv je příliš velký",
+                detail: $"Maximální velikost překryvu je {OverlayMaxBytes / 1024} KiB, odeslaná data mají {byteCount / 1024} KiB.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        game.OverlayJson = serialized;
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Migrations/20260424212915_AddGameOverlayJson.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260424212915_AddGameOverlayJson.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424212915_AddGameOverlayJson")]
+    partial class AddGameOverlayJson
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -313,10 +316,6 @@ namespace OvcinaHra.Api.Migrations
 
                     b.Property<int>("GameId")
                         .HasColumnType("integer");
-
-                    b.Property<string>("IngredientNotes")
-                        .HasMaxLength(2000)
-                        .HasColumnType("character varying(2000)");
 
                     b.Property<int?>("LocationId")
                         .HasColumnType("integer");
@@ -855,10 +854,6 @@ namespace OvcinaHra.Api.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
-
-                    b.Property<string>("Note")
-                        .HasMaxLength(2000)
-                        .HasColumnType("character varying(2000)");
 
                     b.Property<string>("PhysicalForm")
                         .HasMaxLength(30)

--- a/src/OvcinaHra.Api/Migrations/20260424212915_AddGameOverlayJson.cs
+++ b/src/OvcinaHra.Api/Migrations/20260424212915_AddGameOverlayJson.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameOverlayJson : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OverlayJson",
+                table: "Games",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OverlayJson",
+                table: "Games");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Components/MapOverlayToolbar.razor
+++ b/src/OvcinaHra.Client/Components/MapOverlayToolbar.razor
@@ -10,9 +10,9 @@
         @foreach (var t in Tools)
         {
             <button type="button" class="oh-mo-tool @(t.Key == Tool ? "is-active" : "")"
-                    title="@t.Label" aria-pressed="@(t.Key == Tool)"
+                    title="@t.Label" aria-label="@t.Label" aria-pressed="@(t.Key == Tool)"
                     @onclick="() => SelectToolAsync(t.Key)">
-                <i class="bi @t.Icon"></i>
+                <i class="bi @t.Icon" aria-hidden="true"></i>
             </button>
         }
     </div>

--- a/src/OvcinaHra.Client/Components/MapOverlayToolbar.razor
+++ b/src/OvcinaHra.Client/Components/MapOverlayToolbar.razor
@@ -1,0 +1,143 @@
+@* Floating toolbar for the map overlay editor (issue #96, Phase 1+2).
+   Hosted by MapView when edit mode is active. No state of its own — every
+   change bubbles up through EventCallbacks so the parent keeps the single
+   source of truth (Tool, Color, StrokeWidth, …). *@
+
+<div class="oh-mo-toolbar" role="toolbar" aria-label="Nástroje překryvu mapy">
+
+    @* Tool palette — 6 primitives. Icons per brief. *@
+    <div class="oh-mo-tools" role="group" aria-label="Nástroje">
+        @foreach (var t in Tools)
+        {
+            <button type="button" class="oh-mo-tool @(t.Key == Tool ? "is-active" : "")"
+                    title="@t.Label" aria-pressed="@(t.Key == Tool)"
+                    @onclick="() => SelectToolAsync(t.Key)">
+                <i class="bi @t.Icon"></i>
+            </button>
+        }
+    </div>
+
+    @* Colour palette — 8 kingdom-seal presets + arbitrary. Preset hex taken
+       verbatim from feedback_ovcina_kingdom_seal_palette memory; do not
+       re-saturate. *@
+    <div class="oh-mo-colors" role="group" aria-label="Barva">
+        @foreach (var hex in PresetColors)
+        {
+            <button type="button" class="oh-mo-swatch @(string.Equals(hex, Color, StringComparison.OrdinalIgnoreCase) ? "is-active" : "")"
+                    style="background-color:@hex"
+                    title="@hex" aria-label="@hex"
+                    @onclick="() => SetColorAsync(hex)"></button>
+        }
+        <input type="color" class="oh-mo-color-custom" value="@Color"
+               title="Vlastní barva"
+               @onchange="OnCustomColorChangedAsync" />
+    </div>
+
+    @* Stroke width + fill toggle + font size. *@
+    <div class="oh-mo-stroke" role="group" aria-label="Nastavení tahu a výplně">
+        <label class="oh-mo-label">Tah
+            <input type="range" min="1" max="8" step="1" value="@StrokeWidth"
+                   @onchange="OnStrokeChangedAsync" />
+            <span class="oh-mo-stroke-val">@(((int)StrokeWidth))px</span>
+        </label>
+
+        <label class="oh-mo-label" title="Vyplnit tvar barvou (platí pro obdélník, kruh, mnohoúhelník)">
+            <input type="checkbox" checked="@UseFill"
+                   @onchange="OnUseFillChangedAsync" />
+            Výplň
+        </label>
+
+        @if (Tool == "text")
+        {
+            <label class="oh-mo-label">Písmo
+                <input type="range" min="10" max="32" step="1" value="@FontSize"
+                       @onchange="OnFontSizeChangedAsync" />
+                <span class="oh-mo-stroke-val">@FontSize px</span>
+            </label>
+        }
+    </div>
+
+    @* Save / Cancel. *@
+    <div class="oh-mo-actions" role="group" aria-label="Akce">
+        <button type="button" class="btn btn-outline-secondary btn-sm" title="Zahodit změny"
+                @onclick="OnCancel">
+            Zrušit
+        </button>
+        <button type="button" class="btn btn-primary btn-sm" title="Uložit překryv"
+                @onclick="OnSave">
+            <i class="bi bi-check2-circle"></i> Uložit
+        </button>
+    </div>
+</div>
+
+@code {
+    // Kingdom-seal presets (feedback_ovcina_kingdom_seal_palette) — 4 heraldic
+    // + 4 utility. Do NOT re-saturate; these are wife-approved canonical hex.
+    private static readonly string[] PresetColors = new[]
+    {
+        "#242F3D", // Esgaroth
+        "#243525", // Aradhryand
+        "#8C2423", // Azanulinbar
+        "#504B25", // Arnor
+        "#2D5016", // forest green
+        "#B26223", // autumn amber
+        "#2C1810", // ink
+        "#8B7D5C"  // parchment
+    };
+
+    private sealed record ToolItem(string Key, string Label, string Icon);
+
+    // Czech tool labels. Phase 3 adds "ikona"/"šipka" here too.
+    private static readonly ToolItem[] Tools = new[]
+    {
+        new ToolItem("text",      "Text",         "bi-fonts"),
+        new ToolItem("freehand",  "Kresba",       "bi-vector-pen"),
+        new ToolItem("polyline",  "Čára",         "bi-slash-lg"),
+        new ToolItem("rectangle", "Obdélník",     "bi-square"),
+        new ToolItem("circle",    "Kruh",         "bi-circle"),
+        new ToolItem("polygon",   "Mnohoúhelník", "bi-pentagon")
+    };
+
+    [Parameter] public string Tool { get; set; } = "text";
+    [Parameter] public EventCallback<string> ToolChanged { get; set; }
+
+    [Parameter] public string Color { get; set; } = "#242F3D";
+    [Parameter] public EventCallback<string> ColorChanged { get; set; }
+
+    [Parameter] public bool UseFill { get; set; }
+    [Parameter] public EventCallback<bool> UseFillChanged { get; set; }
+
+    [Parameter] public double StrokeWidth { get; set; } = 2;
+    [Parameter] public EventCallback<double> StrokeWidthChanged { get; set; }
+
+    [Parameter] public int FontSize { get; set; } = 14;
+    [Parameter] public EventCallback<int> FontSizeChanged { get; set; }
+
+    [Parameter] public EventCallback OnSave { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+
+    private Task SelectToolAsync(string key) => ToolChanged.InvokeAsync(key);
+    private Task SetColorAsync(string hex) => ColorChanged.InvokeAsync(hex);
+
+    private async Task OnCustomColorChangedAsync(ChangeEventArgs e)
+    {
+        var hex = e.Value?.ToString();
+        if (!string.IsNullOrWhiteSpace(hex))
+            await ColorChanged.InvokeAsync(hex);
+    }
+
+    private async Task OnStrokeChangedAsync(ChangeEventArgs e)
+    {
+        if (double.TryParse(e.Value?.ToString(), System.Globalization.CultureInfo.InvariantCulture, out var w))
+            await StrokeWidthChanged.InvokeAsync(w);
+    }
+
+    private Task OnUseFillChangedAsync(ChangeEventArgs e)
+        => UseFillChanged.InvokeAsync(e.Value is bool b && b);
+
+    private async Task OnFontSizeChangedAsync(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var n))
+            await FontSizeChanged.InvokeAsync(n);
+    }
+}

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -29,6 +29,16 @@
                            FontSize="@_fontSize" FontSizeChanged="OnFontSizeChanged"
                            OnSave="SaveOverlayAsync"
                            OnCancel="CancelEditAsync" />
+
+        @if (!string.IsNullOrEmpty(_overlayError))
+        {
+            <div class="oh-map-overlay-error alert alert-danger" role="alert">
+                <i class="bi bi-exclamation-triangle-fill"></i>
+                <span>@_overlayError</span>
+                <button type="button" class="btn-close" aria-label="Zavřít chybu"
+                        @onclick="() => _overlayError = null"></button>
+            </div>
+        }
     }
 </div>
 
@@ -79,18 +89,31 @@
 
         // Load overlay once per game. Repeat on GameId change. Wrapped in
         // try/catch per _review-instincts §11 — a dead overlay fetch mustn't
-        // break the rest of the map page.
+        // break the rest of the map page. Marker is set only after a
+        // successful load so transient failures can retry on the next render.
         if (GameId.HasValue && _loadedOverlayForGameId != GameId)
         {
-            _loadedOverlayForGameId = GameId;
             try
             {
-                var dto = await Api.GetAsync<MapOverlayDto>($"/api/games/{GameId.Value}/overlay");
-                _committedShapes = dto?.Shapes ?? new List<MapOverlayShape>();
-                _stagedShapes = new List<MapOverlayShape>(_committedShapes);
+                List<MapOverlayShape> shapes;
+                try
+                {
+                    var dto = await Api.GetAsync<MapOverlayDto>($"/api/games/{GameId.Value}/overlay");
+                    shapes = dto?.Shapes ?? new List<MapOverlayShape>();
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    // 204 NoContent — empty body can't parse as JSON; treat as
+                    // no overlay. Still rendering below so the preview layers
+                    // are initialised for a future editor session.
+                    shapes = new List<MapOverlayShape>();
+                }
+                _committedShapes = shapes;
+                _stagedShapes = new List<MapOverlayShape>(shapes);
                 await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _committedShapes);
+                _loadedOverlayForGameId = GameId;
             }
-            catch { /* best-effort */ }
+            catch { /* network / JS failure — leave _loadedOverlayForGameId unset so a retry is possible */ }
         }
     }
 
@@ -258,10 +281,25 @@
 
     [JSInvokable]
     public async Task OnStyleLoadedCallback()
-        => await OnStyleLoaded.InvokeAsync();
+    {
+        await OnStyleLoaded.InvokeAsync();
+
+        // `ovcinaMap.switchStyle` wipes all style-dependent layers, including
+        // the overlay source / layers that `ovcinaOverlay.render` added.
+        // Re-render so the saved overlay survives basemap swaps.
+        if (GameId.HasValue && _loadedOverlayForGameId == GameId)
+        {
+            try { await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _committedShapes); }
+            catch { /* best-effort */ }
+        }
+    }
 
     public async ValueTask DisposeAsync()
     {
+        // Release overlay editor state first so the map still has live layers
+        // while we tear them down — avoids orphaned keydown listeners and
+        // stuck `dragPan.disable()` if the user navigated mid-draw.
+        try { await JS.InvokeVoidAsync("ovcinaOverlay.dispose", _elementId); } catch { }
         try { await JS.InvokeVoidAsync("ovcinaMap.dispose"); } catch { }
         _dotnetRef?.Dispose();
     }

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -1,6 +1,36 @@
 @implements IAsyncDisposable
+@inject ApiClient Api
 
-<div id="@_elementId" style="width: 100%; height: @Height; border-radius: 4px;"></div>
+<div class="oh-map-host-wrap" style="position:relative;width:100%;height:@Height;">
+    <div id="@_elementId" style="width:100%;height:100%;border-radius:4px;"></div>
+
+    @* Issue #96 — overlay editor controls. Button shown when a GameId is
+       supplied (overlay is a per-game artefact). Toolbar only renders while
+       actively editing. *@
+    @if (GameId.HasValue && !_editMode)
+    {
+        <AuthorizeView>
+            <Authorized>
+                <button type="button" class="btn btn-sm btn-outline-primary oh-map-overlay-edit-btn"
+                        title="Upravit vektorový překryv mapy"
+                        @onclick="EnterEditModeAsync">
+                    <i class="bi bi-vector-pen"></i> Upravit překryv
+                </button>
+            </Authorized>
+        </AuthorizeView>
+    }
+
+    @if (GameId.HasValue && _editMode)
+    {
+        <MapOverlayToolbar Tool="@_tool" ToolChanged="ChangeToolAsync"
+                           Color="@_color" ColorChanged="OnColorChanged"
+                           UseFill="@_useFill" UseFillChanged="OnUseFillChanged"
+                           StrokeWidth="@_strokeWidth" StrokeWidthChanged="OnStrokeWidthChanged"
+                           FontSize="@_fontSize" FontSizeChanged="OnFontSizeChanged"
+                           OnSave="SaveOverlayAsync"
+                           OnCancel="CancelEditAsync" />
+    }
+</div>
 
 @code {
     [Inject] private IJSRuntime JS { get; set; } = null!;
@@ -17,8 +47,26 @@
     [Parameter] public EventCallback<int> OnPieMarkerClick { get; set; }
     [Parameter] public EventCallback<PiePayloadEventArgs> OnPieMarkerDrop { get; set; }
 
+    /// <summary>
+    /// When set, the map loads the game's vector overlay (issue #96) and
+    /// surfaces the "Upravit překryv" editor button.
+    /// </summary>
+    [Parameter] public int? GameId { get; set; }
+
     private readonly string _elementId = $"map-{Guid.NewGuid():N}";
     private DotNetObjectReference<MapView>? _dotnetRef;
+
+    // ---- Overlay editor state ------------------------------------------
+    private List<MapOverlayShape> _committedShapes = new();   // last-saved baseline
+    private List<MapOverlayShape> _stagedShapes = new();      // working copy
+    private bool _editMode;
+    private string _tool = "text";
+    private string _color = "#242F3D";
+    private bool _useFill;
+    private double _strokeWidth = 2;
+    private int _fontSize = 14;
+    private string? _overlayError;
+    private int? _loadedOverlayForGameId;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -27,6 +75,119 @@
             _dotnetRef = DotNetObjectReference.Create(this);
             var apiKey = Config["MapyCz:ApiKey"];
             await JS.InvokeVoidAsync("ovcinaMap.init", _elementId, _dotnetRef, CenterLat, CenterLon, Zoom, apiKey);
+        }
+
+        // Load overlay once per game. Repeat on GameId change. Wrapped in
+        // try/catch per _review-instincts §11 — a dead overlay fetch mustn't
+        // break the rest of the map page.
+        if (GameId.HasValue && _loadedOverlayForGameId != GameId)
+        {
+            _loadedOverlayForGameId = GameId;
+            try
+            {
+                var dto = await Api.GetAsync<MapOverlayDto>($"/api/games/{GameId.Value}/overlay");
+                _committedShapes = dto?.Shapes ?? new List<MapOverlayShape>();
+                _stagedShapes = new List<MapOverlayShape>(_committedShapes);
+                await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _committedShapes);
+            }
+            catch { /* best-effort */ }
+        }
+    }
+
+    // ---- Overlay editor handlers --------------------------------------
+
+    private async Task EnterEditModeAsync()
+    {
+        _editMode = true;
+        _stagedShapes = new List<MapOverlayShape>(_committedShapes);
+        _overlayError = null;
+        await PushStyleToJsAsync();
+        await JS.InvokeVoidAsync("ovcinaOverlay.enterEditMode", _elementId, _tool, _dotnetRef);
+    }
+
+    private async Task CancelEditAsync()
+    {
+        _editMode = false;
+        _stagedShapes = new List<MapOverlayShape>(_committedShapes);
+        await JS.InvokeVoidAsync("ovcinaOverlay.exitEditMode", _elementId);
+        await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _committedShapes);
+    }
+
+    private async Task SaveOverlayAsync()
+    {
+        var dto = new MapOverlayDto(_stagedShapes);
+        var (ok, problem) = await Api.PutWithProblemAsync($"/api/games/{GameId!.Value}/overlay", dto);
+        if (!ok)
+        {
+            _overlayError = problem ?? "Uložení překryvu selhalo.";
+            return;
+        }
+        _committedShapes = new List<MapOverlayShape>(_stagedShapes);
+        _editMode = false;
+        await JS.InvokeVoidAsync("ovcinaOverlay.exitEditMode", _elementId);
+        await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _committedShapes);
+    }
+
+    private async Task ChangeToolAsync(string tool)
+    {
+        _tool = tool;
+        if (_editMode)
+        {
+            await PushStyleToJsAsync();
+            await JS.InvokeVoidAsync("ovcinaOverlay.switchTool", _elementId, _tool);
+        }
+    }
+
+    private async Task OnColorChanged(string color)
+    {
+        _color = color;
+        await PushStyleToJsAsync();
+    }
+
+    private async Task OnUseFillChanged(bool use)
+    {
+        _useFill = use;
+        await PushStyleToJsAsync();
+    }
+
+    private async Task OnStrokeWidthChanged(double w)
+    {
+        _strokeWidth = w;
+        await PushStyleToJsAsync();
+    }
+
+    private async Task OnFontSizeChanged(int size)
+    {
+        _fontSize = size;
+        await PushStyleToJsAsync();
+    }
+
+    private Task PushStyleToJsAsync()
+        => JS.InvokeVoidAsync("ovcinaOverlay.setStyle", new
+        {
+            color = _color,
+            fillColor = _color,       // single colour for both stroke + fill
+            strokeWidth = _strokeWidth,
+            useFill = _useFill,
+            fontSize = _fontSize
+        }).AsTask();
+
+    [JSInvokable]
+    public async Task OnShapeComplete(string shapeJson)
+    {
+        try
+        {
+            var shape = System.Text.Json.JsonSerializer.Deserialize<MapOverlayShape>(
+                shapeJson,
+                new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (shape is null) return;
+            _stagedShapes.Add(shape);
+            await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            // Shape payload malformed — log, don't surface. User can redraw.
+            Console.WriteLine($"Overlay shape deserialisation failed: {ex.Message}");
         }
     }
 

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -28,6 +28,7 @@
 <div style="position: relative;">
     <MapView @ref="mapView"
              CenterLat="49.4532461" CenterLon="18.0203242" Zoom="16"
+             GameId="@GameContext.SelectedGameId"
              OnMapClick="HandleMapClick"
              OnMarkerClick="HandleMarkerClick"
              OnMarkerDrag="HandleMarkerDrag"

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2550,3 +2550,32 @@
 .oh-version-banner-btn{display:inline-flex;align-items:center;gap:4px;padding:4px 14px;background:#F5EDE3;color:#243525;border:1px solid rgba(245,237,227,.4);border-radius:99px;font:600 .8125rem var(--oh-font-body);cursor:pointer;transition:background .15s,transform .15s}
 .oh-version-banner-btn:hover:not(:disabled){background:#fff8f0;transform:translateY(-1px)}
 .oh-version-banner-btn:disabled{opacity:.7;cursor:default}
+
+/* ------------------------------------------------------------
+   MapOverlayToolbar — floating editor strip (issue #96).
+   Scoped to .oh-mo-* so it doesn't bleed into .oh-map-* rules.
+   ------------------------------------------------------------ */
+.oh-mo-toolbar{position:absolute;top:12px;left:50%;transform:translateX(-50%);z-index:20;
+    display:flex;align-items:center;gap:12px;flex-wrap:wrap;
+    padding:8px 12px;background:var(--oh-surface,#fff);border:1px solid var(--oh-border,#d8d2be);
+    border-radius:var(--oh-radius,6px);box-shadow:0 3px 10px rgba(0,0,0,.22);
+    max-width:calc(100% - 24px)}
+.oh-mo-tools,.oh-mo-colors,.oh-mo-stroke,.oh-mo-actions{display:flex;align-items:center;gap:6px}
+.oh-mo-tool{display:inline-flex;align-items:center;justify-content:center;
+    width:34px;height:34px;border:1px solid var(--oh-border,#d8d2be);
+    background:var(--oh-surface-alt,#f5f0e1);border-radius:var(--oh-radius-sm,4px);
+    color:var(--oh-text,#2a2a2a);font-size:1rem;cursor:pointer;transition:.12s ease}
+.oh-mo-tool:hover{background:#eee3c9}
+.oh-mo-tool.is-active{background:#2D5016;color:#fff;border-color:#2D5016}
+.oh-mo-swatch{width:22px;height:22px;border-radius:50%;border:1.5px solid rgba(255,255,255,.85);
+    box-shadow:0 0 0 1px rgba(0,0,0,.2);cursor:pointer;padding:0;transition:transform .1s ease}
+.oh-mo-swatch:hover{transform:scale(1.12)}
+.oh-mo-swatch.is-active{outline:2px solid #2D5016;outline-offset:2px}
+.oh-mo-color-custom{width:28px;height:28px;border:1px solid var(--oh-border,#d8d2be);
+    border-radius:var(--oh-radius-sm,4px);padding:0;cursor:pointer;background:none}
+.oh-mo-label{display:inline-flex;align-items:center;gap:4px;margin:0;
+    font:600 .75rem var(--oh-font-body);color:var(--oh-text-secondary,#6a6a6a)}
+.oh-mo-label input[type="range"]{width:80px;margin:0}
+.oh-mo-stroke-val{font-family:var(--oh-font-mono,Menlo,monospace);color:var(--oh-text,#2a2a2a);
+    font-size:.75rem;min-width:30px;text-align:right}
+.oh-map-overlay-edit-btn{position:absolute;top:12px;right:12px;z-index:19}

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2579,3 +2579,7 @@
 .oh-mo-stroke-val{font-family:var(--oh-font-mono,Menlo,monospace);color:var(--oh-text,#2a2a2a);
     font-size:.75rem;min-width:30px;text-align:right}
 .oh-map-overlay-edit-btn{position:absolute;top:12px;right:12px;z-index:19}
+.oh-map-overlay-error{position:absolute;top:72px;left:50%;transform:translateX(-50%);z-index:21;
+    display:flex;align-items:center;gap:8px;max-width:min(520px,calc(100% - 24px));
+    margin:0;padding:8px 12px;font-size:.875rem}
+.oh-map-overlay-error .btn-close{margin-left:auto}

--- a/src/OvcinaHra.Client/wwwroot/index.html
+++ b/src/OvcinaHra.Client/wwwroot/index.html
@@ -42,6 +42,7 @@
     </div>
     <script src="lib/maplibre-gl/maplibre-gl.js"></script>
     <script src="js/map-interop.js?v=20260411"></script>
+    <script src="js/overlay-interop.js?v=20260424"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script>navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' });</script>
     <script>

--- a/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
@@ -218,14 +218,23 @@
     function enterEditMode(mapId, tool, dotnetRef) {
         const map = getMap(mapId);
         if (!map) return;
-        const inst = ensureInstance(mapId);
-        inst.tool = tool;
-        inst.dotnetRef = dotnetRef;
-        map.getCanvas().style.cursor = 'crosshair';
-        // Disable map-level double-click zoom so polyline/polygon "dblclick to
-        // finish" doesn't also zoom the viewport.
-        if (map.doubleClickZoom && map.doubleClickZoom.disable) map.doubleClickZoom.disable();
-        attachHandlers(map, inst);
+        // If the editor is invoked before `render()` has been called (e.g.
+        // game has no saved overlay yet) the source+layer pair is missing and
+        // preview updates would no-op — make sure both exist before wiring
+        // handlers.
+        const setup = () => {
+            ensureLayers(map, SRC_SAVED, LYR_FILLS, LYR_STROKES, LYR_TEXT);
+            ensureLayers(map, SRC_PREVIEW, LYR_PREVIEW_FILLS, LYR_PREVIEW_STROKES, LYR_PREVIEW_TEXT);
+            const inst = ensureInstance(mapId);
+            inst.tool = tool;
+            inst.dotnetRef = dotnetRef;
+            map.getCanvas().style.cursor = 'crosshair';
+            // Disable map-level double-click zoom so polyline/polygon "dblclick
+            // to finish" doesn't also zoom the viewport.
+            if (map.doubleClickZoom && map.doubleClickZoom.disable) map.doubleClickZoom.disable();
+            attachHandlers(map, inst);
+        };
+        if (map.isStyleLoaded()) setup(); else map.once('styledata', setup);
     }
 
     function switchTool(mapId, tool) {
@@ -269,6 +278,11 @@
     }
 
     function detachHandlers(map, inst) {
+        // Always restore map panning — if the user interrupted a freehand,
+        // rectangle, or circle drag mid-stroke (tool switch / exit / nav away),
+        // the matching mouseup never fired and `dragPan` would stay disabled,
+        // leaving the map stuck.
+        if (map && map.dragPan && map.dragPan.enable) map.dragPan.enable();
         for (const h of inst.handlers) {
             try {
                 if (h.target === map) map.off(h.event, h.fn);
@@ -559,11 +573,42 @@
 
     // ---- Exports ----------------------------------------------------------
 
+    function dispose(mapId) {
+        const inst = instances[mapId];
+        if (!inst) return;
+        const map = getMap(mapId);
+        if (map) {
+            // detachHandlers also re-enables dragPan if it was disabled mid-draw.
+            detachHandlers(map, inst);
+            try { teardownPreview(map); } catch (e) { /* map may be gone */ }
+            // Remove overlay source + layers so a subsequent remount starts
+            // clean — avoids orphaned style-dependent layers when the user
+            // navigates away and back.
+            try {
+                for (const lyr of [
+                    LYR_FILLS, LYR_STROKES, LYR_TEXT,
+                    LYR_PREVIEW_FILLS, LYR_PREVIEW_STROKES, LYR_PREVIEW_TEXT
+                ]) {
+                    if (map.getLayer(lyr)) map.removeLayer(lyr);
+                }
+                for (const src of [SRC_SAVED, SRC_PREVIEW]) {
+                    if (map.getSource(src)) map.removeSource(src);
+                }
+            } catch (e) { /* best-effort */ }
+            try {
+                map.getCanvas().style.cursor = '';
+                if (map.doubleClickZoom && map.doubleClickZoom.enable) map.doubleClickZoom.enable();
+            } catch (e) { /* best-effort */ }
+        }
+        delete instances[mapId];
+    }
+
     window.ovcinaOverlay = {
         render: render,
         enterEditMode: enterEditMode,
         switchTool: switchTool,
         exitEditMode: exitEditMode,
+        dispose: dispose,
         setStyle: setStyle,
         // Exposed for unit-testability / future tools; not called by Blazor.
         _circleToPolygonRing: circleToPolygonRing

--- a/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
@@ -1,0 +1,571 @@
+// Vector overlay editor for the MapLibre map — issue #96, Phase 1+2.
+//
+// Exposes a `window.ovcinaOverlay` global. Pairs with the main `window.ovcinaMap`
+// MapLibre instance (MapPage.razor / TreasurePlanning.razor both boot one map).
+// Operates on the same MapLibre instance — doesn't manage its own map.
+//
+// Shape wire format matches `OvcinaHra.Shared.Dtos.MapOverlayShape`:
+//   { type: "text"|"freehand"|"polyline"|"rectangle"|"circle"|"polygon",
+//     id, color, strokeWidth?, fillColor?, ... geometry ... }
+//
+// Phase 3 will add icons + arrows + select-to-edit; this file intentionally
+// has no selection/hit-test helpers yet.
+
+(function () {
+    const SRC_SAVED = 'oh-overlay-src';
+    const SRC_PREVIEW = 'oh-overlay-preview-src';
+    const LYR_FILLS = 'oh-overlay-fills';
+    const LYR_STROKES = 'oh-overlay-strokes';
+    const LYR_TEXT = 'oh-overlay-text';
+    const LYR_PREVIEW_FILLS = 'oh-overlay-preview-fills';
+    const LYR_PREVIEW_STROKES = 'oh-overlay-preview-strokes';
+    const LYR_PREVIEW_TEXT = 'oh-overlay-preview-text';
+    const CIRCLE_SEGMENTS = 32;
+
+    // Singleton state, keyed by mapId so future multi-map callers don't collide.
+    const instances = {};
+
+    function getMap(mapId) {
+        // Phase 1+2: MapView only boots the global `ovcinaMap`. If we ever host
+        // overlays on a second MapLibre instance, widen this lookup to a
+        // per-mapId registry the client side registers via a hook.
+        return (window.ovcinaMap && window.ovcinaMap._map) ? window.ovcinaMap._map : null;
+    }
+
+    function ensureInstance(mapId) {
+        if (!instances[mapId]) {
+            instances[mapId] = {
+                mapId: mapId,
+                tool: null,
+                dotnetRef: null,
+                handlers: [],           // { target, event, fn } for removal
+                tempPoints: [],         // in-progress polyline/polygon vertices
+                dragStart: null,        // rectangle/circle drag origin {lat, lng}
+                previewFeature: null,
+                keydownHandler: null
+            };
+        }
+        return instances[mapId];
+    }
+
+    // ---- GeoJSON feature builders -----------------------------------------
+
+    function circleToPolygonRing(centerLat, centerLng, radiusMeters, segments) {
+        // Geodesic circle on a sphere (Earth radius 6,371 km). 32 segments
+        // reads visually round down to ~100 m radius; below that users rarely
+        // draw circles anyway. Aviation Formulary §5.
+        const R = 6371000.0;
+        const ring = [];
+        const lat1 = centerLat * Math.PI / 180;
+        const lng1 = centerLng * Math.PI / 180;
+        const d = radiusMeters / R;
+        for (let i = 0; i <= segments; i++) {
+            const brng = (i / segments) * 2 * Math.PI;
+            const lat2 = Math.asin(
+                Math.sin(lat1) * Math.cos(d) +
+                Math.cos(lat1) * Math.sin(d) * Math.cos(brng));
+            const lng2 = lng1 + Math.atan2(
+                Math.sin(brng) * Math.sin(d) * Math.cos(lat1),
+                Math.cos(d) - Math.sin(lat1) * Math.sin(lat2));
+            ring.push([lng2 * 180 / Math.PI, lat2 * 180 / Math.PI]);
+        }
+        return ring;
+    }
+
+    function shapeToFeature(shape) {
+        const base = {
+            type: 'Feature',
+            properties: {
+                shapeType: shape.type,
+                color: shape.color,
+                strokeWidth: shape.strokeWidth || 2,
+                fillColor: shape.fillColor || null,
+                text: shape.text || null,
+                fontSize: shape.fontSize || 14
+            }
+        };
+        switch (shape.type) {
+            case 'text':
+                base.geometry = { type: 'Point', coordinates: [shape.coord.lng, shape.coord.lat] };
+                break;
+            case 'freehand':
+            case 'polyline':
+                base.geometry = {
+                    type: 'LineString',
+                    coordinates: (shape.points || []).map(p => [p.lng, p.lat])
+                };
+                break;
+            case 'rectangle': {
+                const sw = shape.sw, ne = shape.ne;
+                base.geometry = {
+                    type: 'Polygon',
+                    coordinates: [[
+                        [sw.lng, sw.lat],
+                        [ne.lng, sw.lat],
+                        [ne.lng, ne.lat],
+                        [sw.lng, ne.lat],
+                        [sw.lng, sw.lat]
+                    ]]
+                };
+                break;
+            }
+            case 'circle': {
+                base.geometry = {
+                    type: 'Polygon',
+                    coordinates: [circleToPolygonRing(shape.center.lat, shape.center.lng,
+                        shape.radiusMeters, CIRCLE_SEGMENTS)]
+                };
+                break;
+            }
+            case 'polygon': {
+                const pts = (shape.points || []).map(p => [p.lng, p.lat]);
+                if (pts.length > 0) {
+                    const first = pts[0], last = pts[pts.length - 1];
+                    if (first[0] !== last[0] || first[1] !== last[1]) pts.push([first[0], first[1]]);
+                }
+                base.geometry = { type: 'Polygon', coordinates: [pts] };
+                break;
+            }
+            default:
+                return null;
+        }
+        return base;
+    }
+
+    // ---- Source + layer management ----------------------------------------
+
+    function ensureLayers(map, sourceId, fillsId, strokesId, textId) {
+        if (!map.getSource(sourceId)) {
+            map.addSource(sourceId, {
+                type: 'geojson',
+                data: { type: 'FeatureCollection', features: [] }
+            });
+        }
+        if (!map.getLayer(fillsId)) {
+            map.addLayer({
+                id: fillsId,
+                type: 'fill',
+                source: sourceId,
+                filter: ['all',
+                    ['in', ['get', 'shapeType'], ['literal', ['rectangle', 'circle', 'polygon']]],
+                    ['!=', ['get', 'fillColor'], null]
+                ],
+                paint: {
+                    'fill-color': ['coalesce', ['get', 'fillColor'], '#000000'],
+                    'fill-opacity': 0.3
+                }
+            });
+        }
+        if (!map.getLayer(strokesId)) {
+            map.addLayer({
+                id: strokesId,
+                type: 'line',
+                source: sourceId,
+                filter: ['!=', ['get', 'shapeType'], 'text'],
+                paint: {
+                    'line-color': ['coalesce', ['get', 'color'], '#000000'],
+                    'line-width': ['coalesce', ['get', 'strokeWidth'], 2]
+                }
+            });
+        }
+        if (!map.getLayer(textId)) {
+            map.addLayer({
+                id: textId,
+                type: 'symbol',
+                source: sourceId,
+                filter: ['==', ['get', 'shapeType'], 'text'],
+                layout: {
+                    'text-field': ['get', 'text'],
+                    'text-size': ['coalesce', ['get', 'fontSize'], 14],
+                    'text-anchor': 'left',
+                    'text-offset': [0.5, 0],
+                    'text-allow-overlap': true
+                },
+                paint: {
+                    'text-color': ['coalesce', ['get', 'color'], '#000000'],
+                    'text-halo-color': '#ffffff',
+                    'text-halo-width': 2
+                }
+            });
+        }
+    }
+
+    function setSourceData(map, sourceId, features) {
+        const src = map.getSource(sourceId);
+        if (src) src.setData({ type: 'FeatureCollection', features: features });
+    }
+
+    function teardownPreview(map) {
+        setSourceData(map, SRC_PREVIEW, []);
+    }
+
+    // ---- Public API -------------------------------------------------------
+
+    function render(mapId, shapes) {
+        const map = getMap(mapId);
+        if (!map) return;
+        const paint = () => {
+            ensureLayers(map, SRC_SAVED, LYR_FILLS, LYR_STROKES, LYR_TEXT);
+            ensureLayers(map, SRC_PREVIEW, LYR_PREVIEW_FILLS, LYR_PREVIEW_STROKES, LYR_PREVIEW_TEXT);
+            const features = (shapes || [])
+                .map(shapeToFeature)
+                .filter(f => f !== null);
+            setSourceData(map, SRC_SAVED, features);
+        };
+        if (map.isStyleLoaded()) paint(); else map.once('styledata', paint);
+    }
+
+    function enterEditMode(mapId, tool, dotnetRef) {
+        const map = getMap(mapId);
+        if (!map) return;
+        const inst = ensureInstance(mapId);
+        inst.tool = tool;
+        inst.dotnetRef = dotnetRef;
+        map.getCanvas().style.cursor = 'crosshair';
+        // Disable map-level double-click zoom so polyline/polygon "dblclick to
+        // finish" doesn't also zoom the viewport.
+        if (map.doubleClickZoom && map.doubleClickZoom.disable) map.doubleClickZoom.disable();
+        attachHandlers(map, inst);
+    }
+
+    function switchTool(mapId, tool) {
+        const inst = instances[mapId];
+        if (!inst) return;
+        const map = getMap(mapId);
+        if (!map) return;
+        detachHandlers(map, inst);
+        resetInProgress(inst);
+        teardownPreview(map);
+        inst.tool = tool;
+        attachHandlers(map, inst);
+    }
+
+    function exitEditMode(mapId) {
+        const inst = instances[mapId];
+        if (!inst) return;
+        const map = getMap(mapId);
+        if (map) {
+            detachHandlers(map, inst);
+            map.getCanvas().style.cursor = '';
+            if (map.doubleClickZoom && map.doubleClickZoom.enable) map.doubleClickZoom.enable();
+            teardownPreview(map);
+        }
+        resetInProgress(inst);
+        inst.tool = null;
+        inst.dotnetRef = null;
+    }
+
+    // ---- Handler plumbing -------------------------------------------------
+
+    function attachHandlers(map, inst) {
+        switch (inst.tool) {
+            case 'text':      attachTextTool(map, inst); break;
+            case 'freehand':  attachFreehandTool(map, inst); break;
+            case 'polyline':  attachPolylineTool(map, inst, /*closeLoop*/ false); break;
+            case 'polygon':   attachPolylineTool(map, inst, /*closeLoop*/ true); break;
+            case 'rectangle': attachRectangleTool(map, inst); break;
+            case 'circle':    attachCircleTool(map, inst); break;
+        }
+    }
+
+    function detachHandlers(map, inst) {
+        for (const h of inst.handlers) {
+            try {
+                if (h.target === map) map.off(h.event, h.fn);
+                else h.target.removeEventListener(h.event, h.fn);
+            } catch (e) { /* swallow — removing handlers is best-effort */ }
+        }
+        inst.handlers = [];
+        if (inst.keydownHandler) {
+            window.removeEventListener('keydown', inst.keydownHandler);
+            inst.keydownHandler = null;
+        }
+    }
+
+    function resetInProgress(inst) {
+        inst.tempPoints = [];
+        inst.dragStart = null;
+        inst.previewFeature = null;
+    }
+
+    function onMap(map, inst, evt, fn) {
+        map.on(evt, fn);
+        inst.handlers.push({ target: map, event: evt, fn: fn });
+    }
+
+    function emitShape(inst, shape) {
+        if (!inst.dotnetRef) return;
+        try {
+            inst.dotnetRef.invokeMethodAsync('OnShapeComplete', JSON.stringify(shape));
+        } catch (e) {
+            console.warn('Overlay shape emit failed:', e);
+        }
+    }
+
+    function uuid() {
+        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+            return window.crypto.randomUUID();
+        }
+        // RFC4122 v4 fallback for older browsers.
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+            const r = Math.random() * 16 | 0;
+            const v = c === 'x' ? r : (r & 0x3 | 0x8);
+            return v.toString(16);
+        });
+    }
+
+    // ---- Tool: text -------------------------------------------------------
+
+    function attachTextTool(map, inst) {
+        onMap(map, inst, 'click', function (e) {
+            // Phase 1 uses window.prompt; Phase 3 replaces with an inline editor.
+            const text = window.prompt('Text:');
+            if (!text) return;
+            emitShape(inst, {
+                id: uuid(),
+                type: 'text',
+                color: currentStyle().color,
+                coord: { lat: e.lngLat.lat, lng: e.lngLat.lng },
+                text: text,
+                fontSize: currentStyle().fontSize || 14
+            });
+        });
+    }
+
+    // ---- Tool: freehand ---------------------------------------------------
+
+    function attachFreehandTool(map, inst) {
+        let drawing = false;
+        const onDown = function (e) {
+            drawing = true;
+            inst.tempPoints = [{ lat: e.lngLat.lat, lng: e.lngLat.lng }];
+            if (map.dragPan && map.dragPan.disable) map.dragPan.disable();
+        };
+        const onMove = function (e) {
+            if (!drawing) return;
+            inst.tempPoints.push({ lat: e.lngLat.lat, lng: e.lngLat.lng });
+            updatePreview(map, {
+                type: 'freehand', color: currentStyle().color,
+                strokeWidth: currentStyle().strokeWidth, points: inst.tempPoints
+            });
+        };
+        const onUp = function () {
+            if (!drawing) return;
+            drawing = false;
+            if (map.dragPan && map.dragPan.enable) map.dragPan.enable();
+            if (inst.tempPoints.length >= 2) {
+                emitShape(inst, {
+                    id: uuid(),
+                    type: 'freehand',
+                    color: currentStyle().color,
+                    strokeWidth: currentStyle().strokeWidth,
+                    points: inst.tempPoints.slice()
+                });
+            }
+            inst.tempPoints = [];
+            teardownPreview(map);
+        };
+        onMap(map, inst, 'mousedown', onDown);
+        onMap(map, inst, 'mousemove', onMove);
+        onMap(map, inst, 'mouseup', onUp);
+    }
+
+    // ---- Tool: polyline / polygon ----------------------------------------
+
+    function attachPolylineTool(map, inst, closeLoop) {
+        const onClick = function (e) {
+            inst.tempPoints.push({ lat: e.lngLat.lat, lng: e.lngLat.lng });
+            refreshVertexPreview(map, inst, closeLoop);
+        };
+        const onDbl = function () {
+            finalizePolyOrLine(inst, closeLoop);
+            teardownPreview(map);
+        };
+        const onMove = function (e) {
+            if (inst.tempPoints.length === 0) return;
+            const preview = inst.tempPoints.concat([{ lat: e.lngLat.lat, lng: e.lngLat.lng }]);
+            updatePreview(map, closeLoop ? {
+                type: 'polygon', color: currentStyle().color,
+                fillColor: currentStyle().useFill ? currentStyle().fillColor : null,
+                strokeWidth: currentStyle().strokeWidth, points: preview
+            } : {
+                type: 'polyline', color: currentStyle().color,
+                strokeWidth: currentStyle().strokeWidth, points: preview
+            });
+        };
+        onMap(map, inst, 'click', onClick);
+        onMap(map, inst, 'dblclick', onDbl);
+        onMap(map, inst, 'mousemove', onMove);
+        inst.keydownHandler = function (ev) {
+            if (ev.key === 'Enter') { finalizePolyOrLine(inst, closeLoop); teardownPreview(map); }
+            else if (ev.key === 'Escape') { inst.tempPoints = []; teardownPreview(map); }
+        };
+        window.addEventListener('keydown', inst.keydownHandler);
+    }
+
+    function refreshVertexPreview(map, inst, closeLoop) {
+        if (inst.tempPoints.length === 0) { teardownPreview(map); return; }
+        updatePreview(map, closeLoop ? {
+            type: 'polygon', color: currentStyle().color,
+            fillColor: currentStyle().useFill ? currentStyle().fillColor : null,
+            strokeWidth: currentStyle().strokeWidth, points: inst.tempPoints
+        } : {
+            type: 'polyline', color: currentStyle().color,
+            strokeWidth: currentStyle().strokeWidth, points: inst.tempPoints
+        });
+    }
+
+    function finalizePolyOrLine(inst, closeLoop) {
+        if (inst.tempPoints.length < (closeLoop ? 3 : 2)) { inst.tempPoints = []; return; }
+        const points = inst.tempPoints.slice();
+        emitShape(inst, closeLoop ? {
+            id: uuid(), type: 'polygon',
+            color: currentStyle().color,
+            fillColor: currentStyle().useFill ? currentStyle().fillColor : null,
+            strokeWidth: currentStyle().strokeWidth,
+            points: points
+        } : {
+            id: uuid(), type: 'polyline',
+            color: currentStyle().color,
+            strokeWidth: currentStyle().strokeWidth,
+            points: points
+        });
+        inst.tempPoints = [];
+    }
+
+    // ---- Tool: rectangle --------------------------------------------------
+
+    function attachRectangleTool(map, inst) {
+        const onDown = function (e) {
+            inst.dragStart = { lat: e.lngLat.lat, lng: e.lngLat.lng };
+            if (map.dragPan && map.dragPan.disable) map.dragPan.disable();
+        };
+        const onMove = function (e) {
+            if (!inst.dragStart) return;
+            const sw = {
+                lat: Math.min(inst.dragStart.lat, e.lngLat.lat),
+                lng: Math.min(inst.dragStart.lng, e.lngLat.lng)
+            };
+            const ne = {
+                lat: Math.max(inst.dragStart.lat, e.lngLat.lat),
+                lng: Math.max(inst.dragStart.lng, e.lngLat.lng)
+            };
+            updatePreview(map, {
+                type: 'rectangle', color: currentStyle().color,
+                fillColor: currentStyle().useFill ? currentStyle().fillColor : null,
+                strokeWidth: currentStyle().strokeWidth,
+                sw: sw, ne: ne
+            });
+        };
+        const onUp = function (e) {
+            if (!inst.dragStart) return;
+            const sw = {
+                lat: Math.min(inst.dragStart.lat, e.lngLat.lat),
+                lng: Math.min(inst.dragStart.lng, e.lngLat.lng)
+            };
+            const ne = {
+                lat: Math.max(inst.dragStart.lat, e.lngLat.lat),
+                lng: Math.max(inst.dragStart.lng, e.lngLat.lng)
+            };
+            if (map.dragPan && map.dragPan.enable) map.dragPan.enable();
+            if (Math.abs(sw.lat - ne.lat) > 1e-6 && Math.abs(sw.lng - ne.lng) > 1e-6) {
+                emitShape(inst, {
+                    id: uuid(), type: 'rectangle',
+                    color: currentStyle().color,
+                    fillColor: currentStyle().useFill ? currentStyle().fillColor : null,
+                    strokeWidth: currentStyle().strokeWidth,
+                    sw: sw, ne: ne
+                });
+            }
+            inst.dragStart = null;
+            teardownPreview(map);
+        };
+        onMap(map, inst, 'mousedown', onDown);
+        onMap(map, inst, 'mousemove', onMove);
+        onMap(map, inst, 'mouseup', onUp);
+    }
+
+    // ---- Tool: circle -----------------------------------------------------
+
+    function attachCircleTool(map, inst) {
+        const onDown = function (e) {
+            inst.dragStart = { lat: e.lngLat.lat, lng: e.lngLat.lng };
+            if (map.dragPan && map.dragPan.disable) map.dragPan.disable();
+        };
+        const onMove = function (e) {
+            if (!inst.dragStart) return;
+            const r = haversineMeters(inst.dragStart, { lat: e.lngLat.lat, lng: e.lngLat.lng });
+            updatePreview(map, {
+                type: 'circle', color: currentStyle().color,
+                fillColor: currentStyle().useFill ? currentStyle().fillColor : null,
+                strokeWidth: currentStyle().strokeWidth,
+                center: inst.dragStart, radiusMeters: r
+            });
+        };
+        const onUp = function (e) {
+            if (!inst.dragStart) return;
+            const r = haversineMeters(inst.dragStart, { lat: e.lngLat.lat, lng: e.lngLat.lng });
+            if (map.dragPan && map.dragPan.enable) map.dragPan.enable();
+            if (r >= 5) {
+                emitShape(inst, {
+                    id: uuid(), type: 'circle',
+                    color: currentStyle().color,
+                    fillColor: currentStyle().useFill ? currentStyle().fillColor : null,
+                    strokeWidth: currentStyle().strokeWidth,
+                    center: inst.dragStart, radiusMeters: r
+                });
+            }
+            inst.dragStart = null;
+            teardownPreview(map);
+        };
+        onMap(map, inst, 'mousedown', onDown);
+        onMap(map, inst, 'mousemove', onMove);
+        onMap(map, inst, 'mouseup', onUp);
+    }
+
+    function haversineMeters(a, b) {
+        const R = 6371000.0;
+        const lat1 = a.lat * Math.PI / 180, lat2 = b.lat * Math.PI / 180;
+        const dLat = (b.lat - a.lat) * Math.PI / 180;
+        const dLng = (b.lng - a.lng) * Math.PI / 180;
+        const s = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+            + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        return 2 * R * Math.atan2(Math.sqrt(s), Math.sqrt(1 - s));
+    }
+
+    // ---- Preview rendering ------------------------------------------------
+
+    function updatePreview(map, shape) {
+        const feature = shapeToFeature(shape);
+        if (!feature) { teardownPreview(map); return; }
+        setSourceData(map, SRC_PREVIEW, [feature]);
+    }
+
+    // ---- Style config set by the toolbar ----------------------------------
+
+    let _style = {
+        color: '#242F3D',
+        fillColor: '#242F3D',
+        strokeWidth: 2,
+        useFill: false,
+        fontSize: 14
+    };
+
+    function currentStyle() { return _style; }
+
+    function setStyle(partial) {
+        _style = Object.assign({}, _style, partial || {});
+    }
+
+    // ---- Exports ----------------------------------------------------------
+
+    window.ovcinaOverlay = {
+        render: render,
+        enterEditMode: enterEditMode,
+        switchTool: switchTool,
+        exitEditMode: exitEditMode,
+        setStyle: setStyle,
+        // Exposed for unit-testability / future tools; not called by Blazor.
+        _circleToPolygonRing: circleToPolygonRing
+    };
+})();

--- a/src/OvcinaHra.Shared/Domain/Entities/Game.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Game.cs
@@ -27,6 +27,13 @@ public class Game
     public decimal? BoundingBoxNeLat { get; set; }
     public decimal? BoundingBoxNeLng { get; set; }
 
+    /// <summary>
+    /// Vector overlay drawn on top of the map — freeform text, freehand,
+    /// lines, shapes. Persisted as a JSON string of <c>MapOverlayDto</c>.
+    /// Null = no overlay drawn yet. See issue #96.
+    /// </summary>
+    public string? OverlayJson { get; set; }
+
     public ICollection<GameLocation> GameLocations { get; set; } = [];
     public ICollection<GameItem> GameItems { get; set; } = [];
     public ICollection<GameSecretStash> GameSecretStashes { get; set; } = [];

--- a/src/OvcinaHra.Shared/Dtos/MapOverlayDto.cs
+++ b/src/OvcinaHra.Shared/Dtos/MapOverlayDto.cs
@@ -1,0 +1,79 @@
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Dtos;
+
+/// <summary>
+/// Vector overlay drawn on top of a game's map — issue #96. Persisted as a
+/// JSON string on <c>Game.OverlayJson</c>. Phase 1+2 ships 6 primitives
+/// (text, freehand, polyline, rectangle, circle, polygon); icons + arrows
+/// are deferred to Phase 3.
+/// </summary>
+public record MapOverlayDto(List<MapOverlayShape> Shapes);
+
+/// <summary>
+/// Latitude/longitude pair, always in that order, WGS84 decimal degrees.
+/// </summary>
+public record OverlayCoord(double Lat, double Lng);
+
+/// <summary>
+/// Discriminated union over shape variants. The <c>type</c> property in the
+/// JSON payload drives <see cref="System.Text.Json"/> polymorphism. Shape
+/// <c>Id</c> is a client-generated string (GUID) so the client can update
+/// or delete a shape without a round-trip.
+/// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonDerivedType(typeof(TextShape),      "text")]
+[JsonDerivedType(typeof(FreehandShape),  "freehand")]
+[JsonDerivedType(typeof(PolylineShape),  "polyline")]
+[JsonDerivedType(typeof(RectangleShape), "rectangle")]
+[JsonDerivedType(typeof(CircleShape),    "circle")]
+[JsonDerivedType(typeof(PolygonShape),   "polygon")]
+public abstract record MapOverlayShape(string Id, string Color);
+
+public record TextShape(
+    string Id,
+    string Color,
+    OverlayCoord Coord,
+    string Text,
+    int FontSize = 14)
+    : MapOverlayShape(Id, Color);
+
+public record FreehandShape(
+    string Id,
+    string Color,
+    double StrokeWidth,
+    List<OverlayCoord> Points)
+    : MapOverlayShape(Id, Color);
+
+public record PolylineShape(
+    string Id,
+    string Color,
+    double StrokeWidth,
+    List<OverlayCoord> Points)
+    : MapOverlayShape(Id, Color);
+
+public record RectangleShape(
+    string Id,
+    string Color,
+    string? FillColor,
+    double StrokeWidth,
+    OverlayCoord Sw,
+    OverlayCoord Ne)
+    : MapOverlayShape(Id, Color);
+
+public record CircleShape(
+    string Id,
+    string Color,
+    string? FillColor,
+    double StrokeWidth,
+    OverlayCoord Center,
+    double RadiusMeters)
+    : MapOverlayShape(Id, Color);
+
+public record PolygonShape(
+    string Id,
+    string Color,
+    string? FillColor,
+    double StrokeWidth,
+    List<OverlayCoord> Points)
+    : MapOverlayShape(Id, Color);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameEndpointTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
@@ -150,6 +151,110 @@ public class GameEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
             BoundingBoxNeLat: 49.5m, BoundingBoxNeLng: 17.4m));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    // ----- Map overlay (issue #96) ---------------------------------------
+
+    [Fact]
+    public async Task Overlay_GetWhenNotSet_Returns204()
+    {
+        var game = await CreateGameAsync("Overlay-None");
+
+        var response = await Client.GetAsync($"/api/games/{game.Id}/overlay");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Overlay_PutThenGet_RoundTripsAllShapeTypes()
+    {
+        var game = await CreateGameAsync("Overlay-RoundTrip");
+        var dto = new MapOverlayDto(new List<MapOverlayShape>
+        {
+            new TextShape("t1", "#242F3D", new OverlayCoord(49.5, 17.1), "Brodeček", 16),
+            new FreehandShape("f1", "#8C2423", 2, new List<OverlayCoord>
+            {
+                new(49.50, 17.10), new(49.51, 17.11), new(49.52, 17.12)
+            }),
+            new PolylineShape("pl1", "#243525", 3, new List<OverlayCoord>
+            {
+                new(49.60, 17.20), new(49.61, 17.21)
+            }),
+            new RectangleShape("r1", "#504B25", "#504B25", 2,
+                new OverlayCoord(49.70, 17.30), new OverlayCoord(49.72, 17.33)),
+            new CircleShape("c1", "#2D5016", null, 2,
+                new OverlayCoord(49.80, 17.40), 250.0),
+            new PolygonShape("p1", "#B26223", "#B26223", 2, new List<OverlayCoord>
+            {
+                new(49.90, 17.50), new(49.91, 17.52), new(49.89, 17.52)
+            })
+        });
+
+        var putResponse = await Client.PutAsJsonAsync($"/api/games/{game.Id}/overlay", dto);
+        Assert.Equal(HttpStatusCode.NoContent, putResponse.StatusCode);
+
+        var getResponse = await Client.GetAsync($"/api/games/{game.Id}/overlay");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        var roundTripped = await getResponse.Content.ReadFromJsonAsync<MapOverlayDto>();
+        Assert.NotNull(roundTripped);
+        Assert.Equal(6, roundTripped!.Shapes.Count);
+
+        Assert.IsType<TextShape>(roundTripped.Shapes[0]);
+        var text = (TextShape)roundTripped.Shapes[0];
+        Assert.Equal("Brodeček", text.Text);
+        Assert.Equal(16, text.FontSize);
+
+        Assert.IsType<FreehandShape>(roundTripped.Shapes[1]);
+        Assert.Equal(3, ((FreehandShape)roundTripped.Shapes[1]).Points.Count);
+
+        Assert.IsType<PolylineShape>(roundTripped.Shapes[2]);
+        Assert.IsType<RectangleShape>(roundTripped.Shapes[3]);
+
+        Assert.IsType<CircleShape>(roundTripped.Shapes[4]);
+        Assert.Equal(250.0, ((CircleShape)roundTripped.Shapes[4]).RadiusMeters);
+
+        Assert.IsType<PolygonShape>(roundTripped.Shapes[5]);
+        Assert.Equal(3, ((PolygonShape)roundTripped.Shapes[5]).Points.Count);
+    }
+
+    [Fact]
+    public async Task Overlay_PutOversized_Returns400()
+    {
+        var game = await CreateGameAsync("Overlay-Oversize");
+
+        // Generate enough freehand points to blow past the 256 KiB cap.
+        // Each OverlayCoord serialises to ~28 bytes, so 20_000 points is
+        // comfortably over the limit.
+        var points = new List<OverlayCoord>(20_000);
+        for (int i = 0; i < 20_000; i++)
+            points.Add(new OverlayCoord(49.0 + i * 1e-7, 17.0 + i * 1e-7));
+        var dto = new MapOverlayDto(new List<MapOverlayShape>
+        {
+            new FreehandShape("huge", "#242F3D", 2, points)
+        });
+
+        var response = await Client.PutAsJsonAsync($"/api/games/{game.Id}/overlay", dto);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Překryv je příliš velký", problem!.Title);
+        Assert.Contains("KiB", problem.Detail);
+    }
+
+    [Fact]
+    public async Task Overlay_GameNotFound_Returns404()
+    {
+        var dto = new MapOverlayDto(new List<MapOverlayShape>
+        {
+            new TextShape("t1", "#242F3D", new OverlayCoord(49.5, 17.1), "Test")
+        });
+
+        var putResponse = await Client.PutAsJsonAsync("/api/games/999999/overlay", dto);
+        Assert.Equal(HttpStatusCode.NotFound, putResponse.StatusCode);
+
+        var getResponse = await Client.GetAsync("/api/games/999999/overlay");
+        Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
     }
 
     private async Task<GameDetailDto> CreateGameAsync(string name)


### PR DESCRIPTION
Issue #96 Phase 1 + 2 — vector overlay editor on the map. Phase 3 (icons / arrows / select-to-edit) and Phase 4 (undo/redo, import/export) are explicit follow-ups.

## Part A — Data model + API

- `Game.OverlayJson` (nullable TEXT) — one overlay per game, serialized `MapOverlayDto`. Migration `20260424212915_AddGameOverlayJson`.
- `Shared/Dtos/MapOverlayDto.cs` — polymorphic via `[JsonPolymorphic(TypeDiscriminatorPropertyName="type")]` + 6 derived records (`text`, `freehand`, `polyline`, `rectangle`, `circle`, `polygon`). `Id` is a client GUID.
- `GET  /api/games/{id}/overlay` → DTO or 204 NoContent when null. 404 on missing game. Corrupt JSON → treated as empty, not 500.
- `PUT  /api/games/{id}/overlay` → 204 on save. Resource lookup before validation (`_review-instincts` §1). 256 KiB cap → Czech `ProblemDetails` ("Překryv je příliš velký").

## Part B — JS interop (`overlay-interop.js`)

New `window.ovcinaOverlay`, layered on the existing `window.ovcinaMap` MapLibre instance. One GeoJSON source + three layers (fills / strokes / text). `CircleShape` → 32-vertex great-circle polygon approximation via Aviation Formulary. Tool handlers for all 6 primitives with live-preview on a secondary source + Escape/Enter keyboard shortcuts for polyline/polygon.

## Part C — Client

- `Components/MapOverlayToolbar.razor` — floating strip, 6 tool buttons (Czech tooltips), 8 kingdom-seal swatches (verbatim per `feedback_ovcina_kingdom_seal_palette` — not re-saturated), custom-color picker, stroke width slider, font-size slider (text tool only), fill toggle, Uložit / Zrušit.
- `MapView.razor` gains `[Parameter] int? GameId`, loads overlay on first render (best-effort try/catch per §11), gates the "Upravit překryv" button via `<AuthorizeView>`, stages shapes in memory and commits on save via `PutWithProblemAsync` (§2.2). `[JSInvokable] OnShapeComplete` polymorphically deserialises the JS-emitted shape and re-renders.
- `MapPage.razor` — one new attribute: `GameId=\"@GameContext.SelectedGameId\"`. Treasures page untouched (doesn't pass `GameId`).

## Part D — Tests (all 4 green)

- \`Overlay_GetWhenNotSet_Returns204\`
- \`Overlay_PutThenGet_RoundTripsAllShapeTypes\` — one of each primitive survives the round-trip including `CircleShape.RadiusMeters`, polygon point count, text payload.
- \`Overlay_PutOversized_Returns400\` — 20000-point freehand > 256 KiB → \`ProblemDetails.Title == \"Překryv je příliš velký\"\`.
- \`Overlay_GameNotFound_Returns404\`

## Part E — CSS

New `.oh-mo-*` block in `ovcinahra-theme.css` (scoped). `.oh-map-overlay-edit-btn` positions the edit button top-right of the map host.

## Out of scope — deferred to follow-ups

- Phase 3: icon + arrow primitives, click-to-select existing shapes, move / delete / property editor, inline text editor (replaces \`window.prompt\`).
- Phase 4: undo/redo stack, swatch picker polish, import/export JSON.

## Notes

- `<Version>` untouched (rule #18 — auto-bump CI handles it on merge).
- Build clean under `TreatWarningsAsErrors=true`, 0W/0E.
- Playwright E2E still blocked by #92 — overlay round-trip is covered by the server-side Testcontainers suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)