### PR TITLE
fix(map): overlay edit-mode polish + glyphs + save errors

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -166,14 +166,17 @@ public static class GameEndpoints
             return TypedResults.NoContent();
 
         // Best-effort deserialize: if a stored overlay is corrupt (e.g. schema
-        // drift from a future Phase 3 adding new shape types), treat as empty
-        // rather than 500 — the client can then re-save a valid overlay.
+        // drift from a future shape type, or a hand-edited row), treat as
+        // empty rather than 500 — the client can then re-save a valid
+        // overlay. System.Text.Json signals an unknown polymorphic
+        // discriminator with NotSupportedException (not JsonException), so
+        // both must be caught here.
         try
         {
             var dto = JsonSerializer.Deserialize<MapOverlayDto>(game.OverlayJson, OverlayJsonOptions);
             return dto is null ? TypedResults.NoContent() : TypedResults.Ok(dto);
         }
-        catch (JsonException)
+        catch (Exception ex) when (ex is JsonException or NotSupportedException)
         {
             return TypedResults.NoContent();
         }
@@ -194,6 +197,23 @@ public static class GameEndpoints
             return TypedResults.Problem(
                 title: "Překryv je příliš velký",
                 detail: $"Maximální velikost překryvu je {OverlayMaxBytes / 1024} KiB, odeslaná data mají {byteCount / 1024} KiB.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        // Round-trip guard — make sure the JSON we're about to persist will
+        // re-deserialize cleanly. Otherwise a payload with an unknown
+        // polymorphic shape (server is on an older build than the client
+        // during a rolling deploy) would poison the field and every
+        // subsequent GET would crash the editor.
+        try
+        {
+            _ = JsonSerializer.Deserialize<MapOverlayDto>(serialized, OverlayJsonOptions);
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException)
+        {
+            return TypedResults.Problem(
+                title: "Neznámý tvar v překryvu",
+                detail: "Některý z odeslaných tvarů nebyl rozpoznán. Aktualizujte aplikaci a zkuste překryv uložit znovu.",
                 statusCode: StatusCodes.Status400BadRequest);
         }
 

--- a/src/OvcinaHra.Client/Components/MapOverlayToolbar.razor
+++ b/src/OvcinaHra.Client/Components/MapOverlayToolbar.razor
@@ -70,7 +70,12 @@
                         title="@IconLabel(key)" aria-label="@IconLabel(key)"
                         aria-pressed="@(string.Equals(key, IconAsset, StringComparison.Ordinal))"
                         @onclick="() => SetIconAssetAsync(key)">
-                    <img src="@($"/img/overlay-icons/{key}.svg")" alt="@IconLabel(key)" style="color:@Color" />
+                    @* mask-image swap so the SVG silhouette inherits the chosen
+                       stroke color — `currentColor` inside an externally-loaded
+                       <img> doesn't inherit from the host element's `color`. *@
+                    <span class="oh-mo-icon-glyph"
+                          style="@($"-webkit-mask-image:url('/img/overlay-icons/{key}.svg');mask-image:url('/img/overlay-icons/{key}.svg');background-color:{Color};")"
+                          role="img" aria-label="@IconLabel(key)"></span>
                 </button>
             }
             <label class="oh-mo-label">Otočení

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -132,11 +132,14 @@
                     var dto = await Api.GetAsync<MapOverlayDto>($"/api/games/{GameId.Value}/overlay");
                     shapes = dto?.Shapes ?? new List<MapOverlayShape>();
                 }
-                catch (System.Text.Json.JsonException)
+                catch (Exception ex) when (ex is System.Text.Json.JsonException or NotSupportedException)
                 {
-                    // 204 NoContent — empty body can't parse as JSON; treat as
-                    // no overlay. Still rendering below so the preview layers
-                    // are initialised for a future editor session.
+                    // 204 NoContent → empty body can't parse as JSON → JsonException.
+                    // Unknown polymorphic discriminator (server returned a shape
+                    // type a stale client doesn't know yet) → NotSupportedException.
+                    // Either way: treat as no overlay so the editor can still
+                    // open and the user can re-save. Preview layers initialise
+                    // below regardless.
                     shapes = new List<MapOverlayShape>();
                 }
                 _committedShapes = shapes;

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -417,10 +417,21 @@
 
         // `ovcinaMap.switchStyle` wipes all style-dependent layers, including
         // the overlay source / layers that `ovcinaOverlay.render` added.
-        // Re-render so the saved overlay survives basemap swaps.
+        // Re-render so the overlay survives basemap swaps. While editing,
+        // honour the in-memory staged list (with unsaved edits) and re-apply
+        // the active selection highlight — committed-only would silently
+        // discard the user's work.
         if (GameId.HasValue && _loadedOverlayForGameId == GameId)
         {
-            try { await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _committedShapes); }
+            var shapes = _editMode ? _stagedShapes : _committedShapes;
+            try
+            {
+                await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, shapes);
+                if (_editMode && _selectedShape is not null)
+                {
+                    await JS.InvokeVoidAsync("ovcinaOverlay.selectShape", _elementId, _selectedShape);
+                }
+            }
             catch { /* best-effort */ }
         }
     }

--- a/src/OvcinaHra.Client/Components/OverlayPropertyPanel.razor
+++ b/src/OvcinaHra.Client/Components/OverlayPropertyPanel.razor
@@ -71,7 +71,12 @@
                                 class="oh-overlay-pp-icon @(string.Equals(key, ic.AssetKey, StringComparison.Ordinal) ? "is-active" : "")"
                                 title="@IconLabel(key)" aria-label="@IconLabel(key)"
                                 @onclick="() => OnIconAssetChangedAsync(key)">
-                            <img src="@($"/img/overlay-icons/{key}.svg")" alt="@IconLabel(key)" style="color:@ic.Color" />
+                            @* mask-image to actually tint the SVG silhouette —
+                               `currentColor` doesn't propagate into an <img>
+                               element's externally-loaded SVG. *@
+                            <span class="oh-overlay-pp-icon-glyph"
+                                  style="@($"-webkit-mask-image:url('/img/overlay-icons/{key}.svg');mask-image:url('/img/overlay-icons/{key}.svg');background-color:{ic.Color};")"
+                                  role="img" aria-label="@IconLabel(key)"></span>
                         </button>
                     }
                 </div>
@@ -199,8 +204,10 @@
     private async Task OnTextChangedAsync(ChangeEventArgs e)
     {
         if (Shape is not TextShape t) return;
-        var txt = e.Value?.ToString();
-        if (string.IsNullOrEmpty(txt)) return;
+        // Empty string is a valid edit — user may want to clear the text
+        // before retyping. Treat null (no event payload at all) as a no-op.
+        if (e.Value is null) return;
+        var txt = e.Value.ToString() ?? string.Empty;
         await OnChange.InvokeAsync(t with { Text = txt });
     }
 

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2781,6 +2781,10 @@
 .oh-mo-icon:hover{border-color:#504B25}
 .oh-mo-icon.is-active{border-color:#504B25;box-shadow:0 0 0 2px rgba(80,75,37,0.25)}
 .oh-mo-icon img{width:22px;height:22px;display:block}
+.oh-mo-icon-glyph{display:block;width:22px;height:22px;
+    -webkit-mask-repeat:no-repeat;mask-repeat:no-repeat;
+    -webkit-mask-position:center;mask-position:center;
+    -webkit-mask-size:contain;mask-size:contain}
 
 /* Sidecar property panel — anchored top-right of map host. Above MapLibre
    controls (z-index:20) but below the error banner (z-index:21). */
@@ -2819,6 +2823,10 @@
 .oh-overlay-pp-icon:hover{border-color:#504B25}
 .oh-overlay-pp-icon.is-active{border-color:#504B25;box-shadow:0 0 0 2px rgba(80,75,37,0.25)}
 .oh-overlay-pp-icon img{width:22px;height:22px;display:block}
+.oh-overlay-pp-icon-glyph{display:block;width:22px;height:22px;
+    -webkit-mask-repeat:no-repeat;mask-repeat:no-repeat;
+    -webkit-mask-position:center;mask-position:center;
+    -webkit-mask-size:contain;mask-size:contain}
 
 /* Drozd radí inline hint — mascot-attributed advice block. Soft amber band
    so users notice the guidance without reading it as an error. */

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -6,8 +6,18 @@ window.ovcinaMap = {
     _elementId: null,
     _apiKey: null,
 
+    // Glyph URL — required by MapLibre for any layer with `text-field` in
+    // its layout (e.g. the overlay editor's `oh-overlay-preview-text` text
+    // primitive, #96). Without `glyphs`, MapLibre logs:
+    //   "layers.X.layout.text-field: use of 'text-field' requires a style 'glyphs' property"
+    // and the text never renders. We use the MapLibre demo glyph endpoint
+    // for now — TODO(prod): self-host on Azure Blob alongside the rest of
+    // the map assets before the next prod rollout. Tracked in #159 follow-up.
+    _glyphsUrl: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+
     _rasterStyle: {
         version: 8,
+        glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
         sources: {
             'osm': {
                 type: 'raster',
@@ -139,7 +149,11 @@ window.ovcinaMap = {
         var popup = new maplibregl.Popup({ offset: 10 })
             .setHTML('<strong>' + this._escapeHtml(name) + '</strong><br><small>' + this._escapeHtml(kind) + '</small>');
 
-        var marker = new maplibregl.Marker({ element: wrapper, anchor: 'top', draggable: true })
+        // Honour overlay edit-mode (#159 sub-fix 5): if the user toggles
+        // overlay edit-mode and then a stage filter / search re-adds markers,
+        // the freshly-created markers should also come up locked.
+        var initiallyDraggable = !window.__ovcinaOverlayEditMode;
+        var marker = new maplibregl.Marker({ element: wrapper, anchor: 'top', draggable: initiallyDraggable })
             .setLngLat([lon, lat])
             .setPopup(popup)
             .addTo(this._map);
@@ -159,6 +173,20 @@ window.ovcinaMap = {
         });
 
         this._markers[id] = marker;
+    },
+
+    /// <summary>
+    /// Toggle the draggable property on every location marker — called by the
+    /// overlay editor on enter/exit edit-mode (#159 sub-fix 5) so the user
+    /// can't accidentally relocate a pin while drawing on top of it.
+    /// Idempotent; safe to call when no markers are present.
+    /// </summary>
+    setLocationMarkersDraggable: function (enabled) {
+        var on = !!enabled;
+        for (var id in this._markers) {
+            try { this._markers[id].setDraggable(on); }
+            catch (e) { /* MapLibre version differences — best-effort */ }
+        }
     },
 
     removeMarker: function (id) {
@@ -193,6 +221,8 @@ window.ovcinaMap = {
     _makeRasterStyle: function (styleName, apiKey) {
         return {
             version: 8,
+            // See _glyphsUrl above — required for the overlay editor text layer.
+            glyphs: this._glyphsUrl,
             sources: {
                 'mapy-cz': {
                     type: 'raster',

--- a/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
@@ -322,7 +322,21 @@
             const inst = ensureInstance(mapId);
             inst.tool = tool;
             inst.dotnetRef = dotnetRef;
+            inst.editMode = true;
             map.getCanvas().style.cursor = tool === 'select' ? '' : 'crosshair';
+            // Suspend MapLibre handlers that compete with click-to-draw: drag-pan
+            // would steal mousedown+mousemove from freehand/rectangle/circle and
+            // box-zoom would steal Shift+drag (#159 sub-fix 2). Restored on
+            // exitEditMode / dispose. Wheel zoom stays on — users still want
+            // to zoom while drawing big shapes.
+            suspendMapInteractions(map, inst);
+            // Lock location markers so users can't accidentally relocate a pin
+            // while drawing on top of it (#159 sub-fix 5). Same restore path.
+            setLocationMarkersDraggable(false);
+            // Tell Blazor that overlay edit-mode is active so any markers
+            // re-added during the edit (e.g. SetStageFilter repopulates after
+            // a filter toggle) come up locked too.
+            window.__ovcinaOverlayEditMode = true;
             // Disable map-level double-click zoom so polyline/polygon "dblclick
             // to finish" doesn't also zoom the viewport.
             if (map.doubleClickZoom && map.doubleClickZoom.disable) map.doubleClickZoom.disable();
@@ -350,15 +364,66 @@
         const inst = instances[mapId];
         if (!inst) return;
         const map = getMap(mapId);
+        // Clear editMode FIRST so detachHandlers' generic dragPan.enable()
+        // path can fire on its own without fighting the suspension flag.
+        inst.editMode = false;
         if (map) {
             detachHandlers(map, inst);
             map.getCanvas().style.cursor = '';
             if (map.doubleClickZoom && map.doubleClickZoom.enable) map.doubleClickZoom.enable();
+            restoreMapInteractions(map, inst);
             teardownPreview(map);
         }
+        // Restore location markers and the global edit-mode flag regardless
+        // of map presence — a SwitchStyle race could leave markers locked.
+        setLocationMarkersDraggable(true);
+        window.__ovcinaOverlayEditMode = false;
         resetInProgress(inst);
         inst.tool = null;
         inst.dotnetRef = null;
+    }
+
+    // ---- Map-handler suspension (#159 sub-fix 2) -------------------------
+
+    function suspendMapInteractions(map, inst) {
+        // Snapshot prior on/off state so we restore exactly what was there.
+        // MapLibre's handler objects each expose .isEnabled() in v3+; default
+        // to true if missing so we err on the side of restoring.
+        const snap = {};
+        try { snap.dragPan = map.dragPan ? safeIsEnabled(map.dragPan, true) : false; } catch (e) { snap.dragPan = false; }
+        try { snap.boxZoom = map.boxZoom ? safeIsEnabled(map.boxZoom, true) : false; } catch (e) { snap.boxZoom = false; }
+        try { snap.touchRotate = !!(map.touchZoomRotate); } catch (e) { snap.touchRotate = false; }
+        inst.suspendedHandlers = snap;
+        try { if (snap.dragPan && map.dragPan.disable) map.dragPan.disable(); } catch (e) { }
+        try { if (snap.boxZoom && map.boxZoom.disable) map.boxZoom.disable(); } catch (e) { }
+        try { if (snap.touchRotate && map.touchZoomRotate.disableRotation) map.touchZoomRotate.disableRotation(); } catch (e) { }
+    }
+
+    function restoreMapInteractions(map, inst) {
+        const snap = inst.suspendedHandlers || { dragPan: true, boxZoom: true, touchRotate: true };
+        try { if (snap.dragPan && map.dragPan && map.dragPan.enable) map.dragPan.enable(); } catch (e) { }
+        try { if (snap.boxZoom && map.boxZoom && map.boxZoom.enable) map.boxZoom.enable(); } catch (e) { }
+        try { if (snap.touchRotate && map.touchZoomRotate && map.touchZoomRotate.enableRotation) map.touchZoomRotate.enableRotation(); } catch (e) { }
+        inst.suspendedHandlers = null;
+    }
+
+    function safeIsEnabled(handler, fallback) {
+        if (!handler) return fallback;
+        if (typeof handler.isEnabled === 'function') return handler.isEnabled();
+        return fallback;
+    }
+
+    // ---- Location-marker draggable toggle (#159 sub-fix 5) ----------------
+
+    // Bridge to the main `ovcinaMap` JS API. The marker registry lives in
+    // `wwwroot/js/maplibre-interop.js`; we go through a public method so
+    // edit-mode coupling stays one-way (overlay → map, never the reverse).
+    function setLocationMarkersDraggable(enabled) {
+        try {
+            if (window.ovcinaMap && typeof window.ovcinaMap.setLocationMarkersDraggable === 'function') {
+                window.ovcinaMap.setLocationMarkersDraggable(!!enabled);
+            }
+        } catch (e) { /* best-effort — never block the editor on marker plumbing */ }
     }
 
     // ---- Handler plumbing -------------------------------------------------
@@ -377,11 +442,15 @@
     }
 
     function detachHandlers(map, inst) {
-        // Always restore map panning — if the user interrupted a freehand,
-        // rectangle, or circle drag mid-stroke (tool switch / exit / nav away),
-        // the matching mouseup never fired and `dragPan` would stay disabled,
-        // leaving the map stuck.
-        if (map && map.dragPan && map.dragPan.enable) map.dragPan.enable();
+        // Skip the per-tool dragPan re-enable while we're still in overlay
+        // edit mode — `enterEditMode` globally suspended dragPan/boxZoom and
+        // `exitEditMode` restores them via restoreMapInteractions. If we
+        // re-enabled here on every tool switch we'd undo that suspension and
+        // map panning would steal click+drag again (#159 sub-fix 2).
+        // Outside edit mode (e.g. dispose-without-exit edge case), keep the
+        // legacy "always re-enable" so an interrupted draw can never strand
+        // the map.
+        if (!inst.editMode && map && map.dragPan && map.dragPan.enable) map.dragPan.enable();
         for (const h of inst.handlers) {
             try {
                 if (h.target === map) map.off(h.event, h.fn);
@@ -821,9 +890,14 @@
         const inst = instances[mapId];
         if (!inst) return;
         const map = getMap(mapId);
+        // Drop the editMode flag before detachHandlers so its dragPan re-enable
+        // path fires unconditionally (the user navigated away — they want a
+        // working map, suspension or no suspension).
+        inst.editMode = false;
         if (map) {
             // detachHandlers also re-enables dragPan if it was disabled mid-draw.
             detachHandlers(map, inst);
+            try { restoreMapInteractions(map, inst); } catch (e) { /* best-effort */ }
             try { teardownPreview(map); } catch (e) { /* map may be gone */ }
             // Remove overlay source + layers so a subsequent remount starts
             // clean — avoids orphaned style-dependent layers when the user
@@ -851,6 +925,10 @@
                 if (map.doubleClickZoom && map.doubleClickZoom.enable) map.doubleClickZoom.enable();
             } catch (e) { /* best-effort */ }
         }
+        // Unlock markers + clear the global edit-mode flag — same belt-and-
+        // suspenders as exitEditMode in case the page was disposed mid-edit.
+        setLocationMarkersDraggable(true);
+        window.__ovcinaOverlayEditMode = false;
         delete instances[mapId];
     }
 

--- a/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
@@ -261,7 +261,16 @@
     }
 
     function ensureIconsLoaded(map) {
-        if (map.__ovcinaOverlayIconsLoaded) return Promise.resolve();
+        // Re-check the registry every call: a basemap `setStyle()` wipes
+        // `map.images`, so a once-cached promise would short-circuit and the
+        // icons never re-register on the new style. If every asset is already
+        // present we hand back the cached promise (resolved); otherwise a
+        // fresh Promise.all repopulates only the missing keys (loadIconImage
+        // is itself guarded by `map.hasImage`).
+        const allRegistered = ICON_ASSETS.every(function (k) { return map.hasImage(k); });
+        if (allRegistered && map.__ovcinaOverlayIconsLoaded) {
+            return map.__ovcinaOverlayIconsLoaded;
+        }
         map.__ovcinaOverlayIconsLoaded = Promise.all(ICON_ASSETS.map(function (k) {
             return loadIconImage(map, k);
         }));
@@ -651,21 +660,30 @@
     // ---- Tool: select (hit-test → emit shapeId to .NET) -------------------
 
     function attachSelectTool(map, inst) {
-        // Cursor turns to pointer over any shape layer for affordance. We
-        // hit-test against all four saved layers (fills, strokes, text, icons).
-        // queryRenderedFeatures honors layer filters, so unrelated map layers
-        // are ignored automatically.
-        const layers = [LYR_FILLS, LYR_STROKES, LYR_TEXT, LYR_ICONS]
-            .filter(function (id) { return map.getLayer(id) != null; });
+        // Resolve the hit-test layer list per-call, not at attach time. A
+        // basemap style switch removes/re-adds the overlay layers; capturing
+        // IDs once would leave queryRenderedFeatures referencing missing
+        // layers and throw, breaking selection.
+        function activeLayers() {
+            return [LYR_FILLS, LYR_STROKES, LYR_TEXT, LYR_ICONS]
+                .filter(function (id) { return map.getLayer(id) != null; });
+        }
 
         const onMove = function (e) {
+            const layers = activeLayers();
             if (layers.length === 0) return;
-            const f = map.queryRenderedFeatures(e.point, { layers: layers });
-            map.getCanvas().style.cursor = (f && f.length > 0) ? 'pointer' : '';
+            try {
+                const f = map.queryRenderedFeatures(e.point, { layers: layers });
+                map.getCanvas().style.cursor = (f && f.length > 0) ? 'pointer' : '';
+            } catch (err) { /* layer disappeared mid-frame — best-effort */ }
         };
         const onClick = function (e) {
+            const layers = activeLayers();
             if (layers.length === 0) return;
-            const features = map.queryRenderedFeatures(e.point, { layers: layers });
+            let features;
+            try {
+                features = map.queryRenderedFeatures(e.point, { layers: layers });
+            } catch (err) { return; }
             if (!features || features.length === 0) {
                 emitSelection(inst, null);
                 return;
@@ -679,15 +697,24 @@
         onMap(map, inst, 'mousemove', onMove);
         onMap(map, inst, 'click', onClick);
         // Delete key fires while the select tool is active and a shape is
-        // selected — .NET decides whether to confirm + remove.
+        // selected — .NET decides whether to confirm + remove. Bail if the
+        // user is typing in a text field (e.g. property panel TextShape input)
+        // so Backspace doesn't double as "delete shape".
         inst.keydownHandler = function (ev) {
-            if (ev.key === 'Delete' || ev.key === 'Backspace') {
-                if (!inst.dotnetRef) return;
-                try { inst.dotnetRef.invokeMethodAsync('OnDeleteRequested'); }
-                catch (e) { /* swallow */ }
-            }
+            if (ev.key !== 'Delete' && ev.key !== 'Backspace') return;
+            if (isEditableTarget(ev.target) || isEditableTarget(document.activeElement)) return;
+            if (!inst.dotnetRef) return;
+            try { inst.dotnetRef.invokeMethodAsync('OnDeleteRequested'); }
+            catch (e) { /* swallow */ }
         };
         window.addEventListener('keydown', inst.keydownHandler);
+    }
+
+    function isEditableTarget(el) {
+        if (!el || !el.tagName) return false;
+        const tag = el.tagName.toUpperCase();
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+        return el.isContentEditable === true;
     }
 
     function emitSelection(inst, shapeId) {


### PR DESCRIPTION
## Summary

Closes #159 — five reported items on the overlay editor (PR #161). Also bundles the Copilot review fixups from PR #161 that landed too late to make the original merge.

| # | Sub-fix | Outcome |
|---|---|---|
| 1 | "The layover menu appears." | **Non-issue.** Sentence truncation; item 2's "however" reveals item 1 as baseline UX setup, not a bug. |
| 2 | Click+drag pans the map instead of drawing | **Fixed.** `enterEditMode` globally suspends `dragPan`/`boxZoom`/touch rotation; `exitEditMode`+`dispose` restore exactly the prior on/off state. Wheel zoom stays on. |
| 3 | Saving / editing errors (screenshots) | **Fixed.** Server's `GetOverlay` and client's load only caught `JsonException` — but `System.Text.Json` throws `NotSupportedException` for unknown polymorphic discriminators. Both ends now catch both. `UpdateOverlay` round-trips the serialized payload before persisting so a corrupt save can't poison the field. |
| 4 | `text-field requires "glyphs" property` warning | **Fixed.** `_rasterStyle` + `_makeRasterStyle` declare `glyphs: demotiles.maplibre.org/...`. **Dev-grade URL** — see follow-up below. |
| 5 | Location-pin drag during edit mode | **Fixed.** New `ovcinaMap.setLocationMarkersDraggable(bool)` toggles every marker; called from `enterEditMode`/`exitEditMode`. `addMarker` checks `window.__ovcinaOverlayEditMode` so re-renders mid-edit (e.g. `setStageFilter`) come up locked too. |

## Bundled Copilot fixups (would have been a follow-up commit on #161)

- Delete/Backspace ignored when an INPUT/TEXTAREA/SELECT/contentEditable holds focus — typing in the property panel's text field no longer opens the delete-confirm popup.
- `ensureIconsLoaded` re-checks `map.hasImage` for every slug so a basemap `setStyle()` (which wipes the image registry) doesn't leave the icon symbol layer permanently empty.
- `attachSelectTool` resolves the hit-test layer list per-call and wraps `queryRenderedFeatures` in try/catch — a basemap switch mid-edit no longer throws.
- `OnStyleLoadedCallback` re-renders `_stagedShapes` (not `_committedShapes`) when `_editMode` is active and re-applies the active selection highlight, so unsaved edits survive a tile-style swap.
- `OnTextChangedAsync` propagates an empty string so users can clear a `TextShape` before retyping.
- Toolbar + property panel icon thumbnails switched from `<img style="color:...">` to `<span>` with `mask-image` + `background-color`. `currentColor` doesn't propagate into an externally loaded SVG via `<img>`, so the previous markup never tinted previews.

## Files (4 changed)

- `src/OvcinaHra.Api/Endpoints/GameEndpoints.cs:170-225` — widen catch to `NotSupportedException`, add round-trip validation in `UpdateOverlay`.
- `src/OvcinaHra.Client/Components/MapView.razor` — widen the load `catch`; the Copilot fixup commit also wires `OnStyleLoadedCallback` to render staged + restore selection.
- `src/OvcinaHra.Client/wwwroot/js/overlay-interop.js` — `suspendMapInteractions`/`restoreMapInteractions`, `setLocationMarkersDraggable` bridge, `editMode` flag, dispose unlock path.
- `src/OvcinaHra.Client/wwwroot/js/map-interop.js` — `glyphs` property on both raster styles, `setLocationMarkersDraggable` public method, `addMarker` honours the global edit-mode flag.

(The Copilot-fixup-bundle commit also touches `MapOverlayToolbar.razor`, `OverlayPropertyPanel.razor`, `ovcinahra-theme.css` — same files PR #161 introduced.)

## Test plan

- [x] `dotnet build OvcinaHra.slnx` — clean (0 warn / 0 err under `TreatWarningsAsErrors=true`).
- [x] `dotnet test --filter ~Overlay` — 4/4 green via Testcontainers PostgreSQL.
- [ ] Manual: open `/games/{id}/map`, enter edit mode → click+drag draws a freehand. Exit → click+drag pans. Wheel zoom works in both modes.
- [ ] Manual: try to drag a location pin during edit mode → pin stays put. Exit → pin moves again.
- [ ] Manual: save a text overlay then reload → DevTools console no longer logs the `glyphs` warning; text renders.
- [ ] Manual: take an existing game with a saved overlay and force-corrupt the JSON in the DB → editor opens with empty list rather than crashing.

## Follow-up

- File a separate issue for **prod glyph hosting** — replace `demotiles.maplibre.org` with a self-hosted Azure Blob font endpoint before the next prod rollout. The TODO comment in `map-interop.js` flags the swap-out point.

## Notes

- No `csproj` `<Version>` bump (auto-bump CI handles).
- No new database migration. No EF Core changes.
- Treasures page (#160) shares `map-interop.js` — `addMarker` signature is unchanged, only its internal initial-draggable now consults a global flag. Backwards-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)