### PR TITLE
fix(auth): silent token refresh via offline_access (closes #125)

### DIFF
--- a/src/OvcinaHra.Client/Pages/Login.razor
+++ b/src/OvcinaHra.Client/Pages/Login.razor
@@ -155,14 +155,26 @@
         await JS.InvokeVoidAsync("localStorage.setItem", "oidc_verifier", codeVerifier);
 
         var redirectUri = Uri.EscapeDataString($"{Nav.BaseUri}auth-callback");
+        // offline_access is critical: without it, registrace's OpenIddict server
+        // never emits a refresh_token, and TokenRefreshService falls back to the
+        // dev path that doesn't work in production — every user gets bounced to
+        // /login the moment the 15-min access token expires (issue #125).
+        const string Scopes = "openid+profile+email+roles+offline_access";
         var url = $"{oidcAuthority}/connect/authorize" +
             $"?client_id={oidcClientId}" +
             $"&redirect_uri={redirectUri}" +
             $"&response_type=code" +
-            $"&scope=openid+profile+email+roles" +
+            $"&scope={Scopes}" +
             $"&state={state}" +
             $"&code_challenge={codeChallenge}" +
             $"&code_challenge_method=S256";
+
+        // Log the requested scopes (no PII) so a future regression here surfaces
+        // in the browser console immediately. AuthLog already redacts tokens.
+        OvcinaHra.Client.Auth.AuthLog.Event("login.authorize",
+            ("scopes", Scopes),
+            ("client_id", oidcClientId ?? "(none)"));
+
         Nav.NavigateTo(url, forceLoad: true);
     }
 

--- a/src/OvcinaHra.Client/Pages/Login.razor
+++ b/src/OvcinaHra.Client/Pages/Login.razor
@@ -169,9 +169,11 @@
             $"&code_challenge={codeChallenge}" +
             $"&code_challenge_method=S256";
 
-        // Log the requested scopes (no PII) so a future regression here surfaces
-        // in the browser console immediately. AuthLog already redacts tokens.
-        OvcinaHra.Client.Auth.AuthLog.Event("login.authorize",
+        // Log the requested scopes so a future regression here (e.g. the scope
+        // string getting "cleaned up" again) surfaces in the browser console
+        // immediately. We deliberately pass only the scope list + client id —
+        // AuthLog.Event doesn't redact, the no-secrets discipline is on us.
+        AuthLog.Event("login.authorize",
             ("scopes", Scopes),
             ("client_id", oidcClientId ?? "(none)"));
 


### PR DESCRIPTION
Fixes #125 — every active user being bounced to `/login` every ~15 min mid-edit. Cross-repo fix; the matching registrace-side change shipped + deployed before this PR opened.

## Root cause

`Login.razor:162` requested `scope=openid+profile+email+roles` at registrace's `/connect/authorize`. Without `offline_access`, OpenIddict never emits a `refresh_token` on the code-for-token exchange — so `AuthCallback.razor:84` (`if (!string.IsNullOrEmpty(token.RefreshToken))`) was never taken and nothing was stored under the `refresh_token` localStorage key.

`TokenRefreshService` falls through to the dev path `/api/auth/refresh` when no refresh token is stored. That path doesn't accept OIDC-issued users in production → silent retry loop every 30s → at 15min the access token expires → 401 → `UnauthorizedRedirectHandler` clears tokens and redirects to `/login`.

The client-side refresh infra (`TokenRefreshService`, `oidc-refresh` endpoint, 401 retry-once handler) was fully wired and correct — it just never had a refresh token to use.

## Fix

`src/OvcinaHra.Client/Pages/Login.razor`:
- Added `offline_access` to the authorize-URL scope list.
- Pulled scope into a local `const` + a load-bearing comment so future readers don't \"clean it up\".
- Added one `AuthLog.Event(\"login.authorize\", ...)` so the requested scopes (no PII) surface in the browser console alongside the existing `refresh.*` / `401.*` / `authstate.*` events. Future regressions reproduce with a single Console + Network snapshot.

## Cross-repo coordination

Paired registrace PR added `OpenIddictConstants.Permissions.Scopes.OfflineAccess` to the `ovcinahra` client's `Permissions` collection in `DatabaseInitializer.cs`. Without that, requesting `offline_access` here would have been rejected with `invalid_scope` at the authorize call (worse than the current state). Registrace deployed before this PR opened.

## Manual test plan (no Testcontainers — OIDC is live external)

1. Log in via registrace at https://hra.ovcina.cz/login.
2. DevTools → Application → Local Storage → confirm BOTH \`auth_token\` AND \`refresh_token\` keys populated.
3. Console + Network record on.
4. Wait 12+ minutes.
5. Expect Console: \`refresh.start path=oidc\` → \`refresh.ok path=oidc expires_in_s=...\`. Network: \`POST /api/auth/oidc-refresh\` → 200.
6. Continue using the app. Do NOT expect a redirect to /login.
7. Repeat at the next refresh window (~12 min later).

## Notes

- \`<Version>\` untouched (auto-bump CI handles it per \`_review-instincts.md\` rule #18).
- No backend code changes on this side — both \`/api/auth/oidc-exchange\` and \`/api/auth/oidc-refresh\` already forward upstream tokens unmodified.
- \`TokenRefreshService\` coalesces concurrent refreshes via \`_refreshLock\` and skips when current token still has > 60 s remaining; no race-condition concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)