### PR TITLE
fix(ux): remove stray dovednosti button + Item detail polish (closes #146, closes #147)

### DIFF
--- a/src/OvcinaHra.Client/Pages/Games/GameList.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameList.razor
@@ -69,12 +69,9 @@ else
         }
 
         <div class="d-flex gap-2 mt-3">
-            @if (editingId.HasValue)
-            {
-                <button class="btn btn-outline-primary" @onclick="GoToSkills" disabled="@isSaving">
-                    <i class="bi bi-star"></i> Dovednosti
-                </button>
-            }
+            @* Dovednosti button removed per #146 — it didn't belong in the
+               Game edit popup; /games/{id}/skills is reachable via its own
+               nav surfaces. *@
             <div style="flex: 1"></div>
             <button class="btn btn-secondary" @onclick="CloseModal" disabled="@isSaving">Zrušit</button>
             <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving" data-testid="save-game">
@@ -184,14 +181,6 @@ else
     }
 
     private void CloseModal() => isModalVisible = false;
-
-    private void GoToSkills()
-    {
-        if (editingId.HasValue)
-        {
-            Nav.NavigateTo($"/games/{editingId.Value}/skills");
-        }
-    }
 
     private async Task SaveAsync()
     {

--- a/src/OvcinaHra.Client/Pages/Items/ItemDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemDetail.razor
@@ -487,11 +487,13 @@ else
                                 <td class="oh-it-d-num">
                                     @* Per-game setter affordance — restores Price/Stock/IsSold/
                                        IsFindable editing on the detail page (#147 sub-fix (e)).
-                                       Save POSTs UpdateGameItemDto to the existing endpoint. *@
+                                       Save uses PUT /api/items/game-item/{gid}/{itemId} with
+                                       UpdateGameItemDto via the ProblemDetails-aware helper. *@
                                     <button class="btn btn-sm btn-outline-primary"
                                             title="Upravit nastavení v této hře"
+                                            aria-label="Upravit nastavení v této hře"
                                             @onclick="() => OpenShopEdit(s)">
-                                        <i class="bi bi-pencil"></i>
+                                        <i class="bi bi-pencil" aria-hidden="true"></i>
                                     </button>
                                 </td>
                             </tr>
@@ -732,9 +734,11 @@ else
         shopEditError = null;
         try
         {
-            // Mirrors the /items grid pattern (ItemList.razor:1320) — same
-            // endpoint, same DTO shape; the orchestrator is paid the same
-            // server validation either way (#99 block respected).
+            // PutWithProblemAsync surfaces the server's Czech ProblemDetails
+            // verbatim into shopEditError (e.g. the #99 GameItem-in-use block
+            // when something downstream still references it). Same endpoint
+            // + DTO shape as ItemList.razor's per-row inline edit, so the two
+            // surfaces stay coherent.
             var (ok, problem) = await Api.PutWithProblemAsync(
                 $"/api/items/game-item/{shopEditGameId}/{item.Id}",
                 new UpdateGameItemDto(

--- a/src/OvcinaHra.Client/Pages/Items/ItemDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemDetail.razor
@@ -41,7 +41,10 @@ else
                     <span class="oh-it-ichip">@item.PhysicalForm.Value.GetDisplayName()</span>
                 }
                 <span class="oh-it-d-dotsep">·</span>
-                <span class="oh-it-d-id">#I@item.Id.ToString("D3")</span>
+                @* Parenthesise the @() expression so Razor's email-detector
+                   doesn't see `I@item.Id` as a letter@word.word email pattern
+                   and render the @item.Id literally — see #147 sub-fix (a). *@
+                <span class="oh-it-d-id">#I@(item.Id.ToString("D3"))</span>
             </div>
         </div>
         <div class="oh-it-d-ts-actions">
@@ -136,12 +139,12 @@ else
                         </div>
                         <div class="oh-it-d-statrow">
                             <i class="oh-it-d-stat-icon bi bi-gem"></i>
-                            <span class="oh-it-d-stat-lbl">Unikát</span>
+                            <span class="oh-it-d-stat-lbl">Unikátní</span>
                             <span class="oh-it-d-stat-val @(item.IsUnique ? "" : "oh-it-d-stat-val--off")">@(item.IsUnique ? "Ano" : "Ne")</span>
                         </div>
                         <div class="oh-it-d-statrow">
                             <i class="oh-it-d-stat-icon bi bi-hourglass-split"></i>
-                            <span class="oh-it-d-stat-lbl">Limit</span>
+                            <span class="oh-it-d-stat-lbl">Limitovaný</span>
                             <span class="oh-it-d-stat-val @(item.IsLimited ? "" : "oh-it-d-stat-val--off")">@(item.IsLimited ? "Ano" : "Ne")</span>
                         </div>
                         <div class="oh-it-d-statrow">
@@ -149,6 +152,22 @@ else
                             <span class="oh-it-d-stat-lbl">Vyrobitelný</span>
                             <span class="oh-it-d-stat-val @(item.IsCraftable ? "" : "oh-it-d-stat-val--off")">@(item.IsCraftable ? "Ano" : "Ne")</span>
                         </div>
+                        @* Per-game IsFindable for the active GameContext — only
+                           shown when the user has a game selected AND this item
+                           is assigned to it. #147 sub-fix (c). *@
+                        @{
+                            var currentShop = GameContext.SelectedGameId.HasValue
+                                ? usage?.Shops.FirstOrDefault(s => s.Game.GameId == GameContext.SelectedGameId.Value)
+                                : null;
+                        }
+                        @if (currentShop is not null)
+                        {
+                            <div class="oh-it-d-statrow">
+                                <i class="oh-it-d-stat-icon bi bi-search"></i>
+                                <span class="oh-it-d-stat-lbl">Nalezitelný</span>
+                                <span class="oh-it-d-stat-val @(currentShop.IsFindable ? "" : "oh-it-d-stat-val--off")">@(currentShop.IsFindable ? "Ano" : "Ne")</span>
+                            </div>
+                        }
                     </div>
                 </div>
 
@@ -430,6 +449,7 @@ else
                             <th class="oh-it-d-num">Sklad</th>
                             <th>Stav</th>
                             <th>Podmínka</th>
+                            <th class="oh-it-d-num">Akce</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -464,6 +484,16 @@ else
                                         <span class="oh-it-d-shop-cond">@s.SaleCondition</span>
                                     }
                                 </td>
+                                <td class="oh-it-d-num">
+                                    @* Per-game setter affordance — restores Price/Stock/IsSold/
+                                       IsFindable editing on the detail page (#147 sub-fix (e)).
+                                       Save POSTs UpdateGameItemDto to the existing endpoint. *@
+                                    <button class="btn btn-sm btn-outline-primary"
+                                            title="Upravit nastavení v této hře"
+                                            @onclick="() => OpenShopEdit(s)">
+                                        <i class="bi bi-pencil"></i>
+                                    </button>
+                                </td>
                             </tr>
                         }
                     </tbody>
@@ -480,6 +510,54 @@ else
         <div class="d-flex gap-2 justify-content-end">
             <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
             <button class="btn btn-danger" @onclick="ConfirmDeleteAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@* Per-game shop-row editor — restores Price/Stock/IsSold/IsFindable/SaleCondition
+   editing on the detail page (#147 sub-fix (e)). Mirrors the form layout from
+   the /items grid's per-game edit popup so the two surfaces stay coherent. *@
+<DxPopup @bind-Visible="@isShopEditVisible"
+         HeaderText="@($"Nastavení v hře: {shopEditGameName}")"
+         Width="520px">
+    <BodyContentTemplate Context="ctx">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Cena" ColSpanMd="6">
+                <DxSpinEdit Value="@shopEditPrice"
+                            ValueExpression="@(() => shopEditPrice)"
+                            ValueChanged="@((int? v) => { shopEditPrice = v; if (v.HasValue) shopEditIsSold = true; })"
+                            MinValue="0" NullText="(žádná)" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Počet na skladě" ColSpanMd="6">
+                <DxSpinEdit @bind-Value="@shopEditStockCount" MinValue="0" NullText="(neomezeno)" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="" ColSpanMd="12">
+                <div class="d-flex flex-column gap-1 pt-1">
+                    <DxCheckBox @bind-Checked="@shopEditIsSold">Prodávaný</DxCheckBox>
+                    <DxCheckBox @bind-Checked="@shopEditIsFindable">Nalezitelný</DxCheckBox>
+                </div>
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Podmínka prodeje" ColSpanMd="12">
+                <DxTextBox @bind-Text="@shopEditSaleCondition" NullText="(bez podmínky)" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        @if (shopEditError is not null)
+        {
+            <div class="alert alert-danger mt-2">@shopEditError</div>
+        }
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary"
+                    @onclick="() => isShopEditVisible = false"
+                    disabled="@shopEditSaving">Zrušit</button>
+            <button class="btn btn-primary"
+                    @onclick="SaveShopEditAsync"
+                    disabled="@shopEditSaving">
+                @if (shopEditSaving)
+                {
+                    <span class="spinner-border spinner-border-sm me-1"></span>
+                }
+                Uložit
+            </button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
@@ -506,6 +584,18 @@ else
     private string? editNote;
     private bool editIsUnique, editIsLimited, editIsCraftable;
     private int editReqWarrior, editReqArcher, editReqMage, editReqThief;
+
+    // Per-game shop-row edit state (Obchod tab popup) — #147 sub-fix (e).
+    private bool isShopEditVisible;
+    private bool shopEditSaving;
+    private int shopEditGameId;
+    private string? shopEditGameName;
+    private int? shopEditPrice;
+    private int? shopEditStockCount;
+    private bool shopEditIsSold;
+    private bool shopEditIsFindable;
+    private string? shopEditSaleCondition;
+    private string? shopEditError;
 
     private static readonly List<EnumItem<ItemType>> itemTypeValues = Enum.GetValues<ItemType>()
         .Select(v => new EnumItem<ItemType>(v, v.GetDisplayName())).ToList();
@@ -618,6 +708,52 @@ else
         }
         catch (Exception ex) { error = ex.Message; }
         finally { isSaving = false; }
+    }
+
+    // ===== Per-game shop-row edit (#147 sub-fix (e)) =====
+
+    private void OpenShopEdit(ItemUsageShopDto s)
+    {
+        shopEditError = null;
+        shopEditGameId = s.Game.GameId;
+        shopEditGameName = s.Game.GameName;
+        shopEditPrice = s.Price;
+        shopEditStockCount = s.StockCount;
+        shopEditIsSold = s.IsSold;
+        shopEditIsFindable = s.IsFindable;
+        shopEditSaleCondition = s.SaleCondition;
+        isShopEditVisible = true;
+    }
+
+    private async Task SaveShopEditAsync()
+    {
+        if (item is null || shopEditSaving) return;
+        shopEditSaving = true;
+        shopEditError = null;
+        try
+        {
+            // Mirrors the /items grid pattern (ItemList.razor:1320) — same
+            // endpoint, same DTO shape; the orchestrator is paid the same
+            // server validation either way (#99 block respected).
+            var (ok, problem) = await Api.PutWithProblemAsync(
+                $"/api/items/game-item/{shopEditGameId}/{item.Id}",
+                new UpdateGameItemDto(
+                    shopEditPrice,
+                    shopEditStockCount,
+                    shopEditIsSold,
+                    string.IsNullOrWhiteSpace(shopEditSaleCondition) ? null : shopEditSaleCondition.Trim(),
+                    shopEditIsFindable));
+            if (!ok)
+            {
+                shopEditError = problem ?? "Uložení nastavení selhalo.";
+                return;
+            }
+            isShopEditVisible = false;
+            // Reload usage so the table + Karta "Nalezitelný" row reflect the new values.
+            usage = await Api.GetAsync<ItemUsageDto>($"/api/items/{item.Id}/usage");
+        }
+        catch (Exception ex) { shopEditError = ex.Message; }
+        finally { shopEditSaving = false; }
     }
 
     private async Task ConfirmDeleteAsync()

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2270,7 +2270,8 @@
 @media (max-width:900px){.oh-it-d-karta{grid-template-columns:1fr}}
 
 /* 5:7 MTG hero (NOT 4:3) */
-.oh-it-d-hero{position:relative;width:100%;aspect-ratio:5/7;border:2px solid #c4b494;border-radius:4px;overflow:hidden;background:var(--oh-surface-alt);box-shadow:0 3px 14px rgba(45,80,22,.18),inset 0 0 0 1px rgba(255,248,230,.4)}
+/* Hero capped at ~200px — was 100% of the column (huge). #147 sub-fix (b). */
+.oh-it-d-hero{position:relative;width:100%;max-width:200px;aspect-ratio:5/7;border:2px solid #c4b494;border-radius:4px;overflow:hidden;background:var(--oh-surface-alt);box-shadow:0 3px 14px rgba(45,80,22,.18),inset 0 0 0 1px rgba(255,248,230,.4)}
 .oh-it-d-hero img{width:100%;height:100%;object-fit:cover;display:block}
 .oh-it-d-hero-empty{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:8px;color:rgba(139,90,43,.5);font:italic 700 .95rem Georgia,serif;text-align:center;padding:0 18px}
 .oh-it-d-hero-empty i{font-size:3.5rem;opacity:.55}


### PR DESCRIPTION
## Summary

Bundle of two small bug-fix issues (one PR, six surfaces).

### #146 — Remove `Dovednosti` button from Game edit popup
`Pages/Games/GameList.razor:74` — the button + its `GoToSkills` handler are removed. The button didn't belong on a Game-edit surface; `/games/{id}/skills` is reachable from its own nav paths. No orphan usings left behind.

### #147 — Item detail polish (5 sub-fixes)

| # | Surface | Change |
|---|---|---|
| **a** | `ItemDetail.razor:44` | Razor email-detector bug — `#I@item.Id.ToString("D3")` matched the `letter@word.word` pattern and rendered `@item.Id` literally. Fixed by parenthesising → `#I@(item.Id.ToString("D3"))`. Inline comment cites the rule. |
| **b** | `ovcinahra-theme.css:2273` | Hero `.oh-it-d-hero` was column-width (huge). Capped `max-width: 200px` — drops to roughly 1/4 of prior visual size, MTG-card-thumb scale next to the stat block. |
| **c** | `ItemDetail.razor` Karta stats | Added "Nalezitelný" row. Per-game field; shows IsFindable for `GameContext.SelectedGameId` only. Silently hides if no game selected OR item not assigned to the active game. Pulls from the already-loaded `usage.Shops` collection — no extra API call. |
| **d** | `ItemDetail.razor:139,144` | Read-view label fixes: `Unikát → Unikátní`, `Limit → Limitovaný`. The Upravit checkboxes were already correct — these were the read-view labels that drifted. ItemList only has these strings inside Razor comments / internal code paths, no user-facing change there. |
| **e** | `ItemDetail.razor` Obchod tab | Restored per-game setter affordance. Each row in the table grew an "Akce" column with an Upravit button → opens a small DxPopup with Cena / Sklad / Prodávaný / Nalezitelný / Podmínka prodeje controls. Save uses the existing `PUT /api/items/game-item/{gameId}/{itemId}` endpoint with `UpdateGameItemDto` — **no API change** since every field is already on `GameItem` + the DTO. Mirrors the `/items` grid edit-popup layout for coherence. Reloads `usage` on success so both the table and the Karta "Nalezitelný" row reflect the new values without a page refresh. |

## Note on the IsHidden ambiguity

The original brief mentioned an `IsHidden` field — `IsHidden` does not exist anywhere in the codebase (verified `grep -rn IsHidden src/` → 0 hits). User clarified mid-review that the intended field was **`IsFindable` (Nalezitelný)**, which already exists on `GameItem` and `UpdateGameItemDto`. No API change required as a consequence.

## Build

`dotnet build src/OvcinaHra.Client` — clean, **0 warnings, 0 errors** (`TreatWarningsAsErrors=true`).

## Not touched
- `csproj` — auto-bump CI owns it per `_review-instincts.md` #18.
- `Pages/Items/ItemList.razor` — coordinated with Hra3's #149 work; only the Detail-side label fix landed here, ItemList list-side labels stay untouched.
- `Components/MapView.razor`, `Components/MapOverlayToolbar.razor`, `wwwroot/js/overlay-interop.js` — Hra1 territory, untouched.

## Test plan
- [ ] `/games` → click any game's row → edit popup; confirm the "Dovednosti" button no longer renders. Save / Cancel still work.
- [ ] `/items/{id}` → confirm `#I001` (etc.) renders correctly with no literal `@` text.
- [ ] Same page → hero image is thumb-sized (≤200px wide), not column-width.
- [ ] Same page → Karta stats block reads `Unikátní / Limitovaný / Vyrobitelný` (with diacritics) + `Nalezitelný` row appears when a game is selected.
- [ ] Same page → Obchod tab → click any row's Upravit button → popup opens prefilled → tweak any field → Save → table reflects the new values + Karta `Nalezitelný` row updates if it was the active game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)