### PR TITLE
refactor(recipes/map): shared recipe leaf components + prod glyph URL

### DIFF
--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -115,7 +115,12 @@
         {
             _dotnetRef = DotNetObjectReference.Create(this);
             var apiKey = Config["MapyCz:ApiKey"];
-            await JS.InvokeVoidAsync("ovcinaMap.init", _elementId, _dotnetRef, CenterLat, CenterLon, Zoom, apiKey);
+            // #166 — `glyphs` URL is environment-specific. Dev points at
+            // demotiles.maplibre.org (rate-limited, fine for local), prod at
+            // a self-hosted Azure Blob path. See appsettings.Production.json
+            // and the deploy doc for upload steps.
+            var glyphsUrl = Config["MapLibre:GlyphsUrl"];
+            await JS.InvokeVoidAsync("ovcinaMap.init", _elementId, _dotnetRef, CenterLat, CenterLon, Zoom, apiKey, glyphsUrl);
         }
 
         // Load overlay once per game. Repeat on GameId change. Wrapped in

--- a/src/OvcinaHra.Client/Components/RecipeBuildingPicker.razor
+++ b/src/OvcinaHra.Client/Components/RecipeBuildingPicker.razor
@@ -1,0 +1,63 @@
+@* Issue #163 — building list + add control. Same UI shape on both sides:
+   Item recipes call this list "Požadované budovy" (workbenches needed to
+   craft the item); Building recipes call it "Předpoklady (jiné budovy)"
+   (other buildings that must already exist before construction). Caption
+   + placeholder are parameterised to keep the Czech copy distinct. *@
+
+@using OvcinaHra.Shared.Dtos
+
+<div class="mb-2">
+    <strong class="small">@Caption:</strong>
+    @if (Buildings.Count > 0)
+    {
+        @foreach (var b in Buildings)
+        {
+            <span class="badge bg-secondary me-1">
+                @b.BuildingName
+                <button class="btn btn-sm btn-link text-white p-0 ms-1"
+                        @onclick="() => OnRemove.InvokeAsync(b.BuildingId)">
+                    <i class="bi bi-x"></i>
+                </button>
+            </span>
+        }
+    }
+    else
+    {
+        <span class="text-muted small">Žádné.</span>
+    }
+    <div class="d-flex gap-2 align-items-end mt-1">
+        <div style="flex:1">
+            <DxComboBox Data="@AvailableBuildings" @bind-Value="@_newBuildingId"
+                        TextFieldName="Name" ValueFieldName="Id"
+                        NullText="@AddPlaceholder" SearchMode="ListSearchMode.AutoSearch" />
+        </div>
+        <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                disabled="@(_newBuildingId is null)"
+                @onclick="AddAsync">
+            <i class="bi bi-plus"></i>
+        </button>
+    </div>
+</div>
+
+@code {
+    public sealed record BuildingRow(int BuildingId, string BuildingName);
+
+    [Parameter, EditorRequired] public string Caption { get; set; } = "Budovy";
+    [Parameter] public string AddPlaceholder { get; set; } = "(přidat budovu)";
+
+    [Parameter, EditorRequired] public IReadOnlyList<BuildingRow> Buildings { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<BuildingListDto> AvailableBuildings { get; set; } = [];
+
+    [Parameter] public EventCallback<int> OnAdd { get; set; }
+    [Parameter] public EventCallback<int> OnRemove { get; set; }
+
+    private int? _newBuildingId;
+
+    private async Task AddAsync()
+    {
+        if (_newBuildingId is null) return;
+        var id = _newBuildingId.Value;
+        _newBuildingId = null;
+        await OnAdd.InvokeAsync(id);
+    }
+}

--- a/src/OvcinaHra.Client/Components/RecipeBuildingPicker.razor
+++ b/src/OvcinaHra.Client/Components/RecipeBuildingPicker.razor
@@ -15,8 +15,10 @@
             <span class="badge bg-secondary me-1">
                 @b.BuildingName
                 <button class="btn btn-sm btn-link text-white p-0 ms-1"
+                        title="Odebrat budovu"
+                        aria-label="@($"Odebrat budovu {b.BuildingName}")"
                         @onclick="() => OnRemove.InvokeAsync(b.BuildingId)">
-                    <i class="bi bi-x"></i>
+                    <i class="bi bi-x" aria-hidden="true"></i>
                 </button>
             </span>
         }
@@ -32,9 +34,11 @@
                         NullText="@AddPlaceholder" SearchMode="ListSearchMode.AutoSearch" />
         </div>
         <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                title="Přidat budovu"
+                aria-label="Přidat budovu"
                 disabled="@(_newBuildingId is null)"
                 @onclick="AddAsync">
-            <i class="bi bi-plus"></i>
+            <i class="bi bi-plus" aria-hidden="true"></i>
         </button>
     </div>
 </div>

--- a/src/OvcinaHra.Client/Components/RecipeIngredientPicker.razor
+++ b/src/OvcinaHra.Client/Components/RecipeIngredientPicker.razor
@@ -1,0 +1,81 @@
+@* Issue #163 — leaf component shared by ItemList and BuildingList recipe
+   editors. Renders the ingredient table + add-row, emits semantic events.
+   Caller owns persistence + DTO-specific endpoint calls. *@
+
+@using OvcinaHra.Shared.Dtos
+
+<div class="mb-2">
+    <strong class="small">Ingredience:</strong>
+    @if (Ingredients.Count > 0)
+    {
+        <table class="table table-sm mb-1">
+            <tbody>
+                @foreach (var ing in Ingredients)
+                {
+                    <tr>
+                        <td>@ing.ItemName</td>
+                        <td style="width:60px">×@ing.Quantity</td>
+                        <td style="width:40px">
+                            <button class="btn btn-sm btn-link text-danger p-0"
+                                    @onclick="() => OnRemove.InvokeAsync(ing.ItemId)">
+                                <i class="bi bi-x-circle"></i>
+                            </button>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+    else
+    {
+        <p class="text-muted small mb-1">Žádné ingredience.</p>
+    }
+    <div class="d-flex gap-2 align-items-end">
+        <div style="flex:1">
+            <DxComboBox Data="@AvailableItems" @bind-Value="@_newItemId"
+                        TextFieldName="Name" ValueFieldName="Id"
+                        NullText="(přidat ingredienci)" SearchMode="ListSearchMode.AutoSearch" />
+        </div>
+        <div style="width:70px">
+            <DxSpinEdit @bind-Value="@_newQuantity" MinValue="1" />
+        </div>
+        <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                disabled="@(_newItemId is null)"
+                @onclick="AddAsync">
+            <i class="bi bi-plus"></i>
+        </button>
+    </div>
+</div>
+
+@code {
+    /// <summary>
+    /// Flat ingredient row used by both <c>CraftingIngredientDto</c> and
+    /// <c>BuildingRecipeIngredientDto</c>. Each parent maps its own DTO into
+    /// this shape on render — they're structurally identical.
+    /// </summary>
+    public sealed record IngredientRow(int ItemId, string ItemName, int Quantity);
+
+    [Parameter, EditorRequired] public IReadOnlyList<IngredientRow> Ingredients { get; set; } = [];
+
+    /// <summary>List of items the picker may add. <c>ItemListDto</c>
+    /// (or any record with <c>Id</c> + <c>Name</c>) so the combo binds.</summary>
+    [Parameter, EditorRequired] public IReadOnlyList<ItemListDto> AvailableItems { get; set; } = [];
+
+    [Parameter] public EventCallback<(int ItemId, int Quantity)> OnAdd { get; set; }
+    [Parameter] public EventCallback<int> OnRemove { get; set; }
+
+    private int? _newItemId;
+    private int _newQuantity = 1;
+
+    private async Task AddAsync()
+    {
+        if (_newItemId is null) return;
+        var id = _newItemId.Value;
+        var qty = _newQuantity > 0 ? _newQuantity : 1;
+        // Reset form first so a slow callback doesn't double-fire on a second
+        // click — same idempotency stance as the original inline editor.
+        _newItemId = null;
+        _newQuantity = 1;
+        await OnAdd.InvokeAsync((id, qty));
+    }
+}

--- a/src/OvcinaHra.Client/Components/RecipeIngredientPicker.razor
+++ b/src/OvcinaHra.Client/Components/RecipeIngredientPicker.razor
@@ -17,8 +17,10 @@
                         <td style="width:60px">×@ing.Quantity</td>
                         <td style="width:40px">
                             <button class="btn btn-sm btn-link text-danger p-0"
+                                    title="Odebrat ingredienci"
+                                    aria-label="@($"Odebrat ingredienci {ing.ItemName}")"
                                     @onclick="() => OnRemove.InvokeAsync(ing.ItemId)">
-                                <i class="bi bi-x-circle"></i>
+                                <i class="bi bi-x-circle" aria-hidden="true"></i>
                             </button>
                         </td>
                     </tr>
@@ -40,9 +42,11 @@
             <DxSpinEdit @bind-Value="@_newQuantity" MinValue="1" />
         </div>
         <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                title="Přidat ingredienci"
+                aria-label="Přidat ingredienci"
                 disabled="@(_newItemId is null)"
                 @onclick="AddAsync">
-            <i class="bi bi-plus"></i>
+            <i class="bi bi-plus" aria-hidden="true"></i>
         </button>
     </div>
 </div>

--- a/src/OvcinaHra.Client/Components/RecipeNotesEditor.razor
+++ b/src/OvcinaHra.Client/Components/RecipeNotesEditor.razor
@@ -21,6 +21,7 @@
 
     private string? _local;
     private string? _trackedPersisted;
+    private bool _initialized;
 
     /// <summary>Compare locally-edited text to whatever the parent says is
     /// persisted. Empty-string and null are treated as equivalent (the API
@@ -32,12 +33,18 @@
     {
         // Re-sync the editor when the parent reloads with a different
         // persisted value (e.g. recipe switched in the popup, or after a
-        // server-confirmed save). Without this, stale local state would shadow
-        // the new persisted note.
-        if (!ReferenceEquals(_trackedPersisted, PersistedValue))
+        // server-confirmed save). Compare by ORDINAL CONTENT — ReferenceEquals
+        // would falsely re-sync (and clobber in-progress edits) any time the
+        // parent passes a new string instance with the same text, e.g. after
+        // a parent re-render projects the same DTO field. Treat null and
+        // empty string as equivalent so the API normalisation doesn't trigger
+        // a redundant resync (Copilot on PR #173).
+        if (!_initialized
+            || !string.Equals(_trackedPersisted ?? string.Empty, PersistedValue ?? string.Empty, StringComparison.Ordinal))
         {
             _trackedPersisted = PersistedValue;
             _local = PersistedValue;
+            _initialized = true;
         }
     }
 

--- a/src/OvcinaHra.Client/Components/RecipeNotesEditor.razor
+++ b/src/OvcinaHra.Client/Components/RecipeNotesEditor.razor
@@ -1,0 +1,52 @@
+@* Issue #163 — Poznámka k surovinám memo + save button. Save fires only
+   when the local value diverges from the persisted one (matches the
+   pre-extraction inline behaviour). Caller persists. *@
+
+<div class="mb-2">
+    <strong class="small">Poznámka k surovinám:</strong>
+    <DxMemo @bind-Text="@_local" Rows="2"
+            NullText="(žádná poznámka, např. „Byliny — 3× stejný druh“)" />
+    <div class="d-flex gap-2 mt-1">
+        <button class="btn btn-sm btn-outline-primary"
+                disabled="@IsClean"
+                @onclick="SaveAsync">
+            Uložit poznámku
+        </button>
+    </div>
+</div>
+
+@code {
+    [Parameter] public string? PersistedValue { get; set; }
+    [Parameter] public EventCallback<string?> OnSave { get; set; }
+
+    private string? _local;
+    private string? _trackedPersisted;
+
+    /// <summary>Compare locally-edited text to whatever the parent says is
+    /// persisted. Empty-string and null are treated as equivalent (the API
+    /// stores either as "no note").</summary>
+    private bool IsClean
+        => string.Equals(_local ?? string.Empty, PersistedValue ?? string.Empty, StringComparison.Ordinal);
+
+    protected override void OnParametersSet()
+    {
+        // Re-sync the editor when the parent reloads with a different
+        // persisted value (e.g. recipe switched in the popup, or after a
+        // server-confirmed save). Without this, stale local state would shadow
+        // the new persisted note.
+        if (!ReferenceEquals(_trackedPersisted, PersistedValue))
+        {
+            _trackedPersisted = PersistedValue;
+            _local = PersistedValue;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        // Send null when the user clears the field — server normalises
+        // empty/null to "no note", but the existing inline handlers passed
+        // string.Empty. Stay consistent: pass _local through unmodified so
+        // either convention works.
+        await OnSave.InvokeAsync(_local);
+    }
+}

--- a/src/OvcinaHra.Client/Components/RecipeSkillPicker.razor
+++ b/src/OvcinaHra.Client/Components/RecipeSkillPicker.razor
@@ -15,8 +15,10 @@
             <span class="badge bg-secondary me-1">
                 @(gs?.Name ?? $"[Neznámá dovednost #{skillId}]")
                 <button class="btn btn-sm btn-link text-white p-0 ms-1"
+                        title="Odebrat dovednost"
+                        aria-label="@($"Odebrat dovednost {gs?.Name ?? skillId.ToString()}")"
                         @onclick="() => OnRemove.InvokeAsync(skillId)">
-                    <i class="bi bi-x"></i>
+                    <i class="bi bi-x" aria-hidden="true"></i>
                 </button>
             </span>
         }
@@ -34,9 +36,11 @@
                             NullText="(přidat dovednost)" SearchMode="ListSearchMode.AutoSearch" />
             </div>
             <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                    title="Přidat dovednost"
+                    aria-label="Přidat dovednost"
                     disabled="@(_newSkillId is null)"
                     @onclick="AddAsync">
-                <i class="bi bi-plus"></i>
+                <i class="bi bi-plus" aria-hidden="true"></i>
             </button>
         </div>
     }

--- a/src/OvcinaHra.Client/Components/RecipeSkillPicker.razor
+++ b/src/OvcinaHra.Client/Components/RecipeSkillPicker.razor
@@ -1,0 +1,62 @@
+@* Issue #163 — required-skills badge list + add control. The list of
+   GameSkillDtos passed in must be the per-game subset (already created
+   for this game). Stale skill IDs (deleted GameSkill rows) render as
+   "[Neznámá dovednost #N]" so partial data still displays. *@
+
+@using OvcinaHra.Shared.Dtos
+
+<div class="mb-2">
+    <strong class="small">Požadované dovednosti:</strong>
+    @if (SelectedSkillIds.Count > 0)
+    {
+        @foreach (var skillId in SelectedSkillIds)
+        {
+            var gs = AllGameSkills.FirstOrDefault(g => g.Id == skillId);
+            <span class="badge bg-secondary me-1">
+                @(gs?.Name ?? $"[Neznámá dovednost #{skillId}]")
+                <button class="btn btn-sm btn-link text-white p-0 ms-1"
+                        @onclick="() => OnRemove.InvokeAsync(skillId)">
+                    <i class="bi bi-x"></i>
+                </button>
+            </span>
+        }
+    }
+    else
+    {
+        <span class="text-muted small">Žádné.</span>
+    }
+    @if (AvailableSkills.Count > 0)
+    {
+        <div class="d-flex gap-2 align-items-end mt-1">
+            <div style="flex:1">
+                <DxComboBox Data="@AvailableSkills" @bind-Value="@_newSkillId"
+                            TextFieldName="Name" ValueFieldName="Id"
+                            NullText="(přidat dovednost)" SearchMode="ListSearchMode.AutoSearch" />
+            </div>
+            <button class="btn btn-sm btn-outline-primary" style="height:34px"
+                    disabled="@(_newSkillId is null)"
+                    @onclick="AddAsync">
+                <i class="bi bi-plus"></i>
+            </button>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public IReadOnlyList<int> SelectedSkillIds { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<GameSkillDto> AllGameSkills { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<GameSkillDto> AvailableSkills { get; set; } = [];
+
+    [Parameter] public EventCallback<int> OnAdd { get; set; }
+    [Parameter] public EventCallback<int> OnRemove { get; set; }
+
+    private int? _newSkillId;
+
+    private async Task AddAsync()
+    {
+        if (_newSkillId is null) return;
+        var id = _newSkillId.Value;
+        _newSkillId = null;
+        await OnAdd.InvokeAsync(id);
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
@@ -138,93 +138,31 @@ else
                             </button>
                         </div>
                     </div>
-                    <div class="mb-2">
-                        <strong class="small">Ingredience:</strong>
-                        @if (recipe.Ingredients.Count > 0)
-                        {
-                            <table class="table table-sm mb-1">
-                                <tbody>
-                                    @foreach (var ing in recipe.Ingredients)
-                                    {
-                                        <tr>
-                                            <td>@ing.ItemName</td>
-                                            <td style="width:60px">×@ing.Quantity</td>
-                                            <td style="width:40px"><button class="btn btn-sm btn-link text-danger p-0" @onclick="() => RemoveIngredientAsync(ing.ItemId)"><i class="bi bi-x-circle"></i></button></td>
-                                        </tr>
-                                    }
-                                </tbody>
-                            </table>
-                        }
-                        else { <p class="text-muted small mb-1">Žádné ingredience.</p> }
-                        <div class="d-flex gap-2 align-items-end">
-                            <div style="flex:1">
-                                <DxComboBox Data="@allItems" @bind-Value="@newIngItemId"
-                                            TextFieldName="Name" ValueFieldName="Id"
-                                            NullText="(přidat ingredienci)" SearchMode="ListSearchMode.AutoSearch" />
-                            </div>
-                            <div style="width:70px">
-                                <DxSpinEdit @bind-Value="@newIngQuantity" MinValue="1" />
-                            </div>
-                            <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newIngItemId is null)" @onclick="AddIngredientAsync"><i class="bi bi-plus"></i></button>
-                        </div>
-                    </div>
-                    <div class="mb-2">
-                        <strong class="small">Poznámka k surovinám:</strong>
-                        <DxMemo @bind-Text="@recipeIngredientNotes" Rows="2"
-                                NullText="(žádná poznámka, např. „Byliny — 3× stejný druh“)" />
-                        <div class="d-flex gap-2 mt-1">
-                            <button class="btn btn-sm btn-outline-primary"
-                                    disabled="@(string.Equals(recipeIngredientNotes ?? "", recipe.IngredientNotes ?? "", StringComparison.Ordinal))"
-                                    @onclick="SaveRecipeNotesAsync">
-                                Uložit poznámku
-                            </button>
-                        </div>
-                    </div>
-                    <div class="mb-2">
-                        <strong class="small">Předpoklady (jiné budovy):</strong>
-                        @if (recipe.PrerequisiteBuildings.Count > 0)
-                        {
-                            @foreach (var pb in recipe.PrerequisiteBuildings)
-                            {
-                                <span class="badge bg-secondary me-1">@pb.BuildingName <button class="btn btn-sm btn-link text-white p-0 ms-1" @onclick="() => RemovePrereqAsync(pb.BuildingId)"><i class="bi bi-x"></i></button></span>
-                            }
-                        }
-                        else { <span class="text-muted small">Žádné.</span> }
-                        <div class="d-flex gap-2 align-items-end mt-1">
-                            <div style="flex:1">
-                                <DxComboBox Data="@AvailablePrereqBuildings" @bind-Value="@newPrereqBuildingId"
-                                            TextFieldName="Name" ValueFieldName="Id"
-                                            NullText="(přidat předpoklad)" SearchMode="ListSearchMode.AutoSearch" />
-                            </div>
-                            <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newPrereqBuildingId is null)" @onclick="AddPrereqAsync"><i class="bi bi-plus"></i></button>
-                        </div>
-                    </div>
-                    <div class="mb-2">
-                        <strong class="small">Požadované dovednosti:</strong>
-                        @if (recipe.RequiredSkillIds.Count > 0)
-                        {
-                            @foreach (var skillId in recipe.RequiredSkillIds)
-                            {
-                                var gs = gameSkills.FirstOrDefault(g => g.Id == skillId);
-                                <span class="badge bg-secondary me-1">
-                                    @(gs?.Name ?? $"[Neznámá dovednost #{skillId}]")
-                                    <button class="btn btn-sm btn-link text-white p-0 ms-1" @onclick="() => RemoveSkillAsync(skillId)"><i class="bi bi-x"></i></button>
-                                </span>
-                            }
-                        }
-                        else { <span class="text-muted small">Žádné.</span> }
-                        @if (AvailableGameSkills.Count > 0)
-                        {
-                            <div class="d-flex gap-2 align-items-end mt-1">
-                                <div style="flex:1">
-                                    <DxComboBox Data="@AvailableGameSkills" @bind-Value="@newSkillId"
-                                                TextFieldName="Name" ValueFieldName="Id"
-                                                NullText="(přidat dovednost)" SearchMode="ListSearchMode.AutoSearch" />
-                                </div>
-                                <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newSkillId is null)" @onclick="AddSkillAsync"><i class="bi bi-plus"></i></button>
-                            </div>
-                        }
-                    </div>
+                    <RecipeIngredientPicker
+                        Ingredients="@(recipe.Ingredients.Select(i => new RecipeIngredientPicker.IngredientRow(i.ItemId, i.ItemName, i.Quantity)).ToList())"
+                        AvailableItems="@allItems"
+                        OnAdd="@AddIngredientAsync"
+                        OnRemove="@RemoveIngredientAsync" />
+
+                    <RecipeNotesEditor
+                        PersistedValue="@recipe.IngredientNotes"
+                        OnSave="@SaveRecipeNotesAsync" />
+
+                    <RecipeBuildingPicker
+                        Caption="Předpoklady (jiné budovy)"
+                        AddPlaceholder="(přidat předpoklad)"
+                        Buildings="@(recipe.PrerequisiteBuildings.Select(pb => new RecipeBuildingPicker.BuildingRow(pb.BuildingId, pb.BuildingName)).ToList())"
+                        AvailableBuildings="@AvailablePrereqBuildings"
+                        OnAdd="@AddPrereqAsync"
+                        OnRemove="@RemovePrereqAsync" />
+
+                    <RecipeSkillPicker
+                        SelectedSkillIds="@recipe.RequiredSkillIds"
+                        AllGameSkills="@gameSkills"
+                        AvailableSkills="@AvailableGameSkills"
+                        OnAdd="@AddSkillAsync"
+                        OnRemove="@RemoveSkillAsync" />
+
                     <button class="btn btn-sm btn-outline-danger" @onclick="() => isDeleteRecipeVisible = true">Smazat recept</button>
                 }
                 else
@@ -279,18 +217,16 @@ else
 
     // ----- Building crafting recipe state (issue #142) -----
     // Mirrors the Item recipe pattern in ItemList.razor's edit popup. The
-    // duplication is intentional for now — flagged as a follow-up issue
-    // for a shared CraftingRecipeEditor component.
+    // Issue #163 — leaf components (RecipeIngredientPicker /
+    // RecipeBuildingPicker / RecipeSkillPicker / RecipeNotesEditor) own
+    // their own input state, so the parallel `newIngItemId`/`newSkillId`/
+    // etc fields that lived here are gone. The Building-only Cena
+    // (`recipeMoneyCost`) stays page-level — Item recipes don't have it.
     private BuildingRecipeDetailDto? recipe;
     private List<ItemListDto> allItems = [];
     private List<BuildingListDto> allCatalogBuildings = [];
     private List<GameSkillDto> gameSkills = [];
-    private int? newIngItemId;
-    private int newIngQuantity = 1;
-    private int? newPrereqBuildingId;
-    private int? newSkillId;
     private int? recipeMoneyCost;
-    private string? recipeIngredientNotes;
     private bool isDeleteRecipeVisible;
 
     // Skills already required by the recipe shouldn't appear in the picker.
@@ -357,11 +293,6 @@ else
         // already gates rendering on those conditions.
         recipe = null;
         recipeMoneyCost = null;
-        recipeIngredientNotes = null;
-        newIngItemId = null;
-        newIngQuantity = 1;
-        newPrereqBuildingId = null;
-        newSkillId = null;
         if (editingId.HasValue && !Catalog && GameContext.SelectedGameId is int gid)
         {
             // Items eligible as ingredients are catalog-wide (the recipe
@@ -384,7 +315,6 @@ else
     {
         recipe = null;
         recipeMoneyCost = null;
-        recipeIngredientNotes = null;
         if (GameContext.SelectedGameId is not int gid) return;
 
         // /api/building-recipes/by-game/{gid} returns one entry per recipe,
@@ -395,7 +325,6 @@ else
         {
             recipe = await Api.GetAsync<BuildingRecipeDetailDto>($"/api/building-recipes/{match.Id}");
             recipeMoneyCost = recipe?.MoneyCost;
-            recipeIngredientNotes = recipe?.IngredientNotes;
         }
     }
 
@@ -420,22 +349,19 @@ else
             await Api.DeleteAsync($"/api/building-recipes/{recipe.Id}");
             recipe = null;
             recipeMoneyCost = null;
-            recipeIngredientNotes = null;
             isDeleteRecipeVisible = false;
             StateHasChanged();
         }
         catch (Exception ex) { error = ex.Message; isDeleteRecipeVisible = false; }
     }
 
-    private async Task AddIngredientAsync()
+    private async Task AddIngredientAsync((int ItemId, int Quantity) ev)
     {
-        if (recipe is null || newIngItemId is null) return;
+        if (recipe is null) return;
         try
         {
             await Api.PostAsync<AddBuildingRecipeIngredientDto, object>($"/api/building-recipes/{recipe.Id}/ingredients",
-                new AddBuildingRecipeIngredientDto(newIngItemId.Value, newIngQuantity));
-            newIngItemId = null;
-            newIngQuantity = 1;
+                new AddBuildingRecipeIngredientDto(ev.ItemId, ev.Quantity));
             await LoadRecipeAsync(editingId!.Value);
             StateHasChanged();
         }
@@ -454,14 +380,13 @@ else
         catch (Exception ex) { error = ex.Message; }
     }
 
-    private async Task AddPrereqAsync()
+    private async Task AddPrereqAsync(int buildingId)
     {
-        if (recipe is null || newPrereqBuildingId is null) return;
+        if (recipe is null) return;
         try
         {
             await Api.PostAsync<AddBuildingRecipePrerequisiteDto, object>($"/api/building-recipes/{recipe.Id}/prerequisites",
-                new AddBuildingRecipePrerequisiteDto(newPrereqBuildingId.Value));
-            newPrereqBuildingId = null;
+                new AddBuildingRecipePrerequisiteDto(buildingId));
             await LoadRecipeAsync(editingId!.Value);
             StateHasChanged();
         }
@@ -480,12 +405,12 @@ else
         catch (Exception ex) { error = ex.Message; }
     }
 
-    private async Task AddSkillAsync()
+    private async Task AddSkillAsync(int skillId)
     {
-        if (recipe is null || newSkillId is null) return;
+        if (recipe is null) return;
         var next = recipe.RequiredSkillIds.ToList();
-        if (next.Contains(newSkillId.Value)) return;
-        next.Add(newSkillId.Value);
+        if (next.Contains(skillId)) return;
+        next.Add(skillId);
         await PutRecipeAsync(
             moneyCost: recipe.MoneyCost,
             skillIds: next,
@@ -514,10 +439,10 @@ else
             ingredientNotes: recipe.IngredientNotes);
     }
 
-    private async Task SaveRecipeNotesAsync()
+    private async Task SaveRecipeNotesAsync(string? newValue)
     {
         if (recipe is null || editingId is null) return;
-        var normalized = string.IsNullOrWhiteSpace(recipeIngredientNotes) ? null : recipeIngredientNotes.Trim();
+        var normalized = string.IsNullOrWhiteSpace(newValue) ? null : newValue.Trim();
         // Same shape as money — pass `normalized` (which may be null) verbatim
         // so clearing the memo actually persists as null.
         await PutRecipeAsync(
@@ -545,7 +470,6 @@ else
                 RequiredSkillIds: skillIds,
                 IngredientNotes: ingredientNotes);
             await Api.PutAsync($"/api/building-recipes/{recipe.Id}", dto);
-            newSkillId = null;
             await LoadRecipeAsync(editingId!.Value);
             StateHasChanged();
         }

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
@@ -139,7 +139,7 @@ else
                         </div>
                     </div>
                     <RecipeIngredientPicker
-                        Ingredients="@(recipe.Ingredients.Select(i => new RecipeIngredientPicker.IngredientRow(i.ItemId, i.ItemName, i.Quantity)).ToList())"
+                        Ingredients="@_ingredientRows"
                         AvailableItems="@allItems"
                         OnAdd="@AddIngredientAsync"
                         OnRemove="@RemoveIngredientAsync" />
@@ -151,7 +151,7 @@ else
                     <RecipeBuildingPicker
                         Caption="Předpoklady (jiné budovy)"
                         AddPlaceholder="(přidat předpoklad)"
-                        Buildings="@(recipe.PrerequisiteBuildings.Select(pb => new RecipeBuildingPicker.BuildingRow(pb.BuildingId, pb.BuildingName)).ToList())"
+                        Buildings="@_prerequisiteRows"
                         AvailableBuildings="@AvailablePrereqBuildings"
                         OnAdd="@AddPrereqAsync"
                         OnRemove="@RemovePrereqAsync" />
@@ -228,6 +228,11 @@ else
     private List<GameSkillDto> gameSkills = [];
     private int? recipeMoneyCost;
     private bool isDeleteRecipeVisible;
+    // Pre-projected leaf-row caches, refreshed once per recipe load so
+    // popup re-renders don't allocate fresh lists every frame
+    // (Copilot review on PR #173).
+    private IReadOnlyList<RecipeIngredientPicker.IngredientRow> _ingredientRows = [];
+    private IReadOnlyList<RecipeBuildingPicker.BuildingRow> _prerequisiteRows = [];
 
     // Skills already required by the recipe shouldn't appear in the picker.
     private List<GameSkillDto> AvailableGameSkills =>
@@ -315,6 +320,8 @@ else
     {
         recipe = null;
         recipeMoneyCost = null;
+        _ingredientRows = [];
+        _prerequisiteRows = [];
         if (GameContext.SelectedGameId is not int gid) return;
 
         // /api/building-recipes/by-game/{gid} returns one entry per recipe,
@@ -325,6 +332,16 @@ else
         {
             recipe = await Api.GetAsync<BuildingRecipeDetailDto>($"/api/building-recipes/{match.Id}");
             recipeMoneyCost = recipe?.MoneyCost;
+            // Project DTO collections once per recipe load (Copilot on PR #173).
+            if (recipe is not null)
+            {
+                _ingredientRows = recipe.Ingredients
+                    .Select(i => new RecipeIngredientPicker.IngredientRow(i.ItemId, i.ItemName, i.Quantity))
+                    .ToList();
+                _prerequisiteRows = recipe.PrerequisiteBuildings
+                    .Select(pb => new RecipeBuildingPicker.BuildingRow(pb.BuildingId, pb.BuildingName))
+                    .ToList();
+            }
         }
     }
 

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -539,100 +539,42 @@ else
                 <h6 class="mb-2"><i class="bi bi-hammer me-1"></i> Recept (aktuální hra)</h6>
                 @if (recipe is not null)
                 {
-                    <div class="mb-2">
-                        <strong class="small">Ingredience:</strong>
-                        @if (recipe.Ingredients.Count > 0)
-                        {
-                            <table class="table table-sm mb-1">
-                                <tbody>
-                                    @foreach (var ing in recipe.Ingredients)
-                                    {
-                                        <tr>
-                                            <td>@ing.ItemName</td>
-                                            <td style="width:60px">×@ing.Quantity</td>
-                                            <td style="width:40px"><button class="btn btn-sm btn-link text-danger p-0" @onclick="() => RemoveIngredientAsync(ing.ItemId)"><i class="bi bi-x-circle"></i></button></td>
-                                        </tr>
-                                    }
-                                </tbody>
-                            </table>
-                        }
-                        else { <p class="text-muted small mb-1">Žádné ingredience.</p> }
-                        <div class="d-flex gap-2 align-items-end">
-                            <div style="flex:1">
-                                <DxComboBox Data="@allItems" @bind-Value="@newIngItemId"
-                                            TextFieldName="Name" ValueFieldName="Id"
-                                            NullText="(přidat ingredienci)" SearchMode="ListSearchMode.AutoSearch" />
-                            </div>
-                            <div style="width:70px">
-                                <DxSpinEdit @bind-Value="@newIngQuantity" MinValue="1" />
-                            </div>
-                            <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newIngItemId is null)" @onclick="AddIngredientAsync"><i class="bi bi-plus"></i></button>
-                        </div>
-                    </div>
-                    @* Poznámka k surovinám — issue #121. Belongs after the
-                       ingredient list (per the issue text), before Buildings/Skills.
-                       Free-text annotation that's not tied to any one ingredient
-                       — e.g. "Byliny — 3× stejný druh". Save explicitly via
-                       the Uložit poznámku button so a stray click in the memo
+                    <RecipeIngredientPicker
+                        Ingredients="@(recipe.Ingredients.Select(i => new RecipeIngredientPicker.IngredientRow(i.ItemId, i.ItemName, i.Quantity)).ToList())"
+                        AvailableItems="@allItems"
+                        OnAdd="@AddIngredientAsync"
+                        OnRemove="@RemoveIngredientAsync" />
+
+                    @* Poznámka k surovinám — issue #121. Free-text annotation
+                       not tied to any one ingredient (e.g. "Byliny — 3× stejný
+                       druh"). Save explicitly so a stray click in the memo
                        doesn't trigger a stale PUT. *@
-                    <div class="mb-2">
-                        <strong class="small">Poznámka k surovinám:</strong>
-                        <DxMemo @bind-Text="@recipeIngredientNotes" Rows="2"
-                                NullText="(žádná poznámka, např. „Byliny — 3× stejný druh“)" />
-                        <div class="d-flex gap-2 mt-1">
-                            <button class="btn btn-sm btn-outline-primary"
-                                    disabled="@(string.Equals(recipeIngredientNotes ?? "", recipe.IngredientNotes ?? "", StringComparison.Ordinal))"
-                                    @onclick="SaveRecipeNotesAsync">
-                                Uložit poznámku
-                            </button>
-                        </div>
-                    </div>
-                    <div class="mb-2">
-                        <strong class="small">Požadované budovy:</strong>
-                        @if (recipe.BuildingRequirements.Count > 0)
-                        {
-                            @foreach (var br in recipe.BuildingRequirements)
-                            {
-                                <span class="badge bg-secondary me-1">@br.BuildingName <button class="btn btn-sm btn-link text-white p-0 ms-1" @onclick="() => RemoveBuildingReqAsync(br.BuildingId)"><i class="bi bi-x"></i></button></span>
-                            }
-                        }
-                        else { <span class="text-muted small">Žádné.</span> }
-                        <div class="d-flex gap-2 align-items-end mt-1">
-                            <div style="flex:1">
-                                <DxComboBox Data="@allBuildings" @bind-Value="@newBuildingId"
-                                            TextFieldName="Name" ValueFieldName="Id"
-                                            NullText="(přidat budovu)" SearchMode="ListSearchMode.AutoSearch" />
-                            </div>
-                            <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newBuildingId is null)" @onclick="AddBuildingReqAsync"><i class="bi bi-plus"></i></button>
-                        </div>
-                    </div>
-                    <div class="mb-2">
-                        <strong class="small">Požadované dovednosti:</strong>
-                        @if (recipe.RequiredSkillIds.Count > 0)
-                        {
-                            @foreach (var skillId in recipe.RequiredSkillIds)
-                            {
-                                var gs = gameSkills.FirstOrDefault(g => g.Id == skillId);
-                                <span class="badge bg-secondary me-1">
-                                    @(gs?.Name ?? $"[Neznámá dovednost #{skillId}]")
-                                    <button class="btn btn-sm btn-link text-white p-0 ms-1" @onclick="() => RemoveSkillReqAsync(skillId)"><i class="bi bi-x"></i></button>
-                                </span>
-                            }
-                        }
-                        else { <span class="text-muted small">Žádné.</span> }
-                        @if (AvailableGameSkills.Count > 0)
-                        {
-                            <div class="d-flex gap-2 align-items-end mt-1">
-                                <div style="flex:1">
-                                    <DxComboBox Data="@AvailableGameSkills" @bind-Value="@newSkillId"
-                                                TextFieldName="Name" ValueFieldName="Id"
-                                                NullText="(přidat dovednost)" SearchMode="ListSearchMode.AutoSearch" />
-                                </div>
-                                <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newSkillId is null)" @onclick="AddSkillReqAsync"><i class="bi bi-plus"></i></button>
-                            </div>
-                        }
-                    </div>
-                    <button class="btn btn-sm btn-outline-danger" @onclick="DeleteRecipeAsync">Smazat recept</button>
+                    <RecipeNotesEditor
+                        PersistedValue="@recipe.IngredientNotes"
+                        OnSave="@SaveRecipeNotesAsync" />
+
+                    <RecipeBuildingPicker
+                        Caption="Požadované budovy"
+                        AddPlaceholder="(přidat budovu)"
+                        Buildings="@(recipe.BuildingRequirements.Select(br => new RecipeBuildingPicker.BuildingRow(br.BuildingId, br.BuildingName)).ToList())"
+                        AvailableBuildings="@allBuildings"
+                        OnAdd="@AddBuildingReqAsync"
+                        OnRemove="@RemoveBuildingReqAsync" />
+
+                    <RecipeSkillPicker
+                        SelectedSkillIds="@recipe.RequiredSkillIds"
+                        AllGameSkills="@gameSkills"
+                        AvailableSkills="@AvailableGameSkills"
+                        OnAdd="@AddSkillReqAsync"
+                        OnRemove="@RemoveSkillReqAsync" />
+
+                    @* Issue #163 — destructive-confirm rule (matches Building
+                       side). Opening a popup instead of wiring the handler
+                       directly so a stray click can't drop the recipe. *@
+                    <button class="btn btn-sm btn-outline-danger"
+                            @onclick="() => isDeleteRecipeVisible = true">
+                        Smazat recept
+                    </button>
                 }
                 else
                 {
@@ -712,6 +654,20 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+@* Issue #163 — destructive recipe-delete confirmation, matches the pattern
+   already used in BuildingList.razor for #142. Pre-extraction the Item-side
+   wired the delete handler directly to the button, which would drop the
+   recipe on a stray click. *@
+<DxPopup @bind-Visible="@isDeleteRecipeVisible" HeaderText="Smazat recept?" Width="420px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete smazat recept předmětu <strong>@name</strong>? Ingredience, požadované budovy a dovednosti se odeberou společně s receptem.</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isDeleteRecipeVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmDeleteRecipeAsync">Smazat recept</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @code {
     [SupplyParameterFromQuery]
     public bool Catalog { get; set; }
@@ -777,14 +733,9 @@ else
     private List<ItemListDto> allItems = [];
     private List<BuildingListDto> allBuildings = [];
     private List<GameSkillDto> gameSkills = [];
-    private int? newIngItemId;
-    private int newIngQuantity = 1;
-    private int? newBuildingId;
-    private int? newSkillId;
-    // Issue #121 — locally-bound editor copy for IngredientNotes. Server is
-    // the source of truth (LoadRecipeAsync re-reads after saves); this is just
-    // the DxMemo's binding target while the user types.
-    private string? recipeIngredientNotes;
+    // Issue #163 — destructive-confirm popup state for "Smazat recept".
+    // Mirrors the pattern Hra3 used in BuildingList for #142.
+    private bool isDeleteRecipeVisible;
 
     private List<GameSkillDto> AvailableGameSkills =>
         recipe is null
@@ -1154,8 +1105,6 @@ else
     private async Task LoadRecipeAsync(int itemId)
     {
         recipe = null;
-        recipeIngredientNotes = null;
-        newIngItemId = null; newIngQuantity = 1; newBuildingId = null; newSkillId = null;
         var gameId = GameContext.SelectedGameId;
         if (gameId is null || !isCraftable) return;
 
@@ -1166,16 +1115,15 @@ else
         if (match is not null)
         {
             recipe = await Api.GetAsync<CraftingRecipeDetailDto>($"/api/crafting/{match.Id}");
-            recipeIngredientNotes = recipe?.IngredientNotes;
         }
     }
 
-    private async Task AddSkillReqAsync()
+    private async Task AddSkillReqAsync(int skillId)
     {
-        if (recipe is null || newSkillId is null) return;
+        if (recipe is null) return;
         var next = recipe.RequiredSkillIds.ToList();
-        if (next.Contains(newSkillId.Value)) return;
-        next.Add(newSkillId.Value);
+        if (next.Contains(skillId)) return;
+        next.Add(skillId);
         await SaveRecipeSkillsAsync(next);
     }
 
@@ -1196,19 +1144,18 @@ else
             await Api.PutAsync($"/api/crafting/{recipe.Id}",
                 new UpdateCraftingRecipeDto(recipe.OutputItemId, recipe.LocationId, desiredSkillIds,
                     IngredientNotes: recipe.IngredientNotes));
-            newSkillId = null;
             await LoadRecipeAsync(editingId!.Value);
             StateHasChanged();
         }
         catch (Exception ex) { error = ex.Message; }
     }
 
-    private async Task SaveRecipeNotesAsync()
+    private async Task SaveRecipeNotesAsync(string? newValue)
     {
         if (recipe is null || editingId is null) return;
         // Normalize like the server — trim + whitespace→null — so the local
         // UI state matches what actually persists. Issue #121.
-        var normalized = string.IsNullOrWhiteSpace(recipeIngredientNotes) ? null : recipeIngredientNotes.Trim();
+        var normalized = string.IsNullOrWhiteSpace(newValue) ? null : newValue.Trim();
         try
         {
             await Api.PutAsync($"/api/crafting/{recipe.Id}",
@@ -1234,9 +1181,10 @@ else
         catch (Exception ex) { error = ex.Message; }
     }
 
-    private async Task DeleteRecipeAsync()
+    private async Task ConfirmDeleteRecipeAsync()
     {
         if (recipe is null) return;
+        isDeleteRecipeVisible = false;
         try
         {
             await Api.DeleteAsync($"/api/crafting/{recipe.Id}");
@@ -1246,13 +1194,13 @@ else
         catch (Exception ex) { error = ex.Message; }
     }
 
-    private async Task AddIngredientAsync()
+    private async Task AddIngredientAsync((int ItemId, int Quantity) ev)
     {
-        if (recipe is null || newIngItemId is null) return;
+        if (recipe is null) return;
         try
         {
             await Api.PostAsync<AddCraftingIngredientDto, object>($"/api/crafting/{recipe.Id}/ingredients",
-                new AddCraftingIngredientDto(newIngItemId.Value, newIngQuantity));
+                new AddCraftingIngredientDto(ev.ItemId, ev.Quantity));
             await LoadRecipeAsync(editingId!.Value);
             StateHasChanged();
         }
@@ -1271,13 +1219,13 @@ else
         catch (Exception ex) { error = ex.Message; }
     }
 
-    private async Task AddBuildingReqAsync()
+    private async Task AddBuildingReqAsync(int buildingId)
     {
-        if (recipe is null || newBuildingId is null) return;
+        if (recipe is null) return;
         try
         {
             await Api.PostAsync<AddCraftingBuildingReqDto, object>($"/api/crafting/{recipe.Id}/buildings",
-                new AddCraftingBuildingReqDto(newBuildingId.Value));
+                new AddCraftingBuildingReqDto(buildingId));
             await LoadRecipeAsync(editingId!.Value);
             StateHasChanged();
         }

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -540,7 +540,7 @@ else
                 @if (recipe is not null)
                 {
                     <RecipeIngredientPicker
-                        Ingredients="@(recipe.Ingredients.Select(i => new RecipeIngredientPicker.IngredientRow(i.ItemId, i.ItemName, i.Quantity)).ToList())"
+                        Ingredients="@_ingredientRows"
                         AvailableItems="@allItems"
                         OnAdd="@AddIngredientAsync"
                         OnRemove="@RemoveIngredientAsync" />
@@ -556,7 +556,7 @@ else
                     <RecipeBuildingPicker
                         Caption="Požadované budovy"
                         AddPlaceholder="(přidat budovu)"
-                        Buildings="@(recipe.BuildingRequirements.Select(br => new RecipeBuildingPicker.BuildingRow(br.BuildingId, br.BuildingName)).ToList())"
+                        Buildings="@_buildingRows"
                         AvailableBuildings="@allBuildings"
                         OnAdd="@AddBuildingReqAsync"
                         OnRemove="@RemoveBuildingReqAsync" />
@@ -736,6 +736,11 @@ else
     // Issue #163 — destructive-confirm popup state for "Smazat recept".
     // Mirrors the pattern Hra3 used in BuildingList for #142.
     private bool isDeleteRecipeVisible;
+    // Issue #163 — pre-projected rows for the leaf components, refreshed
+    // once when `recipe` loads/changes instead of allocating new lists on
+    // every popup render (Copilot review on PR #173).
+    private IReadOnlyList<RecipeIngredientPicker.IngredientRow> _ingredientRows = [];
+    private IReadOnlyList<RecipeBuildingPicker.BuildingRow> _buildingRows = [];
 
     private List<GameSkillDto> AvailableGameSkills =>
         recipe is null
@@ -1105,6 +1110,8 @@ else
     private async Task LoadRecipeAsync(int itemId)
     {
         recipe = null;
+        _ingredientRows = [];
+        _buildingRows = [];
         var gameId = GameContext.SelectedGameId;
         if (gameId is null || !isCraftable) return;
 
@@ -1115,6 +1122,18 @@ else
         if (match is not null)
         {
             recipe = await Api.GetAsync<CraftingRecipeDetailDto>($"/api/crafting/{match.Id}");
+            // Project DTO collections into the leaf-component row shapes once
+            // here so the popup renders below don't re-allocate on every
+            // re-render (Copilot on PR #173).
+            if (recipe is not null)
+            {
+                _ingredientRows = recipe.Ingredients
+                    .Select(i => new RecipeIngredientPicker.IngredientRow(i.ItemId, i.ItemName, i.Quantity))
+                    .ToList();
+                _buildingRows = recipe.BuildingRequirements
+                    .Select(br => new RecipeBuildingPicker.BuildingRow(br.BuildingId, br.BuildingName))
+                    .ToList();
+            }
         }
     }
 

--- a/src/OvcinaHra.Client/wwwroot/appsettings.Production.json
+++ b/src/OvcinaHra.Client/wwwroot/appsettings.Production.json
@@ -1,5 +1,8 @@
 {
   "ApiBaseUrl": "https://api.hra.ovcina.cz",
   "OidcAuthority": "https://registrace.ovcina.cz",
-  "OidcClientId": "ovcinahra"
+  "OidcClientId": "ovcinahra",
+  "MapLibre": {
+    "GlyphsUrl": "https://ovcinahrastorage.blob.core.windows.net/ovcinahra-fonts/{fontstack}/{range}.pbf"
+  }
 }

--- a/src/OvcinaHra.Client/wwwroot/appsettings.json
+++ b/src/OvcinaHra.Client/wwwroot/appsettings.json
@@ -2,5 +2,8 @@
   "ApiBaseUrl": "https://localhost:5280",
   "MapyCz": {
     "ApiKey": "IRMAF9DrxwqeAjL4DxQvQXQRQIP7trhsoMOoOoRhgP4"
+  },
+  "MapLibre": {
+    "GlyphsUrl": "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf"
   }
 }

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -10,43 +10,51 @@ window.ovcinaMap = {
     // its layout (e.g. the overlay editor's `oh-overlay-preview-text` text
     // primitive, #96). Without `glyphs`, MapLibre logs:
     //   "layers.X.layout.text-field: use of 'text-field' requires a style 'glyphs' property"
-    // and the text never renders. We use the MapLibre demo glyph endpoint
-    // for now — TODO(prod): self-host on Azure Blob alongside the rest of
-    // the map assets before the next prod rollout. Tracked in #159 follow-up.
+    // and the text never renders. The actual URL comes from
+    // `MapLibre:GlyphsUrl` in appsettings (prod points at our Azure Blob,
+    // dev at demotiles). The constant below is the safety fallback if the
+    // setting is missing — never relied on by prod (#166).
+    _defaultGlyphsUrl: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
     _glyphsUrl: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
 
-    _rasterStyle: {
-        version: 8,
-        glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
-        sources: {
-            'osm': {
+    _buildRasterStyle: function () {
+        return {
+            version: 8,
+            glyphs: this._glyphsUrl,
+            sources: {
+                'osm': {
+                    type: 'raster',
+                    tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+                    tileSize: 256,
+                    maxzoom: 19,
+                    attribution: '&copy; <a href="https://www.openstreetmap.org">OpenStreetMap</a>'
+                }
+            },
+            layers: [{
+                id: 'osm-tiles',
                 type: 'raster',
-                tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
-                tileSize: 256,
-                maxzoom: 19,
-                attribution: '&copy; <a href="https://www.openstreetmap.org">OpenStreetMap</a>'
-            }
-        },
-        layers: [{
-            id: 'osm-tiles',
-            type: 'raster',
-            source: 'osm',
-            minzoom: 0,
-            maxzoom: 19
-        }]
+                source: 'osm',
+                minzoom: 0,
+                maxzoom: 19
+            }]
+        };
     },
 
     _mapyCzRasterStyle: function (apiKey) {
         return this._makeRasterStyle('outdoor', apiKey);
     },
 
-    init: function (elementId, dotnetRef, centerLat, centerLon, zoom, mapyCzApiKey) {
+    init: function (elementId, dotnetRef, centerLat, centerLon, zoom, mapyCzApiKey, glyphsUrl) {
         this._dotnetRef = dotnetRef;
         this._elementId = elementId;
         this._apiKey = (mapyCzApiKey && mapyCzApiKey.length > 5) ? mapyCzApiKey : null;
+        // Resolved at init so every style construction below picks up the
+        // environment-specific URL (#166). Empty/missing → fall back to the
+        // demotiles dev URL so local browser-tab smoke testing still works.
+        this._glyphsUrl = (glyphsUrl && glyphsUrl.length > 0) ? glyphsUrl : this._defaultGlyphsUrl;
 
         // Start with Mapy.cz raster (tourist), fall back to OSM
-        var initialStyle = this._apiKey ? this._mapyCzRasterStyle(this._apiKey) : this._rasterStyle;
+        var initialStyle = this._apiKey ? this._mapyCzRasterStyle(this._apiKey) : this._buildRasterStyle();
         this._map = new maplibregl.Map({
             container: elementId,
             style: initialStyle,
@@ -84,7 +92,7 @@ window.ovcinaMap = {
         } else if (styleKey === 'basic' && this._apiKey) {
             style = this._makeRasterStyle('basic', this._apiKey);
         } else {
-            style = this._rasterStyle; // OSM fallback
+            style = this._buildRasterStyle(); // OSM fallback
         }
 
         // Clear markers before style change

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -49,9 +49,12 @@ window.ovcinaMap = {
         this._elementId = elementId;
         this._apiKey = (mapyCzApiKey && mapyCzApiKey.length > 5) ? mapyCzApiKey : null;
         // Resolved at init so every style construction below picks up the
-        // environment-specific URL (#166). Empty/missing → fall back to the
-        // demotiles dev URL so local browser-tab smoke testing still works.
-        this._glyphsUrl = (glyphsUrl && glyphsUrl.length > 0) ? glyphsUrl : this._defaultGlyphsUrl;
+        // environment-specific URL (#166). Empty/missing/whitespace-only →
+        // fall back to the demotiles dev URL so local smoke testing still
+        // works AND a stray space in appsettings.json doesn't ship a broken
+        // URL to MapLibre.
+        var trimmedGlyphsUrl = (typeof glyphsUrl === 'string') ? glyphsUrl.trim() : '';
+        this._glyphsUrl = trimmedGlyphsUrl.length > 0 ? trimmedGlyphsUrl : this._defaultGlyphsUrl;
 
         // Start with Mapy.cz raster (tourist), fall back to OSM
         var initialStyle = this._apiKey ? this._mapyCzRasterStyle(this._apiKey) : this._buildRasterStyle();


### PR DESCRIPTION
## Summary

Closes **#163** + **#166**. Two infra-polish follow-ups bundled — net diff is −109 lines on the two list pages, with no API surface change.

### #163 — Shared recipe leaf components (Path B / partial extraction)

After observation: the two distinct DTO types (`CraftingRecipeDetailDto` vs `BuildingRecipeDetailDto`), distinct endpoint bases, and Building-only `MoneyCost` made a single monolithic `CraftingRecipeEditor` either generic-and-fragile or a thick view-model adapter. Path B keeps the recipe-load / CRUD orchestration in each list page (where it belongs — the page already owns the parent entity context) and extracts the four UI sub-blocks that were genuinely identical:

| Component | Replaces inline block in both list pages |
|---|---|
| `Components/RecipeIngredientPicker.razor` | Ingredient table + AutoSearch combo + qty spin + plus button |
| `Components/RecipeNotesEditor.razor` | Poznámka k surovinám memo + diff-aware "Uložit poznámku" button |
| `Components/RecipeBuildingPicker.razor` | Building badge list + AutoSearch combo + plus button. Caption + placeholder parameterised so Item-side ("Požadované budovy") and Building-side ("Předpoklady (jiné budovy)") keep their distinct Czech copy |
| `Components/RecipeSkillPicker.razor` | Skill badge list + per-game GameSkill combo + plus button |

Both list pages now thread their DTO ingredient/building rows into shared `IngredientRow` / `BuildingRow` records inline at render. Each leaf owns its own input state (the `newIngItemId` / `newSkillId` / etc. fields that lived parallel on both pages are gone — net 5 fields removed per page).

**Bug fix while we're here**: `ItemList.razor`'s "Smazat recept" button used to wire the DELETE handler directly to `@onclick` — violates `feedback_ovcinahra_destructive_confirm`. Now routes through the same `DxPopup` confirm pattern Hra3 used Building-side.

### #166 — Production glyph hosting

Approach (b) per the design discussion: env-specific URL via `MapLibre:GlyphsUrl` configuration setting.

- `appsettings.json` (dev) → `https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf`
- `appsettings.Production.json` → `https://ovcinahrastorage.blob.core.windows.net/ovcinahra-fonts/{fontstack}/{range}.pbf`

`map-interop.js`'s former hardcoded URL is now a "config missing" safety fallback only. `init()` takes the URL as a parameter and threads it into both the OSM-fallback and Mapy.cz raster style builders. The hardcoded `_rasterStyle` literal became `_buildRasterStyle()` so each style construction picks up the resolved URL.

**Deploy action required** before next prod rollout (also noted in commit body):

1. Create container `ovcinahra-fonts` (public-read) on storage account `ovcinahrastorage`.
2. Generate `.pbf` glyph ranges via fontnik. At minimum: Latin Basic (0x0000–0x00FF) + Latin Extended (0x0100–0x017F) so Czech diacritics (Ě, Š, Č, Ř, Ž, Ý, Á, Í, É, Ó, Ů, Ú) render in overlay text shapes.
3. Upload as `{fontstack}/{range}.pbf` (e.g. `Open Sans Regular/0-255.pbf`).

Until step 3 lands, the prod URL 404s — but the code change ships first so the next deploy is just the upload.

## Files (10 changed)

**New:** 4 leaf components in `src/OvcinaHra.Client/Components/`.
**Modified:**
- `Pages/Items/ItemList.razor` — recipe markup swap; handler signatures take params; dead-state cleanup; new delete-confirm `DxPopup`.
- `Pages/Buildings/BuildingList.razor` — recipe markup swap (Cena editor stays page-level); handler signatures take params; dead-state cleanup.
- `Components/MapView.razor` — passes `Config["MapLibre:GlyphsUrl"]` into `ovcinaMap.init`.
- `wwwroot/js/map-interop.js` — `_buildRasterStyle()` + `init(..., glyphsUrl)` plumbing.
- `wwwroot/appsettings.json` + `appsettings.Production.json` — new `MapLibre:GlyphsUrl` settings.

## Test plan

- [x] `dotnet build OvcinaHra.slnx` — clean (0 warn / 0 err under `TreatWarningsAsErrors=true`).
- [x] `dotnet test --filter ~Recipe|~Crafting|~BuildingRecipe` — 36/36 green via Testcontainers PostgreSQL. API surface didn't change.
- [ ] Manual — Item recipe: open `/items` → edit a craftable item → add ingredient, set qty, save; add building req; add skill; clear notes; save notes; click "Smazat recept" → confirm popup appears (was direct DELETE before this PR).
- [ ] Manual — Building recipe: open `/buildings` → edit a building → set Cena, save Cena; add ingredient; add prereq; add skill; click "Smazat recept" → confirm popup appears.
- [ ] Manual — Map: open `/games/{id}/map` → DevTools console no longer requests `demotiles.maplibre.org` in dev; in prod it'll request the blob URL (404 until the deploy step lands — see PR body).

## Notes / out-of-scope

- **API endpoints unchanged.** No migration. No EF Core changes. The leaf components are purely view-layer dedup.
- **No Item↔Building DTO unification.** They stay distinct (semantic difference between "BuildingRequirement" on Item and "Prerequisite" on Building justifies it).
- **No `csproj <Version>` bump** — auto-bump CI handles.
- **Hra3's `Pages/Home.razor` + `Layout/MainLayout.razor` + `Layout/NavMenu.razor` + `DashboardEndpoints.cs` (in flight for #158/#162)** untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)