### PR TITLE
feat(map): overlay editor Phase 3 — icons + select-to-edit

### DIFF
--- a/src/OvcinaHra.Client/Components/MapOverlayToolbar.razor
+++ b/src/OvcinaHra.Client/Components/MapOverlayToolbar.razor
@@ -57,6 +57,35 @@
         }
     </div>
 
+    @* Phase 3 — icon-specific controls. Only visible when the icon tool is
+       active. Asset picker is a small button row (6 SDF icons curated in
+       wwwroot/img/overlay-icons). *@
+    @if (Tool == "icon")
+    {
+        <div class="oh-mo-icons" role="group" aria-label="Volba ikony">
+            @foreach (var key in IconAssets)
+            {
+                <button type="button"
+                        class="oh-mo-icon @(string.Equals(key, IconAsset, StringComparison.Ordinal) ? "is-active" : "")"
+                        title="@IconLabel(key)" aria-label="@IconLabel(key)"
+                        aria-pressed="@(string.Equals(key, IconAsset, StringComparison.Ordinal))"
+                        @onclick="() => SetIconAssetAsync(key)">
+                    <img src="@($"/img/overlay-icons/{key}.svg")" alt="@IconLabel(key)" style="color:@Color" />
+                </button>
+            }
+            <label class="oh-mo-label">Otočení
+                <input type="range" min="0" max="359" step="1" value="@IconRotation"
+                       @onchange="OnIconRotationChangedAsync" />
+                <span class="oh-mo-stroke-val">@(((int)IconRotation))°</span>
+            </label>
+            <label class="oh-mo-label">Velikost
+                <input type="range" min="0.5" max="3" step="0.1" value="@IconScale"
+                       @onchange="OnIconScaleChangedAsync" />
+                <span class="oh-mo-stroke-val">@IconScale.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)×</span>
+            </label>
+        </div>
+    }
+
     @* Save / Cancel. *@
     <div class="oh-mo-actions" role="group" aria-label="Akce">
         <button type="button" class="btn btn-outline-secondary btn-sm" title="Zahodit změny"
@@ -87,15 +116,37 @@
 
     private sealed record ToolItem(string Key, string Label, string Icon);
 
-    // Czech tool labels. Phase 3 adds "ikona"/"šipka" here too.
+    // Czech tool labels. Phase 3 adds "Ikona" + "Vybrat" (select-to-edit).
+    // Arrows skipped — MapLibre has no native arrow-head support, plain
+    // polylines cover the same use case.
     private static readonly ToolItem[] Tools = new[]
     {
+        new ToolItem("select",    "Vybrat",       "bi-cursor"),
         new ToolItem("text",      "Text",         "bi-fonts"),
         new ToolItem("freehand",  "Kresba",       "bi-vector-pen"),
         new ToolItem("polyline",  "Čára",         "bi-slash-lg"),
         new ToolItem("rectangle", "Obdélník",     "bi-square"),
         new ToolItem("circle",    "Kruh",         "bi-circle"),
-        new ToolItem("polygon",   "Mnohoúhelník", "bi-pentagon")
+        new ToolItem("polygon",   "Mnohoúhelník", "bi-pentagon"),
+        new ToolItem("icon",      "Ikona",        "bi-bookmark-star")
+    };
+
+    // Curated SDF icon palette — must match ICON_ASSETS in overlay-interop.js
+    // and the slugs of /wwwroot/img/overlay-icons/{key}.svg.
+    private static readonly string[] IconAssets = new[]
+    {
+        "flag", "tent", "chest", "skull", "door", "fire"
+    };
+
+    private static string IconLabel(string key) => key switch
+    {
+        "flag" => "Vlajka",
+        "tent" => "Stan",
+        "chest" => "Truhla",
+        "skull" => "Lebka",
+        "door" => "Dveře",
+        "fire" => "Oheň",
+        _ => key
     };
 
     [Parameter] public string Tool { get; set; } = "text";
@@ -113,11 +164,33 @@
     [Parameter] public int FontSize { get; set; } = 14;
     [Parameter] public EventCallback<int> FontSizeChanged { get; set; }
 
+    [Parameter] public string IconAsset { get; set; } = "flag";
+    [Parameter] public EventCallback<string> IconAssetChanged { get; set; }
+
+    [Parameter] public double IconRotation { get; set; }
+    [Parameter] public EventCallback<double> IconRotationChanged { get; set; }
+
+    [Parameter] public double IconScale { get; set; } = 1.0;
+    [Parameter] public EventCallback<double> IconScaleChanged { get; set; }
+
     [Parameter] public EventCallback OnSave { get; set; }
     [Parameter] public EventCallback OnCancel { get; set; }
 
     private Task SelectToolAsync(string key) => ToolChanged.InvokeAsync(key);
     private Task SetColorAsync(string hex) => ColorChanged.InvokeAsync(hex);
+    private Task SetIconAssetAsync(string key) => IconAssetChanged.InvokeAsync(key);
+
+    private async Task OnIconRotationChangedAsync(ChangeEventArgs e)
+    {
+        if (double.TryParse(e.Value?.ToString(), System.Globalization.CultureInfo.InvariantCulture, out var v))
+            await IconRotationChanged.InvokeAsync(v);
+    }
+
+    private async Task OnIconScaleChangedAsync(ChangeEventArgs e)
+    {
+        if (double.TryParse(e.Value?.ToString(), System.Globalization.CultureInfo.InvariantCulture, out var v))
+            await IconScaleChanged.InvokeAsync(v);
+    }
 
     private async Task OnCustomColorChangedAsync(ChangeEventArgs e)
     {

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -27,8 +27,19 @@
                            UseFill="@_useFill" UseFillChanged="OnUseFillChanged"
                            StrokeWidth="@_strokeWidth" StrokeWidthChanged="OnStrokeWidthChanged"
                            FontSize="@_fontSize" FontSizeChanged="OnFontSizeChanged"
+                           IconAsset="@_iconAsset" IconAssetChanged="OnIconAssetChanged"
+                           IconRotation="@_iconRotation" IconRotationChanged="OnIconRotationChanged"
+                           IconScale="@_iconScale" IconScaleChanged="OnIconScaleChanged"
                            OnSave="SaveOverlayAsync"
                            OnCancel="CancelEditAsync" />
+
+        @if (_selectedShape is not null)
+        {
+            <OverlayPropertyPanel Shape="_selectedShape"
+                                  OnChange="OnShapeEditedAsync"
+                                  OnDelete="RequestDeleteAsync"
+                                  OnClose="ClearSelectionAsync" />
+        }
 
         @if (!string.IsNullOrEmpty(_overlayError))
         {
@@ -40,6 +51,21 @@
             </div>
         }
     }
+
+    @* Phase 3 — destructive action confirm per
+       feedback_ovcinahra_destructive_confirm. Always route DELETE through a
+       DxPopup, never wire straight to the handler. *@
+    <DxPopup HeaderText="Smazat tvar?" Width="400px"
+             CloseOnEscape="true" ShowCloseButton="true"
+             @bind-Visible="_deleteConfirmVisible">
+        <BodyContentTemplate>
+            <p class="mb-3">Opravdu chcete smazat vybraný tvar překryvu? Tato akce se projeví až po uložení překryvu.</p>
+            <div class="d-flex gap-2 justify-content-end">
+                <button type="button" class="btn btn-secondary" @onclick="() => _deleteConfirmVisible = false">Zrušit</button>
+                <button type="button" class="btn btn-danger" @onclick="ConfirmDeleteAsync">Smazat</button>
+            </div>
+        </BodyContentTemplate>
+    </DxPopup>
 </div>
 
 @code {
@@ -70,11 +96,16 @@
     private List<MapOverlayShape> _committedShapes = new();   // last-saved baseline
     private List<MapOverlayShape> _stagedShapes = new();      // working copy
     private bool _editMode;
-    private string _tool = "text";
+    private string _tool = "select";
     private string _color = "#242F3D";
     private bool _useFill;
     private double _strokeWidth = 2;
     private int _fontSize = 14;
+    private string _iconAsset = "flag";
+    private double _iconRotation;
+    private double _iconScale = 1.0;
+    private MapOverlayShape? _selectedShape;
+    private bool _deleteConfirmVisible;
     private string? _overlayError;
     private int? _loadedOverlayForGameId;
 
@@ -131,7 +162,10 @@
     private async Task CancelEditAsync()
     {
         _editMode = false;
+        _selectedShape = null;
+        _deleteConfirmVisible = false;
         _stagedShapes = new List<MapOverlayShape>(_committedShapes);
+        await JS.InvokeVoidAsync("ovcinaOverlay.clearSelection", _elementId);
         await JS.InvokeVoidAsync("ovcinaOverlay.exitEditMode", _elementId);
         await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _committedShapes);
     }
@@ -147,6 +181,9 @@
         }
         _committedShapes = new List<MapOverlayShape>(_stagedShapes);
         _editMode = false;
+        _selectedShape = null;
+        _deleteConfirmVisible = false;
+        await JS.InvokeVoidAsync("ovcinaOverlay.clearSelection", _elementId);
         await JS.InvokeVoidAsync("ovcinaOverlay.exitEditMode", _elementId);
         await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _committedShapes);
     }
@@ -156,6 +193,13 @@
         _tool = tool;
         if (_editMode)
         {
+            // Switching away from select clears the highlight so it doesn't
+            // linger while the user is drawing a fresh shape elsewhere.
+            if (tool != "select" && _selectedShape is not null)
+            {
+                _selectedShape = null;
+                await JS.InvokeVoidAsync("ovcinaOverlay.clearSelection", _elementId);
+            }
             await PushStyleToJsAsync();
             await JS.InvokeVoidAsync("ovcinaOverlay.switchTool", _elementId, _tool);
         }
@@ -185,6 +229,24 @@
         await PushStyleToJsAsync();
     }
 
+    private async Task OnIconAssetChanged(string key)
+    {
+        _iconAsset = key;
+        await PushStyleToJsAsync();
+    }
+
+    private async Task OnIconRotationChanged(double rot)
+    {
+        _iconRotation = rot;
+        await PushStyleToJsAsync();
+    }
+
+    private async Task OnIconScaleChanged(double scale)
+    {
+        _iconScale = scale;
+        await PushStyleToJsAsync();
+    }
+
     private Task PushStyleToJsAsync()
         => JS.InvokeVoidAsync("ovcinaOverlay.setStyle", new
         {
@@ -192,7 +254,10 @@
             fillColor = _color,       // single colour for both stroke + fill
             strokeWidth = _strokeWidth,
             useFill = _useFill,
-            fontSize = _fontSize
+            fontSize = _fontSize,
+            iconAsset = _iconAsset,
+            iconRotation = _iconRotation,
+            iconScale = _iconScale
         }).AsTask();
 
     [JSInvokable]
@@ -212,6 +277,72 @@
             // Shape payload malformed — log, don't surface. User can redraw.
             Console.WriteLine($"Overlay shape deserialisation failed: {ex.Message}");
         }
+    }
+
+    // ---- Phase 3 — selection / edit / delete --------------------------
+
+    [JSInvokable]
+    public async Task OnShapeSelected(string? shapeId)
+    {
+        if (string.IsNullOrEmpty(shapeId))
+        {
+            _selectedShape = null;
+            await JS.InvokeVoidAsync("ovcinaOverlay.clearSelection", _elementId);
+        }
+        else
+        {
+            _selectedShape = _stagedShapes.FirstOrDefault(s => s.Id == shapeId);
+            if (_selectedShape is not null)
+                await JS.InvokeVoidAsync("ovcinaOverlay.selectShape", _elementId, _selectedShape);
+            else
+                await JS.InvokeVoidAsync("ovcinaOverlay.clearSelection", _elementId);
+        }
+        StateHasChanged();
+    }
+
+    [JSInvokable]
+    public Task OnDeleteRequested()
+    {
+        if (_selectedShape is not null)
+        {
+            _deleteConfirmVisible = true;
+            StateHasChanged();
+        }
+        return Task.CompletedTask;
+    }
+
+    private async Task OnShapeEditedAsync(MapOverlayShape updated)
+    {
+        var ix = _stagedShapes.FindIndex(s => s.Id == updated.Id);
+        if (ix < 0) return;
+        _stagedShapes[ix] = updated;
+        _selectedShape = updated;
+        await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);
+        await JS.InvokeVoidAsync("ovcinaOverlay.selectShape", _elementId, updated);
+    }
+
+    private Task RequestDeleteAsync()
+    {
+        if (_selectedShape is not null)
+            _deleteConfirmVisible = true;
+        return Task.CompletedTask;
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        _deleteConfirmVisible = false;
+        if (_selectedShape is null) return;
+        var id = _selectedShape.Id;
+        _stagedShapes.RemoveAll(s => s.Id == id);
+        _selectedShape = null;
+        await JS.InvokeVoidAsync("ovcinaOverlay.clearSelection", _elementId);
+        await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);
+    }
+
+    private async Task ClearSelectionAsync()
+    {
+        _selectedShape = null;
+        await JS.InvokeVoidAsync("ovcinaOverlay.clearSelection", _elementId);
     }
 
     public async Task AddMarkerAsync(int id, double lat, double lon, string name, string kind, string color = "#e74c3c")

--- a/src/OvcinaHra.Client/Components/OverlayPropertyPanel.razor
+++ b/src/OvcinaHra.Client/Components/OverlayPropertyPanel.razor
@@ -1,0 +1,262 @@
+@* Sidecar property panel for the map overlay editor (issue #96, Phase 3).
+   Anchored top-right of the map host while a shape is selected. Edits emit a
+   new MapOverlayShape via OnChange so the parent (MapView) can swap it in
+   the staged list and re-render the map.
+
+   Records are immutable — every callback produces a new concrete shape via
+   `with`-mutation and bubbles it up. The panel is purely presentational. *@
+
+@using OvcinaHra.Shared.Dtos
+
+<div class="oh-overlay-property-panel" role="region" aria-label="Vlastnosti vybraného tvaru">
+    <div class="oh-overlay-property-panel-header">
+        <strong><i class="bi bi-sliders" aria-hidden="true"></i> Vlastnosti</strong>
+        <button type="button" class="btn-close" aria-label="Zavřít panel" @onclick="OnClose"></button>
+    </div>
+
+    <div class="oh-overlay-property-panel-body">
+        <div class="oh-overlay-pp-type">@TypeLabel</div>
+
+        <label class="oh-overlay-pp-label">Barva tahu
+            <input type="color" class="oh-overlay-pp-color" value="@Shape.Color"
+                   @onchange="OnColorChangedAsync" />
+        </label>
+
+        @if (Shape is not TextShape && Shape is not IconShape)
+        {
+            <label class="oh-overlay-pp-label">Tloušťka tahu
+                <input type="range" min="1" max="8" step="1" value="@StrokeWidthOrDefault"
+                       @onchange="OnStrokeWidthChangedAsync" />
+                <span class="oh-overlay-pp-val">@(((int)StrokeWidthOrDefault))px</span>
+            </label>
+        }
+
+        @switch (Shape)
+        {
+            case TextShape t:
+                <label class="oh-overlay-pp-label">Text
+                    <input type="text" class="form-control form-control-sm" value="@t.Text"
+                           @onchange="OnTextChangedAsync" />
+                </label>
+                <label class="oh-overlay-pp-label">Velikost písma
+                    <input type="range" min="10" max="32" step="1" value="@t.FontSize"
+                           @onchange="OnFontSizeChangedAsync" />
+                    <span class="oh-overlay-pp-val">@t.FontSize px</span>
+                </label>
+                break;
+
+            case RectangleShape:
+            case CircleShape:
+            case PolygonShape:
+                <label class="oh-overlay-pp-label oh-overlay-pp-check">
+                    <input type="checkbox" checked="@HasFill" @onchange="OnUseFillChangedAsync" />
+                    Vyplnit tvar
+                </label>
+                @if (HasFill)
+                {
+                    <label class="oh-overlay-pp-label">Barva výplně
+                        <input type="color" class="oh-overlay-pp-color"
+                               value="@(FillColorOrColor)"
+                               @onchange="OnFillColorChangedAsync" />
+                    </label>
+                }
+                break;
+
+            case IconShape ic:
+                <label class="oh-overlay-pp-label">Ikona</label>
+                <div class="oh-overlay-pp-icon-row">
+                    @foreach (var key in IconAssets)
+                    {
+                        <button type="button"
+                                class="oh-overlay-pp-icon @(string.Equals(key, ic.AssetKey, StringComparison.Ordinal) ? "is-active" : "")"
+                                title="@IconLabel(key)" aria-label="@IconLabel(key)"
+                                @onclick="() => OnIconAssetChangedAsync(key)">
+                            <img src="@($"/img/overlay-icons/{key}.svg")" alt="@IconLabel(key)" style="color:@ic.Color" />
+                        </button>
+                    }
+                </div>
+                <label class="oh-overlay-pp-label">Otočení
+                    <input type="range" min="0" max="359" step="1" value="@ic.Rotation"
+                           @onchange="OnRotationChangedAsync" />
+                    <span class="oh-overlay-pp-val">@(((int)ic.Rotation))°</span>
+                </label>
+                <label class="oh-overlay-pp-label">Velikost
+                    <input type="range" min="0.5" max="3" step="0.1" value="@ic.Scale"
+                           @onchange="OnScaleChangedAsync" />
+                    <span class="oh-overlay-pp-val">@ic.Scale.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)×</span>
+                </label>
+                break;
+        }
+
+        <div class="oh-overlay-pp-drozd" role="note">
+            <i class="bi bi-cloud-fill" aria-hidden="true"></i>
+            <span><strong>Drozd radí:</strong> změny se projeví v náhledu hned, ale uloží se až po stisku „Uložit překryv".</span>
+        </div>
+    </div>
+
+    <div class="oh-overlay-property-panel-footer">
+        <button type="button" class="btn btn-sm btn-outline-danger" title="Smazat tvar"
+                @onclick="OnDelete">
+            <i class="bi bi-trash"></i> Smazat
+        </button>
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public MapOverlayShape Shape { get; set; } = null!;
+    [Parameter] public EventCallback<MapOverlayShape> OnChange { get; set; }
+    [Parameter] public EventCallback OnDelete { get; set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+
+    // Must mirror ICON_ASSETS in overlay-interop.js + IconAssets in MapOverlayToolbar.
+    private static readonly string[] IconAssets = new[]
+    {
+        "flag", "tent", "chest", "skull", "door", "fire"
+    };
+
+    private static string IconLabel(string key) => key switch
+    {
+        "flag" => "Vlajka",
+        "tent" => "Stan",
+        "chest" => "Truhla",
+        "skull" => "Lebka",
+        "door" => "Dveře",
+        "fire" => "Oheň",
+        _ => key
+    };
+
+    private string TypeLabel => Shape switch
+    {
+        TextShape => "Text",
+        FreehandShape => "Kresba",
+        PolylineShape => "Čára",
+        RectangleShape => "Obdélník",
+        CircleShape => "Kruh",
+        PolygonShape => "Mnohoúhelník",
+        IconShape => "Ikona",
+        _ => Shape.GetType().Name
+    };
+
+    private double StrokeWidthOrDefault => Shape switch
+    {
+        FreehandShape f => f.StrokeWidth,
+        PolylineShape p => p.StrokeWidth,
+        RectangleShape r => r.StrokeWidth,
+        CircleShape c => c.StrokeWidth,
+        PolygonShape pg => pg.StrokeWidth,
+        _ => 2
+    };
+
+    private bool HasFill => Shape switch
+    {
+        RectangleShape r => !string.IsNullOrEmpty(r.FillColor),
+        CircleShape c => !string.IsNullOrEmpty(c.FillColor),
+        PolygonShape p => !string.IsNullOrEmpty(p.FillColor),
+        _ => false
+    };
+
+    private string FillColorOrColor => Shape switch
+    {
+        RectangleShape r => r.FillColor ?? r.Color,
+        CircleShape c => c.FillColor ?? c.Color,
+        PolygonShape p => p.FillColor ?? p.Color,
+        _ => Shape.Color
+    };
+
+    private async Task OnColorChangedAsync(ChangeEventArgs e)
+    {
+        var v = e.Value?.ToString();
+        if (string.IsNullOrWhiteSpace(v)) return;
+        MapOverlayShape next = Shape switch
+        {
+            TextShape t => t with { Color = v },
+            FreehandShape f => f with { Color = v },
+            PolylineShape p => p with { Color = v },
+            RectangleShape r => r with { Color = v },
+            CircleShape c => c with { Color = v },
+            PolygonShape pg => pg with { Color = v },
+            IconShape ic => ic with { Color = v },
+            _ => Shape
+        };
+        await OnChange.InvokeAsync(next);
+    }
+
+    private async Task OnStrokeWidthChangedAsync(ChangeEventArgs e)
+    {
+        if (!double.TryParse(e.Value?.ToString(), System.Globalization.CultureInfo.InvariantCulture, out var w)) return;
+        MapOverlayShape next = Shape switch
+        {
+            FreehandShape f => f with { StrokeWidth = w },
+            PolylineShape p => p with { StrokeWidth = w },
+            RectangleShape r => r with { StrokeWidth = w },
+            CircleShape c => c with { StrokeWidth = w },
+            PolygonShape pg => pg with { StrokeWidth = w },
+            _ => Shape
+        };
+        await OnChange.InvokeAsync(next);
+    }
+
+    private async Task OnTextChangedAsync(ChangeEventArgs e)
+    {
+        if (Shape is not TextShape t) return;
+        var txt = e.Value?.ToString();
+        if (string.IsNullOrEmpty(txt)) return;
+        await OnChange.InvokeAsync(t with { Text = txt });
+    }
+
+    private async Task OnFontSizeChangedAsync(ChangeEventArgs e)
+    {
+        if (Shape is not TextShape t) return;
+        if (!int.TryParse(e.Value?.ToString(), out var n)) return;
+        await OnChange.InvokeAsync(t with { FontSize = n });
+    }
+
+    private async Task OnUseFillChangedAsync(ChangeEventArgs e)
+    {
+        var on = e.Value is bool b && b;
+        // Toggle between null (no fill) and current stroke color so users get
+        // a sensible default they can override with the next picker.
+        MapOverlayShape next = Shape switch
+        {
+            RectangleShape r => r with { FillColor = on ? r.FillColor ?? r.Color : null },
+            CircleShape c => c with { FillColor = on ? c.FillColor ?? c.Color : null },
+            PolygonShape p => p with { FillColor = on ? p.FillColor ?? p.Color : null },
+            _ => Shape
+        };
+        await OnChange.InvokeAsync(next);
+    }
+
+    private async Task OnFillColorChangedAsync(ChangeEventArgs e)
+    {
+        var v = e.Value?.ToString();
+        if (string.IsNullOrWhiteSpace(v)) return;
+        MapOverlayShape next = Shape switch
+        {
+            RectangleShape r => r with { FillColor = v },
+            CircleShape c => c with { FillColor = v },
+            PolygonShape p => p with { FillColor = v },
+            _ => Shape
+        };
+        await OnChange.InvokeAsync(next);
+    }
+
+    private async Task OnIconAssetChangedAsync(string key)
+    {
+        if (Shape is not IconShape ic) return;
+        await OnChange.InvokeAsync(ic with { AssetKey = key });
+    }
+
+    private async Task OnRotationChangedAsync(ChangeEventArgs e)
+    {
+        if (Shape is not IconShape ic) return;
+        if (!double.TryParse(e.Value?.ToString(), System.Globalization.CultureInfo.InvariantCulture, out var r)) return;
+        await OnChange.InvokeAsync(ic with { Rotation = r });
+    }
+
+    private async Task OnScaleChangedAsync(ChangeEventArgs e)
+    {
+        if (Shape is not IconShape ic) return;
+        if (!double.TryParse(e.Value?.ToString(), System.Globalization.CultureInfo.InvariantCulture, out var s)) return;
+        await OnChange.InvokeAsync(ic with { Scale = s });
+    }
+}

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2768,3 +2768,62 @@
     .oh-sp-print-spread{box-shadow:none;border:none;page-break-after:always;break-after:page;width:auto;min-height:auto}
     .oh-mana svg{width:12px !important;height:12px !important}
 }
+
+/* ----- Issue #96 Phase 3 — icon palette + property panel + selection chrome ----- */
+
+/* Toolbar icon-tool row */
+.oh-mo-icons{display:flex;flex-wrap:wrap;align-items:center;gap:6px;
+    padding:6px 8px;border-top:1px solid var(--oh-border,#d8d2be);
+    background:var(--oh-surface-tint,rgba(80,75,37,0.04))}
+.oh-mo-icon{width:32px;height:32px;border:1px solid var(--oh-border,#d8d2be);
+    background:var(--oh-bg,#fff);border-radius:4px;display:inline-flex;
+    align-items:center;justify-content:center;cursor:pointer;padding:2px}
+.oh-mo-icon:hover{border-color:#504B25}
+.oh-mo-icon.is-active{border-color:#504B25;box-shadow:0 0 0 2px rgba(80,75,37,0.25)}
+.oh-mo-icon img{width:22px;height:22px;display:block}
+
+/* Sidecar property panel — anchored top-right of map host. Above MapLibre
+   controls (z-index:20) but below the error banner (z-index:21). */
+.oh-overlay-property-panel{position:absolute;top:12px;right:12px;z-index:20;
+    width:340px;max-height:calc(100% - 24px);overflow-y:auto;
+    background:var(--oh-bg,#fff);border:1px solid var(--oh-border,#d8d2be);
+    border-radius:6px;box-shadow:0 4px 16px rgba(36,47,61,0.18);
+    display:flex;flex-direction:column}
+.oh-overlay-property-panel-header{display:flex;align-items:center;
+    justify-content:space-between;padding:8px 12px;
+    border-bottom:1px solid var(--oh-border,#d8d2be);
+    background:var(--oh-surface-tint,rgba(80,75,37,0.04));
+    color:var(--oh-text,#2a2a2a);font-size:.95rem}
+.oh-overlay-property-panel-header .btn-close{width:18px;height:18px}
+.oh-overlay-property-panel-body{padding:10px 12px;display:flex;flex-direction:column;gap:10px}
+.oh-overlay-property-panel-footer{padding:8px 12px;
+    border-top:1px solid var(--oh-border,#d8d2be);
+    display:flex;justify-content:flex-end;gap:6px}
+
+.oh-overlay-pp-type{font-size:.75rem;font-weight:600;text-transform:uppercase;
+    letter-spacing:.04em;color:var(--oh-muted,#6b6650);
+    padding-bottom:4px;border-bottom:1px dashed var(--oh-border,#d8d2be)}
+.oh-overlay-pp-label{display:flex;align-items:center;gap:8px;
+    font-size:.825rem;color:var(--oh-text,#2a2a2a);margin:0}
+.oh-overlay-pp-label input[type="range"]{flex:1}
+.oh-overlay-pp-label input[type="text"]{flex:1;font-size:.825rem}
+.oh-overlay-pp-check{font-weight:500}
+.oh-overlay-pp-color{width:32px;height:28px;border:1px solid var(--oh-border,#d8d2be);
+    border-radius:3px;cursor:pointer;padding:0;background:transparent}
+.oh-overlay-pp-val{font-family:var(--oh-font-mono,Menlo,monospace);font-size:.75rem;
+    color:var(--oh-text,#2a2a2a);min-width:36px;text-align:right}
+.oh-overlay-pp-icon-row{display:flex;flex-wrap:wrap;gap:4px}
+.oh-overlay-pp-icon{width:32px;height:32px;border:1px solid var(--oh-border,#d8d2be);
+    background:var(--oh-bg,#fff);border-radius:4px;display:inline-flex;
+    align-items:center;justify-content:center;cursor:pointer;padding:2px}
+.oh-overlay-pp-icon:hover{border-color:#504B25}
+.oh-overlay-pp-icon.is-active{border-color:#504B25;box-shadow:0 0 0 2px rgba(80,75,37,0.25)}
+.oh-overlay-pp-icon img{width:22px;height:22px;display:block}
+
+/* Drozd radí inline hint — mascot-attributed advice block. Soft amber band
+   so users notice the guidance without reading it as an error. */
+.oh-overlay-pp-drozd{display:flex;align-items:flex-start;gap:6px;
+    padding:6px 8px;font-size:.75rem;line-height:1.35;
+    color:#5b4a17;background:#fdf6e3;border:1px solid #f0d68a;
+    border-left:3px solid #B26223;border-radius:3px}
+.oh-overlay-pp-drozd .bi{color:#B26223;font-size:.95rem;line-height:1}

--- a/src/OvcinaHra.Client/wwwroot/img/overlay-icons/chest.svg
+++ b/src/OvcinaHra.Client/wwwroot/img/overlay-icons/chest.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="currentColor"><path d="M5 11h22v3H5zm0 5h22v12H5zm10 4h2v4h-2zM7 8h18a3 3 0 0 1 3 3H4a3 3 0 0 1 3-3z"/></svg>

--- a/src/OvcinaHra.Client/wwwroot/img/overlay-icons/door.svg
+++ b/src/OvcinaHra.Client/wwwroot/img/overlay-icons/door.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="currentColor"><path d="M8 4v24h16V4zm2 2h12v20H10zm9 11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"/></svg>

--- a/src/OvcinaHra.Client/wwwroot/img/overlay-icons/fire.svg
+++ b/src/OvcinaHra.Client/wwwroot/img/overlay-icons/fire.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="currentColor"><path d="M16 3c1 5-2 7-4 10s-4 6-4 10a8 8 0 0 0 16 0c0-3-2-5-3-8 0 2-1 3-2 3s-1-2-1-4c0-4-1-7-2-11zm0 19a3 3 0 0 1 3 3 3 3 0 0 1-6 0 3 3 0 0 1 3-3z"/></svg>

--- a/src/OvcinaHra.Client/wwwroot/img/overlay-icons/flag.svg
+++ b/src/OvcinaHra.Client/wwwroot/img/overlay-icons/flag.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="currentColor"><path d="M7 4v24h2V18h11l-2-4 2-4H9V4z"/></svg>

--- a/src/OvcinaHra.Client/wwwroot/img/overlay-icons/skull.svg
+++ b/src/OvcinaHra.Client/wwwroot/img/overlay-icons/skull.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="currentColor"><path d="M16 4a10 10 0 0 0-10 10v6l3 3v3h4v-3h6v3h4v-3l3-3v-6A10 10 0 0 0 16 4zm-4 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm8 0a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm-4 5-2 4h4l-2-4z"/></svg>

--- a/src/OvcinaHra.Client/wwwroot/img/overlay-icons/tent.svg
+++ b/src/OvcinaHra.Client/wwwroot/img/overlay-icons/tent.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="currentColor"><path d="M16 4 4 26h7l5-9 5 9h7zM14 26l2-3.5L18 26h-2z"/></svg>

--- a/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
@@ -1,26 +1,37 @@
-// Vector overlay editor for the MapLibre map — issue #96, Phase 1+2.
+// Vector overlay editor for the MapLibre map — issue #96, Phase 1+2 (+3).
 //
 // Exposes a `window.ovcinaOverlay` global. Pairs with the main `window.ovcinaMap`
 // MapLibre instance (MapPage.razor / TreasurePlanning.razor both boot one map).
 // Operates on the same MapLibre instance — doesn't manage its own map.
 //
 // Shape wire format matches `OvcinaHra.Shared.Dtos.MapOverlayShape`:
-//   { type: "text"|"freehand"|"polyline"|"rectangle"|"circle"|"polygon",
+//   { type: "text"|"freehand"|"polyline"|"rectangle"|"circle"|"polygon"|"icon",
 //     id, color, strokeWidth?, fillColor?, ... geometry ... }
 //
-// Phase 3 will add icons + arrows + select-to-edit; this file intentionally
-// has no selection/hit-test helpers yet.
+// Phase 3 adds: icon primitive, select-to-edit (hit-test → property panel),
+// shape update / delete via Blazor → JS interop. Arrows skipped (MapLibre
+// has no native arrow head support and lines suffice).
 
 (function () {
     const SRC_SAVED = 'oh-overlay-src';
     const SRC_PREVIEW = 'oh-overlay-preview-src';
+    const SRC_SELECTION = 'oh-overlay-selection-src';
     const LYR_FILLS = 'oh-overlay-fills';
     const LYR_STROKES = 'oh-overlay-strokes';
     const LYR_TEXT = 'oh-overlay-text';
+    const LYR_ICONS = 'oh-overlay-icons';
     const LYR_PREVIEW_FILLS = 'oh-overlay-preview-fills';
     const LYR_PREVIEW_STROKES = 'oh-overlay-preview-strokes';
     const LYR_PREVIEW_TEXT = 'oh-overlay-preview-text';
+    const LYR_PREVIEW_ICONS = 'oh-overlay-preview-icons';
+    const LYR_SELECTION_FILL = 'oh-overlay-selection-fill';
+    const LYR_SELECTION_LINE = 'oh-overlay-selection-line';
+    const LYR_SELECTION_PT = 'oh-overlay-selection-point';
     const CIRCLE_SEGMENTS = 32;
+    // Phase 3 icon palette — slugs match wwwroot/img/overlay-icons/{key}.svg.
+    // SVGs use fill="currentColor"; we rasterize them with a black silhouette
+    // and add to MapLibre as SDF icons so `icon-color` tints them per shape.
+    const ICON_ASSETS = ['flag', 'tent', 'chest', 'skull', 'door', 'fire'];
 
     // Singleton state, keyed by mapId so future multi-map callers don't collide.
     const instances = {};
@@ -75,17 +86,23 @@
     function shapeToFeature(shape) {
         const base = {
             type: 'Feature',
+            id: shape.id,
             properties: {
+                shapeId: shape.id,
                 shapeType: shape.type,
                 color: shape.color,
                 strokeWidth: shape.strokeWidth || 2,
                 fillColor: shape.fillColor || null,
                 text: shape.text || null,
-                fontSize: shape.fontSize || 14
+                fontSize: shape.fontSize || 14,
+                iconAsset: shape.assetKey || null,
+                iconRotation: shape.rotation || 0,
+                iconScale: shape.scale || 1.0
             }
         };
         switch (shape.type) {
             case 'text':
+            case 'icon':
                 base.geometry = { type: 'Point', coordinates: [shape.coord.lng, shape.coord.lat] };
                 break;
             case 'freehand':
@@ -134,7 +151,7 @@
 
     // ---- Source + layer management ----------------------------------------
 
-    function ensureLayers(map, sourceId, fillsId, strokesId, textId) {
+    function ensureLayers(map, sourceId, fillsId, strokesId, textId, iconsId) {
         if (!map.getSource(sourceId)) {
             map.addSource(sourceId, {
                 type: 'geojson',
@@ -161,7 +178,10 @@
                 id: strokesId,
                 type: 'line',
                 source: sourceId,
-                filter: ['!=', ['get', 'shapeType'], 'text'],
+                filter: ['all',
+                    ['!=', ['get', 'shapeType'], 'text'],
+                    ['!=', ['get', 'shapeType'], 'icon']
+                ],
                 paint: {
                     'line-color': ['coalesce', ['get', 'color'], '#000000'],
                     'line-width': ['coalesce', ['get', 'strokeWidth'], 2]
@@ -188,6 +208,64 @@
                 }
             });
         }
+        if (iconsId && !map.getLayer(iconsId)) {
+            map.addLayer({
+                id: iconsId,
+                type: 'symbol',
+                source: sourceId,
+                filter: ['==', ['get', 'shapeType'], 'icon'],
+                layout: {
+                    'icon-image': ['get', 'iconAsset'],
+                    'icon-size': ['coalesce', ['get', 'iconScale'], 1.0],
+                    'icon-rotate': ['coalesce', ['get', 'iconRotation'], 0],
+                    'icon-allow-overlap': true,
+                    'icon-ignore-placement': true
+                },
+                paint: {
+                    'icon-color': ['coalesce', ['get', 'color'], '#000000']
+                }
+            });
+        }
+    }
+
+    // ---- Icon image loader ------------------------------------------------
+
+    // Rasterize each /img/overlay-icons/{key}.svg into a 64×64 ImageData and
+    // register it with MapLibre as an SDF image so `icon-color` tints it per
+    // shape. Idempotent — guarded by `map.hasImage`. Triggered on first render
+    // / first edit; tracked on `map.__ovcinaOverlayIconsLoaded` to short-circuit
+    // subsequent calls without re-decoding the SVGs.
+    function loadIconImage(map, key) {
+        return new Promise(function (resolve) {
+            if (map.hasImage(key)) { resolve(); return; }
+            const img = new Image();
+            img.crossOrigin = 'anonymous';
+            const finalize = function () {
+                try {
+                    const size = 64;
+                    const canvas = document.createElement('canvas');
+                    canvas.width = size; canvas.height = size;
+                    const ctx = canvas.getContext('2d');
+                    ctx.clearRect(0, 0, size, size);
+                    ctx.drawImage(img, 0, 0, size, size);
+                    if (!map.hasImage(key)) {
+                        map.addImage(key, ctx.getImageData(0, 0, size, size), { sdf: true });
+                    }
+                } catch (e) { console.warn('Overlay icon load failed:', key, e); }
+                resolve();
+            };
+            img.onload = finalize;
+            img.onerror = function () { console.warn('Overlay icon missing:', key); resolve(); };
+            img.src = '/img/overlay-icons/' + encodeURIComponent(key) + '.svg';
+        });
+    }
+
+    function ensureIconsLoaded(map) {
+        if (map.__ovcinaOverlayIconsLoaded) return Promise.resolve();
+        map.__ovcinaOverlayIconsLoaded = Promise.all(ICON_ASSETS.map(function (k) {
+            return loadIconImage(map, k);
+        }));
+        return map.__ovcinaOverlayIconsLoaded;
     }
 
     function setSourceData(map, sourceId, features) {
@@ -205,12 +283,17 @@
         const map = getMap(mapId);
         if (!map) return;
         const paint = () => {
-            ensureLayers(map, SRC_SAVED, LYR_FILLS, LYR_STROKES, LYR_TEXT);
-            ensureLayers(map, SRC_PREVIEW, LYR_PREVIEW_FILLS, LYR_PREVIEW_STROKES, LYR_PREVIEW_TEXT);
+            ensureLayers(map, SRC_SAVED, LYR_FILLS, LYR_STROKES, LYR_TEXT, LYR_ICONS);
+            ensureLayers(map, SRC_PREVIEW, LYR_PREVIEW_FILLS, LYR_PREVIEW_STROKES, LYR_PREVIEW_TEXT, LYR_PREVIEW_ICONS);
+            ensureSelectionLayers(map);
             const features = (shapes || [])
                 .map(shapeToFeature)
                 .filter(f => f !== null);
             setSourceData(map, SRC_SAVED, features);
+            // Icons load asynchronously — MapLibre will silently fail to render
+            // a symbol whose `icon-image` isn't registered yet, so we trigger
+            // load + force a re-paint when ready.
+            ensureIconsLoaded(map).then(function () { try { map.triggerRepaint(); } catch (e) { } });
         };
         if (map.isStyleLoaded()) paint(); else map.once('styledata', paint);
     }
@@ -223,12 +306,14 @@
         // preview updates would no-op — make sure both exist before wiring
         // handlers.
         const setup = () => {
-            ensureLayers(map, SRC_SAVED, LYR_FILLS, LYR_STROKES, LYR_TEXT);
-            ensureLayers(map, SRC_PREVIEW, LYR_PREVIEW_FILLS, LYR_PREVIEW_STROKES, LYR_PREVIEW_TEXT);
+            ensureLayers(map, SRC_SAVED, LYR_FILLS, LYR_STROKES, LYR_TEXT, LYR_ICONS);
+            ensureLayers(map, SRC_PREVIEW, LYR_PREVIEW_FILLS, LYR_PREVIEW_STROKES, LYR_PREVIEW_TEXT, LYR_PREVIEW_ICONS);
+            ensureSelectionLayers(map);
+            ensureIconsLoaded(map).then(function () { try { map.triggerRepaint(); } catch (e) { } });
             const inst = ensureInstance(mapId);
             inst.tool = tool;
             inst.dotnetRef = dotnetRef;
-            map.getCanvas().style.cursor = 'crosshair';
+            map.getCanvas().style.cursor = tool === 'select' ? '' : 'crosshair';
             // Disable map-level double-click zoom so polyline/polygon "dblclick
             // to finish" doesn't also zoom the viewport.
             if (map.doubleClickZoom && map.doubleClickZoom.disable) map.doubleClickZoom.disable();
@@ -246,6 +331,9 @@
         resetInProgress(inst);
         teardownPreview(map);
         inst.tool = tool;
+        // Cursor: drawing tools get crosshair, select gets default (handler swaps
+        // to pointer on hover-over-shape). Idle (null) also gets default.
+        try { map.getCanvas().style.cursor = (tool && tool !== 'select') ? 'crosshair' : ''; } catch (e) { }
         attachHandlers(map, inst);
     }
 
@@ -274,6 +362,8 @@
             case 'polygon':   attachPolylineTool(map, inst, /*closeLoop*/ true); break;
             case 'rectangle': attachRectangleTool(map, inst); break;
             case 'circle':    attachCircleTool(map, inst); break;
+            case 'icon':      attachIconTool(map, inst); break;
+            case 'select':    attachSelectTool(map, inst); break;
         }
     }
 
@@ -537,6 +627,130 @@
         onMap(map, inst, 'mouseup', onUp);
     }
 
+    // ---- Tool: icon -------------------------------------------------------
+
+    function attachIconTool(map, inst) {
+        // Click-to-drop. Asset key + rotation/scale come from the toolbar style.
+        // Color tints the SDF icon — same color picker as other primitives.
+        onMap(map, inst, 'click', function (e) {
+            const s = currentStyle();
+            const asset = (s.iconAsset && ICON_ASSETS.indexOf(s.iconAsset) >= 0)
+                ? s.iconAsset : ICON_ASSETS[0];
+            emitShape(inst, {
+                id: uuid(),
+                type: 'icon',
+                color: s.color,
+                assetKey: asset,
+                coord: { lat: e.lngLat.lat, lng: e.lngLat.lng },
+                rotation: s.iconRotation || 0,
+                scale: s.iconScale || 1.0
+            });
+        });
+    }
+
+    // ---- Tool: select (hit-test → emit shapeId to .NET) -------------------
+
+    function attachSelectTool(map, inst) {
+        // Cursor turns to pointer over any shape layer for affordance. We
+        // hit-test against all four saved layers (fills, strokes, text, icons).
+        // queryRenderedFeatures honors layer filters, so unrelated map layers
+        // are ignored automatically.
+        const layers = [LYR_FILLS, LYR_STROKES, LYR_TEXT, LYR_ICONS]
+            .filter(function (id) { return map.getLayer(id) != null; });
+
+        const onMove = function (e) {
+            if (layers.length === 0) return;
+            const f = map.queryRenderedFeatures(e.point, { layers: layers });
+            map.getCanvas().style.cursor = (f && f.length > 0) ? 'pointer' : '';
+        };
+        const onClick = function (e) {
+            if (layers.length === 0) return;
+            const features = map.queryRenderedFeatures(e.point, { layers: layers });
+            if (!features || features.length === 0) {
+                emitSelection(inst, null);
+                return;
+            }
+            // Topmost feature wins. Phase 1+2 properties carry shapeId; older
+            // payloads without it would have to fall back on `feature.id`.
+            const f = features[0];
+            const id = (f.properties && f.properties.shapeId) || f.id || null;
+            if (id) emitSelection(inst, id);
+        };
+        onMap(map, inst, 'mousemove', onMove);
+        onMap(map, inst, 'click', onClick);
+        // Delete key fires while the select tool is active and a shape is
+        // selected — .NET decides whether to confirm + remove.
+        inst.keydownHandler = function (ev) {
+            if (ev.key === 'Delete' || ev.key === 'Backspace') {
+                if (!inst.dotnetRef) return;
+                try { inst.dotnetRef.invokeMethodAsync('OnDeleteRequested'); }
+                catch (e) { /* swallow */ }
+            }
+        };
+        window.addEventListener('keydown', inst.keydownHandler);
+    }
+
+    function emitSelection(inst, shapeId) {
+        if (!inst.dotnetRef) return;
+        try {
+            inst.dotnetRef.invokeMethodAsync('OnShapeSelected', shapeId);
+        } catch (e) {
+            console.warn('Overlay shape selection emit failed:', e);
+        }
+    }
+
+    // ---- Selection highlight overlay --------------------------------------
+
+    function ensureSelectionLayers(map) {
+        if (!map.getSource(SRC_SELECTION)) {
+            map.addSource(SRC_SELECTION, {
+                type: 'geojson',
+                data: { type: 'FeatureCollection', features: [] }
+            });
+        }
+        if (!map.getLayer(LYR_SELECTION_FILL)) {
+            map.addLayer({
+                id: LYR_SELECTION_FILL,
+                type: 'fill',
+                source: SRC_SELECTION,
+                filter: ['in', ['geometry-type'], ['literal', ['Polygon', 'MultiPolygon']]],
+                paint: { 'fill-color': '#FFD166', 'fill-opacity': 0.25 }
+            });
+        }
+        if (!map.getLayer(LYR_SELECTION_LINE)) {
+            map.addLayer({
+                id: LYR_SELECTION_LINE,
+                type: 'line',
+                source: SRC_SELECTION,
+                filter: ['!=', ['geometry-type'], 'Point'],
+                paint: {
+                    'line-color': '#FFD166',
+                    'line-width': 3,
+                    'line-dasharray': [2, 1.5]
+                }
+            });
+        }
+        if (!map.getLayer(LYR_SELECTION_PT)) {
+            map.addLayer({
+                id: LYR_SELECTION_PT,
+                type: 'circle',
+                source: SRC_SELECTION,
+                filter: ['==', ['geometry-type'], 'Point'],
+                paint: {
+                    'circle-radius': 14,
+                    'circle-color': 'rgba(255,209,102,0.20)',
+                    'circle-stroke-color': '#FFD166',
+                    'circle-stroke-width': 2
+                }
+            });
+        }
+    }
+
+    function highlightSelection(map, shape) {
+        const f = shape ? shapeToFeature(shape) : null;
+        setSourceData(map, SRC_SELECTION, f ? [f] : []);
+    }
+
     function haversineMeters(a, b) {
         const R = 6371000.0;
         const lat1 = a.lat * Math.PI / 180, lat2 = b.lat * Math.PI / 180;
@@ -562,7 +776,10 @@
         fillColor: '#242F3D',
         strokeWidth: 2,
         useFill: false,
-        fontSize: 14
+        fontSize: 14,
+        iconAsset: 'flag',
+        iconRotation: 0,
+        iconScale: 1.0
     };
 
     function currentStyle() { return _style; }
@@ -586,14 +803,21 @@
             // navigates away and back.
             try {
                 for (const lyr of [
-                    LYR_FILLS, LYR_STROKES, LYR_TEXT,
-                    LYR_PREVIEW_FILLS, LYR_PREVIEW_STROKES, LYR_PREVIEW_TEXT
+                    LYR_FILLS, LYR_STROKES, LYR_TEXT, LYR_ICONS,
+                    LYR_PREVIEW_FILLS, LYR_PREVIEW_STROKES, LYR_PREVIEW_TEXT, LYR_PREVIEW_ICONS,
+                    LYR_SELECTION_FILL, LYR_SELECTION_LINE, LYR_SELECTION_PT
                 ]) {
                     if (map.getLayer(lyr)) map.removeLayer(lyr);
                 }
-                for (const src of [SRC_SAVED, SRC_PREVIEW]) {
+                for (const src of [SRC_SAVED, SRC_PREVIEW, SRC_SELECTION]) {
                     if (map.getSource(src)) map.removeSource(src);
                 }
+                // Drop SDF icon images so a remount can re-register them
+                // cleanly after a style change wipes the image registry.
+                for (const k of ICON_ASSETS) {
+                    if (map.hasImage(k)) { try { map.removeImage(k); } catch (e) { } }
+                }
+                map.__ovcinaOverlayIconsLoaded = null;
             } catch (e) { /* best-effort */ }
             try {
                 map.getCanvas().style.cursor = '';
@@ -603,6 +827,26 @@
         delete instances[mapId];
     }
 
+    // ---- Selection / shape mutation API (called from Blazor) -------------
+
+    function selectShape(mapId, shape) {
+        const map = getMap(mapId);
+        if (!map) return;
+        // `shape` is the deserialized DTO (camelCase JSON). Null clears the
+        // highlight without changing tool / handler state.
+        highlightSelection(map, shape);
+    }
+
+    function clearSelection(mapId) {
+        const map = getMap(mapId);
+        if (!map) return;
+        highlightSelection(map, null);
+    }
+
+    function getIconAssets() {
+        return ICON_ASSETS.slice();
+    }
+
     window.ovcinaOverlay = {
         render: render,
         enterEditMode: enterEditMode,
@@ -610,6 +854,9 @@
         exitEditMode: exitEditMode,
         dispose: dispose,
         setStyle: setStyle,
+        selectShape: selectShape,
+        clearSelection: clearSelection,
+        getIconAssets: getIconAssets,
         // Exposed for unit-testability / future tools; not called by Blazor.
         _circleToPolygonRing: circleToPolygonRing
     };

--- a/src/OvcinaHra.Shared/Dtos/MapOverlayDto.cs
+++ b/src/OvcinaHra.Shared/Dtos/MapOverlayDto.cs
@@ -28,6 +28,7 @@ public record OverlayCoord(double Lat, double Lng);
 [JsonDerivedType(typeof(RectangleShape), "rectangle")]
 [JsonDerivedType(typeof(CircleShape),    "circle")]
 [JsonDerivedType(typeof(PolygonShape),   "polygon")]
+[JsonDerivedType(typeof(IconShape),      "icon")]
 public abstract record MapOverlayShape(string Id, string Color);
 
 public record TextShape(
@@ -76,4 +77,20 @@ public record PolygonShape(
     string? FillColor,
     double StrokeWidth,
     List<OverlayCoord> Points)
+    : MapOverlayShape(Id, Color);
+
+/// <summary>
+/// Curated-asset icon dropped at a point. <see cref="AssetKey"/> is one of
+/// the slugs in <c>wwwroot/img/overlay-icons/</c> (flag, tent, chest, skull,
+/// door, fire). <see cref="Color"/> tints the SVG via <c>currentColor</c>;
+/// rotation is degrees clockwise from north, scale multiplies the base
+/// 32-px viewBox. #96 Phase 3.
+/// </summary>
+public record IconShape(
+    string Id,
+    string Color,
+    string AssetKey,
+    OverlayCoord Coord,
+    double Rotation = 0,
+    double Scale = 1.0)
     : MapOverlayShape(Id, Color);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameEndpointTests.cs
@@ -187,7 +187,11 @@ public class GameEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
             new PolygonShape("p1", "#B26223", "#B26223", 2, new List<OverlayCoord>
             {
                 new(49.90, 17.50), new(49.91, 17.52), new(49.89, 17.52)
-            })
+            }),
+            // Phase 3 — icon primitive. Asset key, rotation, scale must
+            // round-trip through Game.OverlayJson without schema migration.
+            new IconShape("i1", "#8C2423", "flag",
+                new OverlayCoord(49.95, 17.55), Rotation: 45.0, Scale: 1.5)
         });
 
         var putResponse = await Client.PutAsJsonAsync($"/api/games/{game.Id}/overlay", dto);
@@ -198,7 +202,7 @@ public class GameEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
 
         var roundTripped = await getResponse.Content.ReadFromJsonAsync<MapOverlayDto>();
         Assert.NotNull(roundTripped);
-        Assert.Equal(6, roundTripped!.Shapes.Count);
+        Assert.Equal(7, roundTripped!.Shapes.Count);
 
         Assert.IsType<TextShape>(roundTripped.Shapes[0]);
         var text = (TextShape)roundTripped.Shapes[0];
@@ -216,6 +220,14 @@ public class GameEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
 
         Assert.IsType<PolygonShape>(roundTripped.Shapes[5]);
         Assert.Equal(3, ((PolygonShape)roundTripped.Shapes[5]).Points.Count);
+
+        Assert.IsType<IconShape>(roundTripped.Shapes[6]);
+        var icon = (IconShape)roundTripped.Shapes[6];
+        Assert.Equal("flag", icon.AssetKey);
+        Assert.Equal(45.0, icon.Rotation);
+        Assert.Equal(1.5, icon.Scale);
+        Assert.Equal(49.95, icon.Coord.Lat);
+        Assert.Equal(17.55, icon.Coord.Lng);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Phase 3 of issue #96 — extends the Phase 1+2 overlay editor (PR #138) with the icon primitive and select-to-edit. Closes the #96 epic.

- **Icon primitive** — new `IconShape` discriminator value with asset/coord/rotation/scale. 6 curated SDF icons (flag, tent, chest, skull, door, fire) live in `wwwroot/img/overlay-icons/` and are tinted per-shape via MapLibre `icon-color`. **Zero database changes** — `Game.OverlayJson` is a string column; the new shape rides through `[JsonPolymorphic]`.
- **Select-to-edit** — new "Vybrat" tool (default on edit-mode entry). Click a saved shape → JS hit-tests via `queryRenderedFeatures` → emits `shapeId` to Blazor → `OverlayPropertyPanel` opens sidecar (340 px, top-right) with per-type editable fields. Edits stage in memory and commit on the toolbar's existing **Uložit překryv** button — no save-on-blur.
- **Delete** — Delete/Backspace key or panel button → `DxPopup` confirm (per `feedback_ovcinahra_destructive_confirm`).
- **Drozd radí** inline hint band reminds the user staged edits aren't saved until the toolbar Save fires.
- **Arrows skipped** — MapLibre has no native arrow-head support; plain polylines cover the use case (per maintainer direction).

## Files

- `src/OvcinaHra.Shared/Dtos/MapOverlayDto.cs` — `IconShape` record + discriminator entry.
- `src/OvcinaHra.Client/wwwroot/js/overlay-interop.js` — icon SDF loader, icon symbol layer, select tool with hit-test, selection highlight chrome, `selectShape`/`clearSelection` Blazor API.
- `src/OvcinaHra.Client/wwwroot/img/overlay-icons/*.svg` — 6 new 32×32 `currentColor`-fillable SVGs.
- `src/OvcinaHra.Client/Components/MapOverlayToolbar.razor` — adds **Vybrat** + **Ikona** tools, icon asset palette, rotation + scale sliders.
- `src/OvcinaHra.Client/Components/OverlayPropertyPanel.razor` — new sidecar panel; per-type fields via record `with`-mutation.
- `src/OvcinaHra.Client/Components/MapView.razor` — wires selection state, panel callbacks, delete-confirm `DxPopup`, JS-invokable `OnShapeSelected` / `OnDeleteRequested`.
- `src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css` — kingdom-seal-themed property panel + icon row styling.
- `tests/OvcinaHra.Api.Tests/Endpoints/GameEndpointTests.cs` — extends round-trip test with an `IconShape` (asset, rotation, scale, coords).

## Test plan

- [x] `dotnet build src/OvcinaHra.Client` — clean (0 warn / 0 err under `TreatWarningsAsErrors=true`).
- [x] `dotnet build tests/OvcinaHra.Api.Tests` — clean.
- [x] `dotnet test --filter Overlay` — 4/4 green (incl. new `IconShape` round-trip via Testcontainers PostgreSQL).
- [ ] Manual: open `/games/{id}/map`, draw an icon, save, refresh, edit-select-edit, delete, save again — confirm canvas + DB stay in sync.
- [ ] Manual: switch tile style mid-edit (overlay re-renders on `OnStyleLoaded` callback — already wired in Phase 1+2).

## Notes

- No database migration. No `csproj` `<Version>` bump (auto-bump CI handles).
- Component scope respects `Pages/Items|Locations|Characters/*List` boundaries (Hra3 territory for #149).
- ICON_ASSETS slug list duplicated in three places (JS, toolbar, panel) — kept in lockstep by hand for now; deferring abstraction until a 4th consumer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)