### PR TITLE
fix(layout): mobile main menu overlap at viewport bottom (closes #162)

### DIFF
--- a/src/OvcinaHra.Client/Layout/NavMenu.razor.css
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor.css
@@ -385,6 +385,21 @@
     .oh-nav.collapse {
         display: none;
     }
+
+    /* Issue #162 — on mobile the page (not the sidebar) is the scroll
+       container, so .oh-nav-tools' sticky bottom-0 glues it to the viewport
+       bottom and overlaps the last items in .oh-nav-list when the user
+       scrolls. Drop sticky on mobile — the tools section flows naturally
+       at the end of the menu and scrolls with the rest of the list. */
+    .oh-nav-tools {
+        position: static;
+    }
+
+    /* Reserve safe-area inset for iOS home-bar so the very last item
+       isn't tucked under the system gesture region. */
+    .oh-nav-foot {
+        padding-bottom: calc(8px + env(safe-area-inset-bottom, 0));
+    }
 }
 
 @media (min-width: 641px) {


### PR DESCRIPTION
## What

User report in #162 (mobile, 569×1920 viewport screenshot): the bottom items in the main menu visually overlap — "Tajné skrýše" and "Správa Ovčín" stack on the same line, last items get clipped under the menu''s tools/footer rows.

## Root cause

`.oh-nav-tools` carries `position: sticky; bottom: 0;` so on desktop — where `.sidebar { height: 100vh; position: sticky; top: 0 }` makes the sidebar itself the scroll container — the tools section pins to the sidebar''s bottom while `.oh-nav-list` scrolls above it. That works.

On mobile (≤ 640.98px) the sidebar has no height constraint, the page flexes column-stacked (sidebar above main), and the **page** becomes the scroll container. `position: sticky; bottom: 0` then glues the tools row to the *viewport* bottom and overlays whatever menu items are currently in view — exactly the overlap visible in the screenshot.

## Fix

Two narrow rules inside the existing `@media (max-width: 640.98px)` block in `NavMenu.razor.css`:

- `.oh-nav-tools { position: static; }` — tools section flows naturally at the end of the menu and scrolls with the rest of the list. Sticky was only ever needed for the desktop scroll container.
- `.oh-nav-foot { padding-bottom: calc(8px + env(safe-area-inset-bottom, 0)); }` — reserves the iOS home-bar / gesture region so the last item isn''t tucked under the system overlay.

Desktop behavior unchanged — the rules are mobile-scoped.

## Verification

- `dotnet build` clean (0W/0E, `TreatWarningsAsErrors=true`).
- Manual: at ≤ 640.98px viewport, `.oh-nav-tools` is no longer sticky; scrolling shows tools + footer naturally at the menu''s bottom, no overlap.

## No csproj bump

Auto-bump CI handles `<Version>` per `_review-instincts.md` §18.

## Scope note

This PR ships #162 alone. The bundled #158 (home cockpit) was split off into a separate session for scope reasons; the two don''t conflict on files (#162 = `NavMenu.razor.css` only; #158 will land its own `NavMenu.razor` / `MainLayout.razor` changes in a different branch).

Closes #162.