### PR TITLE
hotfix(locations): restore assign-to-game button in catalog actions cell

### DIFF
--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -121,12 +121,37 @@ else
                                     @onclick:stopPropagation="true">
                                 <i class="bi bi-geo-alt-fill"></i>
                             </button>
-                            <button type="button"
-                                    title="Přiřadit quest (propojit)"
-                                    @onclick="() => OpenLinkDialog(loc)"
-                                    @onclick:stopPropagation="true">
-                                <i class="bi bi-link-45deg"></i>
-                            </button>
+                            @if (Catalog)
+                            {
+                                var isAssigned = assignedLocationIds.Contains(loc.Id);
+                                @if (isAssigned)
+                                {
+                                    <button type="button"
+                                            title="Odebrat z aktuální hry"
+                                            @onclick="() => UnassignLocationAsync(loc.Id)"
+                                            @onclick:stopPropagation="true">
+                                        <i class="bi bi-bookmark-dash"></i>
+                                    </button>
+                                }
+                                else
+                                {
+                                    <button type="button"
+                                            title="Přiřadit k aktuální hře"
+                                            @onclick="() => AssignLocationAsync(loc.Id)"
+                                            @onclick:stopPropagation="true">
+                                        <i class="bi bi-bookmark-plus"></i>
+                                    </button>
+                                }
+                            }
+                            else
+                            {
+                                <button type="button"
+                                        title="Propojit jako variantu rodičovské lokace"
+                                        @onclick="() => OpenLinkDialog(loc)"
+                                        @onclick:stopPropagation="true">
+                                    <i class="bi bi-link-45deg"></i>
+                                </button>
+                            }
                             <button type="button"
                                     title="Otevřít na mapě"
                                     @onclick="() => OpenOnMap(loc)"


### PR DESCRIPTION
Closes #168 — production-blocking.

## Problem

In `/locations` catalog view, the third actions-cell button was wired to the parent-link dialog with a misleading "Přiřadit quest (propojit)" title and `bi-link-45deg` icon. Users could no longer quickly assign a catalog location to the active game from the row's actions — they had to use the wider "Přiřazeno" column at the right of the grid, which is often scrolled off-screen.

## Fix

In **catalog mode**, the actions cell now renders an assign/unassign toggle:
- `bi-bookmark-plus` → "Přiřadit k aktuální hře" → `AssignLocationAsync`
- `bi-bookmark-dash` → "Odebrat z aktuální hry" → `UnassignLocationAsync`

In **game mode**, the parent-link button stays — but with a corrected title (`"Propojit jako variantu rodičovské lokace"`). The dialog has always done parent-location linking, the prior "quest" wording was wrong.

## Risk

Pure Razor markup change. No logic, no API change, no tests touched. Reuses existing `AssignLocationAsync` / `UnassignLocationAsync` handlers + `assignedLocationIds` state already loaded in catalog mode.

## Verification post-merge

- `/locations` (catalog) → row actions cell shows bookmark+ toggle for unassigned, bookmark- for assigned. Click moves location between states.
- `/games/{id}/locations` (game view) → row actions cell shows the link icon (now correctly titled).