### PR TITLE
feat(ux): drozd-confused on DxGrid no-rows (closes #149)

### DIFF
--- a/src/OvcinaHra.Client/Components/OvcinaGrid.razor
+++ b/src/OvcinaHra.Client/Components/OvcinaGrid.razor
@@ -12,6 +12,13 @@
    In EditCell mode, clicking an editable cell enters edit; clicking elsewhere
    still fires RowClick — the row-click handler and inline edit coexist. *@
 
+@* EmptyDataAreaTemplate passthrough — issue #149. Razor's compile-time
+   child-content validator rejects a conditional `@if` wrapping the named
+   `<EmptyDataAreaTemplate>` child element, so we forward the template via
+   the **property attribute** form instead. When the consumer doesn't pass
+   anything, the property stays null and DevExpress falls back to its stock
+   "No data" text — no behavior change for the read-only grids that
+   haven't opted in yet. *@
 <DxGrid Data="@Data"
         KeyFieldName="@KeyFieldName"
         SelectionMode="@SelectionMode"
@@ -33,6 +40,7 @@
         EditMode="@(EditMode ?? GridEditMode.PopupEditForm)"
         EditModelSaving="@EditModelSaving"
         CustomizeEditModel="@CustomizeEditModel"
+        EmptyDataAreaTemplate="@EmptyDataAreaTemplate"
         LayoutAutoLoading="OnLayoutLoading"
         LayoutAutoSaving="OnLayoutSaving">
     <Columns>
@@ -70,6 +78,12 @@
     [Parameter] public GridEditMode? EditMode { get; set; }
     [Parameter] public EventCallback<GridEditModelSavingEventArgs> EditModelSaving { get; set; }
     [Parameter] public EventCallback<GridCustomizeEditModelEventArgs> CustomizeEditModel { get; set; }
+
+    // Issue #149: optional no-rows surface (e.g. drozd-confused). When null,
+    // DxGrid renders its stock "No data" text — same as before this passthrough
+    // existed. DxGrid types this slot as a typed `RenderFragment<TContext>`,
+    // so the wrapper parameter mirrors it; pages typically ignore the context.
+    [Parameter] public RenderFragment<GridEmptyDataAreaTemplateContext>? EmptyDataAreaTemplate { get; set; }
     private void OnCustomizeElement(GridCustomizeElementEventArgs e)
     {
         if (e.ElementType == GridElementType.DataRow && e.VisibleIndex % 2 == 1)

--- a/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
+++ b/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
@@ -88,6 +88,26 @@ else
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="ExternalPersonId" Caption="ID v registraci" Width="140px" />
         </Columns>
+        @* Issue #149 — drozd-confused for in-grid no-rows. The page short-circuits
+           to a non-grid empty surface when `characters.Count == 0`, so this
+           template only renders when the user filters/searches via DxGrid's
+           own row UI down to zero matches. *@
+        <EmptyDataAreaTemplate>
+            <div class="text-center text-muted py-5">
+                <div class="oh-lg-drozd-box mx-auto mb-3" aria-hidden="true">
+                    @if (!confusedFailed)
+                    {
+                        <img src="/img/drozd/drozd-confused.svg" alt=""
+                             @onerror="() => confusedFailed = true" />
+                    }
+                    else
+                    {
+                        <i class="bi bi-funnel" style="font-size:90px;color:var(--oh-text-secondary);"></i>
+                    }
+                </div>
+                <p class="mb-0">Žádné postavy neodpovídají filtrům.</p>
+            </div>
+        </EmptyDataAreaTemplate>
     </OvcinaGrid>
 }
 
@@ -280,7 +300,7 @@ else
     private List<CharacterListDto> characters = [];
     private List<CharacterListDto> allCharacters = [];
     private List<KingdomDto> kingdoms = [];
-    private bool loading = true, isModalVisible, isDeleteVisible, isSaving, isImporting, drozdFailed;
+    private bool loading = true, isModalVisible, isDeleteVisible, isSaving, isImporting, drozdFailed, confusedFailed;
     private string modalTitle = "", name = "";
     private string? error, notes, playerFirstName, playerLastName;
     private Race? race;

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -222,6 +222,27 @@ else if (Catalog)
                 </CellDisplayTemplate>
             </DxGridDataColumn>
         </Columns>
+        @* Issue #149 — drozd-confused fires when DxGrid filters/search produce
+           zero rows (the page-level @if branches above intercept the genuinely-
+           empty catalog and the no-game state, so this surface is reachable
+           only via in-grid filters). Reuses .oh-lg-drozd-box circle that the
+           game-empty surface uses, fallback bi-funnel at 90px per the brief. *@
+        <EmptyDataAreaTemplate>
+            <div class="text-center text-muted py-5">
+                <div class="oh-lg-drozd-box mx-auto mb-3" aria-hidden="true">
+                    @if (!confusedFailed)
+                    {
+                        <img src="/img/drozd/drozd-confused.svg" alt=""
+                             @onerror="() => confusedFailed = true" />
+                    }
+                    else
+                    {
+                        <i class="bi bi-funnel" style="font-size:90px;color:var(--oh-text-secondary);"></i>
+                    }
+                </div>
+                <p class="mb-0">Žádné předměty neodpovídají filtrům.</p>
+            </div>
+        </EmptyDataAreaTemplate>
     </OvcinaGrid>
 }
 else
@@ -396,6 +417,25 @@ else
                 </CellEditTemplate>
             </DxGridDataColumn>
         </Columns>
+        @* Issue #149 — drozd-confused for in-grid no-rows. Same pattern as the
+           catalog grid above; shares the confusedFailed flag (one SVG load
+           failure flips both grids to the bi-funnel fallback). *@
+        <EmptyDataAreaTemplate>
+            <div class="text-center text-muted py-5">
+                <div class="oh-lg-drozd-box mx-auto mb-3" aria-hidden="true">
+                    @if (!confusedFailed)
+                    {
+                        <img src="/img/drozd/drozd-confused.svg" alt=""
+                             @onerror="() => confusedFailed = true" />
+                    }
+                    else
+                    {
+                        <i class="bi bi-funnel" style="font-size:90px;color:var(--oh-text-secondary);"></i>
+                    }
+                </div>
+                <p class="mb-0">Žádné předměty neodpovídají filtrům.</p>
+            </div>
+        </EmptyDataAreaTemplate>
     </OvcinaGrid>
 
     <DxContextMenu @ref="contextMenu" ItemClick="OnContextMenuItemClick">
@@ -716,7 +756,7 @@ else
 
     private List<ItemListDto> catalogItems = [];
     private List<GameItemListDto> gameItems = [];
-    private bool loading = true, isModalVisible, isDeleteVisible, isSaving, drozdFailed;
+    private bool loading = true, isModalVisible, isDeleteVisible, isSaving, drozdFailed, confusedFailed;
 
     // Quick-peek popup state (issue: replaces edit-modal-on-row-click per the brief).
     private bool isQuickPeekVisible;

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -99,6 +99,7 @@ else if (Catalog)
                 EditMode="GridEditMode.EditCell"
                 CustomizeEditModel="OnCatalogCustomizeEdit"
                 EditModelSaving="OnCatalogSaving"
+                EmptyDataAreaTemplate="ItemsConfusedEmpty"
                 RowClick="@(e => OpenQuickPeek((ItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             @* Akce — fixed left. Otevřít detail → /items/{id} mirrors the LocationList
@@ -222,27 +223,6 @@ else if (Catalog)
                 </CellDisplayTemplate>
             </DxGridDataColumn>
         </Columns>
-        @* Issue #149 — drozd-confused fires when DxGrid filters/search produce
-           zero rows (the page-level @if branches above intercept the genuinely-
-           empty catalog and the no-game state, so this surface is reachable
-           only via in-grid filters). Reuses .oh-lg-drozd-box circle that the
-           game-empty surface uses, fallback bi-funnel at 90px per the brief. *@
-        <EmptyDataAreaTemplate>
-            <div class="text-center text-muted py-5">
-                <div class="oh-lg-drozd-box mx-auto mb-3" aria-hidden="true">
-                    @if (!confusedFailed)
-                    {
-                        <img src="/img/drozd/drozd-confused.svg" alt=""
-                             @onerror="() => confusedFailed = true" />
-                    }
-                    else
-                    {
-                        <i class="bi bi-funnel" style="font-size:90px;color:var(--oh-text-secondary);"></i>
-                    }
-                </div>
-                <p class="mb-0">Žádné předměty neodpovídají filtrům.</p>
-            </div>
-        </EmptyDataAreaTemplate>
     </OvcinaGrid>
 }
 else
@@ -251,6 +231,7 @@ else
                 EditMode="GridEditMode.EditCell"
                 CustomizeEditModel="OnGameCustomizeEdit"
                 EditModelSaving="OnGameSaving"
+                EmptyDataAreaTemplate="ItemsConfusedEmpty"
                 RowClick="@(e => OpenQuickPeek((GameItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             @* Akce — fixed left. Primary "Otevřít detail" button per issue #97.
@@ -417,25 +398,6 @@ else
                 </CellEditTemplate>
             </DxGridDataColumn>
         </Columns>
-        @* Issue #149 — drozd-confused for in-grid no-rows. Same pattern as the
-           catalog grid above; shares the confusedFailed flag (one SVG load
-           failure flips both grids to the bi-funnel fallback). *@
-        <EmptyDataAreaTemplate>
-            <div class="text-center text-muted py-5">
-                <div class="oh-lg-drozd-box mx-auto mb-3" aria-hidden="true">
-                    @if (!confusedFailed)
-                    {
-                        <img src="/img/drozd/drozd-confused.svg" alt=""
-                             @onerror="() => confusedFailed = true" />
-                    }
-                    else
-                    {
-                        <i class="bi bi-funnel" style="font-size:90px;color:var(--oh-text-secondary);"></i>
-                    }
-                </div>
-                <p class="mb-0">Žádné předměty neodpovídají filtrům.</p>
-            </div>
-        </EmptyDataAreaTemplate>
     </OvcinaGrid>
 
     <DxContextMenu @ref="contextMenu" ItemClick="OnContextMenuItemClick">
@@ -757,6 +719,25 @@ else
     private List<ItemListDto> catalogItems = [];
     private List<GameItemListDto> gameItems = [];
     private bool loading = true, isModalVisible, isDeleteVisible, isSaving, drozdFailed, confusedFailed;
+
+    @* Shared no-rows surface for both the catalog and game grids — issue #149.
+       Both grids render the same Drozd-confused mascot when DxGrid filters
+       trim to zero rows; extracted so a future tweak (icon, copy, sizing)
+       lives in one place. The context arg is unused. *@
+    private RenderFragment<GridEmptyDataAreaTemplateContext> ItemsConfusedEmpty => _ => @<div class="text-center text-muted py-5">
+        <div class="oh-lg-drozd-box mx-auto mb-3" aria-hidden="true">
+            @if (!confusedFailed)
+            {
+                <img src="/img/drozd/drozd-confused.svg" alt=""
+                     @onerror="() => confusedFailed = true" />
+            }
+            else
+            {
+                <i class="bi bi-funnel" style="font-size:90px;color:var(--oh-text-secondary);"></i>
+            }
+        </div>
+        <p class="mb-0">Žádné předměty neodpovídají filtrům.</p>
+    </div>;
 
     // Quick-peek popup state (issue: replaces edit-modal-on-row-click per the brief).
     private bool isQuickPeekVisible;

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -409,6 +409,28 @@ else
                 </CellDisplayTemplate>
             </DxGridDataColumn>
         </Columns>
+        @* Issue #149 — drozd-confused fires when the visibleRows projection
+           filters everything out (search box, kind/region pickers, the toggle
+           switches above the grid, or DxGrid's own filter row). The page-level
+           empty branch above only intercepts `locations.Count == 0`, so this
+           in-grid surface is reachable whenever a non-empty dataset is filtered
+           down to zero. *@
+        <EmptyDataAreaTemplate>
+            <div class="text-center text-muted py-5">
+                <div class="oh-lg-drozd-box mx-auto mb-3" aria-hidden="true">
+                    @if (!confusedFailed)
+                    {
+                        <img src="/img/drozd/drozd-confused.svg" alt=""
+                             @onerror="() => confusedFailed = true" />
+                    }
+                    else
+                    {
+                        <i class="bi bi-funnel" style="font-size:90px;color:var(--oh-text-secondary);"></i>
+                    }
+                </div>
+                <p class="mb-0">Žádné lokace neodpovídají filtrům.</p>
+            </div>
+        </EmptyDataAreaTemplate>
     </OvcinaGrid>
 }
 
@@ -507,6 +529,7 @@ else
     private HashSet<int> assignedLocationIds = [];
     private bool loading = true;
     private bool drozdFailed;   // flips true if /img/drozd/drozd-knocking.svg 404s
+    private bool confusedFailed; // flips true if /img/drozd/drozd-confused.svg 404s (in-grid no-rows, #149)
     private bool isGpsVisible;
     private bool isLinkVisible;
     private bool isSaving;


### PR DESCRIPTION
## What

Continuation of PR #145 (filter-empty surfaces above the grid). The DxGrid no-rows surface — what DevExpress renders inside the grid body when zero rows match the active filter/sort — now shows the same Drozd mascot + Czech message instead of stock "No data" text.

## Wrapper passthrough — `OvcinaGrid.razor`

Added an optional `EmptyDataAreaTemplate` parameter typed as `RenderFragment<GridEmptyDataAreaTemplateContext>` (DxGrid types the slot that way). Forwarded to `<DxGrid>` via the **property attribute** form rather than a child `<EmptyDataAreaTemplate>` element — Razor''s compile-time child-content validator rejects a conditional `@if` wrapping the named child, but a null property attribute compiles fine and DxGrid falls back to its stock empty-text behavior. The 9 read-only grids that don''t pass anything stay unchanged.

## Pages updated

| Page | Notes |
|---|---|
| `Pages/Items/ItemList.razor` (catalog grid) | Reachable when toolbar filters / DxGrid filter row produce zero rows. |
| `Pages/Items/ItemList.razor` (game grid) | Shares the `confusedFailed` flag with the catalog grid. |
| `Pages/Locations/LocationList.razor` | Reachable when search / kind / region / toggle filters reduce `visibleRows` to zero. |
| `Pages/Characters/CharacterList.razor` | Page short-circuits to a non-grid empty when `characters.Count == 0`, so this template only renders when DxGrid filters trim a non-empty dataset to zero. |

## Pattern

State-flag `@onerror` on the `<img>` with empty `alt=""` (decorative); fallback `<i class="bi bi-funnel" style="font-size:90px;color:var(--oh-text-secondary);"></i>` when the SVG 404s. **No** inline DOM mutation — `feedback_blazor_img_onerror_state_and_key` + `_review-instincts.md` §9.

Mascot wrapper reuses existing `.oh-lg-drozd-box` (120×120 circle, 86×86 image) — no new global CSS classes. Cell uses `.text-center text-muted py-5` + `.mx-auto mb-3` Bootstrap utilities (no new classes).

Czech message per page: *"Žádné předměty / lokace / postavy neodpovídají filtrům."*

## Build / verification

- `dotnet build` clean (0W/0E, `TreatWarningsAsErrors=true`).
- `Select-String -Pattern ''onerror="this''` returns zero — no inline DOM mutations introduced.
- Manual check: filter/search a string that matches nothing → Drozd-confused renders inside the grid body.
- No csproj bump (auto-bump handles it).

Closes #149.