### PR TITLE
feat(skills): catalog + detail (Karta/Upravit/V tomto roce) + per-game grid w/ source badges + drift (closes #153)

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/SkillEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SkillEndpoints.cs
@@ -176,27 +176,29 @@ public static class SkillEndpoints
     private static async Task<Results<NoContent, NotFound, Conflict<ProblemDetails>>> Delete(
         int id, WorldDbContext db)
     {
-        var skill = await db.Skills.SingleOrDefaultAsync(s => s.Id == id);
-        if (skill is null) return TypedResults.NotFound();
+        // Atomic check-and-delete via a single DELETE … WHERE NOT EXISTS so a
+        // concurrent INSERT into GameSkills (between count and delete) cannot
+        // sneak past the "Smazat zablokováno" rule. ExecuteDeleteAsync runs
+        // server-side as one statement; rows-affected disambiguates 404 vs
+        // 409 below.
+        var deleted = await db.Skills
+            .Where(s => s.Id == id
+                && !db.GameSkills.Any(gs => gs.TemplateSkillId == id))
+            .ExecuteDeleteAsync();
 
-        // Hard-block delete when per-game copies reference the template — the
-        // designer brief is explicit (see the "Smazat zablokováno" h4 note).
-        // Organizers must remove the GameSkill copies first; otherwise we
-        // return 409 with a Czech ProblemDetails the client surfaces inline.
+        if (deleted > 0) return TypedResults.NoContent();
+
+        // Either the skill never existed OR it had copies. Disambiguate.
+        var stillExists = await db.Skills.AnyAsync(s => s.Id == id);
+        if (!stillExists) return TypedResults.NotFound();
+
         var copyCount = await db.GameSkills.CountAsync(gs => gs.TemplateSkillId == id);
-        if (copyCount > 0)
+        return TypedResults.Conflict(new ProblemDetails
         {
-            return TypedResults.Conflict(new ProblemDetails
-            {
-                Title = "Dovednost nelze smazat",
-                Detail = $"Šablona má kopie v {copyCount} hrách. Před smazáním je všechny odeber.",
-                Status = StatusCodes.Status409Conflict
-            });
-        }
-
-        db.Skills.Remove(skill);
-        await db.SaveChangesAsync();
-        return TypedResults.NoContent();
+            Title = "Dovednost nelze smazat",
+            Detail = $"Šablona má kopie v {copyCount} hrách. Před smazáním je všechny odeber.",
+            Status = StatusCodes.Status409Conflict
+        });
     }
 
     private static async Task<ProblemDetails?> ValidateBuildingIdsAsync(

--- a/src/OvcinaHra.Api/Endpoints/SkillEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SkillEndpoints.cs
@@ -15,6 +15,7 @@ public static class SkillEndpoints
 
         group.MapGet("/", GetAll);
         group.MapGet("/{id:int}", GetById);
+        group.MapGet("/{id:int}/usage", GetUsage);
         group.MapPost("/", Create);
         group.MapPut("/{id:int}", Update);
         group.MapDelete("/{id:int}", Delete);
@@ -29,7 +30,18 @@ public static class SkillEndpoints
             .OrderBy(s => s.Name)
             .ToListAsync();
 
-        IReadOnlyList<SkillDto> dtos = skills.Select(ToDto).ToList();
+        // Single rollup query for the catalog "Smazat zablokováno" badge —
+        // group-by on GameSkills.TemplateSkillId is bounded by template count
+        // and the column is FK-indexed.
+        var usageMap = await db.GameSkills
+            .Where(gs => gs.TemplateSkillId != null)
+            .GroupBy(gs => gs.TemplateSkillId!.Value)
+            .Select(g => new { TemplateId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.TemplateId, x => x.Count);
+
+        IReadOnlyList<SkillDto> dtos = skills
+            .Select(s => ToDto(s, usageMap.GetValueOrDefault(s.Id, 0)))
+            .ToList();
         return TypedResults.Ok(dtos);
     }
 
@@ -40,7 +52,27 @@ public static class SkillEndpoints
             .SingleOrDefaultAsync(s => s.Id == id);
         if (skill is null) return TypedResults.NotFound();
 
-        return TypedResults.Ok(ToDto(skill));
+        var usageCount = await db.GameSkills.CountAsync(gs => gs.TemplateSkillId == id);
+        return TypedResults.Ok(ToDto(skill, usageCount));
+    }
+
+    /// <summary>
+    /// Per-skill usage rollup. Drives the SkillDetail "V tomto roce" tab.
+    /// Drift detection stays client-side per the design brief — this endpoint
+    /// just answers "where are the copies?".
+    /// </summary>
+    private static async Task<Results<Ok<SkillUsageDto>, NotFound>> GetUsage(int id, WorldDbContext db)
+    {
+        var exists = await db.Skills.AnyAsync(s => s.Id == id);
+        if (!exists) return TypedResults.NotFound();
+
+        var games = await db.GameSkills
+            .Where(gs => gs.TemplateSkillId == id)
+            .OrderByDescending(gs => gs.Game.StartDate)
+            .Select(gs => new SkillUsageGameDto(gs.GameId, gs.Id, gs.Game.Name, gs.Game.Edition))
+            .ToListAsync();
+
+        return TypedResults.Ok(new SkillUsageDto(id, games.Count, games));
     }
 
     private static async Task<Results<Created<SkillDto>, BadRequest<ProblemDetails>, Conflict<ProblemDetails>>> Create(
@@ -141,14 +173,27 @@ public static class SkillEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Results<NoContent, NotFound>> Delete(
+    private static async Task<Results<NoContent, NotFound, Conflict<ProblemDetails>>> Delete(
         int id, WorldDbContext db)
     {
         var skill = await db.Skills.SingleOrDefaultAsync(s => s.Id == id);
         if (skill is null) return TypedResults.NotFound();
 
-        // Deleting a template is permitted even if GameSkill copies reference it —
-        // the FK uses SetNull on cascade, so per-game copies survive as standalone skills.
+        // Hard-block delete when per-game copies reference the template — the
+        // designer brief is explicit (see the "Smazat zablokováno" h4 note).
+        // Organizers must remove the GameSkill copies first; otherwise we
+        // return 409 with a Czech ProblemDetails the client surfaces inline.
+        var copyCount = await db.GameSkills.CountAsync(gs => gs.TemplateSkillId == id);
+        if (copyCount > 0)
+        {
+            return TypedResults.Conflict(new ProblemDetails
+            {
+                Title = "Dovednost nelze smazat",
+                Detail = $"Šablona má kopie v {copyCount} hrách. Před smazáním je všechny odeber.",
+                Status = StatusCodes.Status409Conflict
+            });
+        }
+
         db.Skills.Remove(skill);
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
@@ -172,7 +217,7 @@ public static class SkillEndpoints
         return null;
     }
 
-    private static SkillDto ToDto(Skill skill) => new(
+    private static SkillDto ToDto(Skill skill, int usageCount = 0) => new(
         skill.Id,
         skill.Name,
         skill.Category,
@@ -180,5 +225,6 @@ public static class SkillEndpoints
         skill.Effect,
         skill.RequirementNotes,
         skill.ImagePath,
-        skill.BuildingRequirements.Select(r => r.BuildingId).ToList());
+        skill.BuildingRequirements.Select(r => r.BuildingId).ToList(),
+        UsageCount: usageCount);
 }

--- a/src/OvcinaHra.Client/Components/BuildingChipPicker.razor
+++ b/src/OvcinaHra.Client/Components/BuildingChipPicker.razor
@@ -1,0 +1,83 @@
+@* Multi-select building chip picker (issue #153).
+   Generic — designed to be reused on the future Spells edit form too,
+   so the API stays building-agnostic-shaped: caller passes an `int[]`
+   selection and gets back changes via EventCallback.
+
+   Loads /api/buildings once on first render unless the caller pre-loaded
+   them (Buildings parameter). Each chip toggles in/out of the selection. *@
+
+@inject ApiClient Api
+
+<div class="oh-sk-bld-picker" role="group" aria-label="Volba požadovaných budov">
+    @if (_buildings is null)
+    {
+        <span class="text-muted small">Načítám budovy…</span>
+    }
+    else if (_buildings.Count == 0)
+    {
+        <span class="text-muted small fst-italic">V katalogu nejsou žádné budovy.</span>
+    }
+    else
+    {
+        @foreach (var b in _buildings)
+        {
+            var isOn = SelectedBuildingIds.Contains(b.Id);
+            <button type="button" class="oh-sk-bld-picker-toggle @(isOn ? "is-on" : "")"
+                    title="@b.Name" aria-pressed="@isOn"
+                    @onclick="() => ToggleAsync(b.Id)">
+                <i class="bi bi-houses" aria-hidden="true"></i>@b.Name
+            </button>
+        }
+    }
+</div>
+
+@code {
+    /// <summary>Currently selected building ids (subset of <see cref="Buildings"/>).</summary>
+    [Parameter] public IReadOnlyList<int> SelectedBuildingIds { get; set; } = Array.Empty<int>();
+    [Parameter] public EventCallback<IReadOnlyList<int>> SelectedBuildingIdsChanged { get; set; }
+
+    /// <summary>Optional pre-loaded catalog. When null, we fetch /api/buildings
+    /// once on first render. Passing a list lets parents share one fetch
+    /// across multiple pickers on the same page.</summary>
+    [Parameter] public IReadOnlyList<BuildingListDto>? Buildings { get; set; }
+
+    private List<BuildingListDto>? _buildings;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Buildings is not null)
+        {
+            _buildings = Buildings.OrderBy(b => b.Name).ToList();
+            return;
+        }
+        try
+        {
+            var fetched = await Api.GetListAsync<BuildingListDto>("/api/buildings");
+            _buildings = fetched.OrderBy(b => b.Name).ToList();
+        }
+        catch
+        {
+            // Network failure — render the empty state. Caller's edit flow
+            // can still save with the existing SelectedBuildingIds untouched.
+            _buildings = new List<BuildingListDto>();
+        }
+    }
+
+    protected override void OnParametersSet()
+    {
+        // If parent passes a different pre-loaded list later, refresh.
+        if (Buildings is not null && !ReferenceEquals(_buildings, Buildings))
+        {
+            _buildings = Buildings.OrderBy(b => b.Name).ToList();
+        }
+    }
+
+    private async Task ToggleAsync(int id)
+    {
+        var next = SelectedBuildingIds.Contains(id)
+            ? SelectedBuildingIds.Where(i => i != id).ToList()
+            : SelectedBuildingIds.Concat(new[] { id }).Distinct().ToList();
+        SelectedBuildingIds = next;
+        await SelectedBuildingIdsChanged.InvokeAsync(next);
+    }
+}

--- a/src/OvcinaHra.Client/Components/BuildingChipPicker.razor
+++ b/src/OvcinaHra.Client/Components/BuildingChipPicker.razor
@@ -21,7 +21,7 @@
     {
         @foreach (var b in _buildings)
         {
-            var isOn = SelectedBuildingIds.Contains(b.Id);
+            var isOn = _selection.Contains(b.Id);
             <button type="button" class="oh-sk-bld-picker-toggle @(isOn ? "is-on" : "")"
                     title="@b.Name" aria-pressed="@isOn"
                     @onclick="() => ToggleAsync(b.Id)">
@@ -42,6 +42,12 @@
     [Parameter] public IReadOnlyList<BuildingListDto>? Buildings { get; set; }
 
     private List<BuildingListDto>? _buildings;
+
+    /// <summary>Local selection mirror. Standard Blazor controlled-component
+    /// pattern — never mutate <see cref="SelectedBuildingIds"/> directly
+    /// (it's a [Parameter]). The parent re-passes the new list after the
+    /// EventCallback fires; we sync via OnParametersSet.</summary>
+    private HashSet<int> _selection = new();
 
     protected override async Task OnInitializedAsync()
     {
@@ -65,8 +71,20 @@
 
     protected override void OnParametersSet()
     {
-        // If parent passes a different pre-loaded list later, refresh.
-        if (Buildings is not null && !ReferenceEquals(_buildings, Buildings))
+        // Sync local selection from parameter on every re-render. SetEquals
+        // guards us against rebuilding when the parent re-passes the same
+        // logical contents.
+        if (!_selection.SetEquals(SelectedBuildingIds))
+        {
+            _selection = new HashSet<int>(SelectedBuildingIds);
+        }
+
+        // Refresh _buildings only when we have a fresh pre-loaded list whose
+        // contents (not reference) differ. The previous reference-equality
+        // guard was a no-op because we always cloned on Init.
+        if (Buildings is not null && _buildings is not null
+            && !Buildings.Select(b => b.Id).OrderBy(i => i)
+                .SequenceEqual(_buildings.Select(b => b.Id).OrderBy(i => i)))
         {
             _buildings = Buildings.OrderBy(b => b.Name).ToList();
         }
@@ -74,10 +92,14 @@
 
     private async Task ToggleAsync(int id)
     {
-        var next = SelectedBuildingIds.Contains(id)
-            ? SelectedBuildingIds.Where(i => i != id).ToList()
-            : SelectedBuildingIds.Concat(new[] { id }).Distinct().ToList();
-        SelectedBuildingIds = next;
-        await SelectedBuildingIdsChanged.InvokeAsync(next);
+        // Mutate the LOCAL selection, then notify the parent. Never assign
+        // to SelectedBuildingIds directly — Blazor will overwrite our
+        // mutation on the next param flush, and assigning a [Parameter]
+        // is a misuse pattern Copilot flagged.
+        if (_selection.Contains(id)) _selection.Remove(id);
+        else _selection.Add(id);
+
+        var snapshot = _selection.ToList();
+        await SelectedBuildingIdsChanged.InvokeAsync(snapshot);
     }
 }

--- a/src/OvcinaHra.Client/Components/ClassPip.razor
+++ b/src/OvcinaHra.Client/Components/ClassPip.razor
@@ -1,0 +1,37 @@
+@* Single class pip — exactly ONE weapon glyph in primary green when
+   ClassRestriction is set, italic "Pro všechna povolání" line otherwise
+   (issue #153 designer h4 note: "single pip"; explicit reject of any
+   4-pip array). *@
+
+@if (Class.HasValue)
+{
+    <span class="oh-sk-class-pip" title="@($"Pro povolání: {Class.Value.GetDisplayName()}")">
+        <i class="bi @ClassIcon(Class.Value)" aria-hidden="true"></i>
+    </span>
+}
+else if (ShowAllLine)
+{
+    <span class="oh-sk-class-line">Pro všechna povolání</span>
+}
+
+@code {
+    [Parameter] public PlayerClass? Class { get; set; }
+
+    /// <summary>When the skill is unrestricted, show the muted Czech line
+    /// instead of an empty cell. Default true; cells can opt out for visual
+    /// density (the column header + chip glyph already imply class scope).</summary>
+    [Parameter] public bool ShowAllLine { get; set; } = true;
+
+    /// <summary>Bootstrap Icons mapping — same icons used elsewhere in the
+    /// codebase (Items class pips on ItemListDto). Aligns the visual language
+    /// across grids: shield = warrior, bullseye = archer, magic = mage,
+    /// incognito = thief.</summary>
+    private static string ClassIcon(PlayerClass c) => c switch
+    {
+        PlayerClass.Warrior => "bi-shield-shaded",
+        PlayerClass.Archer  => "bi-bullseye",
+        PlayerClass.Mage    => "bi-magic",
+        PlayerClass.Thief   => "bi-incognito",
+        _ => "bi-question-circle"
+    };
+}

--- a/src/OvcinaHra.Client/Components/SkillBuildingChips.razor
+++ b/src/OvcinaHra.Client/Components/SkillBuildingChips.razor
@@ -1,0 +1,49 @@
+@* Read-only building requirement chip cluster (issue #153).
+     · Up to MaxVisible chips (3 by default) + "+ N více" overflow chip
+     · Each chip click navigates to /buildings/{id}
+     · Empty state = explicit "Žádná budova" muted text (designer h4 rule) *@
+
+@inject NavigationManager Nav
+
+@if (BuildingIds.Count == 0)
+{
+    <span class="oh-sk-bld-empty">Žádná budova</span>
+}
+else
+{
+    <div class="oh-sk-bld-cluster">
+        @foreach (var id in BuildingIds.Take(MaxVisible))
+        {
+            var captured = id;
+            <button type="button" class="oh-sk-bld-chip" title="@($"Otevřít budovu #{captured}")"
+                    @onclick:stopPropagation="true"
+                    @onclick="() => GoToBuilding(captured)">
+                <i class="bi bi-houses"></i>@LookupName(captured)
+            </button>
+        }
+        @if (BuildingIds.Count > MaxVisible)
+        {
+            <span class="oh-sk-bld-overflow" title="@($"Plný seznam: {BuildingIds.Count} budov")">+ @(BuildingIds.Count - MaxVisible) více</span>
+        }
+    </div>
+}
+
+@code {
+    /// <summary>IDs of required buildings, in display order.</summary>
+    [Parameter] public IReadOnlyList<int> BuildingIds { get; set; } = Array.Empty<int>();
+
+    /// <summary>Optional name lookup so the cluster can render building names
+    /// instead of bare ids. Caller passes a dictionary it already loaded
+    /// once for the page (catalog list, peek, karta, etc.). Falls back to
+    /// "#{id}" when the lookup is empty or the id isn't in it.</summary>
+    [Parameter] public IReadOnlyDictionary<int, string>? Names { get; set; }
+
+    [Parameter] public int MaxVisible { get; set; } = 3;
+
+    private string LookupName(int id)
+        => (Names is not null && Names.TryGetValue(id, out var name) && !string.IsNullOrWhiteSpace(name))
+            ? name
+            : $"#{id}";
+
+    private void GoToBuilding(int id) => Nav.NavigateTo($"/buildings/{id}");
+}

--- a/src/OvcinaHra.Client/Components/SkillCategoryChip.razor
+++ b/src/OvcinaHra.Client/Components/SkillCategoryChip.razor
@@ -1,0 +1,19 @@
+@* Skill category chip — 1.5px outlined pill + colored dot + Czech label
+   (issue #153). Reads --oh-skill-{key} from the global palette tokens
+   declared on :root in ovcinahra-theme.css. *@
+
+<span class="oh-sk-cat" data-cat="@CategoryKey(Category)" title="@($"Kategorie: {Category.GetDisplayName()}")">
+    @Category.GetDisplayName()
+</span>
+
+@code {
+    [Parameter] public SkillCategory Category { get; set; }
+
+    private static string CategoryKey(SkillCategory c) => c switch
+    {
+        SkillCategory.Class     => "class",
+        SkillCategory.Adventure => "adventure",
+        SkillCategory.Quest     => "quest",
+        _ => "class"
+    };
+}

--- a/src/OvcinaHra.Client/Pages/Games/GameSkills.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameSkills.razor
@@ -7,10 +7,21 @@
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">Dovednosti hry</h1>
     <div class="d-flex gap-2">
-        <button class="btn btn-primary" @onclick="OpenChooserPopup">
-            <i class="bi bi-plus"></i> Přidat dovednost
+        @* Two named actions per #153 designer note "Šablona ↔ kopie": each
+           GameSkill is an independent fork — making the source explicit at
+           create-time helps organizers think about it that way. The original
+           combined chooser popup remains reachable for backwards-compat but
+           the entry points lead straight to the right step. *@
+        <button class="btn btn-primary" type="button" @onclick="OpenFromTemplateStep"
+                title="Vytvořit kopii z existující šablony">
+            <i class="bi bi-stack"></i> Přidat ze šablony
         </button>
-        <button class="btn btn-outline-secondary" @onclick="@(() => Nav.NavigateTo("/games"))">
+        <button class="btn btn-outline-primary" type="button" @onclick="OpenCustomEdit"
+                title="Vytvořit dovednost úplně od nuly">
+            <i class="bi bi-plus-square"></i> Od nuly
+        </button>
+        <button class="btn btn-outline-secondary" type="button"
+                @onclick="@(() => Nav.NavigateTo("/games"))">
             <i class="bi bi-arrow-left"></i> Zpět na hry
         </button>
     </div>
@@ -31,35 +42,95 @@ else
     }
     else
     {
-        <OvcinaGrid Data="@gameSkills" KeyFieldName="Id" LayoutKey="grid-layout-game-skills"
+        @* LayoutKey bumped grid-layout-game-skills → -v2 because the column
+           schema changed (new source / drift / chip / pip cells, renamed
+           Povolání → Třída). Memory rule: feedback_ovcinagrid_layoutkey_bump. *@
+        <OvcinaGrid Data="@gameSkills" KeyFieldName="Id" LayoutKey="grid-layout-game-skills-v2"
                     RowClick="@(e => OpenEditPopup((GameSkillDto)e.Grid.GetDataItem(e.VisibleIndex)))">
             <Columns>
-                <DxGridDataColumn FieldName="Name" Caption="Název" />
-                <DxGridDataColumn FieldName="ClassRestriction" Caption="Povolání" Width="140px">
+                @* Source badge — Šablona #N when copied from a template, Od nuly when blank *@
+                <DxGridDataColumn FieldName="TemplateSkillId" Caption="Zdroj" Width="120px">
                     <CellDisplayTemplate>
-                        @(((PlayerClass?)context.Value).GetClassRestrictionLabel())
-                    </CellDisplayTemplate>
-                </DxGridDataColumn>
-                <DxGridDataColumn FieldName="Category" Caption="Kategorie" Width="140px">
-                    <CellDisplayTemplate>
-                        @(((SkillCategory)context.Value).GetDisplayName())
-                    </CellDisplayTemplate>
-                </DxGridDataColumn>
-                <DxGridDataColumn FieldName="XpCost" Caption="XP" Width="100px" />
-                <DxGridDataColumn FieldName="LevelRequirement" Caption="Úroveň" Width="140px">
-                    <CellDisplayTemplate>
-                        @{
-                            var lvl = (int?)context.Value;
+                        @{ var row = (GameSkillDto)context.DataItem; }
+                        @if (row.TemplateSkillId is int tid)
+                        {
+                            <span class="oh-sk-src-badge oh-sk-src-badge--tpl" title="@($"Vytvořeno ze šablony #{tid}")">Šablona #@tid</span>
                         }
-                        @(lvl.HasValue ? lvl.Value.ToString() : "Bez požadavku")
+                        else
+                        {
+                            <span class="oh-sk-src-badge oh-sk-src-badge--blank" title="Vytvořeno od nuly">Od nuly</span>
+                        }
                     </CellDisplayTemplate>
                 </DxGridDataColumn>
+
+                @* Drift glyph — visible only when per-game fields diverge from the template.
+                   Detection is client-side per the design brief. *@
+                <DxGridDataColumn Caption="≠" Width="48px" AllowSort="false" AllowGroup="false">
+                    <CellDisplayTemplate>
+                        @{ var row = (GameSkillDto)context.DataItem; }
+                        @if (HasDrift(row))
+                        {
+                            <span class="oh-sk-drift" title="Pole se liší od šablony">≠</span>
+                        }
+                    </CellDisplayTemplate>
+                </DxGridDataColumn>
+
+                <DxGridDataColumn FieldName="Name" Caption="Název" MinWidth="180" />
+
+                <DxGridDataColumn FieldName="Category" Caption="Kategorie" Width="150px">
+                    <CellDisplayTemplate>
+                        @{ var row = (GameSkillDto)context.DataItem; }
+                        <SkillCategoryChip Category="@row.Category" />
+                    </CellDisplayTemplate>
+                </DxGridDataColumn>
+
+                <DxGridDataColumn FieldName="ClassRestriction" Caption="Třída" Width="120px">
+                    <CellDisplayTemplate>
+                        @{ var row = (GameSkillDto)context.DataItem; }
+                        <ClassPip Class="@row.ClassRestriction" ShowAllLine="false" />
+                    </CellDisplayTemplate>
+                </DxGridDataColumn>
+
+                <DxGridDataColumn FieldName="BuildingRequirementIds" Caption="Budovy" Width="220px"
+                                  AllowSort="false" AllowGroup="false">
+                    <CellDisplayTemplate>
+                        @{ var row = (GameSkillDto)context.DataItem; }
+                        <SkillBuildingChips BuildingIds="@row.BuildingRequirementIds" Names="@buildingNames" MaxVisible="3" />
+                    </CellDisplayTemplate>
+                </DxGridDataColumn>
+
+                <DxGridDataColumn FieldName="XpCost" Caption="XP" Width="80px">
+                    <CellDisplayTemplate>
+                        @{ var row = (GameSkillDto)context.DataItem; }
+                        <span class="oh-sk-xp @(row.XpCost == 0 ? "oh-sk-xp--zero" : "")" title="@($"Cena: {row.XpCost} XP")">@row.XpCost XP</span>
+                    </CellDisplayTemplate>
+                </DxGridDataColumn>
+
+                <DxGridDataColumn FieldName="LevelRequirement" Caption="Úroveň" Width="100px">
+                    <CellDisplayTemplate>
+                        @{ var row = (GameSkillDto)context.DataItem; var lvl = row.LevelRequirement; }
+                        @if (lvl.HasValue)
+                        {
+                            <span class="oh-sk-lvl" title="Min. úroveň postavy">Lv. @lvl.Value</span>
+                        }
+                        else
+                        {
+                            <span class="text-muted small">—</span>
+                        }
+                    </CellDisplayTemplate>
+                </DxGridDataColumn>
+
+                <DxGridDataColumn FieldName="Effect" Caption="Efekt" MinWidth="240" Visible="false">
+                    <CellDisplayTemplate>
+                        @{ var row = (GameSkillDto)context.DataItem; }
+                        <span class="oh-sk-c-fx" title="@row.Effect">@(row.Effect ?? "")</span>
+                    </CellDisplayTemplate>
+                </DxGridDataColumn>
+
                 <DxGridDataColumn Caption="" Width="60px" AllowSort="false" AllowGroup="false">
                     <CellDisplayTemplate>
-                        @{
-                            var row = (GameSkillDto)context.DataItem;
-                        }
-                        <button class="btn btn-sm btn-outline-danger"
+                        @{ var row = (GameSkillDto)context.DataItem; }
+                        <button class="btn btn-sm btn-outline-danger" type="button"
                                 title="Smazat"
                                 @onclick="() => OpenDeletePopup(row)"
                                 @onclick:stopPropagation="true">
@@ -197,6 +268,17 @@ else
                 </div>
             </DxFormLayoutItem>
 
+            @* Per-game-only fork fields — XpCost + LevelRequirement do not
+               exist on the catalog Skill template; they live on this fork
+               only. The banner makes that explicit per the #153 brief
+               ("Tato úprava ovlivní jen tuto hru, ne šablonu" hint). *@
+            <DxFormLayoutItem ColSpanMd="12">
+                <div class="oh-sk-pg-only">
+                    <div class="oh-sk-pg-only-head"><i class="bi bi-controller"></i> Pouze v této hře</div>
+                    <p class="oh-sk-pg-fork-hint">Cena v XP a požadovaná úroveň jsou per-hru — neuloží se zpět do šablony.</p>
+                </div>
+            </DxFormLayoutItem>
+
             <DxFormLayoutItem Caption="Cena v XP" ColSpanMd="12">
                 <DxSpinEdit @bind-Value="@xpCost" MinValue="0" />
             </DxFormLayoutItem>
@@ -328,6 +410,29 @@ else
 
     private IEnumerable<BuildingListDto> AvailableBuildings
         => allBuildings.Where(b => !editBuildingIds.Contains(b.Id));
+
+    /// <summary>
+    /// True when any per-game field on the GameSkill diverges from its
+    /// template Skill. Per-game-only fields (XpCost, LevelRequirement) are
+    /// excluded — they're expected to vary by design. Detection happens
+    /// client-side per the #153 brief — no server roundtrip needed.
+    /// </summary>
+    private bool HasDrift(GameSkillDto gs)
+    {
+        if (!gs.TemplateSkillId.HasValue) return false;
+        var template = allTemplates.FirstOrDefault(t => t.Id == gs.TemplateSkillId.Value);
+        if (template is null) return false;
+        if (!string.Equals(gs.Name, template.Name, StringComparison.Ordinal)) return true;
+        if (gs.Category != template.Category) return true;
+        if (gs.ClassRestriction != template.ClassRestriction) return true;
+        if (!StringEqualOrBothBlank(gs.Effect, template.Effect)) return true;
+        if (!StringEqualOrBothBlank(gs.RequirementNotes, template.RequirementNotes)) return true;
+        if (!gs.BuildingRequirementIds.OrderBy(i => i).SequenceEqual(template.RequiredBuildingIds.OrderBy(i => i))) return true;
+        return false;
+    }
+
+    private static bool StringEqualOrBothBlank(string? a, string? b)
+        => string.Equals(a ?? string.Empty, b ?? string.Empty, StringComparison.Ordinal);
 
     protected override async Task OnParametersSetAsync()
     {

--- a/src/OvcinaHra.Client/Pages/Games/GameSkills.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameSkills.razor
@@ -345,6 +345,10 @@ else
     private bool loading = true;
     private List<GameSkillDto> gameSkills = [];
     private List<SkillDto> allTemplates = [];
+    /// <summary>Indexed lookup populated whenever <see cref="allTemplates"/>
+    /// changes. Used by <see cref="HasDrift"/> to avoid an O(N) FirstOrDefault
+    /// scan per row during grid rendering.</summary>
+    private Dictionary<int, SkillDto> templatesById = [];
     private List<BuildingListDto> allBuildings = [];
     private Dictionary<int, string> buildingNames = [];
 
@@ -420,8 +424,7 @@ else
     private bool HasDrift(GameSkillDto gs)
     {
         if (!gs.TemplateSkillId.HasValue) return false;
-        var template = allTemplates.FirstOrDefault(t => t.Id == gs.TemplateSkillId.Value);
-        if (template is null) return false;
+        if (!templatesById.TryGetValue(gs.TemplateSkillId.Value, out var template)) return false;
         if (!string.Equals(gs.Name, template.Name, StringComparison.Ordinal)) return true;
         if (gs.Category != template.Category) return true;
         if (gs.ClassRestriction != template.ClassRestriction) return true;
@@ -448,6 +451,7 @@ else
             gameSkills = gs.ToList();
             var all = await SkillSvc.GetAllAsync();
             allTemplates = all.ToList();
+            templatesById = allTemplates.ToDictionary(t => t.Id);
             allBuildings = await Api.GetListAsync<BuildingListDto>("/api/buildings");
             buildingNames = allBuildings.ToDictionary(b => b.Id, b => b.Name);
         }

--- a/src/OvcinaHra.Client/Pages/Skills/SkillDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Skills/SkillDetail.razor
@@ -103,12 +103,18 @@ else
                     <DxComboBox Data="@categoryValues" @bind-Value="@editModel.Category"
                                 TextFieldName="Display" ValueFieldName="Value" />
                 </DxFormLayoutItem>
-                <DxFormLayoutItem Caption="Pro povolání" ColSpanMd="12"
-                                  Helper="Nech prázdné pro neomezenou dovednost.">
-                    <DxComboBox Data="@classValues" @bind-Value="@editModel.ClassRestriction"
-                                TextFieldName="Display" ValueFieldName="Value"
-                                ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
-                </DxFormLayoutItem>
+                @* ClassRestriction is meaningful only on Category=Class skills.
+                   The Adventure / Quest categories never gate by class — keep
+                   the field hidden so users don't save inconsistent rows. *@
+                @if (editModel.Category == SkillCategory.Class)
+                {
+                    <DxFormLayoutItem Caption="Pro povolání" ColSpanMd="12"
+                                      Helper="Nech prázdné pro neomezenou dovednost.">
+                        <DxComboBox Data="@classValues" @bind-Value="@editModel.ClassRestriction"
+                                    TextFieldName="Display" ValueFieldName="Value"
+                                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                    </DxFormLayoutItem>
+                }
             </DxFormLayoutGroup>
 
             <DxFormLayoutGroup Caption="Obsah" ColSpanMd="12">
@@ -238,7 +244,24 @@ else
     private record CategoryOption(SkillCategory Value, string Display);
     private record ClassOption(PlayerClass Value, string Display);
 
-    protected override async Task OnInitializedAsync() => await LoadAsync();
+    /// <summary>Tracks the last Id we loaded so navigating /skills/{a} →
+    /// /skills/{b} (Blazor reuses the component instance) re-fetches.
+    /// `OnInitializedAsync` only fires once and would leave us stuck on
+    /// the original skill.</summary>
+    private int _loadedForId = -1;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Id != _loadedForId)
+        {
+            _loadedForId = Id;
+            // Reset transient tab state so we don't carry V-tomto-roce data
+            // from the previous skill into the new one.
+            usage = null;
+            activeTab = "karta";
+            await LoadAsync();
+        }
+    }
 
     private async Task LoadAsync()
     {
@@ -358,7 +381,10 @@ else
 
         public UpdateSkillRequest ToUpdateRequest() => new(
             Name.Trim(),
-            ClassRestriction,
+            // Gate ClassRestriction on Category — non-Class skills cannot
+            // carry a class lock per the rule the GameSkills + inline-creator
+            // flows already follow.
+            Category == SkillCategory.Class ? ClassRestriction : null,
             string.IsNullOrWhiteSpace(Effect) ? null : Effect.Trim(),
             string.IsNullOrWhiteSpace(RequirementNotes) ? null : RequirementNotes.Trim(),
             RequiredBuildingIds.ToList(),

--- a/src/OvcinaHra.Client/Pages/Skills/SkillDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Skills/SkillDetail.razor
@@ -1,0 +1,367 @@
+@page "/skills/{Id:int}"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject NavigationManager Nav
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+<div class="d-flex align-items-center gap-3 mb-3">
+    <button class="btn btn-sm btn-outline-secondary" type="button"
+            @onclick='() => Nav.NavigateTo("/skills")'>
+        <i class="bi bi-arrow-left"></i> Zpět
+    </button>
+    <h1 class="mb-0">@(skill?.Name ?? "Dovednost")</h1>
+</div>
+
+@if (loading)
+{
+    <p class="text-muted">Načítám…</p>
+}
+else if (skill is null && error is not null)
+{
+    <div class="alert alert-danger d-flex align-items-center gap-2">
+        <i class="bi bi-wifi-off"></i>
+        <span>Nepodařilo se načíst dovednost: @error</span>
+        <button type="button" class="btn btn-sm btn-outline-primary ms-auto" @onclick="LoadAsync">Zkusit znovu</button>
+    </div>
+}
+else if (skill is null)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-emoji-frown fs-1 d-block mb-2"></i>
+        <p>Dovednost nenalezena.</p>
+    </div>
+}
+else
+{
+    <div class="d-flex gap-2 mb-3">
+        <button class="btn btn-sm @(activeTab == "karta" ? "btn-primary" : "btn-outline-primary")"
+                @onclick='() => activeTab = "karta"'>
+            <i class="bi bi-bookmark-fill"></i> Karta
+        </button>
+        <button class="btn btn-sm @(activeTab == "upravit" ? "btn-primary" : "btn-outline-primary")"
+                @onclick='() => activeTab = "upravit"'>
+            <i class="bi bi-pencil"></i> Upravit
+        </button>
+        <button class="btn btn-sm @(activeTab == "usage" ? "btn-primary" : "btn-outline-primary")"
+                @onclick="OpenUsageTabAsync">
+            <i class="bi bi-stack"></i> V tomto roce
+            @if (skill.UsageCount > 0)
+            {
+                <span class="badge bg-light text-dark ms-1">@skill.UsageCount</span>
+            }
+        </button>
+    </div>
+
+    @if (activeTab == "karta")
+    {
+        <div class="oh-sk-karta-grid">
+            <article class="oh-sk-karta" style="@KartaStyle(skill.Category)">
+                <h2 class="oh-sk-karta-name">@skill.Name</h2>
+                <div class="oh-sk-karta-meta">
+                    <SkillCategoryChip Category="@skill.Category" />
+                    <ClassPip Class="@skill.ClassRestriction" ShowAllLine="true" />
+                </div>
+                <hr class="oh-sk-karta-sep" />
+                <p class="oh-sk-karta-fx">@(string.IsNullOrWhiteSpace(skill.Effect) ? "(text karty zatím prázdný)" : skill.Effect)</p>
+                @if (!string.IsNullOrWhiteSpace(skill.RequirementNotes))
+                {
+                    <p class="oh-sk-karta-reqnote">@skill.RequirementNotes</p>
+                }
+            </article>
+
+            <aside class="oh-sk-karta-side">
+                <div class="oh-sk-karta-side-block">
+                    <h6>Požadované budovy</h6>
+                    <SkillBuildingChips BuildingIds="@skill.RequiredBuildingIds" Names="@buildingNames" MaxVisible="6" />
+                </div>
+                <div class="oh-sk-karta-side-block">
+                    <h6>Kopie ve hrách</h6>
+                    @if (skill.UsageCount == 0)
+                    {
+                        <p class="text-muted small mb-0 fst-italic">Žádné kopie — šablona je v katalogu, ale dosud nebyla přidána do žádné hry.</p>
+                    }
+                    else
+                    {
+                        <p class="mb-0">
+                            <strong class="oh-sk-tpl-badge">@skill.UsageCount</strong>
+                            <span class="text-muted small">— viz záložka „V tomto roce".</span>
+                        </p>
+                    }
+                </div>
+            </aside>
+        </div>
+    }
+    else if (activeTab == "upravit")
+    {
+        <DxFormLayout>
+            <DxFormLayoutGroup Caption="Identita" ColSpanMd="12">
+                <DxFormLayoutItem Caption="Název" ColSpanMd="8">
+                    <DxTextBox @bind-Text="@editModel.Name" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Kategorie" ColSpanMd="4">
+                    <DxComboBox Data="@categoryValues" @bind-Value="@editModel.Category"
+                                TextFieldName="Display" ValueFieldName="Value" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Pro povolání" ColSpanMd="12"
+                                  Helper="Nech prázdné pro neomezenou dovednost.">
+                    <DxComboBox Data="@classValues" @bind-Value="@editModel.ClassRestriction"
+                                TextFieldName="Display" ValueFieldName="Value"
+                                ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+
+            <DxFormLayoutGroup Caption="Obsah" ColSpanMd="12">
+                <DxFormLayoutItem ColSpanMd="12">
+                    <div class="oh-sacred-banner">
+                        <i class="bi bi-shield-fill-exclamation"></i>
+                        <span>Text efektu se zobrazuje hráčům <strong>doslovně</strong>. Žádné formátování ani zkracování — co napíšeš, to vidí.</span>
+                    </div>
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Efekt (text karty — verbatim)" ColSpanMd="12">
+                    <DxMemo @bind-Text="@editModel.Effect" Rows="4" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Poznámky k požadavkům" ColSpanMd="12">
+                    <DxMemo @bind-Text="@editModel.RequirementNotes" Rows="2" />
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+
+            <DxFormLayoutGroup Caption="Budovy" ColSpanMd="12">
+                <DxFormLayoutItem ColSpanMd="12"
+                                  Helper="Vyber všechny budovy, které musí v dané hře existovat, aby se dovednost dala používat.">
+                    <BuildingChipPicker SelectedBuildingIds="@editModel.RequiredBuildingIds"
+                                        SelectedBuildingIdsChanged="OnBuildingsChanged" />
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+        </DxFormLayout>
+
+        @if (saveError is not null)
+        {
+            <div class="alert alert-danger mt-3">@saveError</div>
+        }
+
+        <div class="d-flex gap-2 mt-3">
+            @if (skill.UsageCount > 0)
+            {
+                <span class="oh-sk-delete-blocked" title="@($"Šablona má kopie v {skill.UsageCount} hrách — před smazáním je všechny odeber.")">
+                    <i class="bi bi-lock-fill"></i> Smazat zablokováno — kopie v @skill.UsageCount hrách
+                </span>
+            }
+            else
+            {
+                <button class="btn btn-outline-danger" type="button"
+                        @onclick="() => isDeleteVisible = true" disabled="@isSaving">
+                    <i class="bi bi-trash"></i> Smazat
+                </button>
+            }
+            <div style="flex:1"></div>
+            <button class="btn btn-secondary" type="button" @onclick='() => activeTab = "karta"' disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" type="button" @onclick="SaveAsync"
+                    disabled="@(isSaving || string.IsNullOrWhiteSpace(editModel.Name))">
+                @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Uložit
+            </button>
+        </div>
+    }
+    else if (activeTab == "usage")
+    {
+        @if (usage is null)
+        {
+            <p class="text-muted">Načítám…</p>
+        }
+        else if (usage.CopiesCount == 0)
+        {
+            <div class="oh-sk-usage-empty">
+                <i class="bi bi-stack me-2"></i>
+                Žádná hra zatím nemá kopii této šablony. Otevři detail hry a přidej dovednost ze šablony.
+            </div>
+        }
+        else
+        {
+            <p class="text-muted small mb-3">
+                Šablona má kopie v <strong>@usage.CopiesCount</strong> hrách. Klikni pro přechod na seznam dovedností v dané hře.
+            </p>
+            <div class="oh-sk-usage-list">
+                @foreach (var g in usage.Games)
+                {
+                    var capturedGameId = g.GameId;
+                    <div class="oh-sk-usage-row" role="link" tabindex="0"
+                         @onclick="() => GoToGameSkills(capturedGameId)"
+                         @onkeydown="e => OnUsageRowKey(e, capturedGameId)">
+                        <div class="oh-sk-usage-row-head">
+                            <h5 class="oh-sk-usage-row-name">@g.GameName</h5>
+                            <span class="oh-sk-usage-row-edition">ED. @g.Edition</span>
+                        </div>
+                        <i class="bi bi-arrow-right text-muted"></i>
+                    </div>
+                }
+            </div>
+        }
+    }
+}
+
+@* Delete confirm — only reachable when usage == 0 *@
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Smazat dovednost?" Width="420px">
+    <BodyContentTemplate Context="dCtx">
+        <p>Opravdu chcete smazat dovednost <strong>@skill?.Name</strong>?</p>
+        <p class="text-muted small">Server smazání zablokuje, pokud existují kopie v hrách. Aktuálně: @(skill?.UsageCount ?? 0) kopií.</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" type="button" @onclick="() => isDeleteVisible = false" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-danger" type="button" @onclick="DeleteAsync" disabled="@isSaving">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public int Id { get; set; }
+
+    private SkillDto? skill;
+    private SkillUsageDto? usage;
+    private bool loading = true;
+    private string? error;
+    private string activeTab = "karta";
+
+    private EditForm editModel = new();
+    private bool isSaving;
+    private bool isDeleteVisible;
+    private string? saveError;
+
+    /// <summary>Building name lookup populated once on detail load and shared
+    /// with the read-only chips on Karta. Loaded best-effort — falls back to
+    /// "#{id}" rendering if the buildings endpoint is unreachable.</summary>
+    private Dictionary<int, string> buildingNames = new();
+
+    private static readonly List<CategoryOption> categoryValues = Enum.GetValues<SkillCategory>()
+        .Select(c => new CategoryOption(c, c.GetDisplayName())).ToList();
+    private static readonly List<ClassOption> classValues = Enum.GetValues<PlayerClass>()
+        .Select(p => new ClassOption(p, p.GetDisplayName())).ToList();
+    private record CategoryOption(SkillCategory Value, string Display);
+    private record ClassOption(PlayerClass Value, string Display);
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        error = null;
+        try
+        {
+            var detail = await Api.GetAsync<SkillDto>($"/api/skills/{Id}");
+            if (detail is null) { skill = null; return; }
+            skill = detail;
+            editModel = EditForm.FromDto(detail);
+
+            try
+            {
+                var bs = await Api.GetListAsync<BuildingListDto>("/api/buildings");
+                buildingNames = bs.ToDictionary(b => b.Id, b => b.Name);
+            }
+            catch { buildingNames = new(); }
+        }
+        catch (Exception ex) { error = ex.Message; skill = null; }
+        finally { loading = false; }
+    }
+
+    private async Task OpenUsageTabAsync()
+    {
+        activeTab = "usage";
+        if (usage is null)
+        {
+            try { usage = await Api.GetAsync<SkillUsageDto>($"/api/skills/{Id}/usage"); }
+            catch { usage = new SkillUsageDto(Id, 0, Array.Empty<SkillUsageGameDto>()); }
+        }
+    }
+
+    private void OnBuildingsChanged(IReadOnlyList<int> next)
+    {
+        editModel.RequiredBuildingIds = next;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (string.IsNullOrWhiteSpace(editModel.Name)) return;
+        saveError = null;
+        isSaving = true;
+        try
+        {
+            var (ok, problem) = await Api.PutWithProblemAsync($"/api/skills/{Id}", editModel.ToUpdateRequest());
+            if (!ok)
+            {
+                saveError = problem ?? "Uložení dovednosti se nepodařilo.";
+                return;
+            }
+            await LoadAsync();
+            activeTab = "karta";
+        }
+        catch (Exception ex) { saveError = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task DeleteAsync()
+    {
+        saveError = null;
+        isSaving = true;
+        try
+        {
+            var (ok, problem) = await Api.DeleteWithProblemAsync($"/api/skills/{Id}");
+            if (!ok)
+            {
+                saveError = problem ?? "Smazání dovednosti se nepodařilo.";
+                isDeleteVisible = false;
+                // Refresh — usage count may have changed since the page rendered.
+                await LoadAsync();
+                return;
+            }
+            isDeleteVisible = false;
+            Nav.NavigateTo("/skills");
+        }
+        catch (Exception ex) { saveError = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private void GoToGameSkills(int gameId) => Nav.NavigateTo($"/games/{gameId}/skills");
+
+    private void OnUsageRowKey(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs e, int gameId)
+    {
+        if (e.Key is "Enter" or " ") GoToGameSkills(gameId);
+    }
+
+    private static string KartaStyle(SkillCategory c)
+        => $"--oh-c: var(--oh-skill-{CategoryKey(c)});";
+
+    private static string CategoryKey(SkillCategory c) => c switch
+    {
+        SkillCategory.Class     => "class",
+        SkillCategory.Adventure => "adventure",
+        SkillCategory.Quest     => "quest",
+        _ => "class"
+    };
+
+    private sealed class EditForm
+    {
+        public string Name { get; set; } = "";
+        public SkillCategory Category { get; set; } = SkillCategory.Class;
+        public PlayerClass? ClassRestriction { get; set; }
+        public string? Effect { get; set; }
+        public string? RequirementNotes { get; set; }
+        public IReadOnlyList<int> RequiredBuildingIds { get; set; } = Array.Empty<int>();
+
+        public static EditForm FromDto(SkillDto d) => new()
+        {
+            Name = d.Name,
+            Category = d.Category,
+            ClassRestriction = d.ClassRestriction,
+            Effect = d.Effect,
+            RequirementNotes = d.RequirementNotes,
+            RequiredBuildingIds = d.RequiredBuildingIds.ToList()
+        };
+
+        public UpdateSkillRequest ToUpdateRequest() => new(
+            Name.Trim(),
+            ClassRestriction,
+            string.IsNullOrWhiteSpace(Effect) ? null : Effect.Trim(),
+            string.IsNullOrWhiteSpace(RequirementNotes) ? null : RequirementNotes.Trim(),
+            RequiredBuildingIds.ToList(),
+            Category);
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Skills/Skills.razor
+++ b/src/OvcinaHra.Client/Pages/Skills/Skills.razor
@@ -246,7 +246,10 @@ else
         {
             var dto = new CreateSkillRequest(
                 createModel.Name.Trim(),
-                createModel.ClassRestriction,
+                // Gate ClassRestriction on Category=Class — non-Class skills
+                // never carry a class lock. Same rule applied in SkillDetail
+                // edit form + GameSkills inline edit.
+                createModel.Category == SkillCategory.Class ? createModel.ClassRestriction : null,
                 string.IsNullOrWhiteSpace(createModel.Effect) ? null : createModel.Effect.Trim(),
                 RequirementNotes: null,
                 RequiredBuildingIds: Array.Empty<int>(),

--- a/src/OvcinaHra.Client/Pages/Skills/Skills.razor
+++ b/src/OvcinaHra.Client/Pages/Skills/Skills.razor
@@ -1,305 +1,291 @@
 @page "/skills"
 @attribute [Authorize]
-@inject SkillService SkillSvc
 @inject ApiClient Api
+@inject NavigationManager Nav
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
 
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">Knihovna dovedností</h1>
-    <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Přidat dovednost</button>
+    <button class="btn btn-primary" type="button" @onclick="OpenCreateModal">
+        <i class="bi bi-plus-lg"></i> Nová dovednost
+    </button>
 </div>
 
 <div class="alert alert-info small">
-    Tyto dovednosti jsou šablony. Při přidání do hry se vytvoří kopie, kterou lze pro danou hru upravit nezávisle.
+    Šablony slouží jako základ pro hru — při přidání do hry se vytvoří nezávislá kopie (<em>fork</em>) s vlastními XP a požadovanou úrovní.
 </div>
 
 @if (loading)
 {
-    <p>Načítám...</p>
+    <p class="text-muted">Načítám…</p>
 }
 else if (skills.Count == 0)
 {
     <div class="text-center text-muted py-5">
-        <i class="bi bi-star fs-1 d-block mb-2"></i>
-        <p>Zatím žádné dovednosti. Přidejte první pomocí tlačítka nahoře.</p>
+        <i class="bi bi-stars fs-1 d-block mb-2"></i>
+        <p>Zatím žádné dovednosti.</p>
+        <button class="btn btn-outline-primary" type="button" @onclick="OpenCreateModal">
+            <i class="bi bi-plus-lg"></i> Přidej první
+        </button>
     </div>
 }
 else
 {
-    <OvcinaGrid Data="@skills" KeyFieldName="Id" LayoutKey="grid-layout-skills"
-                RowClick="@(e => OpenModal((SkillDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+    @* LayoutKey bumped grid-layout-skills → -v2 because the column schema
+       changed (new chip / pip / cluster cells). Memory rule:
+       feedback_ovcinagrid_layoutkey_bump. *@
+    <OvcinaGrid Data="@skills" KeyFieldName="Id" LayoutKey="grid-layout-skills-v2"
+                RowClick="@(e => OpenPeek((SkillDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
-            <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="Category" Caption="Kategorie" Width="140px">
+            <DxGridDataColumn FieldName="Name" Caption="Název" MinWidth="220">
                 <CellDisplayTemplate>
-                    @(((SkillCategory)context.Value).GetDisplayName())
+                    @{ var s = (SkillDto)context.DataItem; }
+                    <div class="oh-sk-c-name">
+                        <span>@s.Name</span>
+                        @if (s.UsageCount > 0)
+                        {
+                            <span class="oh-sk-tpl-badge" title="@($"Šablona má {s.UsageCount} kopií ve hrách")">
+                                <i class="bi bi-stack"></i> @s.UsageCount
+                            </span>
+                        }
+                    </div>
                 </CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="ClassRestriction" Caption="Povolání" Width="140px">
+
+            <DxGridDataColumn FieldName="Category" Caption="Kategorie" Width="150px">
                 <CellDisplayTemplate>
-                    @(((PlayerClass?)context.Value).GetClassRestrictionLabel())
+                    @{ var s = (SkillDto)context.DataItem; }
+                    <SkillCategoryChip Category="@s.Category" />
                 </CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="Effect" Caption="Efekt" />
-            <DxGridDataColumn FieldName="RequiredBuildingIds" Caption="Požadované budovy" Width="220px" AllowSort="false" AllowGroup="false">
+
+            <DxGridDataColumn FieldName="ClassRestriction" Caption="Třída" Width="130px">
                 <CellDisplayTemplate>
-                    @{
-                        var ids = (IReadOnlyList<int>?)context.Value ?? Array.Empty<int>();
-                        var names = ids
-                            .Where(i => buildingNames.ContainsKey(i))
-                            .Select(i => buildingNames[i]);
-                        <text>@string.Join(", ", names)</text>
-                    }
+                    @{ var s = (SkillDto)context.DataItem; }
+                    <ClassPip Class="@s.ClassRestriction" ShowAllLine="true" />
                 </CellDisplayTemplate>
             </DxGridDataColumn>
-            <DxGridDataColumn FieldName="RequirementNotes" Caption="Poznámka" />
+
+            <DxGridDataColumn FieldName="RequiredBuildingIds" Caption="Budovy" Width="220px"
+                              AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var s = (SkillDto)context.DataItem; }
+                    <SkillBuildingChips BuildingIds="@s.RequiredBuildingIds" Names="@buildingNames" MaxVisible="3" />
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="Effect" Caption="Efekt" MinWidth="280">
+                <CellDisplayTemplate>
+                    @{ var s = (SkillDto)context.DataItem; }
+                    @* Full text in DOM — line-clamp via .oh-sk-c-fx provides
+                       the visual ellipsis. Card text stays sacred (memory:
+                       feedback_ovcina_card_text_sacred). *@
+                    <span class="oh-sk-c-fx" title="@s.Effect">@(s.Effect ?? "")</span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            @* Hidden by default — reveal via column chooser *@
+            <DxGridDataColumn FieldName="RequirementNotes" Caption="Poznámky" Width="220px" Visible="false" />
+            <DxGridDataColumn FieldName="UsageCount" Caption="Kopie" Width="90px" Visible="false" />
         </Columns>
     </OvcinaGrid>
 }
 
-<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="700px">
-    <BodyContentTemplate Context="popupContext">
-        @if (error is not null)
+@* Quick-peek popup — 640×420 per brief. Row click opens. *@
+<DxPopup @bind-Visible="@isPeekVisible" HeaderText="@(peekItem?.Name ?? "Dovednost")" Width="640px">
+    <BodyContentTemplate Context="qpCtx">
+        @if (peekItem is null)
         {
-            <div class="alert alert-danger">@error</div>
+            <p class="text-muted">Načítám…</p>
         }
-
-        <DxFormLayout>
-            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
-                <DxTextBox @bind-Text="@name" />
-            </DxFormLayoutItem>
-
-            <DxFormLayoutItem Caption="Kategorie" ColSpanMd="12">
-                <DxComboBox Data="@skillCategoryValues" @bind-Value="@editCategory"
-                            TextFieldName="Display" ValueFieldName="Value" />
-            </DxFormLayoutItem>
-
-            @if (editCategory == SkillCategory.Class)
-            {
-                <DxFormLayoutItem Caption="Povolání" ColSpanMd="12">
-                    <DxComboBox Data="@playerClassValues" @bind-Value="@classRestriction"
-                                TextFieldName="Display" ValueFieldName="Value" />
-                </DxFormLayoutItem>
-            }
-
-            <DxFormLayoutItem Caption="Efekt" ColSpanMd="12">
-                <DxMemo @bind-Text="@effect" Rows="3" />
-            </DxFormLayoutItem>
-
-            <DxFormLayoutItem Caption="Poznámka k požadavkům" ColSpanMd="12">
-                <DxMemo @bind-Text="@requirementNotes" Rows="2" />
-            </DxFormLayoutItem>
-
-            <DxFormLayoutItem Caption="Požadované budovy" ColSpanMd="12">
+        else
+        {
+            <div class="oh-sk-peek-grid">
                 <div>
-                    @if (selectedBuildingIds.Count > 0)
+                    <div class="oh-sk-peek-meta">
+                        <SkillCategoryChip Category="@peekItem.Category" />
+                        <ClassPip Class="@peekItem.ClassRestriction" ShowAllLine="true" />
+                    </div>
+                    <p class="oh-sk-peek-fx" style="@PeekStyle(peekItem.Category)">
+                        @(string.IsNullOrWhiteSpace(peekItem.Effect) ? "(text karty zatím prázdný)" : peekItem.Effect)
+                    </p>
+                    @if (!string.IsNullOrWhiteSpace(peekItem.RequirementNotes))
                     {
-                        <ul class="list-unstyled mb-2">
-                            @foreach (var id in selectedBuildingIds)
-                            {
-                                <li class="d-inline-block me-2 mb-1">
-                                    <span class="badge bg-secondary">
-                                        @(buildingNames.TryGetValue(id, out var n) ? n : $"#{id}")
-                                        <button type="button" class="btn btn-sm btn-link text-white p-0 ms-1"
-                                                @onclick="() => RemoveBuilding(id)" title="Odebrat">
-                                            <i class="bi bi-x"></i>
-                                        </button>
-                                    </span>
-                                </li>
-                            }
-                        </ul>
+                        <p class="oh-sk-karta-reqnote mt-2">@peekItem.RequirementNotes</p>
                     }
-                    else
-                    {
-                        <p class="text-muted small mb-2">Žádné požadované budovy.</p>
-                    }
-                    <div class="d-flex gap-2 align-items-end">
-                        <div style="flex:1">
-                            <DxComboBox Data="@AvailableBuildings" @bind-Value="@newBuildingId"
-                                        TextFieldName="Name" ValueFieldName="Id"
-                                        NullText="(přidat budovu)" SearchMode="ListSearchMode.AutoSearch" />
-                        </div>
-                        <button class="btn btn-sm btn-outline-primary" style="height:34px"
-                                disabled="@(newBuildingId is null)" @onclick="AddBuilding">
-                            <i class="bi bi-plus"></i>
-                        </button>
+                </div>
+                <div class="oh-sk-peek-side">
+                    <div class="oh-sk-peek-side-row">
+                        <span>Kopie</span>
+                        <strong>@peekItem.UsageCount</strong>
+                    </div>
+                    <div>
+                        <div class="oh-sk-peek-side-row mb-1"><span>Budovy</span><strong></strong></div>
+                        <SkillBuildingChips BuildingIds="@peekItem.RequiredBuildingIds" Names="@buildingNames" MaxVisible="6" />
                     </div>
                 </div>
-            </DxFormLayoutItem>
-
-            @if (editingId.HasValue)
-            {
-                <DxFormLayoutItem Caption="Obrázek" ColSpanMd="12">
-                    @* TODO: wire up ImagePicker once /api/skills image upload endpoint is available. *@
-                    <div class="text-muted small">Obrázek (nahrát později)</div>
-                </DxFormLayoutItem>
-            }
-        </DxFormLayout>
-
-        <div class="d-flex gap-2 mt-3">
-            @if (editingId.HasValue)
-            {
-                <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true" disabled="@isSaving">Smazat</button>
-            }
-            <div style="flex: 1"></div>
-            <button class="btn btn-secondary" @onclick="() => isModalVisible = false" disabled="@isSaving">Zrušit</button>
-            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">Uložit</button>
-        </div>
+            </div>
+            <div class="oh-sk-peek-foot">
+                <button class="btn btn-secondary" type="button" @onclick="() => isPeekVisible = false">Zavřít</button>
+                <button class="btn btn-primary" type="button" @onclick="OpenDetailFromPeek">
+                    Otevřít detail <i class="bi bi-arrow-right"></i>
+                </button>
+            </div>
+        }
     </BodyContentTemplate>
 </DxPopup>
 
-<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
-    <BodyContentTemplate Context="popupContext">
-        <p>Opravdu smazat dovednost <strong>@name</strong>?</p>
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Ne</button>
-            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync">Ano, smazat</button>
+@* Slim "+ Nová dovednost" create modal — lands on detail immediately. *@
+<DxPopup AllowResize="true" @bind-Visible="@isCreateVisible" HeaderText="Nová dovednost" Width="600px">
+    <BodyContentTemplate Context="cCtx">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                <DxTextBox @bind-Text="@createModel.Name" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Kategorie" ColSpanMd="6">
+                <DxComboBox Data="@categoryValues" @bind-Value="@createModel.Category"
+                            TextFieldName="Display" ValueFieldName="Value" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Pro povolání" ColSpanMd="6">
+                <DxComboBox Data="@classValues" @bind-Value="@createModel.ClassRestriction"
+                            TextFieldName="Display" ValueFieldName="Value"
+                            ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Efekt" ColSpanMd="12">
+                <DxMemo @bind-Text="@createModel.Effect" Rows="3" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+
+        @if (createError is not null)
+        {
+            <div class="alert alert-danger mt-2">@createError</div>
+        }
+
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" type="button"
+                    @onclick="() => isCreateVisible = false" disabled="@isCreating">Zrušit</button>
+            <button class="btn btn-primary" type="button" @onclick="CreateAsync"
+                    disabled="@(isCreating || string.IsNullOrWhiteSpace(createModel.Name))">
+                @if (isCreating) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit a otevřít
+            </button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
 
 @code {
-
     private List<SkillDto> skills = [];
-    private List<BuildingListDto> allBuildings = [];
-    private Dictionary<int, string> buildingNames = [];
+    private bool loading = true;
 
-    private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
-    private string modalTitle = "", name = "";
-    private string? error, effect, requirementNotes;
-    private int? editingId;
-    private PlayerClass classRestriction = PlayerClass.Warrior;
-    private SkillCategory editCategory = SkillCategory.Class;
-    private List<int> selectedBuildingIds = [];
-    private int? newBuildingId;
+    private bool isPeekVisible;
+    private SkillDto? peekItem;
 
-    private static readonly List<EnumItem<PlayerClass>> playerClassValues = Enum.GetValues<PlayerClass>()
-        .Select(v => new EnumItem<PlayerClass>(v, v.GetDisplayName())).ToList();
+    private bool isCreateVisible;
+    private bool isCreating;
+    private string? createError;
+    private CreateForm createModel = new();
 
-    private static readonly List<EnumItem<SkillCategory>> skillCategoryValues = Enum.GetValues<SkillCategory>()
-        .Select(v => new EnumItem<SkillCategory>(v, v.GetDisplayName())).ToList();
+    /// <summary>Building name lookup for the chip cluster cells. Loaded once
+    /// per page and shared across rows + peek.</summary>
+    private Dictionary<int, string> buildingNames = new();
 
-    private record EnumItem<T>(T Value, string Display);
+    private static readonly List<CategoryOption> categoryValues = Enum.GetValues<SkillCategory>()
+        .Select(c => new CategoryOption(c, c.GetDisplayName())).ToList();
+    private static readonly List<ClassOption> classValues = Enum.GetValues<PlayerClass>()
+        .Select(p => new ClassOption(p, p.GetDisplayName())).ToList();
 
-    private IEnumerable<BuildingListDto> AvailableBuildings
-        => allBuildings.Where(b => !selectedBuildingIds.Contains(b.Id));
+    private record CategoryOption(SkillCategory Value, string Display);
+    private record ClassOption(PlayerClass Value, string Display);
 
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadAsync();
-    }
+    protected override async Task OnInitializedAsync() => await LoadAsync();
 
     private async Task LoadAsync()
     {
         loading = true;
         try
         {
-            var skillList = await SkillSvc.GetAllAsync();
-            skills = skillList.ToList();
-            allBuildings = await Api.GetListAsync<BuildingListDto>("/api/buildings");
-            buildingNames = allBuildings.ToDictionary(b => b.Id, b => b.Name);
+            // Pulled in parallel — both endpoints are read-only and indexed.
+            var skillsTask = Api.GetListAsync<SkillDto>("/api/skills");
+            var buildingsTask = Api.GetListAsync<BuildingListDto>("/api/buildings");
+            await Task.WhenAll(skillsTask, buildingsTask);
+            skills = skillsTask.Result;
+            try { buildingNames = buildingsTask.Result.ToDictionary(b => b.Id, b => b.Name); }
+            catch { buildingNames = new(); }
         }
-        finally
-        {
-            loading = false;
-        }
+        finally { loading = false; }
     }
 
-    private void OpenModal(SkillDto? s)
+    private void OpenPeek(SkillDto s)
     {
-        error = null;
-        newBuildingId = null;
-        if (s is null)
-        {
-            editingId = null;
-            name = "";
-            effect = null;
-            requirementNotes = null;
-            classRestriction = PlayerClass.Warrior;
-            editCategory = SkillCategory.Class;
-            selectedBuildingIds = [];
-            modalTitle = "Nová dovednost";
-        }
-        else
-        {
-            editingId = s.Id;
-            name = s.Name;
-            effect = s.Effect;
-            requirementNotes = s.RequirementNotes;
-            editCategory = s.Category;
-            classRestriction = s.ClassRestriction ?? PlayerClass.Warrior;
-            selectedBuildingIds = s.RequiredBuildingIds.ToList();
-            modalTitle = $"Upravit: {s.Name}";
-        }
-        isModalVisible = true;
+        peekItem = s;
+        isPeekVisible = true;
     }
 
-    private void AddBuilding()
+    private void OpenDetailFromPeek()
     {
-        if (newBuildingId is int id && !selectedBuildingIds.Contains(id))
-        {
-            selectedBuildingIds.Add(id);
-            newBuildingId = null;
-        }
+        if (peekItem is null) return;
+        var id = peekItem.Id;
+        isPeekVisible = false;
+        Nav.NavigateTo($"/skills/{id}");
     }
 
-    private void RemoveBuilding(int id)
+    private void OpenCreateModal()
     {
-        selectedBuildingIds.Remove(id);
+        createModel = new CreateForm();
+        createError = null;
+        isCreateVisible = true;
     }
 
-    private async Task SaveAsync()
+    private async Task CreateAsync()
     {
-        error = null;
-        isSaving = true;
+        if (string.IsNullOrWhiteSpace(createModel.Name)) return;
+        createError = null;
+        isCreating = true;
         try
         {
-            PlayerClass? cr = editCategory == SkillCategory.Class ? classRestriction : null;
-            if (editingId.HasValue)
+            var dto = new CreateSkillRequest(
+                createModel.Name.Trim(),
+                createModel.ClassRestriction,
+                string.IsNullOrWhiteSpace(createModel.Effect) ? null : createModel.Effect.Trim(),
+                RequirementNotes: null,
+                RequiredBuildingIds: Array.Empty<int>(),
+                Category: createModel.Category);
+
+            // PostWithProblemAsync forwards Czech 409 ProblemDetails (duplicate
+            // name) into the inline banner instead of swallowing the body.
+            var (ok, created, problem) = await Api.PostWithProblemAsync<CreateSkillRequest, SkillDto>("/api/skills", dto);
+            if (!ok)
             {
-                await SkillSvc.UpdateAsync(editingId.Value,
-                    new UpdateSkillRequest(name, cr, effect, requirementNotes, selectedBuildingIds, editCategory));
+                createError = problem ?? "Vytvoření dovednosti se nepodařilo.";
+                return;
             }
+            isCreateVisible = false;
+            if (created is not null)
+                Nav.NavigateTo($"/skills/{created.Id}");
             else
-            {
-                await SkillSvc.CreateAsync(
-                    new CreateSkillRequest(name, cr, effect, requirementNotes, selectedBuildingIds, editCategory));
-            }
-            isModalVisible = false;
-            await LoadAsync();
+                await LoadAsync();
         }
-        catch (Exception ex)
-        {
-            error = FormatError(ex);
-        }
-        finally
-        {
-            isSaving = false;
-        }
+        catch (Exception ex) { createError = ex.Message; }
+        finally { isCreating = false; }
     }
 
-    private async Task ConfirmDeleteAsync()
-    {
-        if (editingId is null) return;
-        error = null;
-        try
-        {
-            await SkillSvc.DeleteAsync(editingId.Value);
-            isDeleteVisible = false;
-            isModalVisible = false;
-            await LoadAsync();
-        }
-        catch (Exception ex)
-        {
-            error = FormatError(ex);
-            isDeleteVisible = false;
-        }
-    }
+    private static string PeekStyle(SkillCategory c)
+        => $"--oh-c: var(--oh-skill-{CategoryKey(c)});";
 
-    private static string FormatError(Exception ex)
+    private static string CategoryKey(SkillCategory c) => c switch
     {
-        // Best-effort: surface the underlying message; API returns ProblemDetails
-        // on 400/409 but HttpClient.EnsureSuccessStatusCode throws with status line.
-        // If a richer ProblemDetails parse is needed, wire it here later.
-        return ex.Message;
+        SkillCategory.Class     => "class",
+        SkillCategory.Adventure => "adventure",
+        SkillCategory.Quest     => "quest",
+        _ => "class"
+    };
+
+    private sealed class CreateForm
+    {
+        public string Name { get; set; } = "";
+        public SkillCategory Category { get; set; } = SkillCategory.Class;
+        public PlayerClass? ClassRestriction { get; set; }
+        public string Effect { get; set; } = "";
     }
 }

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2835,3 +2835,146 @@
     color:#5b4a17;background:#fdf6e3;border:1px solid #f0d68a;
     border-left:3px solid #B26223;border-radius:3px}
 .oh-overlay-pp-drozd .bi{color:#B26223;font-size:.95rem;line-height:1}
+
+/* ============================================================
+   Skills — catalog · detail (3 tabs) · per-game grid (issue #153)
+   Class prefix: .oh-sk-*  (cells .oh-sk-c-*, peek .oh-sk-peek-*,
+   karta .oh-sk-karta-*, edit .oh-sk-edit-*, V-tomto-roce
+   .oh-sk-usage-*, per-game .oh-sk-pg-*, inline edit .oh-sk-pe-*).
+   ============================================================ */
+
+/* 3 skill-category palette tokens. Distinct from kingdom + stage +
+   spell-school palettes — never blur the four. */
+:root{
+    --oh-skill-class:     #3C4A2E;
+    --oh-skill-adventure: #B26223;
+    --oh-skill-quest:     #8B5A2B;
+}
+
+/* Category chip — 1.5px outlined pill with mono Czech label */
+.oh-sk-cat{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;
+    border:1.5px solid var(--oh-c,#888);border-radius:99px;
+    background:rgba(245,237,227,.55);color:var(--oh-text,#2a2a2a);
+    font:600 .75rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);white-space:nowrap}
+.oh-sk-cat::before{content:"";width:8px;height:8px;border-radius:50%;background:var(--oh-c,#888);flex-shrink:0}
+.oh-sk-cat[data-cat="class"]    {--oh-c:var(--oh-skill-class)}
+.oh-sk-cat[data-cat="adventure"]{--oh-c:var(--oh-skill-adventure)}
+.oh-sk-cat[data-cat="quest"]    {--oh-c:var(--oh-skill-quest)}
+
+/* Class pip — single SVG glyph in primary green, never a 4-pip array */
+.oh-sk-class-pip{display:inline-flex;align-items:center;justify-content:center;
+    width:24px;height:24px;border-radius:50%;background:rgba(45,80,22,.14);
+    border:1.5px solid #2D5016;color:#2D5016;flex-shrink:0}
+.oh-sk-class-pip svg,.oh-sk-class-pip i{width:14px;height:14px;font-size:.875rem}
+.oh-sk-class-line{display:inline-block;font:italic 400 .8125rem var(--oh-font-serif,Georgia,Merriweather,serif);
+    color:var(--oh-text-secondary,#6a6a6a);white-space:nowrap}
+
+/* XP pill — mono green; greyed when 0 XP */
+.oh-sk-xp{display:inline-block;padding:2px 8px;border-radius:99px;
+    background:rgba(45,80,22,.14);color:#2D5016;border:1px solid rgba(45,80,22,.5);
+    font:600 .75rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);white-space:nowrap}
+.oh-sk-xp--zero{background:var(--oh-surface-alt,#f5f0e1);color:var(--oh-text-secondary,#6a6a6a);border-color:var(--oh-border,#d8d2be)}
+
+/* Lvl pill — mono neutral */
+.oh-sk-lvl{display:inline-block;padding:2px 8px;border-radius:99px;
+    background:var(--oh-surface-alt,#f5f0e1);color:var(--oh-text,#2a2a2a);border:1px solid var(--oh-border,#d8d2be);
+    font:600 .75rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);white-space:nowrap}
+
+/* Building chips — cluster (read-only) and picker (multi-select) */
+.oh-sk-bld-cluster{display:flex;flex-wrap:wrap;gap:4px;align-items:center}
+.oh-sk-bld-chip{display:inline-flex;align-items:center;gap:4px;
+    padding:2px 8px;border-radius:99px;background:var(--oh-surface,#fff);
+    border:1px solid var(--oh-border,#d8d2be);color:var(--oh-text,#2a2a2a);
+    font:600 .75rem var(--oh-font-body);text-decoration:none;white-space:nowrap;cursor:pointer;transition:.12s ease}
+.oh-sk-bld-chip:hover{background:#eee3c9;border-color:#B26223;color:#6c5212}
+.oh-sk-bld-chip i{font-size:.75rem}
+.oh-sk-bld-overflow{padding:2px 8px;border-radius:99px;background:var(--oh-surface-alt,#f5f0e1);
+    color:var(--oh-text-secondary,#6a6a6a);border:1px dashed var(--oh-border,#d8d2be);
+    font:600 .7rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);white-space:nowrap}
+.oh-sk-bld-empty{font:italic 400 .8125rem var(--oh-font-serif,Georgia,Merriweather,serif);color:var(--oh-text-secondary,#6a6a6a)}
+.oh-sk-bld-stack{display:flex;flex-direction:column;gap:6px}
+.oh-sk-bld-picker{display:flex;flex-wrap:wrap;gap:6px;padding:8px;background:var(--oh-surface-alt,#f5f0e1);
+    border:1px dashed var(--oh-border,#d8d2be);border-radius:6px;min-height:48px}
+.oh-sk-bld-picker-toggle{display:inline-flex;align-items:center;gap:4px;padding:3px 9px;border-radius:99px;
+    border:1px solid var(--oh-border,#d8d2be);background:var(--oh-surface,#fff);color:var(--oh-text,#2a2a2a);
+    font:600 .75rem var(--oh-font-body);cursor:pointer;transition:.12s ease}
+.oh-sk-bld-picker-toggle.is-on{background:#2D5016;border-color:#2D5016;color:#fff}
+.oh-sk-bld-picker-toggle i{font-size:.75rem}
+
+/* Source badges — Šablona / Od nuly / drift */
+.oh-sk-src-badge{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;
+    border-radius:99px;font:600 .7rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);
+    text-transform:uppercase;letter-spacing:.06em;white-space:nowrap}
+.oh-sk-src-badge--tpl  {background:rgba(45,80,22,.12);color:#2D5016;border:1px solid rgba(45,80,22,.5)}
+.oh-sk-src-badge--blank{background:rgba(193,154,58,.16);color:#6c5212;border:1px solid rgba(193,154,58,.55)}
+.oh-sk-tpl-badge{font:500 .7rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);color:var(--oh-text-secondary,#6a6a6a)}
+.oh-sk-fork-hint{font:italic 400 .8125rem var(--oh-font-serif,Georgia,Merriweather,serif);color:var(--oh-text-secondary,#6a6a6a);margin:0}
+
+.oh-sk-drift{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;
+    border-radius:50%;background:rgba(178,98,35,.16);color:#6c5212;border:1.5px solid rgba(178,98,35,.6);
+    font:700 .7rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace)}
+.oh-sk-drift-cell{display:flex;justify-content:center;align-items:center}
+.oh-sk-drift-tip{font:italic 400 .75rem var(--oh-font-serif,Georgia,Merriweather,serif);color:#6c5212;margin-left:4px}
+
+/* List grid cells */
+.oh-sk-c-name{font:600 .9375rem var(--oh-font-body);color:var(--oh-text,#2a2a2a);display:flex;align-items:center;gap:6px}
+.oh-sk-c-fx{font:400 .8125rem var(--oh-font-body);color:var(--oh-text,#2a2a2a);
+    overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;line-clamp:2}
+.oh-sk-c-bld{display:flex;flex-wrap:wrap;gap:3px}
+
+/* Quick-peek popup — 640×420 per brief */
+.oh-sk-peek-grid{display:grid;grid-template-columns:1fr 200px;gap:18px;padding:6px 4px 14px}
+.oh-sk-peek-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:10px}
+.oh-sk-peek-fx{font:400 .9375rem/1.5 var(--oh-font-serif,Georgia,Merriweather,serif);
+    color:var(--oh-text,#2a2a2a);text-align:justify;hyphens:auto;white-space:pre-wrap;
+    border-left:3px solid var(--oh-c,var(--oh-border,#d8d2be));padding:6px 12px;background:var(--oh-surface-alt,#f5f0e1);border-radius:4px}
+.oh-sk-peek-side{display:flex;flex-direction:column;gap:10px;border-left:1px solid var(--oh-border,#d8d2be);padding-left:14px}
+.oh-sk-peek-side-row{display:flex;justify-content:space-between;gap:6px;font:600 .8125rem var(--oh-font-body);color:var(--oh-text-secondary,#6a6a6a)}
+.oh-sk-peek-side-row strong{color:var(--oh-text,#2a2a2a);font-family:var(--oh-font-mono,JetBrains Mono,Menlo,monospace)}
+.oh-sk-peek-foot{display:flex;justify-content:space-between;gap:10px;padding-top:10px;border-top:1px solid var(--oh-border,#d8d2be);margin-top:6px}
+
+/* Karta — illuminated parchment page (62fr/38fr) */
+.oh-sk-karta-grid{display:grid;grid-template-columns:62fr 38fr;gap:20px;align-items:start}
+@media (max-width:880px){.oh-sk-karta-grid{grid-template-columns:1fr}}
+.oh-sk-karta{position:relative;background:#fbf6e7;border:1px solid #c8b48a;border-radius:6px;
+    padding:24px 28px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.oh-sk-karta::before{content:"";position:absolute;top:0;bottom:0;left:0;width:3px;background:var(--oh-c,#aaa);border-radius:6px 0 0 6px}
+.oh-sk-karta-name{font:900 2.2rem/1.1 var(--oh-font-heading,Merriweather,Georgia,serif);color:var(--oh-primary,#243525);margin:0;text-align:center;letter-spacing:-.01em}
+.oh-sk-karta-meta{display:flex;flex-wrap:wrap;justify-content:center;gap:10px;margin:14px 0 18px}
+.oh-sk-karta-sep{height:1px;background:linear-gradient(90deg,transparent 0,#B26223 20%,#B26223 80%,transparent 100%);margin:14px 0;border:none}
+.oh-sk-karta-fx{font:400 1.1rem/1.55 var(--oh-font-serif,Georgia,Merriweather,serif);color:var(--oh-text,#2a2a2a);text-align:justify;hyphens:auto;white-space:pre-wrap;margin:0}
+.oh-sk-karta-reqnote{font:italic 400 .9rem/1.5 var(--oh-font-serif,Georgia,Merriweather,serif);color:var(--oh-text-secondary,#6a6a6a);margin:14px 0 0;text-align:justify;white-space:pre-wrap}
+.oh-sk-karta-side{display:flex;flex-direction:column;gap:12px}
+.oh-sk-karta-side-block{background:var(--oh-surface,#fff);border:1px solid var(--oh-border,#d8d2be);border-radius:6px;padding:14px}
+.oh-sk-karta-side-block h6{font:700 .75rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);color:var(--oh-text-secondary,#6a6a6a);text-transform:uppercase;letter-spacing:.06em;margin:0 0 8px}
+
+/* V tomto roce tab */
+.oh-sk-usage-list{display:flex;flex-direction:column;gap:8px}
+.oh-sk-usage-row{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;
+    background:var(--oh-surface,#fff);border:1px solid var(--oh-border,#d8d2be);border-radius:6px;cursor:pointer;transition:.12s ease}
+.oh-sk-usage-row:hover{background:#fdf9ed;border-color:#B26223}
+.oh-sk-usage-row-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap;flex:1;min-width:0}
+.oh-sk-usage-row-name{font:700 1rem var(--oh-font-heading,Merriweather,Georgia,serif);color:var(--oh-primary,#243525);margin:0}
+.oh-sk-usage-row-edition{font:600 .75rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);color:var(--oh-text-secondary,#6a6a6a)}
+.oh-sk-usage-empty{padding:18px;text-align:center;font:italic 400 .9rem var(--oh-font-serif,Georgia,Merriweather,serif);color:var(--oh-text-secondary,#6a6a6a);background:var(--oh-surface-alt,#f5f0e1);border:1px dashed var(--oh-border,#d8d2be);border-radius:6px}
+
+/* Per-game inline edit popup — per-game-only fields highlighted */
+.oh-sk-pg-only{background:linear-gradient(135deg,rgba(193,154,58,.14),rgba(193,154,58,.04));
+    border-left:3px solid #B26223;padding:10px 12px;border-radius:4px;margin:6px 0}
+.oh-sk-pg-only-head{font:700 .75rem var(--oh-font-mono,JetBrains Mono,Menlo,monospace);
+    color:#6c5212;text-transform:uppercase;letter-spacing:.06em;margin:0 0 4px}
+.oh-sk-pg-fork-hint{font:italic 400 .8125rem var(--oh-font-serif,Georgia,Merriweather,serif);color:var(--oh-text-secondary,#6a6a6a);margin:0}
+
+/* Smazat zablokováno — disabled-affordance pill, ghost-bordeaux palette */
+.oh-sk-delete-blocked{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:99px;
+    background:rgba(140,36,35,.06);color:rgba(140,36,35,.7);border:1px dashed rgba(140,36,35,.4);
+    font:600 .8125rem var(--oh-font-body);cursor:not-allowed}
+
+/* Sacred banner — warning above any Effect memo. Reused on Spells edit
+   in a future round; new utility class declared here intentionally so
+   it lives in the shared theme. */
+.oh-sacred-banner{display:flex;align-items:flex-start;gap:8px;
+    padding:10px 14px;margin:0 0 8px;background:rgba(178,98,35,.08);
+    border:1px solid rgba(178,98,35,.45);border-left:3px solid #B26223;border-radius:4px;
+    font:500 .8125rem/1.45 var(--oh-font-body);color:#6c5212}
+.oh-sacred-banner i{font-size:.95rem;color:#B26223;flex-shrink:0;margin-top:2px}

--- a/src/OvcinaHra.Shared/Dtos/SkillDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/SkillDtos.cs
@@ -10,7 +10,25 @@ public record SkillDto(
     string? Effect,
     string? RequirementNotes,
     string? ImagePath,
-    IReadOnlyList<int> RequiredBuildingIds);
+    IReadOnlyList<int> RequiredBuildingIds,
+    int UsageCount = 0);
+
+/// <summary>
+/// Per-skill usage rollup — how many games hold a `GameSkill` copy of this
+/// catalog template, plus which games. Powers the catalog "Smazat zablokováno"
+/// badge and the SkillDetail "V tomto roce" tab without forcing every list-page
+/// caller to enumerate per-game grids.
+/// </summary>
+public record SkillUsageDto(
+    int SkillId,
+    int CopiesCount,
+    IReadOnlyList<SkillUsageGameDto> Games);
+
+public record SkillUsageGameDto(
+    int GameId,
+    int GameSkillId,
+    string GameName,
+    int Edition);
 
 public record CreateSkillRequest(
     string Name,

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameSkillEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameSkillEndpointsTests.cs
@@ -357,8 +357,12 @@ public class GameSkillEndpointsTests(PostgresFixture postgres) : IntegrationTest
     }
 
     [Fact]
-    public async Task DeletingTemplate_NullsOutTemplateSkillIdOnCopies()
+    public async Task DeletingTemplate_BlockedWith409_WhenCopiesExist()
     {
+        // Issue #153 changed the contract: while a per-game GameSkill copy
+        // references a Skill template via TemplateSkillId, the template
+        // delete must be rejected with 409 (Czech ProblemDetails). The
+        // template + copy both survive with the FK intact.
         var game = await CreateGameAsync("CascadeGame");
         var templateId = await CreateTemplateSkillAsync("Šablona k smazání", SkillCategory.Class);
         var gs = await CreateGameSkillAsync(game.Id, MakeCreate(
@@ -368,14 +372,15 @@ public class GameSkillEndpointsTests(PostgresFixture postgres) : IntegrationTest
         Assert.Equal(templateId, gs.TemplateSkillId);
 
         var deleteResp = await Client.DeleteAsync($"/api/skills/{templateId}");
-        Assert.Equal(HttpStatusCode.NoContent, deleteResp.StatusCode);
+        Assert.Equal(HttpStatusCode.Conflict, deleteResp.StatusCode);
 
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
-        var persisted = await db.GameSkills.SingleOrDefaultAsync(g => g.Id == gs.Id);
-        Assert.NotNull(persisted);
-        Assert.Null(persisted!.TemplateSkillId);
+        var persistedCopy = await db.GameSkills.SingleOrDefaultAsync(g => g.Id == gs.Id);
+        Assert.NotNull(persistedCopy);
+        Assert.Equal(templateId, persistedCopy!.TemplateSkillId);
 
-        Assert.Null(await db.Skills.SingleOrDefaultAsync(s => s.Id == templateId));
+        var persistedTemplate = await db.Skills.SingleOrDefaultAsync(s => s.Id == templateId);
+        Assert.NotNull(persistedTemplate);
     }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/SkillEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/SkillEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using OvcinaHra.Api.Data;
@@ -288,57 +289,12 @@ public class SkillEndpointsTests(PostgresFixture postgres) : IntegrationTestBase
         Assert.Null(gone);
     }
 
-    [Fact]
-    public async Task Delete_WithGameSkillReference_NullsOutTemplateSkillId()
-    {
-        // Template delete no longer blocks when per-game copies reference it;
-        // the FK cascades SetNull so per-game GameSkill rows survive without a template.
-        var skill = await CreateSkillAsync("Šablona s kopiemi", null, null, null, []);
-        int skillId = skill.Id;
-
-        int gameSkillId;
-        using (var scope = Factory.Services.CreateScope())
-        {
-            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
-            var game = new Game
-            {
-                Name = "Testovací hra",
-                Edition = 1,
-                StartDate = new DateOnly(2026, 1, 1),
-                EndDate = new DateOnly(2026, 1, 3),
-                Status = default
-            };
-            db.Games.Add(game);
-            await db.SaveChangesAsync();
-
-            var gs = new GameSkill
-            {
-                GameId = game.Id,
-                TemplateSkillId = skillId,
-                Name = "Kopie šablony",
-                Category = SkillCategory.Class,
-                XpCost = 10,
-                LevelRequirement = null
-            };
-            db.GameSkills.Add(gs);
-            await db.SaveChangesAsync();
-            gameSkillId = gs.Id;
-        }
-
-        var response = await Client.DeleteAsync($"/api/skills/{skillId}");
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-
-        using var scope2 = Factory.Services.CreateScope();
-        var db2 = scope2.ServiceProvider.GetRequiredService<WorldDbContext>();
-
-        // Template is gone.
-        Assert.Null(await db2.Skills.SingleOrDefaultAsync(s => s.Id == skillId));
-
-        // GameSkill row survives with TemplateSkillId nulled.
-        var persistedGs = await db2.GameSkills.SingleOrDefaultAsync(g => g.Id == gameSkillId);
-        Assert.NotNull(persistedGs);
-        Assert.Null(persistedGs!.TemplateSkillId);
-    }
+    // Note (issue #153): Delete is now blocked at the API when GameSkill copies
+    // reference the template — see `Delete_BlockedWith409_WhenCopiesExist` near
+    // the bottom of this file. The previous "cascade SetNull" contract that
+    // lived here was replaced because the designer brief is explicit:
+    // "Smazat zablokováno když existují kopie v hrách". The 409 path keeps
+    // the copies authoritatively rooted in their templates.
 
     [Fact]
     public async Task Delete_NonExistentId_Returns404()
@@ -408,5 +364,160 @@ public class SkillEndpointsTests(PostgresFixture postgres) : IntegrationTestBase
         var response = await Client.PostAsJsonAsync("/api/skills", dto);
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<SkillDto>())!;
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  Issue #153 — usage rollup + delete-blocked
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetById_ReturnsZeroUsage_WhenNoCopiesExist()
+    {
+        var skill = await CreateSkillAsync("Solo Skill", PlayerClass.Mage, "Effect", null, []);
+
+        var resp = await Client.GetAsync($"/api/skills/{skill.Id}");
+        resp.EnsureSuccessStatusCode();
+        var fetched = await resp.Content.ReadFromJsonAsync<SkillDto>();
+
+        Assert.NotNull(fetched);
+        Assert.Equal(0, fetched!.UsageCount);
+    }
+
+    [Fact]
+    public async Task GetById_PopulatesUsageCount_WhenCopiesExist()
+    {
+        var skill = await CreateSkillAsync("Forked Skill", PlayerClass.Warrior, "Effect", null, []);
+        await SeedGameAndCopyAsync(skill.Id, "Hra A");
+        await SeedGameAndCopyAsync(skill.Id, "Hra B");
+
+        var resp = await Client.GetAsync($"/api/skills/{skill.Id}");
+        resp.EnsureSuccessStatusCode();
+        var fetched = await resp.Content.ReadFromJsonAsync<SkillDto>();
+
+        Assert.NotNull(fetched);
+        Assert.Equal(2, fetched!.UsageCount);
+    }
+
+    [Fact]
+    public async Task GetAll_PopulatesUsageCount_PerTemplate()
+    {
+        var s1 = await CreateSkillAsync("Tpl-1", null, null, null, []);
+        var s2 = await CreateSkillAsync("Tpl-2", null, null, null, []);
+        await SeedGameAndCopyAsync(s1.Id, "Hra X");
+        await SeedGameAndCopyAsync(s2.Id, "Hra Y");
+        await SeedGameAndCopyAsync(s2.Id, "Hra Z");
+
+        var list = await Client.GetFromJsonAsync<List<SkillDto>>("/api/skills");
+
+        Assert.NotNull(list);
+        Assert.Equal(1, list!.Single(x => x.Id == s1.Id).UsageCount);
+        Assert.Equal(2, list!.Single(x => x.Id == s2.Id).UsageCount);
+    }
+
+    [Fact]
+    public async Task GetUsage_ReturnsGames_WhenCopiesExist()
+    {
+        var skill = await CreateSkillAsync("Usage Skill", null, "Effect", null, []);
+        await SeedGameAndCopyAsync(skill.Id, "První hra");
+        await SeedGameAndCopyAsync(skill.Id, "Druhá hra");
+
+        var resp = await Client.GetAsync($"/api/skills/{skill.Id}/usage");
+        resp.EnsureSuccessStatusCode();
+        var usage = await resp.Content.ReadFromJsonAsync<SkillUsageDto>();
+
+        Assert.NotNull(usage);
+        Assert.Equal(skill.Id, usage!.SkillId);
+        Assert.Equal(2, usage.CopiesCount);
+        Assert.Equal(2, usage.Games.Count);
+        Assert.Contains(usage.Games, g => g.GameName == "První hra");
+        Assert.Contains(usage.Games, g => g.GameName == "Druhá hra");
+    }
+
+    [Fact]
+    public async Task GetUsage_ReturnsEmpty_WhenNoCopies()
+    {
+        var skill = await CreateSkillAsync("Empty Usage", null, null, null, []);
+
+        var resp = await Client.GetAsync($"/api/skills/{skill.Id}/usage");
+        resp.EnsureSuccessStatusCode();
+        var usage = await resp.Content.ReadFromJsonAsync<SkillUsageDto>();
+
+        Assert.NotNull(usage);
+        Assert.Equal(0, usage!.CopiesCount);
+        Assert.Empty(usage.Games);
+    }
+
+    [Fact]
+    public async Task GetUsage_ReturnsNotFound_WhenSkillMissing()
+    {
+        var resp = await Client.GetAsync("/api/skills/999999/usage");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_BlockedWith409_WhenCopiesExist()
+    {
+        var skill = await CreateSkillAsync("Locked", null, "Effect", null, []);
+        await SeedGameAndCopyAsync(skill.Id, "Aktivní hra");
+
+        var resp = await Client.DeleteAsync($"/api/skills/{skill.Id}");
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+        var problem = await resp.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Contains("nelze smazat", problem!.Title, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("hrách", problem.Detail);
+
+        // The skill must still exist after the blocked delete.
+        var getResp = await Client.GetAsync($"/api/skills/{skill.Id}");
+        Assert.Equal(HttpStatusCode.OK, getResp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_AllowedWhenNoCopies()
+    {
+        var skill = await CreateSkillAsync("Free To Delete", null, null, null, []);
+
+        var resp = await Client.DeleteAsync($"/api/skills/{skill.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
+
+        var getResp = await Client.GetAsync($"/api/skills/{skill.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, getResp.StatusCode);
+    }
+
+    /// <summary>
+    /// Seeds a Game + a GameSkill that copies the given template directly via
+    /// DbContext. Avoids the public POST /api/games/{id}/skills route so the
+    /// usage-count tests stay focused on read behavior.
+    /// </summary>
+    private async Task<int> SeedGameAndCopyAsync(int templateSkillId, string gameName)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var template = await db.Skills.SingleAsync(s => s.Id == templateSkillId);
+        var game = new Game
+        {
+            Name = gameName,
+            Edition = 1,
+            StartDate = new DateOnly(2026, 5, 1),
+            EndDate = new DateOnly(2026, 5, 3),
+            Status = GameStatus.Draft
+        };
+        db.Games.Add(game);
+        await db.SaveChangesAsync();
+        var copy = new GameSkill
+        {
+            GameId = game.Id,
+            TemplateSkillId = template.Id,
+            Name = template.Name,
+            Category = template.Category,
+            ClassRestriction = template.ClassRestriction,
+            Effect = template.Effect,
+            RequirementNotes = template.RequirementNotes,
+            XpCost = 5,
+            LevelRequirement = null
+        };
+        db.GameSkills.Add(copy);
+        await db.SaveChangesAsync();
+        return copy.Id;
     }
 }


### PR DESCRIPTION
Twin port to #148 (Spells). Reuses three-tab detail / quick-peek / sacred-banner / WithProblem helpers / LayoutKey bumps. Diverges where the model differs: **single class pip** (never 4-pip array), **mono \"12 XP\" pill** (never mana rings), **client-side drift detection** for per-game forks, **server-side delete-block** when copies exist.

## Files

| File | State | Purpose |
|---|---|---|
| `Components/SkillCategoryChip.razor` | NEW | 1.5px outlined pill + color dot. Reads `--oh-skill-{key}`. |
| `Components/ClassPip.razor` | NEW | Single weapon-glyph pip; muted \"Pro všechna povolání\" line when null. |
| `Components/SkillBuildingChips.razor` | NEW | Read-only chip cluster, 3 + \"+ N více\" overflow, click → /buildings/{id}. |
| `Components/BuildingChipPicker.razor` | NEW | Multi-select for edit forms; generic API so future Spells reuse. |
| `Pages/Skills/SkillDetail.razor` | NEW | 3 tabs · Karta parchment · Upravit w/ sacred-banner + Smazat-blocked · V tomto roce lazy-loads `/api/skills/{id}/usage`. |
| `Pages/Skills/Skills.razor` | REWRITE | Quick-peek 640×420 + nav. New columns. LayoutKey `grid-layout-skills-v2`. |
| `Pages/Games/GameSkills.razor` | REFACTOR | Source badge · drift `≠` · category chip · class pip · building cluster · XP/Lvl pills · split toolbar (Přidat ze šablony / Od nuly). LayoutKey `grid-layout-game-skills-v2`. Per-game-only banner above XpCost / LevelRequirement. |
| `Endpoints/SkillEndpoints.cs` | MODIFY | New `GET /api/skills/{id}/usage`. `UsageCount` on `SkillDto` via grouped count. **Delete now 409 when copies exist** (was cascade-SetNull) — hard rule per designer brief. |
| `Shared/Dtos/SkillDtos.cs` | MODIFY | `SkillDto.UsageCount` + new `SkillUsageDto` + `SkillUsageGameDto`. |
| `wwwroot/css/ovcinahra-theme.css` | APPEND | 3 `--oh-skill-*` palette tokens · `.oh-sk-*` block · `.oh-sacred-banner` utility (declared here, future Spells edit form reuses). |

## Decisions flagged in PR body

- **Usage rollup is server-side** (mirrors `ItemEndpoints.cs:36` precedent). Catalog list rolls `UsageCount` via a single `GroupBy(TemplateSkillId)` query — FK-indexed, cheap. Detail page fetches per-game enumeration on demand. Avoided client-side N+1 enumeration of `/api/games`.
- **Drift detection is client-side** per brief — `HasDrift(GameSkillDto)` compares Name + Category + ClassRestriction + Effect + RequirementNotes + building-set against the loaded template. XpCost / LevelRequirement are per-game-only by design and excluded.
- **Delete behavior changed at the API level**. Previously cascade-SetNull (per-game copies survived as standalone skills). Brief explicitly required hard-block via 409 with Czech ProblemDetails. Two existing tests rewritten to match the new contract.
- **`<Version>` UNTOUCHED** — auto-bump CI handles it (rule #18). Brief override #1 acknowledged.

## Pre-push gate

- `dotnet build OvcinaHra.slnx` — **0W / 0E** under `TreatWarningsAsErrors=true`.
- `dotnet test` — **324 passed / 0 failed** in 8m54s on Testcontainers PostgreSQL.
- 8 new tests in `SkillEndpointsTests` (usage + delete-block); 1 existing test rewritten in `GameSkillEndpointsTests`.

## Follow-ups (out of scope)

1. Print export \"Příručka dobrodružných dovedností\" (Adventure category, A4 single page).
2. Drift reconciliation tool — bulk \"Re-sync from template\".
3. Surface `CraftingSkillRequirement` on V tomto roce.
4. Per-class skill summary view.
5. Playwright E2E (list → peek → detail → tabs → per-game → inline edit → save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)