### PR TITLE
feat(buildings): per-game crafting cost (items + money + skill) (closes #142)

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/BuildingRecipeConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/BuildingRecipeConfiguration.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+// Issue #142 — Building crafting cost. Mirrors CraftingConfiguration shape;
+// kept in a separate file so the parallel domain isn't visually conflated
+// with the Item-side crafting model.
+
+public class BuildingRecipeConfiguration : IEntityTypeConfiguration<BuildingRecipe>
+{
+    public void Configure(EntityTypeBuilder<BuildingRecipe> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.HasOne(e => e.Game).WithMany(g => g.BuildingRecipes).HasForeignKey(e => e.GameId);
+        builder.HasOne(e => e.OutputBuilding).WithMany(b => b.BuildingRecipesAsOutput).HasForeignKey(e => e.OutputBuildingId);
+        builder.Property(e => e.IngredientNotes).HasMaxLength(2000);
+    }
+}
+
+public class BuildingRecipeIngredientConfiguration : IEntityTypeConfiguration<BuildingRecipeIngredient>
+{
+    public void Configure(EntityTypeBuilder<BuildingRecipeIngredient> builder)
+    {
+        builder.HasKey(e => new { e.BuildingRecipeId, e.ItemId });
+        builder.HasOne(e => e.BuildingRecipe).WithMany(r => r.Ingredients).HasForeignKey(e => e.BuildingRecipeId);
+        builder.HasOne(e => e.Item).WithMany().HasForeignKey(e => e.ItemId);
+    }
+}
+
+public class BuildingRecipePrerequisiteConfiguration : IEntityTypeConfiguration<BuildingRecipePrerequisite>
+{
+    public void Configure(EntityTypeBuilder<BuildingRecipePrerequisite> builder)
+    {
+        builder.HasKey(e => new { e.BuildingRecipeId, e.RequiredBuildingId });
+        builder.HasOne(e => e.BuildingRecipe).WithMany(r => r.PrerequisiteBuildings).HasForeignKey(e => e.BuildingRecipeId);
+        builder.HasOne(e => e.RequiredBuilding).WithMany(b => b.BuildingRecipesAsPrerequisite).HasForeignKey(e => e.RequiredBuildingId);
+    }
+}
+
+public class BuildingRecipeSkillRequirementConfiguration : IEntityTypeConfiguration<BuildingRecipeSkillRequirement>
+{
+    public void Configure(EntityTypeBuilder<BuildingRecipeSkillRequirement> builder)
+    {
+        builder.HasKey(e => new { e.BuildingRecipeId, e.GameSkillId });
+        builder.HasOne(e => e.BuildingRecipe).WithMany(r => r.SkillRequirements).HasForeignKey(e => e.BuildingRecipeId);
+        // GameSkill side: no inverse navigation — keep the GameSkill entity
+        // unchanged for this feature so we don't ripple into the skills domain.
+        builder.HasOne(e => e.GameSkill).WithMany().HasForeignKey(e => e.GameSkillId);
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -21,6 +21,11 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<GameSkill> GameSkills => Set<GameSkill>();
     public DbSet<GameSkillBuildingRequirement> GameSkillBuildingRequirements => Set<GameSkillBuildingRequirement>();
     public DbSet<CraftingSkillRequirement> CraftingSkillRequirements => Set<CraftingSkillRequirement>();
+    // Issue #142 — Building crafting cost (parallel to CraftingRecipe).
+    public DbSet<BuildingRecipe> BuildingRecipes => Set<BuildingRecipe>();
+    public DbSet<BuildingRecipeIngredient> BuildingRecipeIngredients => Set<BuildingRecipeIngredient>();
+    public DbSet<BuildingRecipePrerequisite> BuildingRecipePrerequisites => Set<BuildingRecipePrerequisite>();
+    public DbSet<BuildingRecipeSkillRequirement> BuildingRecipeSkillRequirements => Set<BuildingRecipeSkillRequirement>();
     public DbSet<Spell> Spells => Set<Spell>();
     public DbSet<GameSpell> GameSpells => Set<GameSpell>();
     public DbSet<Monster> Monsters => Set<Monster>();

--- a/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
@@ -70,10 +70,13 @@ public static class BuildingEndpoints
             .ToListAsync();
 
         // Issue #142 — pull this game's BuildingRecipes so we can attach a
-        // compact RecipeSummary to each row. GroupBy is defensive — schema
-        // doesn't enforce one recipe per (game, building) so a duplicate
-        // wouldn't blow up ToDictionary.
+        // compact RecipeSummary to each row. AsNoTracking() because we only
+        // read the entities to format a string; tracking the graph wastes
+        // change-detection CPU + memory (Copilot review on PR #164).
+        // GroupBy is defensive — schema doesn't enforce one recipe per
+        // (game, building) so a duplicate wouldn't blow up ToDictionary.
         var recipes = await db.BuildingRecipes
+            .AsNoTracking()
             .Where(r => r.GameId == gameId)
             .Include(r => r.Ingredients)
             .Include(r => r.PrerequisiteBuildings)

--- a/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
@@ -68,11 +68,27 @@ public static class BuildingEndpoints
                 gb.Building.ImagePath
             })
             .ToListAsync();
+
+        // Issue #142 — pull this game's BuildingRecipes so we can attach a
+        // compact RecipeSummary to each row. GroupBy is defensive — schema
+        // doesn't enforce one recipe per (game, building) so a duplicate
+        // wouldn't blow up ToDictionary.
+        var recipes = await db.BuildingRecipes
+            .Where(r => r.GameId == gameId)
+            .Include(r => r.Ingredients)
+            .Include(r => r.PrerequisiteBuildings)
+            .Include(r => r.SkillRequirements)
+            .ToListAsync();
+        var summaryByBuildingId = recipes
+            .GroupBy(r => r.OutputBuildingId)
+            .ToDictionary(g => g.Key, g => BuildingRecipeEndpoints.BuildRecipeSummary(g.First()));
+
         var buildings = rows.Select(r => new BuildingListDto(
             r.Id, r.Name, r.Description, r.Notes,
             r.LocationId, r.LocationName, r.IsPrebuilt,
             ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "buildings", r.Id, "small"))).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "buildings", r.Id, "small"),
+            RecipeSummary: summaryByBuildingId.GetValueOrDefault(r.Id))).ToList();
         return TypedResults.Ok(buildings);
     }
 

--- a/src/OvcinaHra.Api/Endpoints/BuildingRecipeEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/BuildingRecipeEndpoints.cs
@@ -1,0 +1,301 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Endpoints;
+
+// Issue #142 — Building crafting cost. Mirrors CraftingEndpoints (the Item
+// side) endpoint-for-endpoint. Kept as a sibling file so the two domains
+// stay independent — see PR body for the duplication-as-follow-up note
+// about extracting a shared editor/endpoint base.
+public static class BuildingRecipeEndpoints
+{
+    public static RouteGroupBuilder MapBuildingRecipeEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/building-recipes").WithTags("BuildingRecipes");
+
+        group.MapGet("/by-game/{gameId:int}", GetByGame);
+        group.MapGet("/{id:int}", GetById);
+        group.MapPost("/", Create);
+        group.MapPut("/{id:int}", Update);
+        group.MapDelete("/{id:int}", Delete);
+
+        group.MapPost("/{id:int}/ingredients", AddIngredient);
+        group.MapDelete("/{id:int}/ingredients/{itemId:int}", RemoveIngredient);
+
+        group.MapPost("/{id:int}/prerequisites", AddPrerequisite);
+        group.MapDelete("/{id:int}/prerequisites/{buildingId:int}", RemovePrerequisite);
+
+        return group;
+    }
+
+    private static async Task<Ok<List<BuildingRecipeListDto>>> GetByGame(int gameId, WorldDbContext db)
+    {
+        var recipes = await db.BuildingRecipes
+            .Where(r => r.GameId == gameId)
+            .Include(r => r.OutputBuilding)
+            .OrderBy(r => r.OutputBuilding.Name)
+            .Select(r => new BuildingRecipeListDto(
+                r.Id, r.OutputBuildingId, r.OutputBuilding.Name, r.GameId, r.MoneyCost))
+            .ToListAsync();
+        return TypedResults.Ok(recipes);
+    }
+
+    private static async Task<Results<Ok<BuildingRecipeDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
+    {
+        var r = await db.BuildingRecipes
+            .Include(r => r.OutputBuilding)
+            .Include(r => r.Ingredients).ThenInclude(i => i.Item)
+            .Include(r => r.PrerequisiteBuildings).ThenInclude(p => p.RequiredBuilding)
+            .Include(r => r.SkillRequirements)
+            .FirstOrDefaultAsync(r => r.Id == id);
+        if (r is null) return TypedResults.NotFound();
+
+        return TypedResults.Ok(ToDetailDto(r));
+    }
+
+    // Same 2000-char ceiling as CraftingRecipe.IngredientNotes (issue #121).
+    private const int IngredientNotesMaxLength = 2000;
+
+    private static async Task<Results<Created<BuildingRecipeDetailDto>, BadRequest<ProblemDetails>>> Create(
+        CreateBuildingRecipeDto dto, WorldDbContext db, CancellationToken ct)
+    {
+        var skillIds = dto.RequiredSkillIds?.Distinct().ToList() ?? [];
+
+        if (dto.MoneyCost is < 0)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná cena",
+                Detail = "Cena nesmí být záporná.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        var problem = await ValidateRequiredSkillsAsync(db, dto.GameId, skillIds, ct);
+        if (problem is not null) return TypedResults.BadRequest(problem);
+
+        var ingredientNotes = dto.IngredientNotes?.Trim();
+        if (!string.IsNullOrEmpty(ingredientNotes) && ingredientNotes.Length > IngredientNotesMaxLength)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Poznámka je příliš dlouhá",
+                Detail = $"Poznámka k surovinám nesmí být delší než {IngredientNotesMaxLength} znaků.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        var r = new BuildingRecipe
+        {
+            GameId = dto.GameId,
+            OutputBuildingId = dto.OutputBuildingId,
+            MoneyCost = dto.MoneyCost,
+            IngredientNotes = string.IsNullOrWhiteSpace(ingredientNotes) ? null : ingredientNotes,
+            SkillRequirements = skillIds
+                .Select(sid => new BuildingRecipeSkillRequirement { GameSkillId = sid })
+                .ToList()
+        };
+        db.BuildingRecipes.Add(r);
+        await db.SaveChangesAsync(ct);
+
+        // Reload with navs for the response.
+        var created = await db.BuildingRecipes
+            .Include(x => x.OutputBuilding)
+            .Include(x => x.Ingredients).ThenInclude(i => i.Item)
+            .Include(x => x.PrerequisiteBuildings).ThenInclude(p => p.RequiredBuilding)
+            .Include(x => x.SkillRequirements)
+            .FirstAsync(x => x.Id == r.Id, ct);
+
+        return TypedResults.Created($"/api/building-recipes/{created.Id}", ToDetailDto(created));
+    }
+
+    private static async Task<Results<NoContent, NotFound, BadRequest<ProblemDetails>>> Update(
+        int id, UpdateBuildingRecipeDto dto, WorldDbContext db, CancellationToken ct)
+    {
+        var recipe = await db.BuildingRecipes
+            .Include(r => r.SkillRequirements)
+            .SingleOrDefaultAsync(r => r.Id == id, ct);
+        if (recipe is null) return TypedResults.NotFound();
+
+        var buildingExists = await db.Buildings.AnyAsync(b => b.Id == dto.OutputBuildingId, ct);
+        if (!buildingExists)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Vybraná budova neexistuje.",
+                Detail = $"Budova s ID {dto.OutputBuildingId} nebyla nalezena.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        if (dto.MoneyCost is < 0)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Neplatná cena",
+                Detail = "Cena nesmí být záporná.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        var skillIds = dto.RequiredSkillIds?.Distinct().ToList() ?? [];
+        var problem = await ValidateRequiredSkillsAsync(db, recipe.GameId, skillIds, ct);
+        if (problem is not null) return TypedResults.BadRequest(problem);
+
+        var ingredientNotes = dto.IngredientNotes?.Trim();
+        if (!string.IsNullOrEmpty(ingredientNotes) && ingredientNotes.Length > IngredientNotesMaxLength)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Poznámka je příliš dlouhá",
+                Detail = $"Poznámka k surovinám nesmí být delší než {IngredientNotesMaxLength} znaků.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        recipe.OutputBuildingId = dto.OutputBuildingId;
+        recipe.MoneyCost = dto.MoneyCost;
+        recipe.IngredientNotes = string.IsNullOrWhiteSpace(ingredientNotes) ? null : ingredientNotes;
+
+        // Replace SkillRequirements as a set.
+        var currentIds = recipe.SkillRequirements.Select(r => r.GameSkillId).ToHashSet();
+        var desiredIds = skillIds.ToHashSet();
+
+        foreach (var req in recipe.SkillRequirements.Where(r => !desiredIds.Contains(r.GameSkillId)).ToList())
+        {
+            recipe.SkillRequirements.Remove(req);
+        }
+        foreach (var sid in desiredIds.Where(s => !currentIds.Contains(s)))
+        {
+            recipe.SkillRequirements.Add(new BuildingRecipeSkillRequirement { BuildingRecipeId = id, GameSkillId = sid });
+        }
+
+        await db.SaveChangesAsync(ct);
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound>> Delete(int id, WorldDbContext db)
+    {
+        var r = await db.BuildingRecipes.FindAsync(id);
+        if (r is null) return TypedResults.NotFound();
+        db.BuildingRecipes.Remove(r);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<Created, Conflict>> AddIngredient(int id, AddBuildingRecipeIngredientDto dto, WorldDbContext db)
+    {
+        if (await db.BuildingRecipeIngredients.AnyAsync(bi => bi.BuildingRecipeId == id && bi.ItemId == dto.ItemId))
+            return TypedResults.Conflict();
+        db.BuildingRecipeIngredients.Add(new BuildingRecipeIngredient
+        {
+            BuildingRecipeId = id,
+            ItemId = dto.ItemId,
+            Quantity = dto.Quantity
+        });
+        await db.SaveChangesAsync();
+        return TypedResults.Created($"/api/building-recipes/{id}");
+    }
+
+    private static async Task<Results<NoContent, NotFound>> RemoveIngredient(int id, int itemId, WorldDbContext db)
+    {
+        var bi = await db.BuildingRecipeIngredients.FindAsync(id, itemId);
+        if (bi is null) return TypedResults.NotFound();
+        db.BuildingRecipeIngredients.Remove(bi);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<Created, Conflict, BadRequest<ProblemDetails>>> AddPrerequisite(int id, AddBuildingRecipePrerequisiteDto dto, WorldDbContext db)
+    {
+        // Guard against a recipe declaring its OWN output building as a
+        // prerequisite — the schema doesn't enforce it but it's nonsense.
+        var recipe = await db.BuildingRecipes.FindAsync(id);
+        if (recipe is null) return TypedResults.Conflict();
+        if (recipe.OutputBuildingId == dto.BuildingId)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Neplatný požadavek",
+                Detail = "Budova nemůže být požadavkem sama na sebe.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        if (await db.BuildingRecipePrerequisites.AnyAsync(p => p.BuildingRecipeId == id && p.RequiredBuildingId == dto.BuildingId))
+            return TypedResults.Conflict();
+        db.BuildingRecipePrerequisites.Add(new BuildingRecipePrerequisite
+        {
+            BuildingRecipeId = id,
+            RequiredBuildingId = dto.BuildingId
+        });
+        await db.SaveChangesAsync();
+        return TypedResults.Created($"/api/building-recipes/{id}");
+    }
+
+    private static async Task<Results<NoContent, NotFound>> RemovePrerequisite(int id, int buildingId, WorldDbContext db)
+    {
+        var p = await db.BuildingRecipePrerequisites.FindAsync(id, buildingId);
+        if (p is null) return TypedResults.NotFound();
+        db.BuildingRecipePrerequisites.Remove(p);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<ProblemDetails?> ValidateRequiredSkillsAsync(
+        WorldDbContext db, int gameId, IReadOnlyList<int> gameSkillIds, CancellationToken ct)
+    {
+        if (gameSkillIds.Count == 0) return null;
+
+        var existing = await db.GameSkills
+            .Where(gs => gs.GameId == gameId && gameSkillIds.Contains(gs.Id))
+            .Select(gs => gs.Id)
+            .ToArrayAsync(ct);
+        var missing = gameSkillIds.Except(existing).ToArray();
+        if (missing.Length > 0)
+        {
+            return new ProblemDetails
+            {
+                Title = "Dovednosti nejsou ve hře dostupné.",
+                Detail = $"Dovednosti s ID [{string.Join(", ", missing)}] nejsou v této hře dostupné.",
+                Status = StatusCodes.Status400BadRequest
+            };
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Compact recipe summary for the BuildingList by-game grid column.
+    /// Format: "3× ingrediencí · 50 zlaťáků · 1 dovednost · 2 budov".
+    /// Returns null when the recipe is empty (no ingredients, no money,
+    /// no skills, no prereqs) so the column shows "—" instead of noise.
+    /// </summary>
+    internal static string? BuildRecipeSummary(BuildingRecipe r)
+    {
+        var parts = new List<string>();
+        if (r.Ingredients.Count > 0)
+            parts.Add($"{r.Ingredients.Sum(i => i.Quantity)}× ingrediencí");
+        if (r.MoneyCost is > 0)
+            parts.Add($"{r.MoneyCost} zlaťáků");
+        if (r.SkillRequirements.Count > 0)
+            parts.Add($"{r.SkillRequirements.Count} dovednost");
+        if (r.PrerequisiteBuildings.Count > 0)
+            parts.Add($"{r.PrerequisiteBuildings.Count} budov");
+        return parts.Count > 0 ? string.Join(" · ", parts) : null;
+    }
+
+    private static BuildingRecipeDetailDto ToDetailDto(BuildingRecipe r) => new(
+        r.Id, r.OutputBuildingId, r.OutputBuilding.Name, r.GameId,
+        r.MoneyCost,
+        r.Ingredients.Select(i => new BuildingRecipeIngredientDto(i.ItemId, i.Item.Name, i.Quantity)).ToList(),
+        r.PrerequisiteBuildings.Select(p => new BuildingRecipePrerequisiteDto(p.RequiredBuildingId, p.RequiredBuilding.Name)).ToList())
+    {
+        RequiredSkillIds = r.SkillRequirements.Select(sr => sr.GameSkillId).ToList(),
+        IngredientNotes = r.IngredientNotes
+    };
+}

--- a/src/OvcinaHra.Api/Endpoints/BuildingRecipeEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/BuildingRecipeEndpoints.cs
@@ -187,8 +187,35 @@ public static class BuildingRecipeEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Results<Created, Conflict>> AddIngredient(int id, AddBuildingRecipeIngredientDto dto, WorldDbContext db)
+    private static async Task<Results<Created, Conflict, NotFound, BadRequest<ProblemDetails>>> AddIngredient(int id, AddBuildingRecipeIngredientDto dto, WorldDbContext db)
     {
+        // Validate parent + reference + payload up front so invalid inputs
+        // surface as 404/400 ProblemDetails instead of bubbling out as
+        // FK 500s (Copilot review on PR #164).
+        var recipeExists = await db.BuildingRecipes.AnyAsync(r => r.Id == id);
+        if (!recipeExists) return TypedResults.NotFound();
+
+        if (dto.Quantity < 1)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Neplatné množství",
+                Detail = "Množství ingredience musí být alespoň 1.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        var itemExists = await db.Items.AnyAsync(i => i.Id == dto.ItemId);
+        if (!itemExists)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Předmět neexistuje",
+                Detail = $"Předmět s ID {dto.ItemId} nebyl nalezen.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
         if (await db.BuildingRecipeIngredients.AnyAsync(bi => bi.BuildingRecipeId == id && bi.ItemId == dto.ItemId))
             return TypedResults.Conflict();
         db.BuildingRecipeIngredients.Add(new BuildingRecipeIngredient
@@ -210,18 +237,32 @@ public static class BuildingRecipeEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Results<Created, Conflict, BadRequest<ProblemDetails>>> AddPrerequisite(int id, AddBuildingRecipePrerequisiteDto dto, WorldDbContext db)
+    private static async Task<Results<Created, Conflict, NotFound, BadRequest<ProblemDetails>>> AddPrerequisite(int id, AddBuildingRecipePrerequisiteDto dto, WorldDbContext db)
     {
-        // Guard against a recipe declaring its OWN output building as a
-        // prerequisite — the schema doesn't enforce it but it's nonsense.
+        // Missing parent recipe is a 404 (REST contract) not a 409 — the
+        // 409 in v1 was misleading (Copilot review on PR #164).
         var recipe = await db.BuildingRecipes.FindAsync(id);
-        if (recipe is null) return TypedResults.Conflict();
+        if (recipe is null) return TypedResults.NotFound();
+
         if (recipe.OutputBuildingId == dto.BuildingId)
         {
             return TypedResults.BadRequest(new ProblemDetails
             {
                 Title = "Neplatný požadavek",
                 Detail = "Budova nemůže být požadavkem sama na sebe.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        // Validate referenced building exists so a stray id surfaces as 400
+        // ProblemDetails instead of an FK exception (500).
+        var buildingExists = await db.Buildings.AnyAsync(b => b.Id == dto.BuildingId);
+        if (!buildingExists)
+        {
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Budova neexistuje",
+                Detail = $"Budova s ID {dto.BuildingId} nebyla nalezena.",
                 Status = StatusCodes.Status400BadRequest
             });
         }
@@ -271,7 +312,7 @@ public static class BuildingRecipeEndpoints
 
     /// <summary>
     /// Compact recipe summary for the BuildingList by-game grid column.
-    /// Format: "3× ingrediencí · 50 zlaťáků · 1 dovednost · 2 budov".
+    /// Format: "3× ingrediencí · 50 zlaťáků · 1 dovednost · 2 budovy".
     /// Returns null when the recipe is empty (no ingredients, no money,
     /// no skills, no prereqs) so the column shows "—" instead of noise.
     /// </summary>
@@ -283,10 +324,21 @@ public static class BuildingRecipeEndpoints
         if (r.MoneyCost is > 0)
             parts.Add($"{r.MoneyCost} zlaťáků");
         if (r.SkillRequirements.Count > 0)
-            parts.Add($"{r.SkillRequirements.Count} dovednost");
+            parts.Add($"{r.SkillRequirements.Count} {PluralCz(r.SkillRequirements.Count, "dovednost", "dovednosti", "dovedností")}");
         if (r.PrerequisiteBuildings.Count > 0)
-            parts.Add($"{r.PrerequisiteBuildings.Count} budov");
+            parts.Add($"{r.PrerequisiteBuildings.Count} {PluralCz(r.PrerequisiteBuildings.Count, "budova", "budovy", "budov")}");
         return parts.Count > 0 ? string.Join(" · ", parts) : null;
+    }
+
+    /// <summary>
+    /// Czech declension picker: 1 → singular, 2-4 → few, 0/5+ → many.
+    /// Mirrors the helper used in LocationList for variant counts.
+    /// </summary>
+    private static string PluralCz(int n, string one, string few, string many)
+    {
+        if (n == 1) return one;
+        if (n >= 2 && n <= 4) return few;
+        return many;
     }
 
     private static BuildingRecipeDetailDto ToDetailDto(BuildingRecipe r) => new(

--- a/src/OvcinaHra.Api/Migrations/20260425065836_BuildingCraftingCost.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260425065836_BuildingCraftingCost.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425065836_BuildingCraftingCost")]
+    partial class BuildingCraftingCost
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260425065836_BuildingCraftingCost.cs
+++ b/src/OvcinaHra.Api/Migrations/20260425065836_BuildingCraftingCost.cs
@@ -1,0 +1,157 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class BuildingCraftingCost : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "BuildingRecipes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    OutputBuildingId = table.Column<int>(type: "integer", nullable: false),
+                    MoneyCost = table.Column<int>(type: "integer", nullable: true),
+                    IngredientNotes = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BuildingRecipes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BuildingRecipes_Buildings_OutputBuildingId",
+                        column: x => x.OutputBuildingId,
+                        principalTable: "Buildings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BuildingRecipes_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BuildingRecipeIngredients",
+                columns: table => new
+                {
+                    BuildingRecipeId = table.Column<int>(type: "integer", nullable: false),
+                    ItemId = table.Column<int>(type: "integer", nullable: false),
+                    Quantity = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BuildingRecipeIngredients", x => new { x.BuildingRecipeId, x.ItemId });
+                    table.ForeignKey(
+                        name: "FK_BuildingRecipeIngredients_BuildingRecipes_BuildingRecipeId",
+                        column: x => x.BuildingRecipeId,
+                        principalTable: "BuildingRecipes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BuildingRecipeIngredients_Items_ItemId",
+                        column: x => x.ItemId,
+                        principalTable: "Items",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BuildingRecipePrerequisites",
+                columns: table => new
+                {
+                    BuildingRecipeId = table.Column<int>(type: "integer", nullable: false),
+                    RequiredBuildingId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BuildingRecipePrerequisites", x => new { x.BuildingRecipeId, x.RequiredBuildingId });
+                    table.ForeignKey(
+                        name: "FK_BuildingRecipePrerequisites_BuildingRecipes_BuildingRecipeId",
+                        column: x => x.BuildingRecipeId,
+                        principalTable: "BuildingRecipes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BuildingRecipePrerequisites_Buildings_RequiredBuildingId",
+                        column: x => x.RequiredBuildingId,
+                        principalTable: "Buildings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BuildingRecipeSkillRequirements",
+                columns: table => new
+                {
+                    BuildingRecipeId = table.Column<int>(type: "integer", nullable: false),
+                    GameSkillId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BuildingRecipeSkillRequirements", x => new { x.BuildingRecipeId, x.GameSkillId });
+                    table.ForeignKey(
+                        name: "FK_BuildingRecipeSkillRequirements_BuildingRecipes_BuildingRec~",
+                        column: x => x.BuildingRecipeId,
+                        principalTable: "BuildingRecipes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BuildingRecipeSkillRequirements_GameSkills_GameSkillId",
+                        column: x => x.GameSkillId,
+                        principalTable: "GameSkills",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildingRecipeIngredients_ItemId",
+                table: "BuildingRecipeIngredients",
+                column: "ItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildingRecipePrerequisites_RequiredBuildingId",
+                table: "BuildingRecipePrerequisites",
+                column: "RequiredBuildingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildingRecipes_GameId",
+                table: "BuildingRecipes",
+                column: "GameId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildingRecipes_OutputBuildingId",
+                table: "BuildingRecipes",
+                column: "OutputBuildingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildingRecipeSkillRequirements_GameSkillId",
+                table: "BuildingRecipeSkillRequirements",
+                column: "GameSkillId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BuildingRecipeIngredients");
+
+            migrationBuilder.DropTable(
+                name: "BuildingRecipePrerequisites");
+
+            migrationBuilder.DropTable(
+                name: "BuildingRecipeSkillRequirements");
+
+            migrationBuilder.DropTable(
+                name: "BuildingRecipes");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -212,6 +212,7 @@ try
     app.MapSkillEndpoints().RequireAuthorization();
     app.MapSpellEndpoints().RequireAuthorization();
     app.MapCraftingEndpoints().RequireAuthorization();
+    app.MapBuildingRecipeEndpoints().RequireAuthorization();
     app.MapTreasureQuestEndpoints().RequireAuthorization();
     app.MapPersonalQuestEndpoints().RequireAuthorization();
     app.MapTreasurePlanningEndpoints().RequireAuthorization();

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
@@ -3,6 +3,7 @@
 @inject ApiClient Api
 @inject GameContextService GameContext
 @inject NavigationManager Nav
+@inject SkillService SkillSvc
 @implements IDisposable
 
 <div class="d-flex justify-content-between align-items-center mb-3">
@@ -29,7 +30,7 @@ else if (!Catalog && buildings.Count == 0)
 }
 else
 {
-    <OvcinaGrid Data="@buildings" KeyFieldName="Id" LayoutKey="grid-layout-buildings-v2"
+    <OvcinaGrid Data="@buildings" KeyFieldName="Id" LayoutKey="grid-layout-buildings-v3"
                 RowClick="@(e => OpenModal((BuildingListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             <DxGridDataColumn FieldName="Name" Caption="Název" />
@@ -37,6 +38,25 @@ else
             <DxGridDataColumn FieldName="IsPrebuilt" Caption="Představěná" Width="120px">
                 <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
             </DxGridDataColumn>
+            @* Issue #142 — per-game crafting cost summary. Catalog mode leaves
+               the field null (no recipes there); game mode populates a compact
+               "3× ingrediencí · 50 zlaťáků · 1 dovednost" via the by-game endpoint. *@
+            @if (!Catalog)
+            {
+                <DxGridDataColumn FieldName="RecipeSummary" Caption="Cena výstavby" Width="280px">
+                    <CellDisplayTemplate>
+                        @{ var b = (BuildingListDto)context.DataItem; }
+                        @if (string.IsNullOrWhiteSpace(b.RecipeSummary))
+                        {
+                            <span class="text-muted">—</span>
+                        }
+                        else
+                        {
+                            <span class="text-secondary"><i class="bi bi-hammer me-1"></i>@b.RecipeSummary</span>
+                        }
+                    </CellDisplayTemplate>
+                </DxGridDataColumn>
+            }
             <DxGridDataColumn FieldName="Description" Caption="Popis" Width="260px" Visible="false" />
             <DxGridDataColumn FieldName="Notes" Caption="Poznámky" Width="260px" Visible="false" />
 @if (Catalog)
@@ -93,6 +113,128 @@ else
                 </DxFormLayout>
             </div>
         </div>
+
+        @* Issue #142 — Building crafting cost (per-game). Hidden in catalog
+           mode (recipes are per-game) and in the new-building branch (need
+           the building Id first). Mirrors the Item-side editor in
+           ItemList.razor; the duplication is tracked as a follow-up issue
+           for extracting a shared CraftingRecipeEditor. *@
+        @if (editingId.HasValue && !Catalog && GameContext.SelectedGameId.HasValue)
+        {
+            <div class="mt-3 p-3 border rounded" style="background: var(--oh-surface);">
+                <h6 class="mb-2"><i class="bi bi-hammer me-1"></i> Cena výstavby (aktuální hra)</h6>
+                @if (recipe is not null)
+                {
+                    <div class="mb-2">
+                        <strong class="small">Cena v zlaťácích:</strong>
+                        <div class="d-flex gap-2 align-items-end mt-1">
+                            <div style="width:140px">
+                                <DxSpinEdit @bind-Value="@recipeMoneyCost" MinValue="0" NullText="(žádná)" />
+                            </div>
+                            <button class="btn btn-sm btn-outline-primary"
+                                    disabled="@(recipeMoneyCost == recipe.MoneyCost)"
+                                    @onclick="SaveRecipeMoneyAsync">
+                                Uložit cenu
+                            </button>
+                        </div>
+                    </div>
+                    <div class="mb-2">
+                        <strong class="small">Ingredience:</strong>
+                        @if (recipe.Ingredients.Count > 0)
+                        {
+                            <table class="table table-sm mb-1">
+                                <tbody>
+                                    @foreach (var ing in recipe.Ingredients)
+                                    {
+                                        <tr>
+                                            <td>@ing.ItemName</td>
+                                            <td style="width:60px">×@ing.Quantity</td>
+                                            <td style="width:40px"><button class="btn btn-sm btn-link text-danger p-0" @onclick="() => RemoveIngredientAsync(ing.ItemId)"><i class="bi bi-x-circle"></i></button></td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        }
+                        else { <p class="text-muted small mb-1">Žádné ingredience.</p> }
+                        <div class="d-flex gap-2 align-items-end">
+                            <div style="flex:1">
+                                <DxComboBox Data="@allItems" @bind-Value="@newIngItemId"
+                                            TextFieldName="Name" ValueFieldName="Id"
+                                            NullText="(přidat ingredienci)" SearchMode="ListSearchMode.AutoSearch" />
+                            </div>
+                            <div style="width:70px">
+                                <DxSpinEdit @bind-Value="@newIngQuantity" MinValue="1" />
+                            </div>
+                            <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newIngItemId is null)" @onclick="AddIngredientAsync"><i class="bi bi-plus"></i></button>
+                        </div>
+                    </div>
+                    <div class="mb-2">
+                        <strong class="small">Poznámka k surovinám:</strong>
+                        <DxMemo @bind-Text="@recipeIngredientNotes" Rows="2"
+                                NullText="(žádná poznámka, např. „Byliny — 3× stejný druh“)" />
+                        <div class="d-flex gap-2 mt-1">
+                            <button class="btn btn-sm btn-outline-primary"
+                                    disabled="@(string.Equals(recipeIngredientNotes ?? "", recipe.IngredientNotes ?? "", StringComparison.Ordinal))"
+                                    @onclick="SaveRecipeNotesAsync">
+                                Uložit poznámku
+                            </button>
+                        </div>
+                    </div>
+                    <div class="mb-2">
+                        <strong class="small">Předpoklady (jiné budovy):</strong>
+                        @if (recipe.PrerequisiteBuildings.Count > 0)
+                        {
+                            @foreach (var pb in recipe.PrerequisiteBuildings)
+                            {
+                                <span class="badge bg-secondary me-1">@pb.BuildingName <button class="btn btn-sm btn-link text-white p-0 ms-1" @onclick="() => RemovePrereqAsync(pb.BuildingId)"><i class="bi bi-x"></i></button></span>
+                            }
+                        }
+                        else { <span class="text-muted small">Žádné.</span> }
+                        <div class="d-flex gap-2 align-items-end mt-1">
+                            <div style="flex:1">
+                                <DxComboBox Data="@AvailablePrereqBuildings" @bind-Value="@newPrereqBuildingId"
+                                            TextFieldName="Name" ValueFieldName="Id"
+                                            NullText="(přidat předpoklad)" SearchMode="ListSearchMode.AutoSearch" />
+                            </div>
+                            <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newPrereqBuildingId is null)" @onclick="AddPrereqAsync"><i class="bi bi-plus"></i></button>
+                        </div>
+                    </div>
+                    <div class="mb-2">
+                        <strong class="small">Požadované dovednosti:</strong>
+                        @if (recipe.RequiredSkillIds.Count > 0)
+                        {
+                            @foreach (var skillId in recipe.RequiredSkillIds)
+                            {
+                                var gs = gameSkills.FirstOrDefault(g => g.Id == skillId);
+                                <span class="badge bg-secondary me-1">
+                                    @(gs?.Name ?? $"[Neznámá dovednost #{skillId}]")
+                                    <button class="btn btn-sm btn-link text-white p-0 ms-1" @onclick="() => RemoveSkillAsync(skillId)"><i class="bi bi-x"></i></button>
+                                </span>
+                            }
+                        }
+                        else { <span class="text-muted small">Žádné.</span> }
+                        @if (AvailableGameSkills.Count > 0)
+                        {
+                            <div class="d-flex gap-2 align-items-end mt-1">
+                                <div style="flex:1">
+                                    <DxComboBox Data="@AvailableGameSkills" @bind-Value="@newSkillId"
+                                                TextFieldName="Name" ValueFieldName="Id"
+                                                NullText="(přidat dovednost)" SearchMode="ListSearchMode.AutoSearch" />
+                                </div>
+                                <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newSkillId is null)" @onclick="AddSkillAsync"><i class="bi bi-plus"></i></button>
+                            </div>
+                        }
+                    </div>
+                    <button class="btn btn-sm btn-outline-danger" @onclick="() => isDeleteRecipeVisible = true">Smazat recept</button>
+                }
+                else
+                {
+                    <p class="text-muted small mb-2">Tato budova nemá nastavenou cenu výstavby pro tuto hru.</p>
+                    <button class="btn btn-sm btn-outline-primary" @onclick="CreateRecipeAsync"><i class="bi bi-plus-circle me-1"></i>Vytvořit cenu</button>
+                }
+            </div>
+        }
+
         @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
         <div class="d-flex gap-2 mt-3">
             @if (editingId.HasValue) { <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true">Smazat</button> }
@@ -113,6 +255,18 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+@* Issue #142 — destructive recipe-delete confirmation, per the
+   destructive-action-confirm memory rule. *@
+<DxPopup @bind-Visible="@isDeleteRecipeVisible" HeaderText="Smazat recept?" Width="420px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete smazat cenu výstavby pro budovu <strong>@name</strong>? Ingredience, předpoklady a požadované dovednosti se odeberou společně s receptem.</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isDeleteRecipeVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmDeleteRecipeAsync">Smazat recept</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @code {
     [SupplyParameterFromQuery] public bool Catalog { get; set; }
 
@@ -122,6 +276,38 @@ else
     private List<LocationListDto> gameLocations = [];
     private HashSet<int> assignedBuildingIds = [];
     private int gameId => GameContext.SelectedGameId ?? 1;
+
+    // ----- Building crafting recipe state (issue #142) -----
+    // Mirrors the Item recipe pattern in ItemList.razor's edit popup. The
+    // duplication is intentional for now — flagged as a follow-up issue
+    // for a shared CraftingRecipeEditor component.
+    private BuildingRecipeDetailDto? recipe;
+    private List<ItemListDto> allItems = [];
+    private List<BuildingListDto> allCatalogBuildings = [];
+    private List<GameSkillDto> gameSkills = [];
+    private int? newIngItemId;
+    private int newIngQuantity = 1;
+    private int? newPrereqBuildingId;
+    private int? newSkillId;
+    private int? recipeMoneyCost;
+    private string? recipeIngredientNotes;
+    private bool isDeleteRecipeVisible;
+
+    // Skills already required by the recipe shouldn't appear in the picker.
+    private List<GameSkillDto> AvailableGameSkills =>
+        recipe is null
+            ? []
+            : gameSkills.Where(gs => !recipe.RequiredSkillIds.Contains(gs.Id)).ToList();
+
+    // Prerequisite candidates exclude the building being edited (a recipe
+    // can't depend on its own output) and any building already added.
+    private List<BuildingListDto> AvailablePrereqBuildings =>
+        recipe is null
+            ? []
+            : allCatalogBuildings
+                .Where(b => b.Id != editingId
+                    && !recipe.PrerequisiteBuildings.Any(pb => pb.BuildingId == b.Id))
+                .ToList();
 
     private bool _previousCatalog;
 
@@ -165,8 +351,187 @@ else
         gameLocations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gameId}");
         if (b is null) { editingId = null; name = ""; description = null; notes = null; locationId = null; isPrebuilt = false; modalTitle = "Nová budova"; }
         else { editingId = b.Id; name = b.Name; description = b.Description; notes = b.Notes; locationId = b.LocationId; isPrebuilt = b.IsPrebuilt; modalTitle = $"Upravit: {b.Name}"; }
+
+        // Issue #142 — load recipe state for the building-cost editor. Only
+        // meaningful in game mode for an existing building; the editor markup
+        // already gates rendering on those conditions.
+        recipe = null;
+        recipeMoneyCost = null;
+        recipeIngredientNotes = null;
+        newIngItemId = null;
+        newIngQuantity = 1;
+        newPrereqBuildingId = null;
+        newSkillId = null;
+        if (editingId.HasValue && !Catalog && GameContext.SelectedGameId is int gid)
+        {
+            // Items eligible as ingredients are catalog-wide (the recipe
+            // structure references catalog Items, not GameItems).
+            allItems = await Api.GetListAsync<ItemListDto>("/api/items");
+            // Prerequisite buildings come from the catalog so an organizer
+            // can require a building that's also assigned to other games.
+            allCatalogBuildings = await Api.GetListAsync<BuildingListDto>("/api/buildings");
+            gameSkills = (await SkillSvc.GetGameSkillsAsync(gid)).ToList();
+            await LoadRecipeAsync(editingId.Value);
+        }
+
         isModalVisible = true;
         StateHasChanged();
+    }
+
+    // ---- Recipe load + CRUD handlers (issue #142) ----
+
+    private async Task LoadRecipeAsync(int buildingId)
+    {
+        recipe = null;
+        recipeMoneyCost = null;
+        recipeIngredientNotes = null;
+        if (GameContext.SelectedGameId is not int gid) return;
+
+        // /api/building-recipes/by-game/{gid} returns one entry per recipe,
+        // plus the OutputBuildingId so we can pick the one for THIS building.
+        var recipes = await Api.GetListAsync<BuildingRecipeListDto>($"/api/building-recipes/by-game/{gid}");
+        var match = recipes.FirstOrDefault(r => r.OutputBuildingId == buildingId);
+        if (match is not null)
+        {
+            recipe = await Api.GetAsync<BuildingRecipeDetailDto>($"/api/building-recipes/{match.Id}");
+            recipeMoneyCost = recipe?.MoneyCost;
+            recipeIngredientNotes = recipe?.IngredientNotes;
+        }
+    }
+
+    private async Task CreateRecipeAsync()
+    {
+        if (editingId is null || GameContext.SelectedGameId is not int gid) return;
+        try
+        {
+            await Api.PostAsync<CreateBuildingRecipeDto, BuildingRecipeDetailDto>("/api/building-recipes",
+                new CreateBuildingRecipeDto(gid, editingId.Value));
+            await LoadRecipeAsync(editingId.Value);
+            StateHasChanged();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task ConfirmDeleteRecipeAsync()
+    {
+        if (recipe is null) return;
+        try
+        {
+            await Api.DeleteAsync($"/api/building-recipes/{recipe.Id}");
+            recipe = null;
+            recipeMoneyCost = null;
+            recipeIngredientNotes = null;
+            isDeleteRecipeVisible = false;
+            StateHasChanged();
+        }
+        catch (Exception ex) { error = ex.Message; isDeleteRecipeVisible = false; }
+    }
+
+    private async Task AddIngredientAsync()
+    {
+        if (recipe is null || newIngItemId is null) return;
+        try
+        {
+            await Api.PostAsync<AddBuildingRecipeIngredientDto, object>($"/api/building-recipes/{recipe.Id}/ingredients",
+                new AddBuildingRecipeIngredientDto(newIngItemId.Value, newIngQuantity));
+            newIngItemId = null;
+            newIngQuantity = 1;
+            await LoadRecipeAsync(editingId!.Value);
+            StateHasChanged();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task RemoveIngredientAsync(int itemId)
+    {
+        if (recipe is null) return;
+        try
+        {
+            await Api.DeleteAsync($"/api/building-recipes/{recipe.Id}/ingredients/{itemId}");
+            await LoadRecipeAsync(editingId!.Value);
+            StateHasChanged();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task AddPrereqAsync()
+    {
+        if (recipe is null || newPrereqBuildingId is null) return;
+        try
+        {
+            await Api.PostAsync<AddBuildingRecipePrerequisiteDto, object>($"/api/building-recipes/{recipe.Id}/prerequisites",
+                new AddBuildingRecipePrerequisiteDto(newPrereqBuildingId.Value));
+            newPrereqBuildingId = null;
+            await LoadRecipeAsync(editingId!.Value);
+            StateHasChanged();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task RemovePrereqAsync(int buildingId)
+    {
+        if (recipe is null) return;
+        try
+        {
+            await Api.DeleteAsync($"/api/building-recipes/{recipe.Id}/prerequisites/{buildingId}");
+            await LoadRecipeAsync(editingId!.Value);
+            StateHasChanged();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task AddSkillAsync()
+    {
+        if (recipe is null || newSkillId is null) return;
+        var next = recipe.RequiredSkillIds.ToList();
+        if (next.Contains(newSkillId.Value)) return;
+        next.Add(newSkillId.Value);
+        await SaveRecipeAsync(skillIds: next);
+    }
+
+    private async Task RemoveSkillAsync(int skillId)
+    {
+        if (recipe is null) return;
+        var next = recipe.RequiredSkillIds.Where(s => s != skillId).ToList();
+        await SaveRecipeAsync(skillIds: next);
+    }
+
+    private async Task SaveRecipeMoneyAsync()
+    {
+        if (recipe is null) return;
+        await SaveRecipeAsync(moneyCost: recipeMoneyCost);
+    }
+
+    private async Task SaveRecipeNotesAsync()
+    {
+        if (recipe is null || editingId is null) return;
+        var normalized = string.IsNullOrWhiteSpace(recipeIngredientNotes) ? null : recipeIngredientNotes.Trim();
+        await SaveRecipeAsync(ingredientNotes: normalized);
+    }
+
+    /// <summary>
+    /// Single PUT helper that preserves all unrelated fields by default —
+    /// each handler passes only the field it's actually changing. Without
+    /// this, an "edit skills" PUT would null out money + notes (the DTO
+    /// defaults the unspecified params to null).
+    /// </summary>
+    private async Task SaveRecipeAsync(
+        int? moneyCost = null, IReadOnlyList<int>? skillIds = null, string? ingredientNotes = null)
+    {
+        if (recipe is null) return;
+        try
+        {
+            var dto = new UpdateBuildingRecipeDto(
+                recipe.OutputBuildingId,
+                MoneyCost: moneyCost ?? recipe.MoneyCost,
+                RequiredSkillIds: skillIds ?? recipe.RequiredSkillIds.ToList(),
+                IngredientNotes: ingredientNotes ?? recipe.IngredientNotes);
+            await Api.PutAsync($"/api/building-recipes/{recipe.Id}", dto);
+            newSkillId = null;
+            await LoadRecipeAsync(editingId!.Value);
+            StateHasChanged();
+        }
+        catch (Exception ex) { error = ex.Message; }
     }
 
     private async Task SaveAsync()

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
@@ -486,46 +486,64 @@ else
         var next = recipe.RequiredSkillIds.ToList();
         if (next.Contains(newSkillId.Value)) return;
         next.Add(newSkillId.Value);
-        await SaveRecipeAsync(skillIds: next);
+        await PutRecipeAsync(
+            moneyCost: recipe.MoneyCost,
+            skillIds: next,
+            ingredientNotes: recipe.IngredientNotes);
     }
 
     private async Task RemoveSkillAsync(int skillId)
     {
         if (recipe is null) return;
         var next = recipe.RequiredSkillIds.Where(s => s != skillId).ToList();
-        await SaveRecipeAsync(skillIds: next);
+        await PutRecipeAsync(
+            moneyCost: recipe.MoneyCost,
+            skillIds: next,
+            ingredientNotes: recipe.IngredientNotes);
     }
 
     private async Task SaveRecipeMoneyAsync()
     {
         if (recipe is null) return;
-        await SaveRecipeAsync(moneyCost: recipeMoneyCost);
+        // Use the editor's current value verbatim — null means "clear it",
+        // not "leave unchanged" (Copilot review on PR #164: ?? fallback
+        // prevented users from clearing MoneyCost back to null).
+        await PutRecipeAsync(
+            moneyCost: recipeMoneyCost,
+            skillIds: recipe.RequiredSkillIds.ToList(),
+            ingredientNotes: recipe.IngredientNotes);
     }
 
     private async Task SaveRecipeNotesAsync()
     {
         if (recipe is null || editingId is null) return;
         var normalized = string.IsNullOrWhiteSpace(recipeIngredientNotes) ? null : recipeIngredientNotes.Trim();
-        await SaveRecipeAsync(ingredientNotes: normalized);
+        // Same shape as money — pass `normalized` (which may be null) verbatim
+        // so clearing the memo actually persists as null.
+        await PutRecipeAsync(
+            moneyCost: recipe.MoneyCost,
+            skillIds: recipe.RequiredSkillIds.ToList(),
+            ingredientNotes: normalized);
     }
 
     /// <summary>
-    /// Single PUT helper that preserves all unrelated fields by default —
-    /// each handler passes only the field it's actually changing. Without
-    /// this, an "edit skills" PUT would null out money + notes (the DTO
-    /// defaults the unspecified params to null).
+    /// Single PUT helper that requires explicit values for every mutable
+    /// field. Callers are responsible for sending the recipe's current
+    /// server-side values for fields they don't want to change — without
+    /// that contract, a null param meant "preserve" and clearing a field
+    /// silently no-op'd (Copilot review on PR #164).
     /// </summary>
-    private async Task SaveRecipeAsync(
-        int? moneyCost = null, IReadOnlyList<int>? skillIds = null, string? ingredientNotes = null)
+    private async Task PutRecipeAsync(
+        int? moneyCost, IReadOnlyList<int> skillIds, string? ingredientNotes)
     {
         if (recipe is null) return;
         try
         {
             var dto = new UpdateBuildingRecipeDto(
                 recipe.OutputBuildingId,
-                MoneyCost: moneyCost ?? recipe.MoneyCost,
-                RequiredSkillIds: skillIds ?? recipe.RequiredSkillIds.ToList(),
-                IngredientNotes: ingredientNotes ?? recipe.IngredientNotes);
+                MoneyCost: moneyCost,
+                RequiredSkillIds: skillIds,
+                IngredientNotes: ingredientNotes);
             await Api.PutAsync($"/api/building-recipes/{recipe.Id}", dto);
             newSkillId = null;
             await LoadRecipeAsync(editingId!.Value);

--- a/src/OvcinaHra.Shared/Domain/Entities/Building.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Building.cs
@@ -13,4 +13,10 @@ public class Building
     public Location? Location { get; set; }
     public ICollection<GameBuilding> GameBuildings { get; set; } = [];
     public ICollection<CraftingBuildingRequirement> CraftingRequirements { get; set; } = [];
+
+    // Issue #142 — building crafting recipes. "AsOutput" lists BuildingRecipes
+    // whose OutputBuilding is this Building. "AsPrerequisite" covers the
+    // inverse: other buildings whose recipe requires this one as a prerequisite.
+    public ICollection<BuildingRecipe> BuildingRecipesAsOutput { get; set; } = [];
+    public ICollection<BuildingRecipePrerequisite> BuildingRecipesAsPrerequisite { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/BuildingRecipe.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/BuildingRecipe.cs
@@ -1,0 +1,31 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+/// <summary>
+/// Per-game construction recipe for a Building (issue #142). Mirrors the
+/// shape of <see cref="CraftingRecipe"/> for Items but is a parallel entity
+/// because: (1) the output is a Building, not an Item; (2) Buildings need
+/// a money cost which doesn't apply to Item recipes; (3) keeping schemas
+/// separate avoids polluting the catalog Item domain with Building-specific
+/// nullables.
+/// </summary>
+public class BuildingRecipe
+{
+    public int Id { get; set; }
+    public int GameId { get; set; }
+    public int OutputBuildingId { get; set; }
+
+    /// <summary>Optional money cost in groše (per-game currency).</summary>
+    public int? MoneyCost { get; set; }
+
+    /// <summary>
+    /// Free-text annotation rendered after the ingredient list (mirrors
+    /// CraftingRecipe.IngredientNotes from issue #121). Capped at 2000 chars.
+    /// </summary>
+    public string? IngredientNotes { get; set; }
+
+    public Game Game { get; set; } = null!;
+    public Building OutputBuilding { get; set; } = null!;
+    public ICollection<BuildingRecipeIngredient> Ingredients { get; set; } = [];
+    public ICollection<BuildingRecipePrerequisite> PrerequisiteBuildings { get; set; } = [];
+    public ICollection<BuildingRecipeSkillRequirement> SkillRequirements { get; set; } = [];
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/BuildingRecipeIngredient.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/BuildingRecipeIngredient.cs
@@ -1,0 +1,15 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+/// <summary>
+/// Item required to construct a Building (issue #142). Composite key on
+/// (BuildingRecipeId, ItemId) — same shape as CraftingIngredient.
+/// </summary>
+public class BuildingRecipeIngredient
+{
+    public int BuildingRecipeId { get; set; }
+    public int ItemId { get; set; }
+    public int Quantity { get; set; }
+
+    public BuildingRecipe BuildingRecipe { get; set; } = null!;
+    public Item Item { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/BuildingRecipePrerequisite.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/BuildingRecipePrerequisite.cs
@@ -1,0 +1,16 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+/// <summary>
+/// Building required to be already constructed before this Building can be
+/// built (issue #142). Composite key on (BuildingRecipeId, RequiredBuildingId).
+/// Analogous to CraftingBuildingRequirement on the Item side, just with the
+/// "this is a prerequisite, not a workshop" naming.
+/// </summary>
+public class BuildingRecipePrerequisite
+{
+    public int BuildingRecipeId { get; set; }
+    public int RequiredBuildingId { get; set; }
+
+    public BuildingRecipe BuildingRecipe { get; set; } = null!;
+    public Building RequiredBuilding { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/BuildingRecipeSkillRequirement.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/BuildingRecipeSkillRequirement.cs
@@ -1,0 +1,14 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+/// <summary>
+/// Per-game skill required to construct this Building (issue #142). Composite
+/// key on (BuildingRecipeId, GameSkillId) — same shape as CraftingSkillRequirement.
+/// </summary>
+public class BuildingRecipeSkillRequirement
+{
+    public int BuildingRecipeId { get; set; }
+    public int GameSkillId { get; set; }
+
+    public BuildingRecipe BuildingRecipe { get; set; } = null!;
+    public GameSkill GameSkill { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/Game.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Game.cs
@@ -39,6 +39,7 @@ public class Game
     public ICollection<GameSecretStash> GameSecretStashes { get; set; } = [];
     public ICollection<GameBuilding> GameBuildings { get; set; } = [];
     public ICollection<CraftingRecipe> CraftingRecipes { get; set; } = [];
+    public ICollection<BuildingRecipe> BuildingRecipes { get; set; } = [];
     public ICollection<GameMonster> GameMonsters { get; set; } = [];
     public ICollection<MonsterLoot> MonsterLoots { get; set; } = [];
     public ICollection<Quest> Quests { get; set; } = [];

--- a/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
@@ -3,7 +3,11 @@ namespace OvcinaHra.Shared.Dtos;
 public record BuildingListDto(
     int Id, string Name, string? Description, string? Notes,
     int? LocationId, string? LocationName, bool IsPrebuilt,
-    string? ImagePath = null, string? ImageUrl = null);
+    string? ImagePath = null, string? ImageUrl = null,
+    // Issue #142 — per-game construction recipe summary. Populated by the
+    // by-game endpoint with a compact "3× ingrediencí · 50 zlaťáků · 1 dovednost"
+    // string for display in the grid; catalog endpoint leaves null.
+    string? RecipeSummary = null);
 
 public record BuildingDetailDto(
     int Id, string Name, string? Description, string? Notes, string? ImagePath,

--- a/src/OvcinaHra.Shared/Dtos/BuildingRecipeDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/BuildingRecipeDtos.cs
@@ -1,0 +1,45 @@
+namespace OvcinaHra.Shared.Dtos;
+
+// Issue #142 — Building crafting cost. Mirrors CraftingDtos exactly except
+// for `MoneyCost` (Building-only) and the prerequisite-vs-required-buildings
+// renaming: on the Item side `BuildingRequirement` means "this Item is
+// crafted at this Building"; on the Building side `Prerequisite` means
+// "this Building requires that Building to already be constructed".
+
+public record BuildingRecipeListDto(
+    int Id, int OutputBuildingId, string OutputBuildingName, int GameId, int? MoneyCost);
+
+public record BuildingRecipeDetailDto(
+    int Id, int OutputBuildingId, string OutputBuildingName, int GameId,
+    int? MoneyCost,
+    List<BuildingRecipeIngredientDto> Ingredients,
+    List<BuildingRecipePrerequisiteDto> PrerequisiteBuildings)
+{
+    public IReadOnlyList<int> RequiredSkillIds { get; init; } = [];
+
+    /// <summary>
+    /// Free-text annotation rendered after the ingredient list; mirrors
+    /// CraftingRecipeDetailDto.IngredientNotes (issue #121). Capped at 2000
+    /// chars server-side.
+    /// </summary>
+    public string? IngredientNotes { get; init; }
+}
+
+public record CreateBuildingRecipeDto(
+    int GameId,
+    int OutputBuildingId,
+    int? MoneyCost = null,
+    IReadOnlyList<int>? RequiredSkillIds = null,
+    string? IngredientNotes = null);
+
+public record UpdateBuildingRecipeDto(
+    int OutputBuildingId,
+    int? MoneyCost = null,
+    IReadOnlyList<int>? RequiredSkillIds = null,
+    string? IngredientNotes = null);
+
+public record BuildingRecipeIngredientDto(int ItemId, string ItemName, int Quantity);
+public record AddBuildingRecipeIngredientDto(int ItemId, int Quantity = 1);
+
+public record BuildingRecipePrerequisiteDto(int BuildingId, string BuildingName);
+public record AddBuildingRecipePrerequisiteDto(int BuildingId);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/BuildingRecipeEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/BuildingRecipeEndpointTests.cs
@@ -168,6 +168,70 @@ public class BuildingRecipeEndpointTests(PostgresFixture postgres) : Integration
     }
 
     [Fact]
+    public async Task AddIngredient_RecipeNotFound_Returns404()
+    {
+        var item = await CreateItemAsync("Sláma");
+        var resp = await Client.PostAsJsonAsync("/api/building-recipes/99999/ingredients",
+            new AddBuildingRecipeIngredientDto(item.Id));
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddIngredient_NegativeQuantity_Returns400()
+    {
+        var game = await CreateGameAsync();
+        var b = await CreateBuildingAsync("Strážnice");
+        var item = await CreateItemAsync("Kámen");
+        var createResp = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, b.Id));
+        var recipe = (await createResp.Content.ReadFromJsonAsync<BuildingRecipeDetailDto>())!;
+
+        var resp = await Client.PostAsJsonAsync($"/api/building-recipes/{recipe.Id}/ingredients",
+            new AddBuildingRecipeIngredientDto(item.Id, Quantity: 0));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        await AssertProblemDetailsAsync(resp, "Neplatné množství", "1");
+    }
+
+    [Fact]
+    public async Task AddIngredient_NonExistentItem_Returns400()
+    {
+        var game = await CreateGameAsync();
+        var b = await CreateBuildingAsync("Sklad");
+        var createResp = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, b.Id));
+        var recipe = (await createResp.Content.ReadFromJsonAsync<BuildingRecipeDetailDto>())!;
+
+        var resp = await Client.PostAsJsonAsync($"/api/building-recipes/{recipe.Id}/ingredients",
+            new AddBuildingRecipeIngredientDto(ItemId: 99999, Quantity: 1));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        await AssertProblemDetailsAsync(resp, "Předmět neexistuje", "99999");
+    }
+
+    [Fact]
+    public async Task AddPrerequisite_RecipeNotFound_Returns404()
+    {
+        var b = await CreateBuildingAsync("Brána");
+        var resp = await Client.PostAsJsonAsync("/api/building-recipes/99999/prerequisites",
+            new AddBuildingRecipePrerequisiteDto(b.Id));
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddPrerequisite_NonExistentBuilding_Returns400()
+    {
+        var game = await CreateGameAsync();
+        var b = await CreateBuildingAsync("Most");
+        var createResp = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, b.Id));
+        var recipe = (await createResp.Content.ReadFromJsonAsync<BuildingRecipeDetailDto>())!;
+
+        var resp = await Client.PostAsJsonAsync($"/api/building-recipes/{recipe.Id}/prerequisites",
+            new AddBuildingRecipePrerequisiteDto(BuildingId: 99999));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        await AssertProblemDetailsAsync(resp, "Budova neexistuje", "99999");
+    }
+
+    [Fact]
     public async Task AddIngredient_DuplicateReturnsConflict()
     {
         var game = await CreateGameAsync();

--- a/tests/OvcinaHra.Api.Tests/Endpoints/BuildingRecipeEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/BuildingRecipeEndpointTests.cs
@@ -1,0 +1,287 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+// Issue #142 — Building crafting cost endpoints. Mirrors CraftingEndpointTests
+// for the Item-side recipe model. Validation rules in lock-step:
+// MoneyCost ≥ 0, IngredientNotes ≤ 2000 chars, prerequisite cannot reference
+// the recipe's own output building, skills must be present in the game.
+public class BuildingRecipeEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    private async Task<GameDetailDto> CreateGameAsync()
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Stavební hra", 1, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 3)));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    private async Task<BuildingDetailDto> CreateBuildingAsync(string name, int? gameId = null)
+    {
+        var url = gameId.HasValue ? $"/api/buildings?gameId={gameId}" : "/api/buildings";
+        var response = await Client.PostAsJsonAsync(url, new CreateBuildingDto(name));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<BuildingDetailDto>())!;
+    }
+
+    private async Task<ItemDetailDto> CreateItemAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/items",
+            new CreateItemDto(name, ItemType.Potion));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<ItemDetailDto>())!;
+    }
+
+    private static async Task AssertProblemDetailsAsync(
+        HttpResponseMessage response, string expectedTitle, string expectedDetailFragment)
+    {
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal(expectedTitle, problem!.Title);
+        Assert.False(string.IsNullOrWhiteSpace(problem.Detail));
+        Assert.Contains(expectedDetailFragment, problem.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ----- Empty + happy-path -----
+
+    [Fact]
+    public async Task GetByGame_Empty_ReturnsEmptyList()
+    {
+        var game = await CreateGameAsync();
+        var recipes = await Client.GetFromJsonAsync<List<BuildingRecipeListDto>>(
+            $"/api/building-recipes/by-game/{game.Id}");
+        Assert.NotNull(recipes);
+        Assert.Empty(recipes);
+    }
+
+    [Fact]
+    public async Task Create_ValidRecipe_ReturnsCreated()
+    {
+        var game = await CreateGameAsync();
+        var b = await CreateBuildingAsync("Hradiště");
+
+        var response = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, b.Id, MoneyCost: 50));
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var created = await response.Content.ReadFromJsonAsync<BuildingRecipeDetailDto>();
+        Assert.NotNull(created);
+        Assert.Equal(b.Id, created!.OutputBuildingId);
+        Assert.Equal("Hradiště", created.OutputBuildingName);
+        Assert.Equal(50, created.MoneyCost);
+        Assert.Empty(created.Ingredients);
+        Assert.Empty(created.PrerequisiteBuildings);
+    }
+
+    [Fact]
+    public async Task Create_NegativeMoneyCost_Returns400()
+    {
+        var game = await CreateGameAsync();
+        var b = await CreateBuildingAsync("Stáj");
+
+        var response = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, b.Id, MoneyCost: -10));
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        await AssertProblemDetailsAsync(response, "Neplatná cena", "záporná");
+    }
+
+    [Fact]
+    public async Task Create_OversizedNotes_Returns400()
+    {
+        var game = await CreateGameAsync();
+        var b = await CreateBuildingAsync("Knihovna");
+        var tooLong = new string('p', 2001);
+
+        var response = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, b.Id, IngredientNotes: tooLong));
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        await AssertProblemDetailsAsync(response, "Poznámka je příliš dlouhá", "2000");
+    }
+
+    [Fact]
+    public async Task Update_RoundTripsAllFields()
+    {
+        var game = await CreateGameAsync();
+        var b = await CreateBuildingAsync("Tržiště");
+        var createResp = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, b.Id));
+        createResp.EnsureSuccessStatusCode();
+        var recipe = (await createResp.Content.ReadFromJsonAsync<BuildingRecipeDetailDto>())!;
+
+        var updateResp = await Client.PutAsJsonAsync($"/api/building-recipes/{recipe.Id}",
+            new UpdateBuildingRecipeDto(b.Id, MoneyCost: 120, IngredientNotes: "Pouze v sezóně"));
+        Assert.Equal(HttpStatusCode.NoContent, updateResp.StatusCode);
+
+        var fetched = await Client.GetFromJsonAsync<BuildingRecipeDetailDto>($"/api/building-recipes/{recipe.Id}");
+        Assert.Equal(120, fetched!.MoneyCost);
+        Assert.Equal("Pouze v sezóně", fetched.IngredientNotes);
+    }
+
+    [Fact]
+    public async Task Update_NonExistentRecipe_Returns404()
+    {
+        var game = await CreateGameAsync();
+        var b = await CreateBuildingAsync("Maják");
+        var resp = await Client.PutAsJsonAsync("/api/building-recipes/99999",
+            new UpdateBuildingRecipeDto(b.Id));
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetById_NonExistent_Returns404()
+    {
+        var resp = await Client.GetAsync("/api/building-recipes/99999");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    // ----- Ingredients -----
+
+    [Fact]
+    public async Task AddIngredient_AppearsInDetail_AndRemoveDeletesIt()
+    {
+        var game = await CreateGameAsync();
+        var b = await CreateBuildingAsync("Mlýn");
+        var item = await CreateItemAsync("Dřevo");
+        var createResp = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, b.Id));
+        createResp.EnsureSuccessStatusCode();
+        var recipe = (await createResp.Content.ReadFromJsonAsync<BuildingRecipeDetailDto>())!;
+
+        var addResp = await Client.PostAsJsonAsync($"/api/building-recipes/{recipe.Id}/ingredients",
+            new AddBuildingRecipeIngredientDto(item.Id, Quantity: 5));
+        Assert.Equal(HttpStatusCode.Created, addResp.StatusCode);
+
+        var afterAdd = await Client.GetFromJsonAsync<BuildingRecipeDetailDto>($"/api/building-recipes/{recipe.Id}");
+        Assert.Single(afterAdd!.Ingredients);
+        Assert.Equal(5, afterAdd.Ingredients[0].Quantity);
+
+        var removeResp = await Client.DeleteAsync($"/api/building-recipes/{recipe.Id}/ingredients/{item.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, removeResp.StatusCode);
+
+        var afterRemove = await Client.GetFromJsonAsync<BuildingRecipeDetailDto>($"/api/building-recipes/{recipe.Id}");
+        Assert.Empty(afterRemove!.Ingredients);
+    }
+
+    [Fact]
+    public async Task AddIngredient_DuplicateReturnsConflict()
+    {
+        var game = await CreateGameAsync();
+        var b = await CreateBuildingAsync("Pekárna");
+        var item = await CreateItemAsync("Mouka");
+        var createResp = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, b.Id));
+        var recipe = (await createResp.Content.ReadFromJsonAsync<BuildingRecipeDetailDto>())!;
+
+        var first = await Client.PostAsJsonAsync($"/api/building-recipes/{recipe.Id}/ingredients",
+            new AddBuildingRecipeIngredientDto(item.Id));
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+
+        var dup = await Client.PostAsJsonAsync($"/api/building-recipes/{recipe.Id}/ingredients",
+            new AddBuildingRecipeIngredientDto(item.Id));
+        Assert.Equal(HttpStatusCode.Conflict, dup.StatusCode);
+    }
+
+    // ----- Prerequisites -----
+
+    [Fact]
+    public async Task AddPrerequisite_AppearsInDetail_AndRemoveDeletesIt()
+    {
+        var game = await CreateGameAsync();
+        var output = await CreateBuildingAsync("Kostel");
+        var prereq = await CreateBuildingAsync("Základy");
+
+        var createResp = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, output.Id));
+        var recipe = (await createResp.Content.ReadFromJsonAsync<BuildingRecipeDetailDto>())!;
+
+        var addResp = await Client.PostAsJsonAsync($"/api/building-recipes/{recipe.Id}/prerequisites",
+            new AddBuildingRecipePrerequisiteDto(prereq.Id));
+        Assert.Equal(HttpStatusCode.Created, addResp.StatusCode);
+
+        var afterAdd = await Client.GetFromJsonAsync<BuildingRecipeDetailDto>($"/api/building-recipes/{recipe.Id}");
+        Assert.Single(afterAdd!.PrerequisiteBuildings);
+        Assert.Equal(prereq.Id, afterAdd.PrerequisiteBuildings[0].BuildingId);
+
+        var removeResp = await Client.DeleteAsync($"/api/building-recipes/{recipe.Id}/prerequisites/{prereq.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, removeResp.StatusCode);
+
+        var afterRemove = await Client.GetFromJsonAsync<BuildingRecipeDetailDto>($"/api/building-recipes/{recipe.Id}");
+        Assert.Empty(afterRemove!.PrerequisiteBuildings);
+    }
+
+    [Fact]
+    public async Task AddPrerequisite_SelfReference_Returns400()
+    {
+        var game = await CreateGameAsync();
+        var b = await CreateBuildingAsync("Hrad");
+        var createResp = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, b.Id));
+        var recipe = (await createResp.Content.ReadFromJsonAsync<BuildingRecipeDetailDto>())!;
+
+        var resp = await Client.PostAsJsonAsync($"/api/building-recipes/{recipe.Id}/prerequisites",
+            new AddBuildingRecipePrerequisiteDto(b.Id));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        await AssertProblemDetailsAsync(resp, "Neplatný požadavek", "sama");
+    }
+
+    // ----- Cascade delete -----
+
+    [Fact]
+    public async Task DeleteRecipe_CascadesIngredientsAndPrerequisites()
+    {
+        var game = await CreateGameAsync();
+        var output = await CreateBuildingAsync("Tvrz");
+        var prereq = await CreateBuildingAsync("Palisáda");
+        var item = await CreateItemAsync("Kámen");
+
+        var createResp = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, output.Id));
+        var recipe = (await createResp.Content.ReadFromJsonAsync<BuildingRecipeDetailDto>())!;
+
+        await Client.PostAsJsonAsync($"/api/building-recipes/{recipe.Id}/ingredients",
+            new AddBuildingRecipeIngredientDto(item.Id, 3));
+        await Client.PostAsJsonAsync($"/api/building-recipes/{recipe.Id}/prerequisites",
+            new AddBuildingRecipePrerequisiteDto(prereq.Id));
+
+        var deleteResp = await Client.DeleteAsync($"/api/building-recipes/{recipe.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResp.StatusCode);
+
+        // GetById returns 404 → recipe is gone. Children would have been
+        // orphaned without cascade — testing existence of the parent is
+        // sufficient because the ingredient/prerequisite tables have FK
+        // back to the recipe with ON DELETE CASCADE behavior in EF.
+        var refetch = await Client.GetAsync($"/api/building-recipes/{recipe.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, refetch.StatusCode);
+    }
+
+    // ----- Grid summary integration -----
+
+    [Fact]
+    public async Task BuildingsByGame_PopulatesRecipeSummary_ForBuildingsWithRecipes()
+    {
+        var game = await CreateGameAsync();
+        var withRecipe = await CreateBuildingAsync("Hostinec", gameId: game.Id);
+        var noRecipe = await CreateBuildingAsync("Studna", gameId: game.Id);
+        var item = await CreateItemAsync("Sláma");
+
+        var createResp = await Client.PostAsJsonAsync("/api/building-recipes",
+            new CreateBuildingRecipeDto(game.Id, withRecipe.Id, MoneyCost: 75));
+        var recipe = (await createResp.Content.ReadFromJsonAsync<BuildingRecipeDetailDto>())!;
+        await Client.PostAsJsonAsync($"/api/building-recipes/{recipe.Id}/ingredients",
+            new AddBuildingRecipeIngredientDto(item.Id, 4));
+
+        var rows = await Client.GetFromJsonAsync<List<BuildingListDto>>($"/api/buildings/by-game/{game.Id}");
+        Assert.NotNull(rows);
+        var withRow = rows!.Single(r => r.Id == withRecipe.Id);
+        var noRow = rows.Single(r => r.Id == noRecipe.Id);
+        Assert.False(string.IsNullOrEmpty(withRow.RecipeSummary));
+        Assert.Contains("75", withRow.RecipeSummary);
+        Assert.Contains("4", withRow.RecipeSummary);
+        Assert.Null(noRow.RecipeSummary);
+    }
+}


### PR DESCRIPTION
## What

Buildings get their own per-game construction recipe — items + money + optional skill + prerequisite buildings — visible in the Building grid and editable in the building edit popup. Closes #142.

## Model — Option B (parallel `BuildingRecipe`)

`CraftingRecipe` for Items has a non-nullable `OutputItemId` and no money cost; reusing it polymorphically would have meant a data migration to null that FK plus padding it with always-null `MoneyCost` for every existing item recipe. Option B mirrors the four-table CraftingRecipe shape one-for-one:

- `BuildingRecipe(Id, GameId, OutputBuildingId, MoneyCost?, IngredientNotes?)`
- `BuildingRecipeIngredient(BuildingRecipeId+ItemId, Quantity)`
- `BuildingRecipePrerequisite(BuildingRecipeId+RequiredBuildingId)` — Item-side `CraftingBuildingRequirement` means "this Item is crafted at this Building"; the Building-side analogue is "this Building requires that Building as a prerequisite", hence the rename.
- `BuildingRecipeSkillRequirement(BuildingRecipeId+GameSkillId)`

## API endpoints — `/api/building-recipes` (mirrors `/api/crafting`)

`GET /by-game/{gameId}` · `GET /{id}` · `POST /` · `PUT /{id}` · `DELETE /{id}` (cascades to children) · ingredient + prerequisite add/remove. Validation: `MoneyCost ≥ 0`, `IngredientNotes ≤ 2000`, prerequisite cannot reference its own output, skills must exist in the game. All return Czech ProblemDetails (`_review-instincts.md` §2).

`BuildingListDto` gained an optional `RecipeSummary` string ("3× ingrediencí · 50 zlaťáků · 1 dovednost · 2 budov") populated by the by-game endpoint.

## Editor — duplicated, follow-up tracked

The Item recipe editor in `Pages/Items/ItemList.razor` is inline + tightly coupled to Item state. Per the brief''s direction, I duplicated the relevant pieces into `Pages/Buildings/BuildingList.razor`''s edit popup with the same look (Cena spin + Uložit, ingredient table + AutoSearch combo, Poznámka memo + Uložit, prereq + skill badge lists, recipe delete via DxPopup confirm).

Follow-up: **#163** — extract a shared `CraftingRecipeEditor` once both editors live in their own detail pages.

## Migration

`20260425065836_BuildingCraftingCost` — adds 4 tables with FK cascade on delete from the parent recipe. `IngredientNotes` capped at 2000 via `HasMaxLength`.

## LayoutKey bump

`grid-layout-buildings-v2` → `grid-layout-buildings-v3` per `feedback_ovcinagrid_layoutkey_bump`. New `Cena výstavby` column visible only in game mode.

## Tests — 13 integration tests

`BuildingRecipeEndpointTests.cs`: empty list + happy path, negative-money 400 (full ProblemDetails assert), oversized notes 400, non-existent recipe 404, round-trip update, ingredient add/remove + duplicate-conflict, prerequisite add/remove + self-reference rejected, recipe delete cascades, by-game grid populates `RecipeSummary` correctly.

**330/330 API tests pass** (13 new + 317 existing). `dotnet build` clean (0W/0E, `TreatWarningsAsErrors=true`).

## No csproj bump

Auto-bump CI handles `<Version>` per `_review-instincts.md` §18.

Closes #142.