### PR TITLE
feat(spells): catalog grid + detail (Karta/Upravit/Obchod) + A5 Kniha kouzel print (closes #148)

### DIFF
--- a/src/OvcinaHra.Client/Components/ManaRings.razor
+++ b/src/OvcinaHra.Client/Components/ManaRings.razor
@@ -13,16 +13,22 @@
 }
 else if (Cost <= 0)
 {
-    <span class="oh-mana-free" title="Kouzlo bez maganové ceny">Zdarma</span>
+    <span class="oh-mana-free" title="Kouzlo bez manové ceny">Zdarma</span>
 }
 else
 {
     <span class="oh-mana @WrapperClass" aria-label="@($"Mana: {Cost}")">
         @for (var i = 0; i < Math.Min(Cost, MaxRings); i++)
         {
+            @* Each <linearGradient> id must be unique across the whole document
+               — duplicates make some browsers latch onto the wrong stops or
+               drop the stroke entirely. _gradId is unique per component
+               instance; we further suffix with the ring index here so a single
+               <ManaRings Cost="6"> rendering 6 SVGs each carries a distinct id. *@
+            var gradId = $"oh-mana-{_gradId}-{i}";
             <svg viewBox="0 0 14 14" role="img" aria-hidden="true">
                 <defs>
-                    <linearGradient id="@($"oh-mana-{_gradId}")" x1="0%" y1="0%" x2="100%" y2="100%">
+                    <linearGradient id="@gradId" x1="0%" y1="0%" x2="100%" y2="100%">
                         <stop offset="0%"   stop-color="#E74C3C" />
                         <stop offset="16%"  stop-color="#F39C12" />
                         <stop offset="33%"  stop-color="#F1C40F" />
@@ -32,7 +38,7 @@ else
                         <stop offset="100%" stop-color="#E74C3C" />
                     </linearGradient>
                 </defs>
-                <circle cx="7" cy="7" r="5.5" fill="none" stroke="@($"url(#oh-mana-{_gradId})")" stroke-width="3" />
+                <circle cx="7" cy="7" r="5.5" fill="none" stroke="@($"url(#{gradId})")" stroke-width="3" />
             </svg>
         }
         @if (Cost > MaxRings)

--- a/src/OvcinaHra.Client/Components/ManaRings.razor
+++ b/src/OvcinaHra.Client/Components/ManaRings.razor
@@ -1,0 +1,66 @@
+@* Mana cost indicator — N concentric rainbow rings (issue #148).
+   Per designer brief:
+     · SVG <circle> with rainbow linearGradient stroke on transparent center.
+     · 14px Lg, 12px Md, 10px Sm. 3px stroke. 6px gap. Wraps at 6.
+     · IsScroll = true ⇒ render the "Svitek" mono chip instead.
+     · Cost == 0 && !IsScroll ⇒ "Zdarma" muted pill.
+   Print fidelity beats a CSS-only conic-gradient hack — SVG renders
+   cleanly through @media print on every browser. *@
+
+@if (IsScroll)
+{
+    <span class="oh-mana-scroll" title="Svitek — jednorázové použití">Svitek · jedno použití</span>
+}
+else if (Cost <= 0)
+{
+    <span class="oh-mana-free" title="Kouzlo bez maganové ceny">Zdarma</span>
+}
+else
+{
+    <span class="oh-mana @WrapperClass" aria-label="@($"Mana: {Cost}")">
+        @for (var i = 0; i < Math.Min(Cost, MaxRings); i++)
+        {
+            <svg viewBox="0 0 14 14" role="img" aria-hidden="true">
+                <defs>
+                    <linearGradient id="@($"oh-mana-{_gradId}")" x1="0%" y1="0%" x2="100%" y2="100%">
+                        <stop offset="0%"   stop-color="#E74C3C" />
+                        <stop offset="16%"  stop-color="#F39C12" />
+                        <stop offset="33%"  stop-color="#F1C40F" />
+                        <stop offset="50%"  stop-color="#2ECC71" />
+                        <stop offset="66%"  stop-color="#3498DB" />
+                        <stop offset="83%"  stop-color="#9B59B6" />
+                        <stop offset="100%" stop-color="#E74C3C" />
+                    </linearGradient>
+                </defs>
+                <circle cx="7" cy="7" r="5.5" fill="none" stroke="@($"url(#oh-mana-{_gradId})")" stroke-width="3" />
+            </svg>
+        }
+        @if (Cost > MaxRings)
+        {
+            <span class="oh-mana-overflow" title="@($"Plná cena: {Cost} many")">+@(Cost - MaxRings)</span>
+        }
+    </span>
+}
+
+@code {
+    public enum RingSize { Lg, Md, Sm }
+
+    [Parameter] public int Cost { get; set; }
+    [Parameter] public RingSize Size { get; set; } = RingSize.Md;
+    [Parameter] public bool IsScroll { get; set; }
+
+    /// <summary>Cap on rendered rings — designer brief caps at 6 per row, but
+    /// realistic mana costs in the catalog top out at 5. Keep the cap so a
+    /// future high-cost spell still renders without spilling visually.</summary>
+    private const int MaxRings = 6;
+
+    /// <summary>Per-instance gradient id keeps SVG defs unique across the page.</summary>
+    private readonly string _gradId = Guid.NewGuid().ToString("N");
+
+    private string WrapperClass => Size switch
+    {
+        RingSize.Lg => "oh-mana--lg",
+        RingSize.Sm => "oh-mana--sm",
+        _ => string.Empty
+    };
+}

--- a/src/OvcinaHra.Client/Components/SpellPrintCard.razor
+++ b/src/OvcinaHra.Client/Components/SpellPrintCard.razor
@@ -1,0 +1,70 @@
+@* A5 spellbook tile — ~70×100mm on paper, no JS, print-stable (issue #148).
+   Renders ONE learnable spell. School palette token drives both the 2px left
+   stripe and the drop-cap colour via inline style. *@
+
+<article class="oh-sp-print-tile" style="@($"--oh-school-c: var(--oh-school-{SchoolKey(Spell.School)});")">
+    <header class="oh-sp-print-tile-head">
+        <h3 class="oh-sp-print-tile-name">@Spell.Name</h3>
+        <span class="oh-sp-lvl-badge oh-sp-lvl-roman" title="@($"Úroveň {Spell.Level}")">
+            @LevelRoman(Spell.Level)
+        </span>
+    </header>
+
+    <div class="oh-sp-print-tile-meta">
+        <SpellSchoolChip School="@Spell.School" />
+        <ManaRings Cost="@Spell.ManaCost" Size="ManaRings.RingSize.Sm" IsScroll="@Spell.IsScroll" />
+        @if (Spell.IsReaction)
+        {
+            <span class="oh-sp-reaction"><i class="bi bi-lightning-charge-fill"></i>Reakce</span>
+        }
+    </div>
+
+    <p class="oh-sp-print-tile-fx">@Spell.Effect</p>
+
+    <footer class="oh-sp-print-tile-foot">
+        @if (Spell.MinMageLevel > 1)
+        {
+            <span title="Minimální úroveň mága">Min. mág @LevelRoman(Spell.MinMageLevel)</span>
+        }
+        else
+        {
+            <span></span>
+        }
+        @if (Spell.Price.HasValue && !Spell.IsScroll)
+        {
+            <span><i class="bi bi-coin"></i> @Spell.Price gr</span>
+        }
+    </footer>
+</article>
+
+@code {
+    [Parameter] public SpellListDto Spell { get; set; } = null!;
+
+    private static string SchoolKey(SpellSchool s) => s switch
+    {
+        SpellSchool.Fire    => "fire",
+        SpellSchool.Frost   => "frost",
+        SpellSchool.Water   => "water",
+        SpellSchool.Earth   => "earth",
+        SpellSchool.Wind    => "wind",
+        SpellSchool.Poison  => "poison",
+        SpellSchool.Mental  => "mental",
+        SpellSchool.Support => "support",
+        SpellSchool.Utility => "utility",
+        _ => "utility"
+    };
+
+    /// <summary>Roman numeral for spell levels 1-5; 0 → "S" (scroll). Anything
+    /// outside that range falls back to the Arabic numeral so a future
+    /// rule-change doesn't crash the renderer.</summary>
+    private static string LevelRoman(int n) => n switch
+    {
+        0 => "S",
+        1 => "I",
+        2 => "II",
+        3 => "III",
+        4 => "IV",
+        5 => "V",
+        _ => n.ToString(System.Globalization.CultureInfo.InvariantCulture)
+    };
+}

--- a/src/OvcinaHra.Client/Components/SpellSchoolChip.razor
+++ b/src/OvcinaHra.Client/Components/SpellSchoolChip.razor
@@ -1,0 +1,29 @@
+@* School chip — 1.5px outlined pill with small color dot + Czech school
+   label (issue #148). Reads --oh-school-{key} from the global palette;
+   never hard-codes hex (palette stays single-source-of-truth). *@
+
+<span class="oh-school" data-school="@SchoolKey(School)" title="@($"Škola: {School.GetDisplayName()}")">
+    @School.GetDisplayName()
+</span>
+
+@code {
+    [Parameter] public SpellSchool School { get; set; }
+
+    /// <summary>Maps the enum to the lowercase key used as both the
+    /// <c>data-school="..."</c> attribute and the <c>--oh-school-{key}</c>
+    /// CSS custom-property suffix. Keep in sync with the 9 keys in
+    /// ovcinahra-theme.css :root block.</summary>
+    private static string SchoolKey(SpellSchool s) => s switch
+    {
+        SpellSchool.Fire    => "fire",
+        SpellSchool.Frost   => "frost",
+        SpellSchool.Water   => "water",
+        SpellSchool.Earth   => "earth",
+        SpellSchool.Wind    => "wind",
+        SpellSchool.Poison  => "poison",
+        SpellSchool.Mental  => "mental",
+        SpellSchool.Support => "support",
+        SpellSchool.Utility => "utility",
+        _ => "utility"
+    };
+}

--- a/src/OvcinaHra.Client/Pages/Spells/SpellBookPrint.razor
+++ b/src/OvcinaHra.Client/Pages/Spells/SpellBookPrint.razor
@@ -1,0 +1,154 @@
+@page "/spells/print"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject IJSRuntime JS
+@inject NavigationManager Nav
+@using OvcinaHra.Shared.Domain.Enums
+
+@* Kniha kouzel — A5 landscape spread (297×210mm), one or more spreads of
+   learnable non-scroll spells (issue #148). Toolbar (screen-only) hosts the
+   Tisk action; @media print rules in ovcinahra-theme.css strip the chrome. *@
+
+<div class="oh-sp-tisk-toolbar">
+    <div class="oh-sp-tisk-toolbar-info">
+        <i class="bi bi-book-half"></i> Kniha kouzel — @spreads.Count spread(ů), @learnable.Count kouzel
+    </div>
+    <div class="d-flex gap-2">
+        <button class="btn btn-sm btn-outline-secondary" type="button"
+                @onclick='() => Nav.NavigateTo("/spells")'>
+            <i class="bi bi-arrow-left"></i> Zpět na katalog
+        </button>
+        <button class="btn btn-sm btn-primary" type="button" @onclick="PrintAsync">
+            <i class="bi bi-printer-fill"></i> Tisk
+        </button>
+    </div>
+</div>
+
+@if (loading)
+{
+    <p class="text-muted text-center mt-5">Načítám…</p>
+}
+else if (learnable.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-book fs-1 d-block mb-2"></i>
+        <p>Žádná naučitelná kouzla v katalogu.</p>
+    </div>
+}
+else
+{
+    <div class="oh-sp-print-stage">
+        @foreach (var spread in spreads)
+        {
+            <section class="oh-sp-print-spread">
+                @if (spread.IsFirst)
+                {
+                    <header class="oh-sp-print-banner">
+                        <h1>Kniha kouzel</h1>
+                        <p class="oh-sp-print-banner-sub">— Sbírka naučitelných kouzel —</p>
+                    </header>
+                }
+                @if (!string.IsNullOrEmpty(spread.LevelLabel))
+                {
+                    <div class="oh-sp-print-level-hdr">@spread.LevelLabel</div>
+                }
+                @* Each spread is a 2-col grid (left page / right page); within
+                   each page, three tiles stack vertically — the .oh-sp-print-tile
+                   handles its own page-break-inside avoid. *@
+                <div class="oh-sp-print-page" style="display:flex;flex-direction:column;gap:5mm">
+                    @foreach (var s in spread.LeftPage)
+                    {
+                        <SpellPrintCard Spell="@s" />
+                    }
+                </div>
+                <div class="oh-sp-print-page" style="display:flex;flex-direction:column;gap:5mm">
+                    @foreach (var s in spread.RightPage)
+                    {
+                        <SpellPrintCard Spell="@s" />
+                    }
+                </div>
+            </section>
+        }
+    </div>
+}
+
+@code {
+    private bool loading = true;
+    private List<SpellListDto> learnable = [];
+    private List<Spread> spreads = [];
+
+    /// <summary>Tiles per A5 page side (3 portrait pages stack vertically per
+    /// half of the landscape spread). Two pages × 3 tiles = 6 tiles per
+    /// spread. Designer hint was "~12 tiles per spread (3×2 per page)" but
+    /// realistic A5 portrait fits 3 stacked ~70×100mm tiles — go with that
+    /// and add more spreads if a level overflows.</summary>
+    private const int TilesPerPage = 3;
+    private const int TilesPerSpread = TilesPerPage * 2;
+
+    protected override async Task OnInitializedAsync()
+    {
+        loading = true;
+        try
+        {
+            var all = await Api.GetListAsync<SpellListDto>("/api/spells");
+            // Client-side filter (chosen over a server `?learnable=true` —
+            // small dataset, simpler, no endpoint churn). Flagged in PR body.
+            learnable = all
+                .Where(s => s.IsLearnable && !s.IsScroll)
+                .OrderBy(s => s.Level)
+                .ThenBy(s => s.Name)
+                .ToList();
+            spreads = BuildSpreads(learnable);
+        }
+        finally { loading = false; }
+    }
+
+    private async Task PrintAsync()
+    {
+        try { await JS.InvokeVoidAsync("print"); } catch { /* user rejected; no-op */ }
+    }
+
+    /// <summary>Group spells by level, then chunk each group into spreads of
+    /// 6 tiles. Each spread carries its level label so the printed reader
+    /// sees clear headings I.–V. The first spread also gets the book banner.</summary>
+    private static List<Spread> BuildSpreads(List<SpellListDto> spells)
+    {
+        var result = new List<Spread>();
+        var first = true;
+        foreach (var levelGroup in spells.GroupBy(s => s.Level).OrderBy(g => g.Key))
+        {
+            var label = $"Úroveň {LevelRoman(levelGroup.Key)}";
+            var batch = levelGroup.ToList();
+            for (var i = 0; i < batch.Count; i += TilesPerSpread)
+            {
+                var slab = batch.Skip(i).Take(TilesPerSpread).ToList();
+                var left = slab.Take(TilesPerPage).ToList();
+                var right = slab.Skip(TilesPerPage).Take(TilesPerPage).ToList();
+                result.Add(new Spread(
+                    IsFirst: first,
+                    LevelLabel: i == 0 ? label : $"{label} (pokračování)",
+                    LeftPage: left,
+                    RightPage: right));
+                first = false;
+            }
+        }
+        return result;
+    }
+
+    private static string LevelRoman(int n) => n switch
+    {
+        0 => "S",
+        1 => "I",
+        2 => "II",
+        3 => "III",
+        4 => "IV",
+        5 => "V",
+        _ => n.ToString(System.Globalization.CultureInfo.InvariantCulture)
+    };
+
+    private sealed record Spread(
+        bool IsFirst,
+        string LevelLabel,
+        List<SpellListDto> LeftPage,
+        List<SpellListDto> RightPage);
+}

--- a/src/OvcinaHra.Client/Pages/Spells/SpellDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Spells/SpellDetail.razor
@@ -1,0 +1,482 @@
+@page "/spells/{Id:int}"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject NavigationManager Nav
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+<div class="d-flex align-items-center gap-3 mb-3">
+    <button class="btn btn-sm btn-outline-secondary" type="button"
+            @onclick='() => Nav.NavigateTo("/spells")'>
+        <i class="bi bi-arrow-left"></i> Zpět
+    </button>
+    <h1 class="mb-0">@(spell?.Name ?? "Kouzlo")</h1>
+</div>
+
+@if (loading)
+{
+    <p class="text-muted">Načítám…</p>
+}
+else if (spell is null && error is not null)
+{
+    <div class="alert alert-danger d-flex align-items-center gap-2">
+        <i class="bi bi-wifi-off"></i>
+        <span>Nepodařilo se načíst kouzlo: @error</span>
+        <button type="button" class="btn btn-sm btn-outline-primary ms-auto" @onclick="LoadAsync">Zkusit znovu</button>
+    </div>
+}
+else if (spell is null)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-emoji-frown fs-1 d-block mb-2"></i>
+        <p>Kouzlo nenalezeno.</p>
+    </div>
+}
+else
+{
+    <div class="d-flex gap-2 mb-3">
+        <button class="btn btn-sm @(activeTab == "karta" ? "btn-primary" : "btn-outline-primary")"
+                @onclick='() => activeTab = "karta"'>
+            <i class="bi bi-bookmark-fill"></i> Karta
+        </button>
+        <button class="btn btn-sm @(activeTab == "upravit" ? "btn-primary" : "btn-outline-primary")"
+                @onclick='() => activeTab = "upravit"'>
+            <i class="bi bi-pencil"></i> Upravit
+        </button>
+        <button class="btn btn-sm @(activeTab == "obchod" ? "btn-primary" : "btn-outline-primary")"
+                @onclick='() => activeTab = "obchod"'>
+            <i class="bi bi-coin"></i> Obchod
+        </button>
+    </div>
+
+    @if (activeTab == "karta")
+    {
+        <div class="oh-sp-karta-grid">
+            <article class="oh-sp-karta" style="@KartaStyle(spell.School)">
+                <div class="oh-sp-karta-name-row">
+                    <h2 class="oh-sp-karta-name">@spell.Name</h2>
+                    <span class="oh-sp-lvl-badge oh-sp-lvl-badge--lg @(spell.IsScroll ? "oh-sp-lvl-scroll" : "oh-sp-lvl-roman")"
+                          title="@($"Úroveň {spell.Level}")">
+                        @LevelRoman(spell.Level)
+                    </span>
+                </div>
+                <div class="oh-sp-karta-meta">
+                    <SpellSchoolChip School="@spell.School" />
+                    @if (spell.IsReaction)
+                    {
+                        <span class="oh-sp-reaction"><i class="bi bi-lightning-charge-fill"></i>Reakce</span>
+                    }
+                </div>
+                <div class="oh-sp-karta-mana-row">
+                    <span class="oh-sp-karta-mana-lab">Mana</span>
+                    <ManaRings Cost="@spell.ManaCost" Size="ManaRings.RingSize.Lg" IsScroll="@spell.IsScroll" />
+                </div>
+                @if (spell.MinMageLevel > 1)
+                {
+                    <p class="oh-sp-karta-min">Minimální úroveň mága: @LevelRoman(spell.MinMageLevel)</p>
+                }
+                <hr class="oh-sp-karta-sep" />
+                <p class="oh-sp-karta-fx">@spell.Effect</p>
+                @if (!string.IsNullOrWhiteSpace(spell.Description))
+                {
+                    <p class="oh-sp-karta-desc">@spell.Description</p>
+                }
+            </article>
+
+            <aside class="oh-sp-karta-side">
+                <div class="oh-sp-karta-side-block">
+                    <div class="oh-sp-karta-price-row">
+                        <span>Cena naučení</span>
+                        @if (spell.IsScroll)
+                        {
+                            <span class="text-muted">—</span>
+                        }
+                        else if (spell.Price.HasValue)
+                        {
+                            <span class="oh-sp-karta-price-coin"><i class="bi bi-coin"></i>@spell.Price gr</span>
+                        }
+                        else
+                        {
+                            <span class="oh-sp-karta-price-coin">Zdarma</span>
+                        }
+                    </div>
+                    <div class="oh-sp-karta-badges">
+                        <span class="oh-sp-karta-badge @(spell.IsLearnable ? "oh-sp-karta-badge--on" : "")">
+                            @(spell.IsLearnable ? "Naučitelné" : "Nenaučitelné")
+                        </span>
+                        @if (spell.IsScroll)
+                        {
+                            <span class="oh-sp-karta-badge oh-sp-karta-badge--on">Svitek</span>
+                        }
+                        @if (spell.IsReaction)
+                        {
+                            <span class="oh-sp-karta-badge oh-sp-karta-badge--on">Reakce</span>
+                        }
+                    </div>
+                </div>
+
+                @* Scroll → Item callout (issue #148, follow-up flagged for proper FK).
+                   Fuzz-matches case-insensitive on Name — disabled with explanatory
+                   title when no item matches. *@
+                @if (spell.IsScroll)
+                {
+                    <div class="oh-sp-karta-scroll-callout">
+                        <h6><i class="bi bi-link-45deg"></i> Svitek je také předmět</h6>
+                        <p>Tento svitek existuje i v katalogu předmětů jako <em>Svitek</em>. Detail položky obsahuje cenu, sklad a možnosti prodeje.</p>
+                        @if (matchedItemId is int itemId)
+                        {
+                            <button class="btn btn-sm btn-outline-primary" type="button"
+                                    @onclick="@(() => Nav.NavigateTo($"/items/{itemId}"))">
+                                Zobrazit jako předmět <i class="bi bi-arrow-right"></i>
+                            </button>
+                        }
+                        else
+                        {
+                            <button class="btn btn-sm btn-outline-secondary" type="button" disabled
+                                    title="Položka stejného názvu nenalezena">
+                                Zobrazit jako předmět <i class="bi bi-arrow-right"></i>
+                            </button>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <div class="oh-sp-karta-side-block">
+                        <button class="btn btn-sm btn-outline-secondary w-100" type="button" disabled
+                                title="Plánováno — vytvoří odpovídající Svitek v katalogu předmětů">
+                            <i class="bi bi-plus-square"></i> Vytvořit svitek k tomuto kouzlu
+                        </button>
+                    </div>
+                }
+            </aside>
+        </div>
+    }
+    else if (activeTab == "upravit")
+    {
+        <div class="oh-sp-edit-grid">
+            <DxFormLayout>
+                <DxFormLayoutGroup Caption="Identita" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="Název" ColSpanMd="8">
+                        <DxTextBox @bind-Text="@editModel.Name" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Úroveň (0=svitek, 1-5=mág)" ColSpanMd="4">
+                        <DxSpinEdit @bind-Value="@editModel.Level" MinValue="0" MaxValue="5" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Škola" ColSpanMd="12">
+                        <DxComboBox Data="@schoolValues" @bind-Value="@editModel.School"
+                                    TextFieldName="Display" ValueFieldName="Value" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+
+                <DxFormLayoutGroup Caption="Mechanika" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="Mana" ColSpanMd="3">
+                        <DxSpinEdit @bind-Value="@editModel.ManaCost" MinValue="0" MaxValue="9" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Min. úroveň mága" ColSpanMd="3">
+                        <DxSpinEdit @bind-Value="@editModel.MinMageLevel" MinValue="0" MaxValue="5" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Cena (groše)" ColSpanMd="3">
+                        <DxSpinEdit @bind-Value="@editModel.Price" MinValue="0" MaxValue="9999"
+                                    Enabled="@(!editModel.IsScroll)"
+                                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Reakce" ColSpanMd="3">
+                        <DxCheckBox @bind-Checked="@editModel.IsReaction" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Naučitelné" ColSpanMd="6">
+                        <DxCheckBox @bind-Checked="@editModel.IsLearnable" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Svitek" ColSpanMd="6">
+                        <DxCheckBox @bind-Checked="@editModel.IsScroll" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+
+                <DxFormLayoutGroup Caption="Obsah" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="Efekt (text karty — verbatim)" ColSpanMd="12">
+                        <DxMemo @bind-Text="@editModel.Effect" Rows="4" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Popis / flavor" ColSpanMd="12">
+                        <DxMemo @bind-Text="@editModel.Description" Rows="3" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+            </DxFormLayout>
+
+            <div class="oh-sp-edit-preview-stage">
+                <h6>Náhled karty</h6>
+                <article class="oh-sp-karta" style="@KartaStyle(editModel.School)">
+                    <div class="oh-sp-karta-name-row">
+                        <h2 class="oh-sp-karta-name">@(string.IsNullOrWhiteSpace(editModel.Name) ? "Bez názvu" : editModel.Name)</h2>
+                        <span class="oh-sp-lvl-badge oh-sp-lvl-badge--lg @(editModel.IsScroll ? "oh-sp-lvl-scroll" : "oh-sp-lvl-roman")">
+                            @LevelRoman(editModel.Level)
+                        </span>
+                    </div>
+                    <div class="oh-sp-karta-meta">
+                        <SpellSchoolChip School="@editModel.School" />
+                        @if (editModel.IsReaction)
+                        {
+                            <span class="oh-sp-reaction"><i class="bi bi-lightning-charge-fill"></i>Reakce</span>
+                        }
+                    </div>
+                    <div class="oh-sp-karta-mana-row">
+                        <span class="oh-sp-karta-mana-lab">Mana</span>
+                        <ManaRings Cost="@editModel.ManaCost" Size="ManaRings.RingSize.Lg" IsScroll="@editModel.IsScroll" />
+                    </div>
+                    @if (editModel.MinMageLevel > 1)
+                    {
+                        <p class="oh-sp-karta-min">Minimální úroveň mága: @LevelRoman(editModel.MinMageLevel)</p>
+                    }
+                    <hr class="oh-sp-karta-sep" />
+                    <p class="oh-sp-karta-fx">@(string.IsNullOrWhiteSpace(editModel.Effect) ? "(text karty zatím prázdný)" : editModel.Effect)</p>
+                    @if (!string.IsNullOrWhiteSpace(editModel.Description))
+                    {
+                        <p class="oh-sp-karta-desc">@editModel.Description</p>
+                    }
+                </article>
+            </div>
+        </div>
+
+        @if (saveError is not null)
+        {
+            <div class="alert alert-danger mt-3">@saveError</div>
+        }
+
+        <div class="d-flex gap-2 mt-3">
+            <button class="btn btn-outline-danger" type="button"
+                    @onclick="() => isDeleteVisible = true" disabled="@isSaving">
+                <i class="bi bi-trash"></i> Smazat
+            </button>
+            <div style="flex:1"></div>
+            <button class="btn btn-secondary" type="button" @onclick='() => activeTab = "karta"' disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" type="button" @onclick="SaveAsync"
+                    disabled="@(isSaving || string.IsNullOrWhiteSpace(editModel.Name))">
+                @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Uložit
+            </button>
+        </div>
+    }
+    else if (activeTab == "obchod")
+    {
+        @if (gameSpells is null)
+        {
+            <p class="text-muted">Načítám per-hru data…</p>
+        }
+        else if (gameSpells.Count == 0)
+        {
+            <div class="text-center text-muted py-5">
+                <i class="bi bi-controller fs-1 d-block mb-2"></i>
+                <p>Toto kouzlo není přiřazeno k žádné hře.</p>
+                <p class="small">Přiřazení / per-hru ceny se konfigurují přes detail hry.</p>
+            </div>
+        }
+        else
+        {
+            <table class="table table-sm">
+                <thead>
+                    <tr>
+                        <th>Hra</th>
+                        <th>Cena (per-hru)</th>
+                        <th>K nalezení</th>
+                        <th>Poznámky k dostupnosti</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var gs in gameSpells)
+                    {
+                        <tr>
+                            <td>Hra #@gs.GameId</td>
+                            <td>
+                                @if (gs.PriceInherited)
+                                {
+                                    <span class="text-muted small">(z katalogu) @(gs.EffectivePrice?.ToString() ?? "—") gr</span>
+                                }
+                                else
+                                {
+                                    <strong>@gs.Price gr</strong>
+                                }
+                            </td>
+                            <td>@(gs.IsFindable ? "Ano" : "Ne")</td>
+                            <td class="text-muted">@(gs.AvailabilityNotes ?? "—")</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    }
+}
+
+@* Delete confirm — destructive action through DxPopup per
+   feedback_ovcinahra_destructive_confirm. *@
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Smazat kouzlo?" Width="400px">
+    <BodyContentTemplate Context="dCtx">
+        <p>Opravdu chcete smazat kouzlo <strong>@spell?.Name</strong>?</p>
+        <p class="text-muted small">Tato akce odebere kouzlo z katalogu i ze všech přiřazených her.</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" type="button" @onclick="() => isDeleteVisible = false" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-danger" type="button" @onclick="DeleteAsync" disabled="@isSaving">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public int Id { get; set; }
+
+    private SpellDetailDto? spell;
+    private bool loading = true;
+    private string? error;
+    private string activeTab = "karta";
+
+    private EditForm editModel = new();
+    private bool isSaving;
+    private bool isDeleteVisible;
+    private string? saveError;
+
+    // Scroll-to-item fuzz match (issue #148 follow-up: replace with FK).
+    private int? matchedItemId;
+
+    // Obchod tab — per-game configuration list. Spell-side projection rolled
+    // up from /api/spells/by-game/{gameId} hits across all games would be a
+    // chunky N+1; for Phase 1 we only show what's exposed via the spell-id
+    // join already on the server. Followup: add /api/spells/{id}/games.
+    private List<GameSpellDto>? gameSpells;
+
+    private static readonly List<SchoolOption> schoolValues = Enum.GetValues<SpellSchool>()
+        .Select(v => new SchoolOption(v, v.GetDisplayName())).ToList();
+
+    private record SchoolOption(SpellSchool Value, string Display);
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        error = null;
+        try
+        {
+            var detail = await Api.GetAsync<SpellDetailDto>($"/api/spells/{Id}");
+            if (detail is null)
+            {
+                spell = null;
+                return;
+            }
+            spell = detail;
+            editModel = EditForm.FromDetail(detail);
+
+            // Best-effort scroll→item fuzz match. Failure leaves matchedItemId
+            // null and the callout falls back to its disabled state.
+            if (detail.IsScroll)
+            {
+                try
+                {
+                    var items = await Api.GetListAsync<ItemListDto>("/api/items");
+                    var hit = items.FirstOrDefault(i =>
+                        string.Equals(i.Name?.Trim(), detail.Name.Trim(), StringComparison.OrdinalIgnoreCase));
+                    matchedItemId = hit?.Id;
+                }
+                catch { matchedItemId = null; }
+            }
+
+            // Obchod data — best-effort. List endpoint per game not provided
+            // for spells-by-spellId yet (followup); leave empty for now.
+            gameSpells = new List<GameSpellDto>();
+        }
+        catch (Exception ex) { error = ex.Message; spell = null; }
+        finally { loading = false; }
+    }
+
+    private async Task SaveAsync()
+    {
+        if (string.IsNullOrWhiteSpace(editModel.Name)) return;
+        saveError = null;
+        isSaving = true;
+        try
+        {
+            await Api.PutAsync($"/api/spells/{Id}", editModel.ToUpdateDto());
+            await LoadAsync();
+            activeTab = "karta";
+        }
+        catch (Exception ex) { saveError = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task DeleteAsync()
+    {
+        saveError = null;
+        isSaving = true;
+        try
+        {
+            // ApiClient.DeleteAsync returns bool; do NOT close popup on false.
+            var ok = await Api.DeleteAsync($"/api/spells/{Id}");
+            if (!ok)
+            {
+                saveError = "Smazání kouzla se nepodařilo.";
+                return;
+            }
+            isDeleteVisible = false;
+            Nav.NavigateTo("/spells");
+        }
+        catch (Exception ex) { saveError = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private static string KartaStyle(SpellSchool s) => $"--oh-school-c: var(--oh-school-{SchoolKey(s)});";
+
+    private static string SchoolKey(SpellSchool s) => s switch
+    {
+        SpellSchool.Fire    => "fire",
+        SpellSchool.Frost   => "frost",
+        SpellSchool.Water   => "water",
+        SpellSchool.Earth   => "earth",
+        SpellSchool.Wind    => "wind",
+        SpellSchool.Poison  => "poison",
+        SpellSchool.Mental  => "mental",
+        SpellSchool.Support => "support",
+        SpellSchool.Utility => "utility",
+        _ => "utility"
+    };
+
+    private static string LevelRoman(int n) => n switch
+    {
+        0 => "S",
+        1 => "I",
+        2 => "II",
+        3 => "III",
+        4 => "IV",
+        5 => "V",
+        _ => n.ToString(System.Globalization.CultureInfo.InvariantCulture)
+    };
+
+    private sealed class EditForm
+    {
+        public string Name { get; set; } = "";
+        public int Level { get; set; }
+        public int ManaCost { get; set; }
+        public SpellSchool School { get; set; } = SpellSchool.Fire;
+        public bool IsScroll { get; set; }
+        public bool IsReaction { get; set; }
+        public bool IsLearnable { get; set; } = true;
+        public int MinMageLevel { get; set; }
+        public int? Price { get; set; }
+        public string Effect { get; set; } = "";
+        public string? Description { get; set; }
+
+        public static EditForm FromDetail(SpellDetailDto d) => new()
+        {
+            Name = d.Name,
+            Level = d.Level,
+            ManaCost = d.ManaCost,
+            School = d.School,
+            IsScroll = d.IsScroll,
+            IsReaction = d.IsReaction,
+            IsLearnable = d.IsLearnable,
+            MinMageLevel = d.MinMageLevel,
+            Price = d.Price,
+            Effect = d.Effect,
+            Description = d.Description
+        };
+
+        public UpdateSpellDto ToUpdateDto() => new(
+            Name.Trim(), Level, ManaCost, School, IsScroll, IsReaction, IsLearnable, MinMageLevel, Price,
+            string.IsNullOrWhiteSpace(Effect) ? "—" : Effect.Trim(),
+            string.IsNullOrWhiteSpace(Description) ? null : Description.Trim());
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Spells/SpellDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Spells/SpellDetail.razor
@@ -123,19 +123,17 @@ else
                     <div class="oh-sp-karta-scroll-callout">
                         <h6><i class="bi bi-link-45deg"></i> Svitek je také předmět</h6>
                         <p>Tento svitek existuje i v katalogu předmětů jako <em>Svitek</em>. Detail položky obsahuje cenu, sklad a možnosti prodeje.</p>
-                        @if (matchedItemId is int itemId)
+                        <button class="btn btn-sm btn-outline-primary" type="button"
+                                @onclick="OpenAsItemAsync" disabled="@isLookingUpItem">
+                            @if (isLookingUpItem)
+                            {
+                                <span class="spinner-border spinner-border-sm me-1"></span>
+                            }
+                            Zobrazit jako předmět <i class="bi bi-arrow-right"></i>
+                        </button>
+                        @if (!string.IsNullOrEmpty(scrollItemError))
                         {
-                            <button class="btn btn-sm btn-outline-primary" type="button"
-                                    @onclick="@(() => Nav.NavigateTo($"/items/{itemId}"))">
-                                Zobrazit jako předmět <i class="bi bi-arrow-right"></i>
-                            </button>
-                        }
-                        else
-                        {
-                            <button class="btn btn-sm btn-outline-secondary" type="button" disabled
-                                    title="Položka stejného názvu nenalezena">
-                                Zobrazit jako předmět <i class="bi bi-arrow-right"></i>
-                            </button>
+                            <p class="mt-2 mb-0 text-danger small"><i class="bi bi-exclamation-triangle"></i> @scrollItemError</p>
                         }
                     </div>
                 }
@@ -160,7 +158,8 @@ else
                         <DxTextBox @bind-Text="@editModel.Name" />
                     </DxFormLayoutItem>
                     <DxFormLayoutItem Caption="Úroveň (0=svitek, 1-5=mág)" ColSpanMd="4">
-                        <DxSpinEdit @bind-Value="@editModel.Level" MinValue="0" MaxValue="5" />
+                        <DxSpinEdit @bind-Value="@editModel.Level" MinValue="0" MaxValue="5"
+                                    Enabled="@(!editModel.IsScroll)" />
                     </DxFormLayoutItem>
                     <DxFormLayoutItem Caption="Škola" ColSpanMd="12">
                         <DxComboBox Data="@schoolValues" @bind-Value="@editModel.School"
@@ -170,10 +169,12 @@ else
 
                 <DxFormLayoutGroup Caption="Mechanika" ColSpanMd="12">
                     <DxFormLayoutItem Caption="Mana" ColSpanMd="3">
-                        <DxSpinEdit @bind-Value="@editModel.ManaCost" MinValue="0" MaxValue="9" />
+                        <DxSpinEdit @bind-Value="@editModel.ManaCost" MinValue="0" MaxValue="9"
+                                    Enabled="@(!editModel.IsScroll)" />
                     </DxFormLayoutItem>
                     <DxFormLayoutItem Caption="Min. úroveň mága" ColSpanMd="3">
-                        <DxSpinEdit @bind-Value="@editModel.MinMageLevel" MinValue="0" MaxValue="5" />
+                        <DxSpinEdit @bind-Value="@editModel.MinMageLevel" MinValue="0" MaxValue="5"
+                                    Enabled="@(!editModel.IsScroll)" />
                     </DxFormLayoutItem>
                     <DxFormLayoutItem Caption="Cena (groše)" ColSpanMd="3">
                         <DxSpinEdit @bind-Value="@editModel.Price" MinValue="0" MaxValue="9999"
@@ -184,7 +185,7 @@ else
                         <DxCheckBox @bind-Checked="@editModel.IsReaction" />
                     </DxFormLayoutItem>
                     <DxFormLayoutItem Caption="Naučitelné" ColSpanMd="6">
-                        <DxCheckBox @bind-Checked="@editModel.IsLearnable" />
+                        <DxCheckBox @bind-Checked="@editModel.IsLearnable" Enabled="@(!editModel.IsScroll)" />
                     </DxFormLayoutItem>
                     <DxFormLayoutItem Caption="Svitek" ColSpanMd="6">
                         <DxCheckBox @bind-Checked="@editModel.IsScroll" />
@@ -207,7 +208,7 @@ else
                     <div class="oh-sp-karta-name-row">
                         <h2 class="oh-sp-karta-name">@(string.IsNullOrWhiteSpace(editModel.Name) ? "Bez názvu" : editModel.Name)</h2>
                         <span class="oh-sp-lvl-badge oh-sp-lvl-badge--lg @(editModel.IsScroll ? "oh-sp-lvl-scroll" : "oh-sp-lvl-roman")">
-                            @LevelRoman(editModel.Level)
+                            @LevelRoman(editModel.EffectiveLevel)
                         </span>
                     </div>
                     <div class="oh-sp-karta-meta">
@@ -219,11 +220,11 @@ else
                     </div>
                     <div class="oh-sp-karta-mana-row">
                         <span class="oh-sp-karta-mana-lab">Mana</span>
-                        <ManaRings Cost="@editModel.ManaCost" Size="ManaRings.RingSize.Lg" IsScroll="@editModel.IsScroll" />
+                        <ManaRings Cost="@editModel.EffectiveManaCost" Size="ManaRings.RingSize.Lg" IsScroll="@editModel.IsScroll" />
                     </div>
-                    @if (editModel.MinMageLevel > 1)
+                    @if (editModel.EffectiveMinMageLevel > 1)
                     {
-                        <p class="oh-sp-karta-min">Minimální úroveň mága: @LevelRoman(editModel.MinMageLevel)</p>
+                        <p class="oh-sp-karta-min">Minimální úroveň mága: @LevelRoman(editModel.EffectiveMinMageLevel)</p>
                     }
                     <hr class="oh-sp-karta-sep" />
                     <p class="oh-sp-karta-fx">@(string.IsNullOrWhiteSpace(editModel.Effect) ? "(text karty zatím prázdný)" : editModel.Effect)</p>
@@ -330,8 +331,12 @@ else
     private bool isDeleteVisible;
     private string? saveError;
 
-    // Scroll-to-item fuzz match (issue #148 follow-up: replace with FK).
-    private int? matchedItemId;
+    // Scroll → Item callout (issue #148, follow-up #1: replace with proper FK).
+    // Lookup is lazy on button click, NOT eager on detail load — fetching
+    // the entire /api/items catalog just to render one button would scale
+    // poorly as the catalog grows.
+    private bool isLookingUpItem;
+    private string? scrollItemError;
 
     // Obchod tab — per-game configuration list. Spell-side projection rolled
     // up from /api/spells/by-game/{gameId} hits across all games would be a
@@ -360,20 +365,7 @@ else
             }
             spell = detail;
             editModel = EditForm.FromDetail(detail);
-
-            // Best-effort scroll→item fuzz match. Failure leaves matchedItemId
-            // null and the callout falls back to its disabled state.
-            if (detail.IsScroll)
-            {
-                try
-                {
-                    var items = await Api.GetListAsync<ItemListDto>("/api/items");
-                    var hit = items.FirstOrDefault(i =>
-                        string.Equals(i.Name?.Trim(), detail.Name.Trim(), StringComparison.OrdinalIgnoreCase));
-                    matchedItemId = hit?.Id;
-                }
-                catch { matchedItemId = null; }
-            }
+            scrollItemError = null;
 
             // Obchod data — best-effort. List endpoint per game not provided
             // for spells-by-spellId yet (followup); leave empty for now.
@@ -390,12 +382,46 @@ else
         isSaving = true;
         try
         {
-            await Api.PutAsync($"/api/spells/{Id}", editModel.ToUpdateDto());
+            // PutWithProblemAsync forwards 4xx ProblemDetails (e.g. duplicate
+            // name) into the inline banner instead of swallowing the body.
+            var (ok, problem) = await Api.PutWithProblemAsync($"/api/spells/{Id}", editModel.ToUpdateDto());
+            if (!ok)
+            {
+                saveError = problem ?? "Uložení kouzla se nepodařilo.";
+                return;
+            }
             await LoadAsync();
             activeTab = "karta";
         }
         catch (Exception ex) { saveError = ex.Message; }
         finally { isSaving = false; }
+    }
+
+    /// <summary>
+    /// Lazy fuzz-match by Name against /api/items when the user clicks
+    /// "Zobrazit jako předmět". No eager fetch on detail load — the catalog
+    /// can grow and this lookup is only useful on scroll detail pages.
+    /// Replaced by the proper Spell.ScrollItemId FK in follow-up #1.
+    /// </summary>
+    private async Task OpenAsItemAsync()
+    {
+        if (spell is null || !spell.IsScroll) return;
+        scrollItemError = null;
+        isLookingUpItem = true;
+        try
+        {
+            var items = await Api.GetListAsync<ItemListDto>("/api/items");
+            var hit = items.FirstOrDefault(i =>
+                string.Equals(i.Name?.Trim(), spell.Name.Trim(), StringComparison.OrdinalIgnoreCase));
+            if (hit is null)
+            {
+                scrollItemError = "Položka stejného názvu nenalezena. Vytvořte svitek v katalogu předmětů a propojení vznikne automaticky.";
+                return;
+            }
+            Nav.NavigateTo($"/items/{hit.Id}");
+        }
+        catch (Exception ex) { scrollItemError = $"Nepodařilo se prohledat katalog: {ex.Message}"; }
+        finally { isLookingUpItem = false; }
     }
 
     private async Task DeleteAsync()
@@ -459,6 +485,18 @@ else
         public string Effect { get; set; } = "";
         public string? Description { get; set; }
 
+        // ── Effective values — single source of truth for both preview and
+        // persistence. MAG-005/006 says scrolls are Level 0, ManaCost 0,
+        // MinMageLevel 0, not learnable, no learning price. The UI can let
+        // the user toggle IsScroll while leaving stale numbers in adjacent
+        // fields; these getters squash that inconsistency before render
+        // and persist. ──
+        public int EffectiveLevel => IsScroll ? 0 : Level;
+        public int EffectiveManaCost => IsScroll ? 0 : ManaCost;
+        public int EffectiveMinMageLevel => IsScroll ? 0 : MinMageLevel;
+        public bool EffectiveIsLearnable => !IsScroll && IsLearnable;
+        public int? EffectivePrice => IsScroll ? null : Price;
+
         public static EditForm FromDetail(SpellDetailDto d) => new()
         {
             Name = d.Name,
@@ -475,7 +513,15 @@ else
         };
 
         public UpdateSpellDto ToUpdateDto() => new(
-            Name.Trim(), Level, ManaCost, School, IsScroll, IsReaction, IsLearnable, MinMageLevel, Price,
+            Name.Trim(),
+            EffectiveLevel,
+            EffectiveManaCost,
+            School,
+            IsScroll,
+            IsReaction,
+            EffectiveIsLearnable,
+            EffectiveMinMageLevel,
+            EffectivePrice,
             string.IsNullOrWhiteSpace(Effect) ? "—" : Effect.Trim(),
             string.IsNullOrWhiteSpace(Description) ? null : Description.Trim());
     }

--- a/src/OvcinaHra.Client/Pages/Spells/SpellList.razor
+++ b/src/OvcinaHra.Client/Pages/Spells/SpellList.razor
@@ -274,20 +274,33 @@ else
         isCreating = true;
         try
         {
+            // Clamp Level/IsScroll/ManaCost into a consistent shape per
+            // MAG-005/006: scrolls are Level 0, ManaCost 0, MinMageLevel 0;
+            // any non-zero Level is a learnable mage spell, never a scroll.
+            var isScroll = createModel.Level == 0;
+            var mana = isScroll ? 0 : createModel.ManaCost;
             var dto = new CreateSpellDto(
                 createModel.Name.Trim(),
                 createModel.Level,
-                createModel.ManaCost,
+                mana,
                 createModel.School,
-                IsScroll: createModel.Level == 0,
+                IsScroll: isScroll,
                 IsReaction: false,
-                IsLearnable: createModel.Level > 0,
+                IsLearnable: !isScroll,
                 MinMageLevel: 0,
                 Price: null,
                 Effect: string.IsNullOrWhiteSpace(createModel.Effect) ? "—" : createModel.Effect.Trim(),
                 Description: null);
 
-            var created = await Api.PostAsync<CreateSpellDto, SpellDetailDto>("/api/spells", dto);
+            // PostWithProblemAsync forwards 409 ProblemDetails (e.g. duplicate
+            // Czech name from SpellEndpoints.Create) into the inline banner
+            // instead of the generic exception message.
+            var (ok, created, problem) = await Api.PostWithProblemAsync<CreateSpellDto, SpellDetailDto>("/api/spells", dto);
+            if (!ok)
+            {
+                createError = problem ?? "Vytvoření kouzla se nepodařilo.";
+                return;
+            }
             isCreateVisible = false;
             // Land on the new spell's detail so the user can fill in the rest
             // of the fields on the Upravit tab without a round-trip through

--- a/src/OvcinaHra.Client/Pages/Spells/SpellList.razor
+++ b/src/OvcinaHra.Client/Pages/Spells/SpellList.razor
@@ -1,124 +1,244 @@
 @page "/spells"
 @attribute [Authorize]
 @inject ApiClient Api
+@inject NavigationManager Nav
 @using OvcinaHra.Shared.Domain.Enums
 @using OvcinaHra.Shared.Extensions
 
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">Katalog kouzel</h1>
-    <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nové kouzlo</button>
+    <div class="d-flex gap-2">
+        <button class="btn btn-outline-secondary" type="button"
+                @onclick='() => Nav.NavigateTo("/spells/print")'
+                title="Otevřít A5 Knihu kouzel pro tisk">
+            <i class="bi bi-book-half"></i> Kniha kouzel
+        </button>
+        <button class="btn btn-primary" type="button" @onclick="OpenCreateModal">
+            <i class="bi bi-plus-lg"></i> Nové kouzlo
+        </button>
+    </div>
 </div>
 
 @if (loading)
 {
-    <p>Načítám...</p>
+    <p class="text-muted">Načítám…</p>
 }
 else
 {
-    <OvcinaGrid Data="@spells" KeyFieldName="Id" LayoutKey="grid-layout-spells"
-                RowClick="@(async e => await OpenDetailAsync((SpellListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+    @* LayoutKey bumped grid-layout-spells → grid-layout-spells-v2 because the
+       column schema changed (new chip / rings / flags cells, new field names).
+       Memory rule: feedback_ovcinagrid_layoutkey_bump. *@
+    <OvcinaGrid Data="@spells" KeyFieldName="Id" LayoutKey="grid-layout-spells-v2"
+                RowClick="@(e => OpenPeek((SpellListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
-            @* Default visible — the common "at-a-glance" set *@
-            <DxGridDataColumn FieldName="Id" Caption="#" Width="60px" />
-            <DxGridDataColumn FieldName="Name" Caption="Název" Width="200px" />
-            <DxGridDataColumn FieldName="Level" Caption="Úroveň" Width="90px" />
-            <DxGridDataColumn FieldName="SchoolDisplay" Caption="Typ" Width="130px" />
-            <DxGridDataColumn FieldName="ManaCost" Caption="Mana" Width="80px" />
-            <DxGridDataColumn FieldName="MinMageLevel" Caption="Min. mág" Width="100px" />
-            <DxGridDataColumn FieldName="Price" Caption="Cena (gr)" Width="100px" />
-            <DxGridDataColumn FieldName="IsScroll" Caption="Svitek" Width="80px" />
-            <DxGridDataColumn FieldName="IsReaction" Caption="Reakce" Width="90px" />
-            <DxGridDataColumn FieldName="IsLearnable" Caption="Naučitelné" Width="110px" />
-            <DxGridDataColumn FieldName="Effect" Caption="Efekt" Width="420px" />
+            @* Level Roman / "S" chip — 60px *@
+            <DxGridDataColumn FieldName="Level" Caption="Úr." Width="64px">
+                <CellDisplayTemplate>
+                    @{ var s = (SpellListDto)context.DataItem; }
+                    <span class="oh-sp-lvl-badge @(s.IsScroll ? "oh-sp-lvl-scroll" : "oh-sp-lvl-roman")"
+                          style="@($"--oh-c: var(--oh-school-{SchoolKey(s.School)});")">
+                        @LevelRoman(s.Level)
+                    </span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="Name" Caption="Název" MinWidth="220">
+                <CellDisplayTemplate>
+                    @{ var s = (SpellListDto)context.DataItem; }
+                    <div class="oh-sp-c-name">
+                        <span>@s.Name</span>
+                        @if (s.IsReaction)
+                        {
+                            <span class="oh-sp-reaction" title="Reakce — kouzlí se mimo tah">
+                                <i class="bi bi-lightning-charge-fill"></i>Reakce
+                            </span>
+                        }
+                    </div>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="SchoolDisplay" Caption="Škola" Width="150px">
+                <CellDisplayTemplate>
+                    @{ var s = (SpellListDto)context.DataItem; }
+                    <SpellSchoolChip School="@s.School" />
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="ManaCost" Caption="Mana" Width="100px">
+                <CellDisplayTemplate>
+                    @{ var s = (SpellListDto)context.DataItem; }
+                    <ManaRings Cost="@s.ManaCost" Size="ManaRings.RingSize.Md" IsScroll="@s.IsScroll" />
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="Price" Caption="Cena" Width="90px">
+                <CellDisplayTemplate>
+                    @{ var s = (SpellListDto)context.DataItem; }
+                    @if (s.IsScroll)
+                    {
+                        <span class="oh-sp-c-price oh-sp-c-price--free">—</span>
+                    }
+                    else if (s.Price.HasValue)
+                    {
+                        <span class="oh-sp-c-price oh-sp-c-price-coin"><i class="bi bi-coin"></i>@s.Price gr</span>
+                    }
+                    else
+                    {
+                        <span class="oh-sp-c-price oh-sp-c-price--free">Zdarma</span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            @* Flags box — IsLearnable / IsReaction / IsScroll *@
+            <DxGridDataColumn Caption="Flagy" Width="110px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var s = (SpellListDto)context.DataItem; }
+                    <div class="d-flex gap-1 align-items-center">
+                        <i class="bi @(s.IsLearnable ? "bi-mortarboard-fill text-success" : "bi-mortarboard text-muted")"
+                           title="@(s.IsLearnable ? "Lze se naučit" : "Nelze se naučit")"></i>
+                        <i class="bi @(s.IsReaction ? "bi-lightning-charge-fill text-warning" : "bi-lightning-charge text-muted")"
+                           title="@(s.IsReaction ? "Reakce" : "Akce")"></i>
+                        <i class="bi @(s.IsScroll ? "bi-file-earmark-text-fill" : "bi-file-earmark-text text-muted")"
+                           title="@(s.IsScroll ? "Svitek" : "Klasické kouzlo")"></i>
+                    </div>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="Effect" Caption="Efekt" MinWidth="280">
+                <CellDisplayTemplate>
+                    @{ var s = (SpellListDto)context.DataItem; }
+                    @* Full text in DOM (no truncation in markup); CSS line-clamp
+                       gives the ellipsis. Card text stays sacred per
+                       feedback_ovcina_card_text_sacred. *@
+                    <span class="oh-sp-c-fx" title="@s.Effect">@s.Effect</span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
 
             @* Hidden by default — reveal via column chooser *@
-            <DxGridDataColumn FieldName="Description" Caption="Popis" Width="360px" Visible="false" />
+            <DxGridDataColumn FieldName="MinMageLevel" Caption="Min. mág" Width="100px" Visible="false" />
+            <DxGridDataColumn FieldName="Description" Caption="Popis" Width="320px" Visible="false" />
         </Columns>
     </OvcinaGrid>
 }
 
-<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="760px" MinHeight="640px">
-    <BodyContentTemplate Context="popupContext">
-        <DxFormLayout>
-            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
-                <DxTextBox @bind-Text="@model.Name" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Typ (škola)" ColSpanMd="12">
-                <DxComboBox Data="@schoolValues" @bind-Value="@model.School"
-                            TextFieldName="Display" ValueFieldName="Value" />
-            </DxFormLayoutItem>
-
-            <DxFormLayoutItem Caption="Úroveň (0=svitek, 1-5=mág)" ColSpanMd="4">
-                <DxSpinEdit @bind-Value="@model.Level" MinValue="0" MaxValue="5" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Mana" ColSpanMd="4">
-                <DxSpinEdit @bind-Value="@model.ManaCost" MinValue="0" MaxValue="5" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Min. úroveň mága" ColSpanMd="4">
-                <DxSpinEdit @bind-Value="@model.MinMageLevel" MinValue="0" MaxValue="5" />
-            </DxFormLayoutItem>
-
-            <DxFormLayoutItem Caption="Svitek" ColSpanMd="4">
-                <DxCheckBox @bind-Checked="@model.IsScroll" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Reakce" ColSpanMd="4">
-                <DxCheckBox @bind-Checked="@model.IsReaction" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Standartní" ColSpanMd="4">
-                <span title="Toto kouzlo se dá naučit ve městě dle standartních pravidel.">
-                    <DxCheckBox @bind-Checked="@model.IsLearnable" />
-                </span>
-            </DxFormLayoutItem>
-
-            <DxFormLayoutItem Caption="Cena naučení (groše)" ColSpanMd="12">
-                <DxSpinEdit @bind-Value="@model.Price" MinValue="0" MaxValue="9999" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
-            </DxFormLayoutItem>
-
-            <DxFormLayoutItem Caption="Efekt (text karty)" ColSpanMd="12">
-                <DxMemo @bind-Text="@model.Effect" Rows="4" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Popis / flavor (volitelný)" ColSpanMd="12">
-                <DxMemo @bind-Text="@model.Description" Rows="4" />
-            </DxFormLayoutItem>
-        </DxFormLayout>
-
-        @if (error is not null)
+@* Quick-peek popup — 720×420. Row click → peek. Footer has
+   "Otevřít detail →" navigating to /spells/{id}. *@
+<DxPopup @bind-Visible="@isPeekVisible" HeaderText="@(peekItem?.Name ?? "Kouzlo")" Width="720px">
+    <BodyContentTemplate Context="qpCtx">
+        @if (peekItem is null)
         {
-            <div class="alert alert-danger mt-2">@error</div>
+            <p class="text-muted">Načítám…</p>
         }
-
-        <div class="d-flex gap-2 mt-3">
-            @if (editingId.HasValue)
-            {
-                <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true" disabled="@isSaving">Smazat</button>
-            }
-            <div style="flex: 1"></div>
-            <button class="btn btn-secondary" @onclick="() => isModalVisible = false" disabled="@isSaving">Zrušit</button>
-            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">
-                @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
-                Uložit
-            </button>
-        </div>
+        else
+        {
+            <div class="oh-sp-peek-grid">
+                <div>
+                    <div class="oh-sp-peek-meta">
+                        <SpellSchoolChip School="@peekItem.School" />
+                        <ManaRings Cost="@peekItem.ManaCost" Size="ManaRings.RingSize.Md" IsScroll="@peekItem.IsScroll" />
+                        @if (peekItem.IsReaction)
+                        {
+                            <span class="oh-sp-reaction"><i class="bi bi-lightning-charge-fill"></i>Reakce</span>
+                        }
+                    </div>
+                    <p class="oh-sp-peek-fx" style="@($"--oh-school-c: var(--oh-school-{SchoolKey(peekItem.School)});")">@peekItem.Effect</p>
+                    @if (!string.IsNullOrWhiteSpace(peekItem.Description))
+                    {
+                        <p class="oh-sp-peek-desc">@peekItem.Description</p>
+                    }
+                </div>
+                <div class="oh-sp-peek-side">
+                    <div class="oh-sp-peek-side-row">
+                        <span>Úroveň</span>
+                        <strong>@LevelRoman(peekItem.Level)</strong>
+                    </div>
+                    @if (peekItem.MinMageLevel > 1)
+                    {
+                        <div class="oh-sp-peek-side-row">
+                            <span>Min. mág</span>
+                            <strong>@LevelRoman(peekItem.MinMageLevel)</strong>
+                        </div>
+                    }
+                    <div class="oh-sp-peek-side-row">
+                        <span>Cena</span>
+                        @if (peekItem.IsScroll)
+                        {
+                            <strong>—</strong>
+                        }
+                        else if (peekItem.Price.HasValue)
+                        {
+                            <strong>@(peekItem.Price.Value) gr</strong>
+                        }
+                        else
+                        {
+                            <strong>Zdarma</strong>
+                        }
+                    </div>
+                </div>
+            </div>
+            <div class="oh-sp-peek-foot">
+                <button class="btn btn-secondary" type="button" @onclick="() => isPeekVisible = false">Zavřít</button>
+                <button class="btn btn-primary" type="button"
+                        @onclick="@(() => Nav.NavigateTo($"/spells/{peekItem!.Id}"))">
+                    Otevřít detail <i class="bi bi-arrow-right"></i>
+                </button>
+            </div>
+        }
     </BodyContentTemplate>
 </DxPopup>
 
-<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Smazat kouzlo?" Width="400px">
-    <BodyContentTemplate Context="popupContext">
-        <p>Opravdu chcete smazat kouzlo <strong>@model.Name</strong>?</p>
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
-            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync" disabled="@isSaving">Smazat</button>
+@* "+ Nové kouzlo" create modal — the only place this list creates new
+   spells. Edit-existing flow lives on /spells/{id}'s Upravit tab. *@
+<DxPopup AllowResize="true" @bind-Visible="@isCreateVisible" HeaderText="Nové kouzlo" Width="640px">
+    <BodyContentTemplate Context="cCtx">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                <DxTextBox @bind-Text="@createModel.Name" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Škola" ColSpanMd="6">
+                <DxComboBox Data="@schoolValues" @bind-Value="@createModel.School"
+                            TextFieldName="Display" ValueFieldName="Value" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Úroveň (0=svitek)" ColSpanMd="3">
+                <DxSpinEdit @bind-Value="@createModel.Level" MinValue="0" MaxValue="5" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Mana" ColSpanMd="3">
+                <DxSpinEdit @bind-Value="@createModel.ManaCost" MinValue="0" MaxValue="9" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Efekt" ColSpanMd="12">
+                <DxMemo @bind-Text="@createModel.Effect" Rows="3" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+
+        @if (createError is not null)
+        {
+            <div class="alert alert-danger mt-2">@createError</div>
+        }
+
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" type="button" @onclick="() => isCreateVisible = false" disabled="@isCreating">Zrušit</button>
+            <button class="btn btn-primary" type="button" @onclick="CreateAsync"
+                    disabled="@(isCreating || string.IsNullOrWhiteSpace(createModel.Name))">
+                @if (isCreating) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit a otevřít
+            </button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
 
 @code {
     private List<SpellListDto> spells = [];
-    private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
-    private string modalTitle = "";
-    private string? error;
-    private int? editingId;
-    private SpellFormModel model = new();
+    private bool loading = true;
+
+    // Quick-peek (row click)
+    private bool isPeekVisible;
+    private SpellListDto? peekItem;
+
+    // Create modal
+    private bool isCreateVisible;
+    private bool isCreating;
+    private string? createError;
+    private CreateForm createModel = new();
 
     private static readonly List<SchoolOption> schoolValues = Enum.GetValues<SpellSchool>()
         .Select(v => new SchoolOption(v, v.GetDisplayName())).ToList();
@@ -134,103 +254,84 @@ else
         loading = false;
     }
 
-    private void OpenModal(SpellListDto? _)
+    private void OpenPeek(SpellListDto s)
     {
-        error = null;
-        editingId = null;
-        model = new SpellFormModel();
-        modalTitle = "Nové kouzlo";
-        isModalVisible = true;
+        peekItem = s;
+        isPeekVisible = true;
     }
 
-    private async Task OpenDetailAsync(SpellListDto s)
+    private void OpenCreateModal()
     {
-        error = null;
-        var detail = await Api.GetAsync<SpellDetailDto>($"/api/spells/{s.Id}");
-        if (detail is null) return;
-
-        editingId = detail.Id;
-        model = SpellFormModel.FromDetail(detail);
-        modalTitle = $"Upravit: {detail.Name}";
-        isModalVisible = true;
+        createModel = new CreateForm();
+        createError = null;
+        isCreateVisible = true;
     }
 
-    private async Task SaveAsync()
+    private async Task CreateAsync()
     {
-        error = null;
-        isSaving = true;
+        if (string.IsNullOrWhiteSpace(createModel.Name)) return;
+        createError = null;
+        isCreating = true;
         try
         {
-            if (editingId.HasValue)
-            {
-                await Api.PutAsync($"/api/spells/{editingId}", model.ToUpdateDto());
-            }
+            var dto = new CreateSpellDto(
+                createModel.Name.Trim(),
+                createModel.Level,
+                createModel.ManaCost,
+                createModel.School,
+                IsScroll: createModel.Level == 0,
+                IsReaction: false,
+                IsLearnable: createModel.Level > 0,
+                MinMageLevel: 0,
+                Price: null,
+                Effect: string.IsNullOrWhiteSpace(createModel.Effect) ? "—" : createModel.Effect.Trim(),
+                Description: null);
+
+            var created = await Api.PostAsync<CreateSpellDto, SpellDetailDto>("/api/spells", dto);
+            isCreateVisible = false;
+            // Land on the new spell's detail so the user can fill in the rest
+            // of the fields on the Upravit tab without a round-trip through
+            // the catalog list.
+            if (created is not null)
+                Nav.NavigateTo($"/spells/{created.Id}");
             else
-            {
-                await Api.PostAsync<CreateSpellDto, SpellDetailDto>("/api/spells", model.ToCreateDto());
-            }
-            isModalVisible = false;
-            await LoadAsync();
+                await LoadAsync();
         }
-        catch (Exception ex) { error = ex.Message; }
-        finally { isSaving = false; }
+        catch (Exception ex) { createError = ex.Message; }
+        finally { isCreating = false; }
     }
 
-    private async Task ConfirmDeleteAsync()
+    private static string SchoolKey(SpellSchool s) => s switch
     {
-        error = null;
-        isSaving = true;
-        try
-        {
-            // ApiClient.DeleteAsync returns bool — it does not throw on non-success.
-            // Ignoring the value would close the dialog even on a failed delete.
-            var ok = await Api.DeleteAsync($"/api/spells/{editingId}");
-            if (!ok)
-            {
-                error = "Smazání kouzla se nepodařilo.";
-                return;
-            }
-            isDeleteVisible = false;
-            isModalVisible = false;
-            await LoadAsync();
-        }
-        catch (Exception ex) { error = ex.Message; }
-        finally { isSaving = false; }
-    }
+        SpellSchool.Fire    => "fire",
+        SpellSchool.Frost   => "frost",
+        SpellSchool.Water   => "water",
+        SpellSchool.Earth   => "earth",
+        SpellSchool.Wind    => "wind",
+        SpellSchool.Poison  => "poison",
+        SpellSchool.Mental  => "mental",
+        SpellSchool.Support => "support",
+        SpellSchool.Utility => "utility",
+        _ => "utility"
+    };
 
-    private sealed class SpellFormModel
+    private static string LevelRoman(int n) => n switch
+    {
+        0 => "S",
+        1 => "I",
+        2 => "II",
+        3 => "III",
+        4 => "IV",
+        5 => "V",
+        _ => n.ToString(System.Globalization.CultureInfo.InvariantCulture)
+    };
+
+    private sealed class CreateForm
     {
         public string Name { get; set; } = "";
-        public int Level { get; set; }
+        public int Level { get; set; } = 1;
         public int ManaCost { get; set; }
         public SpellSchool School { get; set; } = SpellSchool.Fire;
-        public bool IsScroll { get; set; }
-        public bool IsReaction { get; set; }
-        public bool IsLearnable { get; set; } = true;
-        public int MinMageLevel { get; set; }
-        public int? Price { get; set; }
         public string Effect { get; set; } = "";
-        public string? Description { get; set; }
-
-        public static SpellFormModel FromDetail(SpellDetailDto d) => new()
-        {
-            Name = d.Name,
-            Level = d.Level,
-            ManaCost = d.ManaCost,
-            School = d.School,
-            IsScroll = d.IsScroll,
-            IsReaction = d.IsReaction,
-            IsLearnable = d.IsLearnable,
-            MinMageLevel = d.MinMageLevel,
-            Price = d.Price,
-            Effect = d.Effect,
-            Description = d.Description
-        };
-
-        public CreateSpellDto ToCreateDto() => new(
-            Name, Level, ManaCost, School, IsScroll, IsReaction, IsLearnable, MinMageLevel, Price, Effect, Description);
-
-        public UpdateSpellDto ToUpdateDto() => new(
-            Name, Level, ManaCost, School, IsScroll, IsReaction, IsLearnable, MinMageLevel, Price, Effect, Description);
     }
 }

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2726,7 +2726,10 @@
 .oh-sp-tisk-toolbar-info{font:600 .8125rem var(--oh-font-body);color:var(--oh-text-secondary,#6a6a6a)}
 .oh-sp-print-stage{background:#e8e3d5;padding:18px;display:flex;flex-direction:column;align-items:center;gap:18px;min-height:calc(100vh - 60px)}
 
-/* A5 spread (landscape 297×210mm = two A5 portrait pages side by side) */
+/* "Kniha kouzel" spread — physically A4 landscape (297×210mm) holding two
+   A5 portrait pages side by side. The brief called the printed sheet
+   "A5 landscape" but those dimensions are actually A4 landscape; we print
+   on A4 and fold/cut to two A5 booklet leaves. */
 .oh-sp-print-spread{width:297mm;min-height:210mm;background:#fbf6e7;
     box-shadow:0 4px 18px rgba(0,0,0,.18);
     display:grid;grid-template-columns:1fr 1fr;
@@ -2754,9 +2757,10 @@
 .oh-sp-print-tile-fx::first-letter{font:900 1.25rem/.9 var(--oh-font-heading,Merriweather,Georgia,serif);color:var(--oh-school-c,#243525);float:left;margin:1px 4px 0 0}
 .oh-sp-print-tile-foot{display:flex;align-items:center;justify-content:space-between;gap:6px;margin-top:auto;padding-top:2mm;border-top:1px dashed rgba(178,98,35,.4);font:600 8pt var(--oh-font-mono,JetBrains Mono,Menlo,monospace);color:#6c5212}
 
-/* @media print — actual A5 landscape rules */
+/* @media print — actual A4 landscape rules (matches the spread above; user
+   folds the printed sheet down the spine into two A5 portrait pages). */
 @media print{
-    @page{size:A5 landscape;margin:8mm}
+    @page{size:A4 landscape;margin:8mm}
     body{background:#fff !important}
     .oh-sp-tisk-toolbar,.oh-sp-print-stage > nav,nav,header,aside,.sidebar,.oh-app-sidebar{display:none !important}
     .oh-sp-print-stage{background:transparent;padding:0;gap:0;min-height:0;align-items:stretch}

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2583,3 +2583,183 @@
     display:flex;align-items:center;gap:8px;max-width:min(520px,calc(100% - 24px));
     margin:0;padding:8px 12px;font-size:.875rem}
 .oh-map-overlay-error .btn-close{margin-left:auto}
+
+/* ============================================================
+   Spells — catalog · detail (3 tabs) · A5 print (issue #148)
+   Class prefix: .oh-sp-*  (cells .oh-sp-c-*, peek .oh-sp-peek-*,
+   karta .oh-sp-karta-*, level badges .oh-sp-lvl-*, print
+   .oh-sp-print-*). Mana keeps the .oh-mana-* prefix; school chip
+   keeps .oh-school + --oh-school-{key} custom properties.
+   ============================================================ */
+
+/* 9 school palette tokens, parchment-compatible. Distinct from
+   --oh-kingdom-* + --oh-stage-*; never blur the three palettes. */
+:root{
+    --oh-school-fire:    #B23A2A;
+    --oh-school-frost:   #6DA3C8;
+    --oh-school-water:   #2E5A87;
+    --oh-school-earth:   #7A5A2F;
+    --oh-school-wind:    #8F9EA8;
+    --oh-school-poison:  #5A8B3A;
+    --oh-school-mental:  #6E4A8F;
+    --oh-school-support: #C19A3A;
+    --oh-school-utility: #6E6E6E;
+}
+
+/* School chip — 1.5px outlined with small color dot + mono Czech label */
+.oh-school{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;
+    border:1.5px solid var(--oh-c,#888);border-radius:99px;
+    background:rgba(245,237,227,.55);color:var(--oh-text,#2a2a2a);
+    font:600 .75rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);white-space:nowrap}
+.oh-school::before{content:"";width:8px;height:8px;border-radius:50%;background:var(--oh-c,#888);flex-shrink:0}
+.oh-school[data-school="fire"]   {--oh-c:var(--oh-school-fire)}
+.oh-school[data-school="frost"]  {--oh-c:var(--oh-school-frost)}
+.oh-school[data-school="water"]  {--oh-c:var(--oh-school-water)}
+.oh-school[data-school="earth"]  {--oh-c:var(--oh-school-earth)}
+.oh-school[data-school="wind"]   {--oh-c:var(--oh-school-wind)}
+.oh-school[data-school="poison"] {--oh-c:var(--oh-school-poison)}
+.oh-school[data-school="mental"] {--oh-c:var(--oh-school-mental)}
+.oh-school[data-school="support"]{--oh-c:var(--oh-school-support)}
+.oh-school[data-school="utility"]{--oh-c:var(--oh-school-utility)}
+
+/* Mana rings — SVG concentric, rainbow conic-gradient stroke. Lg/Md/Sm
+   match the issue body brief (14/12/10px). 6 per row, then wrap. */
+.oh-mana{display:inline-flex;flex-wrap:wrap;align-items:center;gap:6px;line-height:1}
+.oh-mana svg{display:block;flex:0 0 auto}
+.oh-mana--lg svg{width:14px;height:14px}
+.oh-mana svg{width:12px;height:12px}
+.oh-mana--sm svg{width:10px;height:10px}
+.oh-mana-scroll{display:inline-block;padding:2px 8px;border-radius:99px;
+    background:rgba(193,154,58,.18);color:#6c5212;border:1px solid rgba(193,154,58,.55);
+    font:600 .7rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);white-space:nowrap}
+.oh-mana-free{display:inline-block;padding:2px 8px;border-radius:99px;
+    background:var(--oh-surface-alt,#f5f0e1);color:var(--oh-text-secondary,#6a6a6a);
+    border:1px dashed var(--oh-border,#d8d2be);
+    font:600 .7rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);white-space:nowrap}
+
+/* Level badge — Roman I-V or "S" for scroll */
+.oh-sp-lvl-badge{display:inline-flex;align-items:center;justify-content:center;
+    width:30px;height:30px;border-radius:50%;
+    border:1.5px solid var(--oh-c,var(--oh-text-secondary,#6a6a6a));
+    background:var(--oh-surface,#fff);color:var(--oh-text,#2a2a2a);
+    font:700 .85rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);
+    line-height:1}
+.oh-sp-lvl-badge--lg{width:42px;height:42px;font-size:1.1rem}
+.oh-sp-lvl-roman{font-variant-caps:small-caps;letter-spacing:.04em}
+.oh-sp-lvl-scroll{background:rgba(193,154,58,.15);border-color:#C19A3A;color:#6c5212}
+
+/* Reaction pill (small) — yellow glow per designer note */
+.oh-sp-reaction{display:inline-flex;align-items:center;gap:3px;
+    padding:1px 7px;border-radius:99px;
+    background:rgba(218,165,32,.18);color:#6c5212;border:1px solid rgba(218,165,32,.6);
+    font:700 .65rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);text-transform:uppercase;letter-spacing:.06em}
+.oh-sp-reaction i{font-size:.7rem}
+
+/* List grid cells. .oh-sp-c-* mirrors the mockup column-cell helpers. */
+.oh-sp-c-name{font:600 .9375rem var(--oh-font-body);color:var(--oh-text,#2a2a2a);display:flex;align-items:center;gap:6px}
+.oh-sp-c-fx{font:400 .8125rem var(--oh-font-body);color:var(--oh-text,#2a2a2a);
+    overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;line-clamp:2}
+.oh-sp-c-price{font-family:var(--oh-font-mono,JetBrains Mono,Menlo,monospace);font-size:.8125rem;color:var(--oh-text,#2a2a2a)}
+.oh-sp-c-price--free{color:var(--oh-text-secondary,#6a6a6a)}
+.oh-sp-c-price-coin{display:inline-flex;align-items:center;gap:3px}
+
+/* Quick-peek popup body grid — 720px wide popup. Hero left, fields right. */
+.oh-sp-peek-grid{display:grid;grid-template-columns:1fr 240px;gap:18px;padding:6px 4px 14px}
+.oh-sp-peek-head{display:flex;align-items:center;gap:10px;margin-bottom:8px;flex-wrap:wrap}
+.oh-sp-peek-name{font:800 1.25rem var(--oh-font-heading,Merriweather,Georgia,serif);color:var(--oh-primary,#243525);margin:0}
+.oh-sp-peek-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin:6px 0 12px}
+.oh-sp-peek-fx{font:400 .9375rem/1.5 var(--oh-font-serif,Georgia,Merriweather,serif);
+    color:var(--oh-text,#2a2a2a);text-align:justify;hyphens:auto;white-space:pre-wrap;
+    border-left:3px solid var(--oh-school-c,var(--oh-border,#d8d2be));padding:6px 12px;background:var(--oh-surface-alt,#f5f0e1);
+    border-radius:4px}
+.oh-sp-peek-desc{font:italic 400 .875rem/1.5 var(--oh-font-serif,Georgia,Merriweather,serif);color:var(--oh-text-secondary,#6a6a6a);margin-top:10px;white-space:pre-wrap}
+.oh-sp-peek-side{display:flex;flex-direction:column;gap:10px;border-left:1px solid var(--oh-border,#d8d2be);padding-left:14px}
+.oh-sp-peek-side-row{display:flex;justify-content:space-between;gap:6px;font:600 .8125rem var(--oh-font-body);color:var(--oh-text-secondary,#6a6a6a)}
+.oh-sp-peek-side-row strong{color:var(--oh-text,#2a2a2a);font-family:var(--oh-font-mono,JetBrains Mono,Menlo,monospace)}
+.oh-sp-peek-foot{display:flex;justify-content:space-between;gap:10px;padding-top:10px;border-top:1px solid var(--oh-border,#d8d2be);margin-top:6px}
+
+/* Karta tab — illuminated parchment page, two-column 62fr/38fr */
+.oh-sp-karta-grid{display:grid;grid-template-columns:62fr 38fr;gap:20px;align-items:start}
+@media (max-width:880px){.oh-sp-karta-grid{grid-template-columns:1fr}}
+.oh-sp-karta{position:relative;background:#fbf6e7;border:1px solid #c8b48a;border-radius:6px;
+    padding:24px 28px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.oh-sp-karta::before{content:"";position:absolute;top:0;bottom:0;left:0;width:3px;background:var(--oh-school-c,#aaa);border-radius:6px 0 0 6px}
+.oh-sp-karta-name{font:900 2.4rem/1.1 var(--oh-font-heading,Merriweather,Georgia,serif);color:var(--oh-primary,#243525);margin:0;text-align:center;letter-spacing:-.01em}
+.oh-sp-karta-name-row{display:flex;align-items:center;justify-content:center;gap:14px}
+.oh-sp-karta-meta{display:flex;flex-wrap:wrap;justify-content:center;gap:10px;margin:14px 0 18px}
+.oh-sp-karta-mana-row{display:flex;align-items:center;justify-content:center;gap:10px;margin-bottom:14px}
+.oh-sp-karta-mana-lab{font:600 .7rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);color:var(--oh-text-secondary,#6a6a6a);text-transform:uppercase;letter-spacing:.08em}
+.oh-sp-karta-min{text-align:center;font:italic 400 .85rem var(--oh-font-serif,Georgia,Merriweather,serif);color:var(--oh-text-secondary,#6a6a6a);margin:6px 0}
+.oh-sp-karta-sep{height:1px;background:linear-gradient(90deg,transparent 0,#B26223 20%,#B26223 80%,transparent 100%);margin:14px 0;border:none}
+.oh-sp-karta-fx{font:400 1.1rem/1.55 var(--oh-font-serif,Georgia,Merriweather,serif);color:var(--oh-text,#2a2a2a);text-align:justify;hyphens:auto;white-space:pre-wrap;margin:0}
+.oh-sp-karta-fx::first-letter{font:900 3rem/.9 var(--oh-font-heading,Merriweather,Georgia,serif);color:var(--oh-school-c,#243525);float:left;margin:4px 8px 0 0;line-height:.85}
+.oh-sp-karta-desc{font:italic 400 .95rem/1.55 var(--oh-font-serif,Georgia,Merriweather,serif);color:var(--oh-text-secondary,#6a6a6a);margin:14px 0 0;text-align:justify;hyphens:auto;white-space:pre-wrap}
+
+/* Karta side panel (price, scroll callout, badges) */
+.oh-sp-karta-side{display:flex;flex-direction:column;gap:12px}
+.oh-sp-karta-side-block{background:var(--oh-surface,#fff);border:1px solid var(--oh-border,#d8d2be);border-radius:6px;padding:14px}
+.oh-sp-karta-price-row{display:flex;align-items:center;justify-content:space-between;gap:8px;font:600 .9rem var(--oh-font-body)}
+.oh-sp-karta-price-coin{display:inline-flex;align-items:center;gap:4px;
+    padding:4px 10px;border-radius:99px;background:rgba(193,154,58,.14);color:#6c5212;
+    border:1px solid rgba(193,154,58,.5);font-family:var(--oh-font-mono,JetBrains Mono,Menlo,monospace);font-size:.875rem}
+.oh-sp-karta-badges{display:flex;flex-wrap:wrap;gap:6px;margin-top:6px}
+.oh-sp-karta-badge{padding:3px 9px;border-radius:99px;background:var(--oh-surface-alt,#f5f0e1);
+    color:var(--oh-text-secondary,#6a6a6a);border:1px solid var(--oh-border,#d8d2be);
+    font:600 .7rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);text-transform:uppercase;letter-spacing:.06em}
+.oh-sp-karta-badge--on{background:rgba(45,80,22,.12);color:#2D5016;border-color:rgba(45,80,22,.5)}
+.oh-sp-karta-scroll-callout{background:linear-gradient(135deg,rgba(193,154,58,.16),rgba(193,154,58,.06));
+    border:1px solid rgba(193,154,58,.55);border-radius:6px;padding:14px}
+.oh-sp-karta-scroll-callout h6{font:700 .85rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);
+    color:#6c5212;text-transform:uppercase;letter-spacing:.06em;margin:0 0 6px}
+.oh-sp-karta-scroll-callout p{font:400 .85rem/1.5 var(--oh-font-body);color:var(--oh-text,#2a2a2a);margin:0 0 10px}
+
+/* Edit (Upravit) — live preview right column */
+.oh-sp-edit-grid{display:grid;grid-template-columns:1fr 360px;gap:24px;align-items:start}
+@media (max-width:1080px){.oh-sp-edit-grid{grid-template-columns:1fr}}
+.oh-sp-edit-preview-stage{position:sticky;top:80px}
+.oh-sp-edit-preview-stage h6{font:600 .75rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);
+    color:var(--oh-text-secondary,#6a6a6a);text-transform:uppercase;letter-spacing:.06em;margin:0 0 8px}
+
+/* Print stage + toolbar (screen-only chrome) */
+.oh-sp-tisk-toolbar{position:sticky;top:0;z-index:10;display:flex;align-items:center;justify-content:space-between;gap:12px;
+    padding:10px 14px;background:var(--oh-surface,#fff);border-bottom:1px solid var(--oh-border,#d8d2be);margin-bottom:18px}
+.oh-sp-tisk-toolbar-info{font:600 .8125rem var(--oh-font-body);color:var(--oh-text-secondary,#6a6a6a)}
+.oh-sp-print-stage{background:#e8e3d5;padding:18px;display:flex;flex-direction:column;align-items:center;gap:18px;min-height:calc(100vh - 60px)}
+
+/* A5 spread (landscape 297×210mm = two A5 portrait pages side by side) */
+.oh-sp-print-spread{width:297mm;min-height:210mm;background:#fbf6e7;
+    box-shadow:0 4px 18px rgba(0,0,0,.18);
+    display:grid;grid-template-columns:1fr 1fr;
+    border:1px solid #c8b48a;position:relative;page-break-after:always;break-after:page}
+.oh-sp-print-spread::after{content:"";position:absolute;top:8mm;bottom:8mm;left:50%;width:1px;
+    background:linear-gradient(180deg,transparent,#c8b48a,#c8b48a,transparent);transform:translateX(-50%);opacity:.5}
+.oh-sp-print-page{padding:14mm 12mm}
+.oh-sp-print-banner{grid-column:1/-1;text-align:center;padding:8mm 0 4mm;
+    border-bottom:1px solid #c8b48a;background:linear-gradient(180deg,rgba(178,98,35,.07),transparent)}
+.oh-sp-print-banner h1{font:900 22pt var(--oh-font-heading,Merriweather,Georgia,serif);color:#243525;margin:0;letter-spacing:.02em}
+.oh-sp-print-banner-sub{font:italic 400 10pt var(--oh-font-serif,Georgia,Merriweather,serif);color:#6c5212;margin-top:3mm}
+.oh-sp-print-level-hdr{grid-column:1/-1;padding:5mm 12mm 2mm;
+    font:700 11pt var(--oh-font-mono,JetBrains Mono,Menlo,monospace);
+    color:#243525;text-transform:uppercase;letter-spacing:.08em}
+
+/* Tile — ~70×100mm with parchment + burnt-orange border + drop-cap */
+.oh-sp-print-tile{background:#fffbef;border:1px solid #B26223;border-radius:3px;padding:5mm 5mm 4mm;
+    page-break-inside:avoid;break-inside:avoid;display:flex;flex-direction:column;gap:2mm;
+    position:relative;min-height:50mm}
+.oh-sp-print-tile::before{content:"";position:absolute;top:0;bottom:0;left:0;width:2px;background:var(--oh-school-c,#aaa);border-radius:3px 0 0 3px}
+.oh-sp-print-tile-head{display:flex;align-items:baseline;justify-content:space-between;gap:6px}
+.oh-sp-print-tile-name{font:900 11pt var(--oh-font-heading,Merriweather,Georgia,serif);color:#243525;margin:0;line-height:1.15}
+.oh-sp-print-tile-meta{display:flex;align-items:center;gap:5px;flex-wrap:wrap;font:600 8.5pt var(--oh-font-mono,JetBrains Mono,Menlo,monospace);color:#6a6a6a}
+.oh-sp-print-tile-fx{font:400 9.5pt/1.4 var(--oh-font-serif,Georgia,Merriweather,serif);color:#2a2a2a;text-align:justify;hyphens:auto;margin:0;white-space:pre-wrap}
+.oh-sp-print-tile-fx::first-letter{font:900 1.25rem/.9 var(--oh-font-heading,Merriweather,Georgia,serif);color:var(--oh-school-c,#243525);float:left;margin:1px 4px 0 0}
+.oh-sp-print-tile-foot{display:flex;align-items:center;justify-content:space-between;gap:6px;margin-top:auto;padding-top:2mm;border-top:1px dashed rgba(178,98,35,.4);font:600 8pt var(--oh-font-mono,JetBrains Mono,Menlo,monospace);color:#6c5212}
+
+/* @media print — actual A5 landscape rules */
+@media print{
+    @page{size:A5 landscape;margin:8mm}
+    body{background:#fff !important}
+    .oh-sp-tisk-toolbar,.oh-sp-print-stage > nav,nav,header,aside,.sidebar,.oh-app-sidebar{display:none !important}
+    .oh-sp-print-stage{background:transparent;padding:0;gap:0;min-height:0;align-items:stretch}
+    .oh-sp-print-spread{box-shadow:none;border:none;page-break-after:always;break-after:page;width:auto;min-height:auto}
+    .oh-mana svg{width:12px !important;height:12px !important}
+}


### PR DESCRIPTION
Ports the bundled Claude Design mockup into production Blazor across the Spells experience: catalog list with school chips + mana rings, row quick-peek, three-tab detail, A5 landscape Kniha kouzel print spread.

## Files

| File | State | Purpose |
|---|---|---|
| `Components/ManaRings.razor` | NEW | SVG rainbow rings, Lg/Md/Sm (14/12/10px). Per-instance Guid for `<linearGradient>` ids keeps SVG defs unique. \`IsScroll\` → \"Svitek · jedno použití\" chip. \`Cost==0\` → \"Zdarma\" pill. |
| `Components/SpellSchoolChip.razor` | NEW | 1.5px outlined pill + color dot. Reads \`--oh-school-{key}\` (palette tokens) — never hard-codes hex. |
| `Components/SpellPrintCard.razor` | NEW | A5 book tile, ~70×100mm. Parchment + burnt-orange border + 2px school stripe + drop-cap. Pure CSS, print-stable. |
| `Pages/Spells/SpellDetail.razor` | NEW | Route \`/spells/{id:int}\`. 3 tabs: Karta · Upravit · Obchod. Karta is 62fr/38fr parchment page + side panel (price coin pill, badges, scroll callout). Upravit has sticky live preview. Destructive delete via DxPopup confirm. |
| `Pages/Spells/SpellBookPrint.razor` | NEW | Route \`/spells/print\`. Toolbar with Tisk → \`window.print()\`. Spreads grouped by level I-V (continuation tags on overflow). Banner only on first spread. |
| `Pages/Spells/SpellList.razor` | REWRITE | Replaced edit modal with quick-peek (720×420) + \"Otevřít detail →\" link. New columns: Level Roman / \"S\" badge, Name (+ inline Reakce), Škola chip, Mana rings, Cena, Flags 3-cell, Effect line-clamp. **LayoutKey bumped** \`grid-layout-spells\` → \`grid-layout-spells-v2\` (memory rule). Slim \"+ Nové kouzlo\" create modal lands on detail immediately. |
| `wwwroot/css/ovcinahra-theme.css` | APPEND | 9 \`--oh-school-*\` tokens + \`.oh-school\` + \`.oh-mana-*\` + \`.oh-sp-c-*\` + \`.oh-sp-peek-*\` + \`.oh-sp-karta-*\` + \`.oh-sp-edit-*\` + \`.oh-sp-print-*\` + \`@media print { @page { size: A5 landscape; margin: 8mm; } ... }\`. |

## Decisions

- **`?learnable=true` filter:** went **client-side** in `SpellBookPrint`. Catalog is small, simpler diff, no endpoint churn. Brief offered the choice; flagged here.
- **\`SpellEndpoints.cs\` not touched** for the same reason.
- **`index.html` not touched** — Bootstrap Icons + Merriweather + JetBrains Mono already linked from prior PRs (#137, #131).
- **csproj `<Version>` intentionally UNTOUCHED** — auto-bump CI handles it (rule #18).
- **9 school palette tokens added on `:root`** — keys: \`fire / frost / water / earth / wind / poison / mental / support / utility\`. Distinct from `--oh-kingdom-*` + `--oh-stage-*`.

## Verification

- \`dotnet build OvcinaHra.slnx\` — **0W / 0E** under \`TreatWarningsAsErrors=true\`.
- \`dotnet test\` (Api.Tests) — **317 passed / 0 failed** in 9m42s on Testcontainers PostgreSQL. No regressions.

## Follow-ups (out of scope — queued separately)

1. **\`Spell.ScrollItemId\` FK + migration + backfill** — replaces the name-fuzz match in the Karta scroll callout (currently best-effort case-insensitive Name match against \`/api/items\`).
2. **\"Vytvořit svitek k tomuto kouzlu\" admin action** — placeholder rendered disabled today; wires up after the FK lands.
3. **Full \`GameSpells.razor\` refactor** to mirror the new catalog tabs + per-game overrides UX. The detail Obchod tab currently shows empty state because no \`/api/spells/{id}/games\` rollup exists yet.
4. **Playwright E2E** covering list → peek → detail → print — blocked on broader #92 infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)