### PR TITLE
feat(timeline): /timeline cockpit (agenda + Gantt) + /timeline/print A4 + GameTimeSlot.Stage

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/TimelineConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/TimelineConfiguration.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
 
 namespace OvcinaHra.Api.Data.Configurations;
 
@@ -9,6 +10,10 @@ public class GameTimeSlotConfiguration : IEntityTypeConfiguration<GameTimeSlot>
     public void Configure(EntityTypeBuilder<GameTimeSlot> builder)
     {
         builder.HasKey(e => e.Id);
+        builder.Property(e => e.Stage)
+            .HasConversion<string>()
+            .HasMaxLength(20)
+            .HasDefaultValue(TreasureQuestDifficulty.Start);
         builder.HasOne(e => e.BattlefieldBonus).WithMany(b => b.TimeSlots).HasForeignKey(e => e.BattlefieldBonusId);
         builder.HasOne(e => e.Game).WithMany(g => g.TimeSlots).HasForeignKey(e => e.GameId);
     }

--- a/src/OvcinaHra.Api/Endpoints/TimelineEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TimelineEndpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Endpoints;
@@ -30,34 +31,79 @@ public static class TimelineEndpoints
     // Time slots
     private static async Task<Ok<List<GameTimeSlotDto>>> GetSlotsByGame(int gameId, WorldDbContext db)
     {
-        var slots = await db.GameTimeSlots
+        var rows = await db.GameTimeSlots
+            .AsNoTracking()
             .Where(s => s.GameId == gameId)
             .OrderBy(s => s.StartTime)
-            .Select(s => new GameTimeSlotDto(s.Id, s.InGameYear, s.StartTime, (decimal)s.Duration.TotalHours, s.Rules, s.BattlefieldBonusId, s.GameId))
+            .Select(s => new SlotProjection(
+                s.Id, s.InGameYear, s.StartTime, s.Duration, s.Stage, s.Rules,
+                s.BattlefieldBonusId, s.GameId,
+                s.BattlefieldBonus != null ? s.BattlefieldBonus.Name : null,
+                s.EventTimeSlots.Select(ets => new EventProjection(
+                    ets.GameEvent.Id,
+                    ets.GameEvent.Name,
+                    ets.GameEvent.EventQuests.Any(),
+                    ets.GameEvent.EventNpcs.Any())).ToList()))
             .ToListAsync();
-        return TypedResults.Ok(slots);
+        return TypedResults.Ok(rows.Select(ToDto).ToList());
     }
 
     private static async Task<Created<GameTimeSlotDto>> CreateSlot(CreateGameTimeSlotDto dto, WorldDbContext db)
     {
+        var stage = NormalizeStage(dto.Stage);
         var s = new GameTimeSlot
         {
-            GameId = dto.GameId, StartTime = DateTime.SpecifyKind(dto.StartTime, DateTimeKind.Utc),
+            GameId = dto.GameId,
+            StartTime = DateTime.SpecifyKind(dto.StartTime, DateTimeKind.Utc),
             Duration = TimeSpan.FromHours((double)dto.DurationHours),
-            InGameYear = dto.InGameYear, Rules = dto.Rules, BattlefieldBonusId = dto.BattlefieldBonusId
+            InGameYear = dto.InGameYear,
+            Rules = dto.Rules,
+            BattlefieldBonusId = dto.BattlefieldBonusId,
+            Stage = stage
         };
         db.GameTimeSlots.Add(s);
         await db.SaveChangesAsync();
-        return TypedResults.Created($"/api/timeline/slots/{s.Id}",
-            new GameTimeSlotDto(s.Id, s.InGameYear, s.StartTime, (decimal)s.Duration.TotalHours, s.Rules, s.BattlefieldBonusId, s.GameId));
+
+        if (dto.LinkedGameEventIds is { Count: > 0 } ids)
+        {
+            foreach (var eventId in ids.Distinct())
+            {
+                db.GameEventTimeSlots.Add(new GameEventTimeSlot { GameTimeSlotId = s.Id, GameEventId = eventId });
+            }
+            await db.SaveChangesAsync();
+        }
+
+        var enriched = await LoadSlotDtoAsync(s.Id, db);
+        return TypedResults.Created($"/api/timeline/slots/{s.Id}", enriched);
     }
 
     private static async Task<Results<NoContent, NotFound>> UpdateSlot(int id, UpdateGameTimeSlotDto dto, WorldDbContext db)
     {
         var s = await db.GameTimeSlots.FindAsync(id);
         if (s is null) return TypedResults.NotFound();
-        s.StartTime = DateTime.SpecifyKind(dto.StartTime, DateTimeKind.Utc); s.Duration = TimeSpan.FromHours((double)dto.DurationHours); s.InGameYear = dto.InGameYear;
-        s.Rules = dto.Rules; s.BattlefieldBonusId = dto.BattlefieldBonusId;
+
+        s.StartTime = DateTime.SpecifyKind(dto.StartTime, DateTimeKind.Utc);
+        s.Duration = TimeSpan.FromHours((double)dto.DurationHours);
+        s.InGameYear = dto.InGameYear;
+        s.Rules = dto.Rules;
+        s.BattlefieldBonusId = dto.BattlefieldBonusId;
+        s.Stage = NormalizeStage(dto.Stage);
+
+        if (dto.LinkedGameEventIds is { } incoming)
+        {
+            var desired = incoming.Distinct().ToHashSet();
+            var existing = await db.GameEventTimeSlots
+                .Where(ets => ets.GameTimeSlotId == id)
+                .ToListAsync();
+
+            foreach (var stale in existing.Where(ets => !desired.Contains(ets.GameEventId)))
+                db.GameEventTimeSlots.Remove(stale);
+
+            var existingIds = existing.Select(ets => ets.GameEventId).ToHashSet();
+            foreach (var newId in desired.Where(eid => !existingIds.Contains(eid)))
+                db.GameEventTimeSlots.Add(new GameEventTimeSlot { GameTimeSlotId = id, GameEventId = newId });
+        }
+
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }
@@ -75,6 +121,7 @@ public static class TimelineEndpoints
     private static async Task<Ok<List<BattlefieldBonusDto>>> GetBonusesByGame(int gameId, WorldDbContext db)
     {
         var bonuses = await db.BattlefieldBonuses
+            .AsNoTracking()
             .Where(b => b.GameId == gameId)
             .OrderBy(b => b.Name)
             .Select(b => new BattlefieldBonusDto(b.Id, b.Name, b.AttackBonus, b.DefenseBonus, b.Description, b.ImagePath, b.GameId))
@@ -86,8 +133,11 @@ public static class TimelineEndpoints
     {
         var b = new BattlefieldBonus
         {
-            GameId = dto.GameId, AttackBonus = dto.AttackBonus, DefenseBonus = dto.DefenseBonus,
-            Name = dto.Name, Description = dto.Description
+            GameId = dto.GameId,
+            AttackBonus = dto.AttackBonus,
+            DefenseBonus = dto.DefenseBonus,
+            Name = dto.Name,
+            Description = dto.Description
         };
         db.BattlefieldBonuses.Add(b);
         await db.SaveChangesAsync();
@@ -99,7 +149,10 @@ public static class TimelineEndpoints
     {
         var b = await db.BattlefieldBonuses.FindAsync(id);
         if (b is null) return TypedResults.NotFound();
-        b.Name = dto.Name; b.AttackBonus = dto.AttackBonus; b.DefenseBonus = dto.DefenseBonus; b.Description = dto.Description;
+        b.Name = dto.Name;
+        b.AttackBonus = dto.AttackBonus;
+        b.DefenseBonus = dto.DefenseBonus;
+        b.Description = dto.Description;
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }
@@ -112,4 +165,52 @@ public static class TimelineEndpoints
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }
+
+    // ---- helpers ----
+
+    private static async Task<GameTimeSlotDto> LoadSlotDtoAsync(int id, WorldDbContext db)
+    {
+        var row = await db.GameTimeSlots
+            .AsNoTracking()
+            .Where(s => s.Id == id)
+            .Select(s => new SlotProjection(
+                s.Id, s.InGameYear, s.StartTime, s.Duration, s.Stage, s.Rules,
+                s.BattlefieldBonusId, s.GameId,
+                s.BattlefieldBonus != null ? s.BattlefieldBonus.Name : null,
+                s.EventTimeSlots.Select(ets => new EventProjection(
+                    ets.GameEvent.Id,
+                    ets.GameEvent.Name,
+                    ets.GameEvent.EventQuests.Any(),
+                    ets.GameEvent.EventNpcs.Any())).ToList()))
+            .SingleAsync();
+        return ToDto(row);
+    }
+
+    private static GameTimeSlotDto ToDto(SlotProjection r) =>
+        new(r.Id, r.InGameYear, r.StartTime, (decimal)r.Duration.TotalHours,
+            r.Rules, r.BattlefieldBonusId, r.GameId, r.Stage, r.BonusName)
+        {
+            LinkedEvents = r.Events
+                .Select(e => new LinkedGameEventDto(e.Id, e.Name, ClassifyKind(e.HasQuests, e.HasNpcs)))
+                .ToList()
+        };
+
+    private static GameEventKind ClassifyKind(bool hasQuests, bool hasNpcs) =>
+        hasQuests ? GameEventKind.Quest :
+        hasNpcs ? GameEventKind.Encounter :
+        GameEventKind.Other;
+
+    // Guard against malformed integer payloads — JsonStringEnumConverter
+    // catches strings, but a raw int from a non-conforming client would
+    // persist as an undefined enum value (per review-instincts §5.3).
+    private static TreasureQuestDifficulty NormalizeStage(TreasureQuestDifficulty stage) =>
+        Enum.IsDefined(typeof(TreasureQuestDifficulty), stage) ? stage : TreasureQuestDifficulty.Start;
+
+    private record SlotProjection(
+        int Id, int? InGameYear, DateTime StartTime, TimeSpan Duration,
+        TreasureQuestDifficulty Stage, string? Rules,
+        int? BattlefieldBonusId, int GameId, string? BonusName,
+        List<EventProjection> Events);
+
+    private record EventProjection(int Id, string Name, bool HasQuests, bool HasNpcs);
 }

--- a/src/OvcinaHra.Api/Endpoints/TimelineEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TimelineEndpoints.cs
@@ -48,8 +48,16 @@ public static class TimelineEndpoints
         return TypedResults.Ok(rows.Select(ToDto).ToList());
     }
 
-    private static async Task<Created<GameTimeSlotDto>> CreateSlot(CreateGameTimeSlotDto dto, WorldDbContext db)
+    private static async Task<Results<Created<GameTimeSlotDto>, ProblemHttpResult>> CreateSlot(CreateGameTimeSlotDto dto, WorldDbContext db)
     {
+        // Validate linked events belong to the same game BEFORE inserting,
+        // so an invalid id surfaces as a Czech 400 instead of a 500 FK violation.
+        if (dto.LinkedGameEventIds is { Count: > 0 } incoming)
+        {
+            var validation = await ValidateLinkedEventsAsync(dto.GameId, incoming, db);
+            if (validation is { } problem) return problem;
+        }
+
         var stage = NormalizeStage(dto.Stage);
         var s = new GameTimeSlot
         {
@@ -77,21 +85,28 @@ public static class TimelineEndpoints
         return TypedResults.Created($"/api/timeline/slots/{s.Id}", enriched);
     }
 
-    private static async Task<Results<NoContent, NotFound>> UpdateSlot(int id, UpdateGameTimeSlotDto dto, WorldDbContext db)
+    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> UpdateSlot(int id, UpdateGameTimeSlotDto dto, WorldDbContext db)
     {
         var s = await db.GameTimeSlots.FindAsync(id);
         if (s is null) return TypedResults.NotFound();
+
+        if (dto.LinkedGameEventIds is { } incoming)
+        {
+            var validation = await ValidateLinkedEventsAsync(s.GameId, incoming, db);
+            if (validation is { } problem) return problem;
+        }
 
         s.StartTime = DateTime.SpecifyKind(dto.StartTime, DateTimeKind.Utc);
         s.Duration = TimeSpan.FromHours((double)dto.DurationHours);
         s.InGameYear = dto.InGameYear;
         s.Rules = dto.Rules;
         s.BattlefieldBonusId = dto.BattlefieldBonusId;
-        s.Stage = NormalizeStage(dto.Stage);
+        // Null Stage on the DTO means "leave existing Stage alone" (back-compat).
+        if (dto.Stage is { } stage) s.Stage = NormalizeStage(stage);
 
-        if (dto.LinkedGameEventIds is { } incoming)
+        if (dto.LinkedGameEventIds is { } desiredList)
         {
-            var desired = incoming.Distinct().ToHashSet();
+            var desired = desiredList.Distinct().ToHashSet();
             var existing = await db.GameEventTimeSlots
                 .Where(ets => ets.GameTimeSlotId == id)
                 .ToListAsync();
@@ -106,6 +121,28 @@ public static class TimelineEndpoints
 
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
+    }
+
+    /// <summary>
+    /// Returns a 400 ProblemDetails if any incoming GameEvent id is missing or
+    /// belongs to a different game; otherwise null.
+    /// </summary>
+    private static async Task<ProblemHttpResult?> ValidateLinkedEventsAsync(int gameId, IReadOnlyList<int> incomingIds, WorldDbContext db)
+    {
+        var distinct = incomingIds.Distinct().ToList();
+        if (distinct.Count == 0) return null;
+
+        var validIds = await db.GameEvents
+            .Where(e => e.GameId == gameId && distinct.Contains(e.Id))
+            .Select(e => e.Id)
+            .ToListAsync();
+
+        if (validIds.Count == distinct.Count) return null;
+
+        return TypedResults.Problem(
+            title: "Uložení selhalo",
+            detail: "Některé události nepatří k této hře nebo neexistují.",
+            statusCode: StatusCodes.Status400BadRequest);
     }
 
     private static async Task<Results<NoContent, NotFound>> DeleteSlot(int id, WorldDbContext db)

--- a/src/OvcinaHra.Api/Migrations/20260425113242_AddStageToGameTimeSlot.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260425113242_AddStageToGameTimeSlot.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425113242_AddStageToGameTimeSlot")]
+    partial class AddStageToGameTimeSlot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260425113242_AddStageToGameTimeSlot.cs
+++ b/src/OvcinaHra.Api/Migrations/20260425113242_AddStageToGameTimeSlot.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStageToGameTimeSlot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Stage",
+                table: "GameTimeSlots",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "Start");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Stage",
+                table: "GameTimeSlots");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Components/GanttCanvas.razor
+++ b/src/OvcinaHra.Client/Components/GanttCanvas.razor
@@ -1,0 +1,162 @@
+@using System.Globalization
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Dtos
+
+<div class="oh-tl-gantt-wrap">
+    <div class="oh-tl-gantt-toolbar">
+        <span>Měřítko:</span>
+        <div class="oh-tl-gantt-zoom">
+            <button type="button" @onclick="() => SetZoom(_pxPerHour - 15)" title="Oddálit"><i class="bi bi-zoom-out"></i></button>
+            <button type="button" @onclick="() => SetZoom(60)">100%</button>
+            <button type="button" @onclick="() => SetZoom(_pxPerHour + 15)" title="Přiblížit"><i class="bi bi-zoom-in"></i></button>
+        </div>
+        <span style="font-size:.75rem">@_pxPerHour px/h · 1 px ≈ @((60.0 / _pxPerHour).ToString("0.#", CultureInfo.InvariantCulture)) min</span>
+    </div>
+
+    @if (Slots.Count == 0)
+    {
+        <div class="oh-tl-empty">
+            <i class="bi bi-bar-chart-steps"></i>
+            <div class="oh-tl-empty-title">Žádné bloky pro Gantt zobrazení</div>
+            <p>Přidej časové bloky a uvidíš je tady jako vodorovné pruhy.</p>
+        </div>
+    }
+    else
+    {
+        <div class="oh-tl-gantt-canvas">
+            <div class="oh-tl-gantt-track" style="@($"width: {_totalWidth.ToString("0", CultureInfo.InvariantCulture)}px")">
+                @* Stage bands behind bars *@
+                @foreach (var s in Slots)
+                {
+                    var left = LeftFor(s.StartTime);
+                    var width = Math.Max(40, (double)s.DurationHours * _pxPerHour);
+                    <div class="oh-tl-gx-stage-band oh-tl-gx-stage-band--@StageMod(s.Stage)"
+                         @key="@($"band-{s.Id}")"
+                         style="@($"left: {left.ToString("0.##", CultureInfo.InvariantCulture)}px; width: {width.ToString("0.##", CultureInfo.InvariantCulture)}px")"></div>
+                }
+
+                @* Hour ticks *@
+                @foreach (var t in HourTicks())
+                {
+                    <div class="oh-tl-gx-tick" style="@($"left: {t.ToString("0.##", CultureInfo.InvariantCulture)}px")"></div>
+                }
+
+                @* Day boundary lines *@
+                @foreach (var b in DayBoundaries())
+                {
+                    <div class="oh-tl-gx-day-bound" style="@($"left: {b.ToString("0.##", CultureInfo.InvariantCulture)}px")"></div>
+                }
+
+                @* Day labels in the axis row *@
+                <div class="oh-tl-gx-axis">
+                    @foreach (var d in DayLabels())
+                    {
+                        <span class="oh-tl-gx-day"
+                              style="@($"left: {d.Left.ToString("0.##", CultureInfo.InvariantCulture)}px; width: {d.Width.ToString("0.##", CultureInfo.InvariantCulture)}px")">@d.Label</span>
+                    }
+                </div>
+
+                @* Slot bars *@
+                @foreach (var s in Slots)
+                {
+                    var left = LeftFor(s.StartTime);
+                    var width = Math.Max(40, (double)s.DurationHours * _pxPerHour);
+                    <SlotGanttBar @key="s.Id" Slot="@s"
+                                  Left="@left" Width="@width" Top="44"
+                                  IsActive="@(IsActiveSlot(s))"
+                                  IsPast="@(IsPastSlot(s))"
+                                  OnEdit="OnEdit" />
+                }
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public IReadOnlyList<GameTimeSlotDto> Slots { get; set; } = [];
+    [Parameter] public DateTime Now { get; set; } = DateTime.Now;
+    [Parameter] public EventCallback<int> OnEdit { get; set; }
+
+    private int _pxPerHour = 60;
+    private DateTime _canvasStart;
+    private DateTime _canvasEnd;
+    private double _totalWidth;
+
+    protected override void OnParametersSet()
+    {
+        if (Slots.Count == 0) return;
+
+        // Local-time view; the API stores StartTime UTC.
+        var locals = Slots.Select(s => new { Start = s.StartTime.ToLocalTime(), End = s.EndTime.ToLocalTime() }).ToList();
+        var min = locals.Min(s => s.Start);
+        var max = locals.Max(s => s.End);
+
+        // Snap to whole hours so ticks line up with axis.
+        _canvasStart = new DateTime(min.Year, min.Month, min.Day, min.Hour, 0, 0, DateTimeKind.Local);
+        var endHour = max.Minute > 0 || max.Second > 0 ? max.Hour + 1 : max.Hour;
+        _canvasEnd = new DateTime(max.Year, max.Month, max.Day, 0, 0, 0, DateTimeKind.Local).AddHours(endHour);
+
+        var totalHours = (_canvasEnd - _canvasStart).TotalHours;
+        _totalWidth = Math.Max(800, totalHours * _pxPerHour);
+    }
+
+    private void SetZoom(int target)
+    {
+        _pxPerHour = Math.Clamp(target, 20, 180);
+        var totalHours = (_canvasEnd - _canvasStart).TotalHours;
+        _totalWidth = Math.Max(800, totalHours * _pxPerHour);
+    }
+
+    private double LeftFor(DateTime utcStart)
+    {
+        var local = utcStart.ToLocalTime();
+        return (local - _canvasStart).TotalHours * _pxPerHour;
+    }
+
+    private IEnumerable<double> HourTicks()
+    {
+        for (var t = _canvasStart; t < _canvasEnd; t = t.AddHours(1))
+            yield return (t - _canvasStart).TotalHours * _pxPerHour;
+    }
+
+    private IEnumerable<double> DayBoundaries()
+    {
+        // Skip the 0-position; only render midnights *between* days.
+        var first = _canvasStart.Date.AddDays(1);
+        for (var d = first; d < _canvasEnd; d = d.AddDays(1))
+            yield return (d - _canvasStart).TotalHours * _pxPerHour;
+    }
+
+    private IEnumerable<(double Left, double Width, string Label)> DayLabels()
+    {
+        var cs = CultureInfo.GetCultureInfo("cs-CZ");
+        var d = _canvasStart.Date;
+        while (d < _canvasEnd)
+        {
+            var dayStart = d < _canvasStart ? _canvasStart : d;
+            var dayEnd = d.AddDays(1) > _canvasEnd ? _canvasEnd : d.AddDays(1);
+            var left = (dayStart - _canvasStart).TotalHours * _pxPerHour;
+            var width = (dayEnd - dayStart).TotalHours * _pxPerHour;
+            yield return (left, width, d.ToString("ddd · d.M.", cs));
+            d = d.AddDays(1);
+        }
+    }
+
+    private bool IsActiveSlot(GameTimeSlotDto s)
+    {
+        var localStart = s.StartTime.ToLocalTime();
+        var localEnd = s.EndTime.ToLocalTime();
+        return localStart <= Now && Now < localEnd;
+    }
+
+    private bool IsPastSlot(GameTimeSlotDto s) => s.EndTime.ToLocalTime() < Now;
+
+    private static string StageMod(TreasureQuestDifficulty d) => d switch
+    {
+        TreasureQuestDifficulty.Start => "start",
+        TreasureQuestDifficulty.Early => "early",
+        TreasureQuestDifficulty.Midgame => "midgame",
+        TreasureQuestDifficulty.Lategame => "lategame",
+        _ => "start"
+    };
+}

--- a/src/OvcinaHra.Client/Components/SlotCard.razor
+++ b/src/OvcinaHra.Client/Components/SlotCard.razor
@@ -1,0 +1,134 @@
+@using System.Globalization
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Dtos
+
+@{
+    var stage = Slot.Stage;
+    var stageMod = StageModifier(stage);
+    var classes = $"oh-tl-slot oh-tl-slot--{stageMod}"
+        + (IsActive ? " oh-tl-slot--active" : "")
+        + (IsPast ? " oh-tl-slot--past" : "");
+    var cs = CultureInfo.GetCultureInfo("cs-CZ");
+    var startLocal = Slot.StartTime.ToLocalTime();
+    var endLocal = Slot.EndTime.ToLocalTime();
+    var rulesExpanded = IsActive || forceExpanded;
+}
+
+<div class="@classes" @onclick="OnCardClick" role="button" tabindex="0"
+     @onkeydown="OnKeyDown" aria-label="@($"Časový blok {startLocal:HH:mm}")">
+    <div class="oh-tl-slot-head">
+        <span class="oh-tl-slot-time">@startLocal.ToString("HH:mm", cs) – @endLocal.ToString("HH:mm", cs)</span>
+        <h3 class="oh-tl-slot-title">@SlotTitle</h3>
+        <StageChip Difficulty="@stage" />
+        @if (IsActive)
+        {
+            <span class="oh-tl-slot-pill" title="Aktivní časový blok">
+                <i class="bi bi-broadcast"></i>
+                Probíhá @RemainingText
+            </span>
+        }
+    </div>
+
+    @if (HasAnyChip())
+    {
+        <div class="oh-tl-slot-chips">
+            @foreach (var ev in Slot.LinkedEvents)
+            {
+                var (chipMod, icon) = ChipFor(ev.Kind);
+                <span class="oh-tl-chip @chipMod" @key="ev.Id">
+                    <i class="bi @icon"></i>@ev.Name
+                </span>
+            }
+            @if (!string.IsNullOrWhiteSpace(Slot.BattlefieldBonusName))
+            {
+                <span class="oh-tl-chip oh-tl-chip--bonus">
+                    <i class="bi bi-shield-check"></i>@Slot.BattlefieldBonusName
+                </span>
+            }
+            @if (StageTransitionFrom is not null && StageTransitionFrom != stage)
+            {
+                <span class="oh-tl-chip oh-tl-chip--transition" title="Začíná nová fáze">
+                    <i class="bi bi-arrow-right"></i>@stage.GetDisplayName() začíná
+                </span>
+            }
+        </div>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(Slot.Rules))
+    {
+        if (rulesExpanded)
+        {
+            <div class="oh-tl-slot-rules">@Slot.Rules</div>
+        }
+        else
+        {
+            <button type="button" class="oh-tl-seg-btn"
+                    style="padding:4px 0;color:var(--oh-text-secondary);font-size:.8rem"
+                    @onclick:stopPropagation="true"
+                    @onclick="() => forceExpanded = true">
+                <i class="bi bi-chevron-down"></i> Pravidla
+            </button>
+        }
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public GameTimeSlotDto Slot { get; set; } = default!;
+    [Parameter] public bool IsActive { get; set; }
+    [Parameter] public bool IsPast { get; set; }
+    /// <summary>Stage of the previous slot — when different from this slot's, render the transition badge.</summary>
+    [Parameter] public TreasureQuestDifficulty? StageTransitionFrom { get; set; }
+    [Parameter] public EventCallback<int> OnEdit { get; set; }
+
+    private bool forceExpanded;
+
+    // Title falls back to a Czech default since GameTimeSlot has no Name field —
+    // the slot's identity is its time + stage. If Rules starts with a heading-like
+    // line we surface it; otherwise label by Stage.
+    private string SlotTitle =>
+        !string.IsNullOrWhiteSpace(Slot.Rules) && Slot.Rules.Length <= 60
+            ? Slot.Rules.Split('\n')[0].Trim()
+            : $"Blok – {Slot.Stage.GetDisplayName()}";
+
+    private string RemainingText
+    {
+        get
+        {
+            if (!IsActive) return "";
+            var remain = Slot.EndTime.ToLocalTime() - DateTime.Now;
+            if (remain <= TimeSpan.Zero) return "končí";
+            var h = (int)remain.TotalHours;
+            var m = remain.Minutes;
+            return h > 0 ? $"· zbývá {h}h {m}min" : $"· zbývá {m}min";
+        }
+    }
+
+    private bool HasAnyChip() =>
+        Slot.LinkedEvents.Count > 0
+        || !string.IsNullOrWhiteSpace(Slot.BattlefieldBonusName)
+        || (StageTransitionFrom is not null && StageTransitionFrom != Slot.Stage);
+
+    private static string StageModifier(TreasureQuestDifficulty d) => d switch
+    {
+        TreasureQuestDifficulty.Start => "start",
+        TreasureQuestDifficulty.Early => "early",
+        TreasureQuestDifficulty.Midgame => "midgame",
+        TreasureQuestDifficulty.Lategame => "lategame",
+        _ => "start"
+    };
+
+    private static (string Cls, string Icon) ChipFor(GameEventKind k) => k switch
+    {
+        GameEventKind.Quest => ("oh-tl-chip--quest", "bi-journal-bookmark"),
+        GameEventKind.Encounter => ("oh-tl-chip--encounter", "bi-bug"),
+        _ => ("oh-tl-chip--other", "bi-three-dots")
+    };
+
+    private async Task OnCardClick() => await OnEdit.InvokeAsync(Slot.Id);
+
+    private async Task OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or " ")
+            await OnEdit.InvokeAsync(Slot.Id);
+    }
+}

--- a/src/OvcinaHra.Client/Components/SlotEditPopup.razor
+++ b/src/OvcinaHra.Client/Components/SlotEditPopup.razor
@@ -252,7 +252,13 @@
 
     private async Task Close()
     {
+        // Reset transient state so the popup can't be reopened with a stale
+        // confirm dialog still on screen, a leftover error banner, or a
+        // mid-flight `saving` flag from a prior open.
         isVisible = false;
+        isDeleteConfirmVisible = false;
+        error = null;
+        saving = false;
         if (Visible)
         {
             await VisibleChanged.InvokeAsync(false);

--- a/src/OvcinaHra.Client/Components/SlotEditPopup.razor
+++ b/src/OvcinaHra.Client/Components/SlotEditPopup.razor
@@ -1,0 +1,261 @@
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Extensions
+@inject ApiClient Api
+
+<DxPopup AllowResize="true" @bind-Visible="@isVisible" HeaderText="@HeaderText" Width="640px">
+    <BodyContentTemplate Context="popupCtx">
+        <DxFormLayout>
+            <DxFormLayoutGroup Caption="Identita" ColSpanMd="12">
+                <DxFormLayoutItem Caption="Začátek" ColSpanMd="6">
+                    <DxDateEdit @bind-Date="@startTime" TimeSectionVisible="true" DisplayFormat="d.M.yyyy HH:mm" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Délka (h)" ColSpanMd="3">
+                    <DxSpinEdit @bind-Value="@durationHours" MinValue="0.5m" MaxValue="24m" Increment="0.5m" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Herní rok" ColSpanMd="3">
+                    <DxSpinEdit @bind-Value="@inGameYear" MinValue="0" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Fáze hry" ColSpanMd="6">
+                    <DxComboBox Data="@stageChoices" @bind-Value="@stage"
+                                TextFieldName="@nameof(StageChoice.Display)"
+                                ValueFieldName="@nameof(StageChoice.Value)" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Bojový bonus" ColSpanMd="6">
+                    <DxComboBox Data="@bonuses" @bind-Value="@bonusId"
+                                TextFieldName="@nameof(BattlefieldBonusDto.Name)"
+                                ValueFieldName="@nameof(BattlefieldBonusDto.Id)"
+                                NullText="Žádný"
+                                ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+
+            <DxFormLayoutGroup Caption="Obsah" ColSpanMd="12">
+                <DxFormLayoutItem Caption="Pravidla / poznámka" ColSpanMd="12">
+                    <DxMemo @bind-Text="@rules" Rows="4" />
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+
+            <DxFormLayoutGroup Caption="Vazby" ColSpanMd="12">
+                <DxFormLayoutItem Caption="Události" ColSpanMd="12">
+                    @if (gameEvents.Count == 0)
+                    {
+                        <span style="color:var(--oh-text-secondary);font-size:.85rem">
+                            Žádné události. Vytvoř je v sekci Události.
+                        </span>
+                    }
+                    else
+                    {
+                        <div class="oh-tl-slot-chips">
+                            @foreach (var ev in gameEvents)
+                            {
+                                var on = linkedEventIds.Contains(ev.Id);
+                                <button type="button"
+                                        class="oh-tl-chip @(on ? "oh-tl-chip--quest" : "oh-tl-chip--other")"
+                                        style="cursor:pointer"
+                                        @onclick="() => ToggleEvent(ev.Id)">
+                                    <i class="bi @(on ? "bi-check2" : "bi-plus")"></i>@ev.Name
+                                </button>
+                            }
+                        </div>
+                    }
+                </DxFormLayoutItem>
+            </DxFormLayoutGroup>
+        </DxFormLayout>
+
+        @if (!string.IsNullOrEmpty(error))
+        {
+            <div class="alert alert-danger mt-2">@error</div>
+        }
+
+        <div class="d-flex gap-2 mt-3">
+            @if (editingId.HasValue)
+            {
+                <button type="button" class="btn btn-outline-danger" @onclick="() => isDeleteConfirmVisible = true">
+                    <i class="bi bi-trash"></i> Smazat
+                </button>
+            }
+            <div style="flex:1"></div>
+            <button type="button" class="btn btn-secondary" @onclick="Close">Zrušit</button>
+            <button type="button" class="btn btn-primary" @onclick="SaveAsync" disabled="@saving">
+                @(saving ? "Ukládám…" : "Uložit")
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<DxPopup @bind-Visible="@isDeleteConfirmVisible" HeaderText="Smazat časový blok?" Width="420px">
+    <BodyContentTemplate Context="confirmCtx">
+        <p>Tato akce je nevratná. Propojené události zůstanou zachovány.</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button type="button" class="btn btn-secondary" @onclick="() => isDeleteConfirmVisible = false">Zrušit</button>
+            <button type="button" class="btn btn-danger" @onclick="DeleteAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter, EditorRequired] public int GameId { get; set; }
+    [Parameter] public GameTimeSlotDto? EditSlot { get; set; }
+    [Parameter] public IReadOnlyList<BattlefieldBonusDto> Bonuses { get; set; } = [];
+    [Parameter] public IReadOnlyList<GameEventListDto> GameEvents { get; set; } = [];
+    [Parameter] public EventCallback OnSaved { get; set; }
+    [Parameter] public EventCallback OnDeleted { get; set; }
+
+    private bool isVisible;
+    private bool isDeleteConfirmVisible;
+    private bool saving;
+    private string? error;
+
+    private int? editingId;
+    private DateTime startTime = DateTime.Now;
+    private decimal durationHours = 2m;
+    private int? inGameYear;
+    private TreasureQuestDifficulty stage = TreasureQuestDifficulty.Start;
+    private int? bonusId;
+    private string? rules;
+    private HashSet<int> linkedEventIds = [];
+
+    private IReadOnlyList<BattlefieldBonusDto> bonuses = [];
+    private IReadOnlyList<GameEventListDto> gameEvents = [];
+
+    private record StageChoice(TreasureQuestDifficulty Value, string Display);
+    private static readonly IReadOnlyList<StageChoice> stageChoices =
+        Enum.GetValues<TreasureQuestDifficulty>()
+            .Select(v => new StageChoice(v, v.GetDisplayName()))
+            .ToList();
+
+    private string HeaderText => editingId.HasValue
+        ? $"Upravit blok – {startTime:d.M.yyyy HH:mm}"
+        : "Nový časový blok";
+
+    private bool _wasVisible;
+
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        await base.SetParametersAsync(parameters);
+        bonuses = Bonuses;
+        gameEvents = GameEvents;
+
+        if (Visible && !_wasVisible)
+        {
+            ResetForm();
+            isVisible = true;
+        }
+        else if (!Visible && _wasVisible)
+        {
+            isVisible = false;
+        }
+        _wasVisible = Visible;
+    }
+
+    private void ResetForm()
+    {
+        error = null;
+        if (EditSlot is null)
+        {
+            editingId = null;
+            startTime = DateTime.Now.Date.AddHours(10);
+            durationHours = 2m;
+            inGameYear = null;
+            stage = TreasureQuestDifficulty.Start;
+            bonusId = null;
+            rules = null;
+            linkedEventIds = [];
+        }
+        else
+        {
+            editingId = EditSlot.Id;
+            startTime = EditSlot.StartTime.ToLocalTime();
+            durationHours = EditSlot.DurationHours;
+            inGameYear = EditSlot.InGameYear;
+            stage = EditSlot.Stage;
+            bonusId = EditSlot.BattlefieldBonusId;
+            rules = EditSlot.Rules;
+            linkedEventIds = EditSlot.LinkedEvents.Select(e => e.Id).ToHashSet();
+        }
+    }
+
+    private void ToggleEvent(int id)
+    {
+        if (!linkedEventIds.Add(id)) linkedEventIds.Remove(id);
+    }
+
+    private async Task SaveAsync()
+    {
+        error = null;
+        saving = true;
+        try
+        {
+            var ids = linkedEventIds.Count > 0 ? linkedEventIds.ToList() : null;
+            // StartTime is collected in local time via DxDateEdit; persist as UTC to match the API contract.
+            var startUtc = DateTime.SpecifyKind(startTime, DateTimeKind.Local).ToUniversalTime();
+
+            if (editingId is { } id)
+            {
+                var (ok, problem) = await Api.PutWithProblemAsync($"/api/timeline/slots/{id}",
+                    new UpdateGameTimeSlotDto(startUtc, durationHours, inGameYear, rules, bonusId, stage, ids));
+                if (!ok)
+                {
+                    error = problem ?? "Uložení selhalo.";
+                    return;
+                }
+            }
+            else
+            {
+                var (ok, _, problem) = await Api.PostWithProblemAsync<CreateGameTimeSlotDto, GameTimeSlotDto>(
+                    "/api/timeline/slots",
+                    new CreateGameTimeSlotDto(GameId, startUtc, durationHours, inGameYear, rules, bonusId, stage, ids));
+                if (!ok)
+                {
+                    error = problem ?? "Vytvoření selhalo.";
+                    return;
+                }
+            }
+            await Close();
+            await OnSaved.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private async Task DeleteAsync()
+    {
+        if (editingId is not { } id) return;
+        try
+        {
+            var (ok, problem) = await Api.DeleteWithProblemAsync($"/api/timeline/slots/{id}");
+            if (!ok)
+            {
+                error = problem ?? "Smazání selhalo.";
+                isDeleteConfirmVisible = false;
+                return;
+            }
+            isDeleteConfirmVisible = false;
+            await Close();
+            await OnDeleted.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            isDeleteConfirmVisible = false;
+        }
+    }
+
+    private async Task Close()
+    {
+        isVisible = false;
+        if (Visible)
+        {
+            await VisibleChanged.InvokeAsync(false);
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Components/SlotGanttBar.razor
+++ b/src/OvcinaHra.Client/Components/SlotGanttBar.razor
@@ -1,0 +1,77 @@
+@using System.Globalization
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Dtos
+
+@{
+    var stageMod = Slot.Stage switch
+    {
+        TreasureQuestDifficulty.Start => "start",
+        TreasureQuestDifficulty.Early => "early",
+        TreasureQuestDifficulty.Midgame => "midgame",
+        TreasureQuestDifficulty.Lategame => "lategame",
+        _ => "start"
+    };
+    var classes = $"oh-tl-gbar oh-tl-gbar--{stageMod}"
+        + (IsActive ? " oh-tl-gbar--active" : "")
+        + (IsPast ? " oh-tl-gbar--past" : "");
+    var cs = CultureInfo.GetCultureInfo("cs-CZ");
+    var startLocal = Slot.StartTime.ToLocalTime();
+    var endLocal = Slot.EndTime.ToLocalTime();
+    var glyphs = ChipGlyphs();
+}
+
+<div class="@classes"
+     style="@($"left: {Left.ToString("0.##", CultureInfo.InvariantCulture)}px; width: {Width.ToString("0.##", CultureInfo.InvariantCulture)}px; top: {Top}px")"
+     title="@Tooltip"
+     @onclick="async () => await OnEdit.InvokeAsync(Slot.Id)">
+    <span class="oh-tl-gbar-time">@startLocal.ToString("HH:mm", cs)–@endLocal.ToString("HH:mm", cs)</span>
+    <span class="oh-tl-gbar-title">@Title</span>
+    @if (glyphs.Count > 0)
+    {
+        <span class="oh-tl-gbar-glyphs">
+            @foreach (var g in glyphs)
+            {
+                <i class="bi @g" @key="g"></i>
+            }
+        </span>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public GameTimeSlotDto Slot { get; set; } = default!;
+    [Parameter] public double Left { get; set; }
+    [Parameter] public double Width { get; set; }
+    [Parameter] public int Top { get; set; }
+    [Parameter] public bool IsActive { get; set; }
+    [Parameter] public bool IsPast { get; set; }
+    [Parameter] public EventCallback<int> OnEdit { get; set; }
+
+    private string Title =>
+        !string.IsNullOrWhiteSpace(Slot.Rules) && Slot.Rules.Length <= 60
+            ? Slot.Rules.Split('\n')[0].Trim()
+            : Slot.Stage.GetDisplayName();
+
+    private string Tooltip
+    {
+        get
+        {
+            var parts = new List<string> { $"{Slot.StageDisplay} · {Slot.DurationHours:0.#}h" };
+            if (Slot.LinkedEvents.Count > 0)
+                parts.Add($"Události: {string.Join(", ", Slot.LinkedEvents.Select(e => e.Name))}");
+            if (!string.IsNullOrWhiteSpace(Slot.BattlefieldBonusName))
+                parts.Add($"Bonus: {Slot.BattlefieldBonusName}");
+            if (!string.IsNullOrWhiteSpace(Slot.Rules))
+                parts.Add(Slot.Rules);
+            return string.Join("\n", parts);
+        }
+    }
+
+    private List<string> ChipGlyphs()
+    {
+        var list = new List<string>();
+        if (Slot.LinkedEvents.Any(e => e.Kind == GameEventKind.Quest)) list.Add("bi-journal-bookmark");
+        if (Slot.LinkedEvents.Any(e => e.Kind == GameEventKind.Encounter)) list.Add("bi-bug");
+        if (!string.IsNullOrWhiteSpace(Slot.BattlefieldBonusName)) list.Add("bi-shield-check");
+        return list;
+    }
+}

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -77,7 +77,7 @@
                 {
                     <NavLink class="oh-nav-item" href="timeline">
                         <span class="oh-nav-rail"></span>
-                        <i class="bi bi-clock-fill ni"></i><span class="oh-nav-label">Časová osa</span>
+                        <i class="bi bi-clock-fill ni"></i><span class="oh-nav-label">Harmonogram</span>
                     </NavLink>
                     <NavLink class="oh-nav-item" href="treasures">
                         <span class="oh-nav-rail"></span>

--- a/src/OvcinaHra.Client/Layout/PrintLayout.razor
+++ b/src/OvcinaHra.Client/Layout/PrintLayout.razor
@@ -1,0 +1,7 @@
+@inherits LayoutComponentBase
+
+@* Chrome-free layout used by /timeline/print and any other A4 export pages.
+   No nav menu, no header bar — keeps the on-screen preview faithful to print. *@
+<main style="background:#fff;min-height:100vh">
+    @Body
+</main>

--- a/src/OvcinaHra.Client/Pages/Timeline/TimelinePage.razor
+++ b/src/OvcinaHra.Client/Pages/Timeline/TimelinePage.razor
@@ -1,105 +1,173 @@
 @page "/timeline"
 @attribute [Authorize]
+@using System.Globalization
+@using System.Threading
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Dtos
 @inject ApiClient Api
 @inject GameContextService GameContext
+@inject IJSRuntime JS
 @implements IDisposable
 
-<h1 class="mb-3">Časová osa</h1>
+<PageTitle>Harmonogram hry</PageTitle>
 
-@if (loading) { <p>Načítám...</p> }
-else if (slots.Count == 0 && bonuses.Count == 0)
-{
-    <div class="text-center text-muted py-5">
-        <i class="bi bi-clock-history fs-1 d-block mb-2"></i>
-        <p>Žádné časové bloky pro tuto hru.</p>
-        <button class="btn btn-primary" @onclick="() => OpenSlotModal(null)">+ Nové období</button>
+@{ var cs = CultureInfo.GetCultureInfo("cs-CZ"); }
+
+<div class="oh-tl-bar">
+    <div class="oh-tl-bar-row">
+        <div>
+            <h1 class="oh-tl-bar-title">Harmonogram hry</h1>
+            <div class="oh-tl-bar-sub">@(GameContext.GameName ?? "Žádná hra")</div>
+        </div>
+        <div class="oh-tl-bar-spacer"></div>
+        @if (gameRunning && currentStage is { } stg)
+        {
+            <span class="oh-tl-act-pill" style="@($"color: {StageColor(stg)}")">
+                <i class="bi bi-broadcast"></i>Aktuálně: @stg.GetDisplayName()
+            </span>
+        }
+        <div class="oh-tl-seg" role="tablist" aria-label="Pohled">
+            <button type="button" class="oh-tl-seg-btn @(view == "agenda" ? "on" : "")"
+                    role="tab" aria-selected="@(view == "agenda")"
+                    @onclick='() => SetViewAsync("agenda")'>Agenda</button>
+            <button type="button" class="oh-tl-seg-btn @(view == "gantt" ? "on" : "")"
+                    role="tab" aria-selected="@(view == "gantt")"
+                    @onclick='() => SetViewAsync("gantt")'>Gantt</button>
+        </div>
+        <button type="button" class="btn btn-primary btn-sm" @onclick="OpenCreate">
+            <i class="bi bi-plus-lg"></i> Nový časový blok
+        </button>
+        <a class="btn btn-outline-secondary btn-sm" href="timeline/print" target="_blank" rel="noopener">
+            <i class="bi bi-printer"></i> Tisk
+        </a>
+        <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => isBonusesOpen = true">
+            <i class="bi bi-shield-check"></i> Bonusy
+        </button>
     </div>
+    @if (slots.Count > 0)
+    {
+        <div class="oh-tl-filter-row">
+            <span><i class="bi bi-funnel"></i> Filtrovat:</span>
+            @foreach (var stage in Enum.GetValues<TreasureQuestDifficulty>())
+            {
+                <label style="display:inline-flex;align-items:center;gap:4px">
+                    <input type="checkbox" checked="@stageFilter[stage]"
+                           @onchange="@((ChangeEventArgs e) => ToggleStage(stage, (bool)(e.Value ?? false)))" />
+                    @stage.GetDisplayName()
+                </label>
+            }
+            <label style="display:inline-flex;align-items:center;gap:4px">
+                <input type="checkbox" @bind="onlyWithBonus" /> jen s bonusem
+            </label>
+            <label style="display:inline-flex;align-items:center;gap:4px">
+                <input type="checkbox" @bind="onlyWithEvents" /> jen s událostmi
+            </label>
+        </div>
+    }
+</div>
+
+@if (loading)
+{
+    <p class="oh-tl-agenda">Načítám…</p>
+}
+else if (slots.Count == 0)
+{
+    <div class="oh-tl-empty">
+        <i class="bi bi-clock-history"></i>
+        <div class="oh-tl-empty-title">Žádné časové bloky pro tuto hru</div>
+        <p>Začni rozkreslovat harmonogram – Agenda i Gantt pohled jsou připravené.</p>
+        <button type="button" class="btn btn-primary mt-2" @onclick="OpenCreate">
+            <i class="bi bi-plus-lg"></i> Nový časový blok
+        </button>
+    </div>
+}
+else if (view == "gantt")
+{
+    <GanttCanvas Slots="@FilteredSlots" Now="@_now" OnEdit="OpenEdit" />
 }
 else
 {
-    <div class="row">
-        @* LEFT: Time slots (wider) *@
-        <div class="col-md-7">
-            <div class="d-flex justify-content-between align-items-center mb-2">
-                <h5 class="mb-0">Časová období</h5>
-                <button class="btn btn-sm btn-primary" @onclick="() => OpenSlotModal(null)">+ Nové období</button>
-            </div>
-            <OvcinaGrid Data="@slots" KeyFieldName="Id" LayoutKey="grid-layout-timeline-slots"
-                        RowClick="@(e => OpenSlotModal((GameTimeSlotDto)e.Grid.GetDataItem(e.VisibleIndex)))">
-                <Columns>
-                    <DxGridDataColumn FieldName="StartTime" Caption="Začátek" Width="160px" DisplayFormat="d.M.yyyy HH:mm" />
-                    <DxGridDataColumn FieldName="DurationHours" Caption="Délka (h)" Width="100px" />
-                    <DxGridDataColumn FieldName="InGameYear" Caption="Herní rok" Width="100px" />
-                    <DxGridDataColumn FieldName="Rules" Caption="Pravidla" />
-                    <DxGridDataColumn FieldName="BattlefieldBonusId" Caption="Bonus" Width="100px" Visible="false" />
-                </Columns>
-            </OvcinaGrid>
-        </div>
-
-        @* RIGHT: Battlefield bonuses (narrower) *@
-        <div class="col-md-5">
-            <div class="d-flex justify-content-between align-items-center mb-2">
-                <h5 class="mb-0">Bojové bonusy</h5>
-                <button class="btn btn-sm btn-primary" @onclick="() => OpenBonusModal(null)">+ Nový bonus</button>
-            </div>
-            <OvcinaGrid Data="@bonuses" KeyFieldName="Id" LayoutKey="grid-layout-timeline-bonuses"
-                        RowClick="@(e => OpenBonusModal((BattlefieldBonusDto)e.Grid.GetDataItem(e.VisibleIndex)))">
-                <Columns>
-                    <DxGridDataColumn FieldName="Name" Caption="Název" />
-                    <DxGridDataColumn FieldName="AttackBonus" Caption="Útok" Width="70px" />
-                    <DxGridDataColumn FieldName="DefenseBonus" Caption="Obrana" Width="70px" />
-                    <DxGridDataColumn FieldName="Description" Caption="Popis" Visible="false" />
-                </Columns>
-            </OvcinaGrid>
-        </div>
+    <div class="oh-tl-agenda">
+        @{
+            DateTime? lastDay = null;
+            TreasureQuestDifficulty? prevStage = null;
+        }
+        @foreach (var s in FilteredSlots)
+        {
+            var local = s.StartTime.ToLocalTime();
+            var day = local.Date;
+            if (lastDay != day)
+            {
+                lastDay = day;
+                <div class="oh-tl-day-sep" @key="@($"day-{day:yyyyMMdd}")">
+                    <span class="oh-tl-day-wkd">@local.ToString("dddd", cs)</span>
+                    <span class="oh-tl-day-dt">@local.ToString("d. MMMM yyyy", cs)</span>
+                </div>
+            }
+            <SlotCard @key="s.Id" Slot="@s"
+                      IsActive="@(IsActive(s))"
+                      IsPast="@(IsPast(s))"
+                      StageTransitionFrom="@prevStage"
+                      OnEdit="OpenEdit" />
+            prevStage = s.Stage;
+        }
     </div>
 }
 
-@* === SLOT POPUP === *@
-<DxPopup AllowResize="true" @bind-Visible="@isSlotVisible" HeaderText="@slotTitle" Width="550px">
-    <BodyContentTemplate Context="popupContext">
-        <DxFormLayout>
-            <DxFormLayoutItem Caption="Začátek" ColSpanMd="6">
-                <DxDateEdit @bind-Date="@slotStartTime" TimeSectionVisible="true" DisplayFormat="d.M.yyyy HH:mm" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Délka (hodiny)" ColSpanMd="6">
-                <DxSpinEdit @bind-Value="@slotDurationHours" MinValue="0.5m" MaxValue="24m" Increment="0.5m" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Herní rok" ColSpanMd="6">
-                <DxSpinEdit @bind-Value="@slotInGameYear" MinValue="0" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Bojový bonus" ColSpanMd="6">
-                <DxComboBox Data="@bonuses" @bind-Value="@slotBonusId"
-                            TextFieldName="Name" ValueFieldName="Id"
-                            NullText="Žádný" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Pravidla" ColSpanMd="12">
-                <DxMemo @bind-Text="@slotRules" Rows="3" />
-            </DxFormLayoutItem>
-        </DxFormLayout>
-        @if (slotError is not null) { <div class="alert alert-danger mt-2">@slotError</div> }
-        <div class="d-flex gap-2 mt-3">
-            @if (editingSlotId.HasValue) { <button class="btn btn-outline-danger" @onclick="() => isSlotDeleteVisible = true">Smazat</button> }
-            <div style="flex: 1"></div>
-            <button class="btn btn-secondary" @onclick="() => isSlotVisible = false">Zrušit</button>
-            <button class="btn btn-primary" @onclick="SaveSlotAsync" disabled="@slotSaving">Uložit</button>
+<SlotEditPopup @bind-Visible="@isEditOpen"
+               GameId="@gameId"
+               EditSlot="@editSlot"
+               Bonuses="@bonuses"
+               GameEvents="@gameEvents"
+               OnSaved="OnEditSavedAsync"
+               OnDeleted="OnEditSavedAsync" />
+
+@* Bonus management popup — preserves prior CRUD. No DxGrid here. *@
+<DxPopup @bind-Visible="@isBonusesOpen" HeaderText="Bojové bonusy" Width="640px">
+    <BodyContentTemplate Context="bonusListCtx">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <span>@bonuses.Count záznamů</span>
+            <button type="button" class="btn btn-sm btn-primary" @onclick="OpenBonusCreate">
+                <i class="bi bi-plus-lg"></i> Nový bonus
+            </button>
         </div>
+        @if (bonuses.Count == 0)
+        {
+            <p style="color:var(--oh-text-secondary)">Žádné bonusy. Přidej první.</p>
+        }
+        else
+        {
+            <ul class="list-group">
+                @foreach (var b in bonuses)
+                {
+                    <li class="list-group-item d-flex justify-content-between align-items-center" @key="b.Id">
+                        <div>
+                            <strong>@b.Name</strong>
+                            <span style="color:var(--oh-text-secondary);margin-left:8px;font-family:'JetBrains Mono',monospace">
+                                Útok @b.AttackBonus · Obrana @b.DefenseBonus
+                            </span>
+                            @if (!string.IsNullOrWhiteSpace(b.Description))
+                            {
+                                <div style="font-size:.85rem;color:var(--oh-text-secondary)">@b.Description</div>
+                            }
+                        </div>
+                        <div class="d-flex gap-1">
+                            <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => OpenBonusEdit(b)">
+                                <i class="bi bi-pencil"></i>
+                            </button>
+                            <button type="button" class="btn btn-sm btn-outline-danger" @onclick="() => StartBonusDelete(b)">
+                                <i class="bi bi-trash"></i>
+                            </button>
+                        </div>
+                    </li>
+                }
+            </ul>
+        }
     </BodyContentTemplate>
 </DxPopup>
 
-<DxPopup @bind-Visible="@isSlotDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
-    <BodyContentTemplate Context="popupContext">
-        <p>Smazat časové období?</p>
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="() => isSlotDeleteVisible = false">Zrušit</button>
-            <button class="btn btn-danger" @onclick="DeleteSlotAsync">Smazat</button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
-
-@* === BONUS POPUP === *@
-<DxPopup AllowResize="true" @bind-Visible="@isBonusVisible" HeaderText="@bonusTitle" Width="450px">
-    <BodyContentTemplate Context="popupContext">
+<DxPopup @bind-Visible="@isBonusEditOpen" HeaderText="@bonusHeader" Width="500px">
+    <BodyContentTemplate Context="bonusEditCtx">
         <DxFormLayout>
             <DxFormLayoutItem Caption="Název" ColSpanMd="12">
                 <DxTextBox @bind-Text="@bonusName" />
@@ -115,162 +183,259 @@ else
             </DxFormLayoutItem>
         </DxFormLayout>
         @if (bonusError is not null) { <div class="alert alert-danger mt-2">@bonusError</div> }
-        <div class="d-flex gap-2 mt-3">
-            @if (editingBonusId.HasValue) { <button class="btn btn-outline-danger" @onclick="() => isBonusDeleteVisible = true">Smazat</button> }
-            <div style="flex: 1"></div>
-            <button class="btn btn-secondary" @onclick="() => isBonusVisible = false">Zrušit</button>
-            <button class="btn btn-primary" @onclick="SaveBonusAsync" disabled="@bonusSaving">Uložit</button>
+        <div class="d-flex gap-2 mt-3 justify-content-end">
+            <button type="button" class="btn btn-secondary" @onclick="() => isBonusEditOpen = false">Zrušit</button>
+            <button type="button" class="btn btn-primary" @onclick="SaveBonusAsync">Uložit</button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
 
-<DxPopup @bind-Visible="@isBonusDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
-    <BodyContentTemplate Context="popupContext">
-        <p>Smazat bonus <strong>@bonusName</strong>?</p>
+<DxPopup @bind-Visible="@isBonusDeleteOpen" HeaderText="Smazat bonus?" Width="420px">
+    <BodyContentTemplate Context="bonusDeleteCtx">
+        <p>Smazat bonus <strong>@(bonusDeleteTarget?.Name ?? "")</strong>? Tato akce je nevratná. Sloty, které bonus používaly, ho ztratí.</p>
         <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="() => isBonusDeleteVisible = false">Zrušit</button>
-            <button class="btn btn-danger" @onclick="DeleteBonusAsync">Smazat</button>
+            <button type="button" class="btn btn-secondary" @onclick="() => isBonusDeleteOpen = false">Zrušit</button>
+            <button type="button" class="btn btn-danger" @onclick="DeleteBonusAsync">Smazat</button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
 
 @code {
-    // Data
+    private const string ViewKey = "oh-timeline-view";
+
     private List<GameTimeSlotDto> slots = [];
     private List<BattlefieldBonusDto> bonuses = [];
+    private List<GameEventListDto> gameEvents = [];
     private bool loading = true;
-    private int gameId => GameContext.SelectedGameId ?? 1;
+    private string view = "agenda";
+    private DateTime _now = DateTime.Now;
+    private Timer? _tickTimer;
 
-    // Slot state
-    private bool isSlotVisible, isSlotDeleteVisible, slotSaving;
-    private string slotTitle = "";
-    private string? slotError, slotRules;
-    private int? editingSlotId, slotInGameYear, slotBonusId;
-    private DateTime slotStartTime = new(2026, 5, 1, 10, 0, 0);
-    private decimal slotDurationHours = 2m;
+    private int gameId => GameContext.SelectedGameId ?? 0;
 
-    // Bonus state
-    private bool isBonusVisible, isBonusDeleteVisible, bonusSaving;
-    private string bonusTitle = "", bonusName = "";
-    private string? bonusError, bonusDescription;
+    // Filters
+    private readonly Dictionary<TreasureQuestDifficulty, bool> stageFilter =
+        Enum.GetValues<TreasureQuestDifficulty>().ToDictionary(s => s, _ => true);
+    private bool onlyWithBonus;
+    private bool onlyWithEvents;
+
+    // Edit popup
+    private bool isEditOpen;
+    private GameTimeSlotDto? editSlot;
+
+    // Bonus management
+    private bool isBonusesOpen;
+    private bool isBonusEditOpen;
+    private bool isBonusDeleteOpen;
+    private string bonusHeader = "";
     private int? editingBonusId;
-    private int bonusAttack, bonusDefense;
+    private string bonusName = "";
+    private int bonusAttack;
+    private int bonusDefense;
+    private string? bonusDescription;
+    private string? bonusError;
+    private BattlefieldBonusDto? bonusDeleteTarget;
 
-    // Lifecycle
+    private bool gameRunning => slots.Any(s => s.StartTime.ToLocalTime() <= _now);
+
+    private TreasureQuestDifficulty? currentStage =>
+        slots
+            .Where(s => s.StartTime.ToLocalTime() <= _now)
+            .OrderByDescending(s => s.StartTime)
+            .Select(s => (TreasureQuestDifficulty?)s.Stage)
+            .FirstOrDefault();
+
+    private List<GameTimeSlotDto> FilteredSlots =>
+        slots.Where(s =>
+            stageFilter[s.Stage]
+            && (!onlyWithBonus || s.BattlefieldBonusId is not null)
+            && (!onlyWithEvents || s.LinkedEvents.Count > 0))
+        .OrderBy(s => s.StartTime)
+        .ToList();
+
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
         GameContext.OnGameChanged += OnGameChanged;
         await LoadAsync();
+        // 30-second re-tick: re-evaluates IsActive / IsPast, refreshes the
+        // active-slot pill counter without a server roundtrip.
+        _tickTimer = new Timer(_ =>
+        {
+            _now = DateTime.Now;
+            _ = InvokeAsync(StateHasChanged);
+        }, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+        try
+        {
+            var stored = await JS.InvokeAsync<string?>("localStorage.getItem", ViewKey);
+            if ((stored == "agenda" || stored == "gantt") && stored != view)
+            {
+                view = stored;
+                StateHasChanged();
+            }
+        }
+        catch { /* prerender / JS unavailable */ }
     }
 
     private async Task LoadAsync()
     {
+        if (gameId == 0)
+        {
+            loading = false;
+            return;
+        }
         loading = true;
-        var slotsTask = Api.GetListAsync<GameTimeSlotDto>($"/api/timeline/slots/by-game/{gameId}");
-        var bonusesTask = Api.GetListAsync<BattlefieldBonusDto>($"/api/timeline/bonuses/by-game/{gameId}");
-        await Task.WhenAll(slotsTask, bonusesTask);
-        slots = slotsTask.Result;
-        bonuses = bonusesTask.Result;
+        try
+        {
+            var slotsTask = Api.GetListAsync<GameTimeSlotDto>($"/api/timeline/slots/by-game/{gameId}");
+            var bonusesTask = Api.GetListAsync<BattlefieldBonusDto>($"/api/timeline/bonuses/by-game/{gameId}");
+            var eventsTask = Api.GetListAsync<GameEventListDto>($"/api/games/{gameId}/events");
+            await Task.WhenAll(slotsTask, bonusesTask, eventsTask);
+            slots = slotsTask.Result;
+            bonuses = bonusesTask.Result;
+            gameEvents = eventsTask.Result;
+            _now = DateTime.Now;
+        }
+        catch
+        {
+            // Best-effort — page renders empty banner on next render.
+            slots = [];
+            bonuses = [];
+            gameEvents = [];
+        }
         loading = false;
     }
 
-    private async void OnGameChanged() { await LoadAsync(); StateHasChanged(); }
-    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
-
-    // === SLOT ===
-    private void OpenSlotModal(GameTimeSlotDto? s)
+    private async void OnGameChanged()
     {
-        slotError = null;
-        if (s is null)
-        {
-            editingSlotId = null; slotStartTime = new DateTime(2026, 5, 1, 10, 0, 0);
-            slotDurationHours = 2m; slotInGameYear = null; slotRules = null; slotBonusId = null;
-            slotTitle = "Nové časové období";
-        }
-        else
-        {
-            editingSlotId = s.Id; slotStartTime = s.StartTime;
-            slotDurationHours = s.DurationHours;
-            slotInGameYear = s.InGameYear; slotRules = s.Rules;
-            slotBonusId = s.BattlefieldBonusId;
-            slotTitle = $"Upravit období: {s.StartTime:d.M.yyyy HH:mm}";
-        }
-        isSlotVisible = true;
+        await LoadAsync();
+        StateHasChanged();
     }
 
-    private async Task SaveSlotAsync()
+    public void Dispose()
     {
-        slotError = null; slotSaving = true;
-        try
-        {
-            var durationHours = slotDurationHours;
-            if (editingSlotId.HasValue)
-                await Api.PutAsync($"/api/timeline/slots/{editingSlotId}",
-                    new UpdateGameTimeSlotDto(slotStartTime, durationHours, slotInGameYear, slotRules, slotBonusId));
-            else
-                await Api.PostAsync<CreateGameTimeSlotDto, GameTimeSlotDto>("/api/timeline/slots",
-                    new CreateGameTimeSlotDto(gameId, slotStartTime, durationHours, slotInGameYear, slotRules, slotBonusId));
-            isSlotVisible = false; await LoadAsync(); StateHasChanged();
-        }
-        catch (Exception ex) { slotError = ex.Message; }
-        finally { slotSaving = false; }
+        GameContext.OnGameChanged -= OnGameChanged;
+        _tickTimer?.Dispose();
     }
 
-    private async Task DeleteSlotAsync()
+    private async Task SetViewAsync(string next)
     {
-        try
-        {
-            await Api.DeleteAsync($"/api/timeline/slots/{editingSlotId}");
-            isSlotDeleteVisible = false; isSlotVisible = false;
-            await LoadAsync(); StateHasChanged();
-        }
-        catch (Exception ex) { slotError = ex.Message; }
+        if (view == next) return;
+        view = next;
+        try { await JS.InvokeVoidAsync("localStorage.setItem", ViewKey, next); }
+        catch { /* non-fatal */ }
     }
 
-    // === BONUS ===
-    private void OpenBonusModal(BattlefieldBonusDto? b)
+    private void ToggleStage(TreasureQuestDifficulty stage, bool on) => stageFilter[stage] = on;
+
+    private void OpenCreate()
+    {
+        editSlot = null;
+        isEditOpen = true;
+    }
+
+    private void OpenEdit(int id)
+    {
+        editSlot = slots.FirstOrDefault(s => s.Id == id);
+        if (editSlot is not null) isEditOpen = true;
+    }
+
+    private async Task OnEditSavedAsync()
+    {
+        await LoadAsync();
+        StateHasChanged();
+    }
+
+    private bool IsActive(GameTimeSlotDto s)
+    {
+        var local = s.StartTime.ToLocalTime();
+        return local <= _now && _now < local.Add(TimeSpan.FromHours((double)s.DurationHours));
+    }
+
+    private bool IsPast(GameTimeSlotDto s) =>
+        s.StartTime.ToLocalTime().Add(TimeSpan.FromHours((double)s.DurationHours)) < _now;
+
+    private static string StageColor(TreasureQuestDifficulty d) => d switch
+    {
+        TreasureQuestDifficulty.Start => "#7FA657",
+        TreasureQuestDifficulty.Early => "#D4A63C",
+        TreasureQuestDifficulty.Midgame => "#C17B3D",
+        TreasureQuestDifficulty.Lategame => "#8C2423",
+        _ => "#7FA657"
+    };
+
+    // --- Bonus CRUD (preserved from prior page) ---
+
+    private void OpenBonusCreate()
     {
         bonusError = null;
-        if (b is null)
-        {
-            editingBonusId = null; bonusName = ""; bonusAttack = 0; bonusDefense = 0; bonusDescription = null;
-            bonusTitle = "Nový bojový bonus";
-        }
-        else
-        {
-            editingBonusId = b.Id; bonusName = b.Name ?? ""; bonusAttack = b.AttackBonus;
-            bonusDefense = b.DefenseBonus; bonusDescription = b.Description;
-            bonusTitle = $"Upravit: {b.Name}";
-        }
-        isBonusVisible = true;
+        editingBonusId = null;
+        bonusName = "";
+        bonusAttack = 0;
+        bonusDefense = 0;
+        bonusDescription = null;
+        bonusHeader = "Nový bojový bonus";
+        isBonusEditOpen = true;
+    }
+
+    private void OpenBonusEdit(BattlefieldBonusDto b)
+    {
+        bonusError = null;
+        editingBonusId = b.Id;
+        bonusName = b.Name ?? "";
+        bonusAttack = b.AttackBonus;
+        bonusDefense = b.DefenseBonus;
+        bonusDescription = b.Description;
+        bonusHeader = $"Upravit: {b.Name}";
+        isBonusEditOpen = true;
     }
 
     private async Task SaveBonusAsync()
     {
-        bonusError = null; bonusSaving = true;
+        bonusError = null;
         try
         {
-            if (editingBonusId.HasValue)
-                await Api.PutAsync($"/api/timeline/bonuses/{editingBonusId}",
+            if (editingBonusId is { } id)
+            {
+                var (ok, problem) = await Api.PutWithProblemAsync($"/api/timeline/bonuses/{id}",
                     new UpdateBattlefieldBonusDto(bonusName, bonusAttack, bonusDefense, bonusDescription));
+                if (!ok) { bonusError = problem ?? "Uložení selhalo."; return; }
+            }
             else
-                await Api.PostAsync<CreateBattlefieldBonusDto, BattlefieldBonusDto>("/api/timeline/bonuses",
+            {
+                var (ok, _, problem) = await Api.PostWithProblemAsync<CreateBattlefieldBonusDto, BattlefieldBonusDto>(
+                    "/api/timeline/bonuses",
                     new CreateBattlefieldBonusDto(gameId, bonusAttack, bonusDefense, bonusName, bonusDescription));
-            isBonusVisible = false; await LoadAsync(); StateHasChanged();
+                if (!ok) { bonusError = problem ?? "Vytvoření selhalo."; return; }
+            }
+            isBonusEditOpen = false;
+            await LoadAsync();
+            StateHasChanged();
         }
         catch (Exception ex) { bonusError = ex.Message; }
-        finally { bonusSaving = false; }
+    }
+
+    private void StartBonusDelete(BattlefieldBonusDto b)
+    {
+        bonusDeleteTarget = b;
+        isBonusDeleteOpen = true;
     }
 
     private async Task DeleteBonusAsync()
     {
-        try
+        if (bonusDeleteTarget is null) return;
+        var (ok, _) = await Api.DeleteWithProblemAsync($"/api/timeline/bonuses/{bonusDeleteTarget.Id}");
+        isBonusDeleteOpen = false;
+        if (ok)
         {
-            await Api.DeleteAsync($"/api/timeline/bonuses/{editingBonusId}");
-            isBonusDeleteVisible = false; isBonusVisible = false;
-            await LoadAsync(); StateHasChanged();
+            bonusDeleteTarget = null;
+            await LoadAsync();
+            StateHasChanged();
         }
-        catch (Exception ex) { bonusError = ex.Message; }
     }
 }

--- a/src/OvcinaHra.Client/Pages/Timeline/TimelinePage.razor
+++ b/src/OvcinaHra.Client/Pages/Timeline/TimelinePage.razor
@@ -286,6 +286,13 @@ else
     {
         if (gameId == 0)
         {
+            // No game selected — clear stale collections and close any open popup
+            // so the empty banner renders against an honest state.
+            slots = [];
+            bonuses = [];
+            gameEvents = [];
+            isEditOpen = false;
+            editSlot = null;
             loading = false;
             return;
         }

--- a/src/OvcinaHra.Client/Pages/Timeline/TimelinePrint.razor
+++ b/src/OvcinaHra.Client/Pages/Timeline/TimelinePrint.razor
@@ -18,7 +18,7 @@
         <button type="button" class="btn btn-primary btn-sm" @onclick="PrintAsync">
             <i class="bi bi-printer"></i> Tisk
         </button>
-        <a class="btn btn-outline-secondary btn-sm" href="timeline">
+        <a class="btn btn-outline-secondary btn-sm" href="/timeline">
             <i class="bi bi-x-lg"></i> Zavřít
         </a>
     </div>

--- a/src/OvcinaHra.Client/Pages/Timeline/TimelinePrint.razor
+++ b/src/OvcinaHra.Client/Pages/Timeline/TimelinePrint.razor
@@ -1,0 +1,131 @@
+@page "/timeline/print"
+@attribute [Authorize]
+@layout PrintLayout
+@using System.Globalization
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Dtos
+@inject ApiClient Api
+@inject GameContextService GameContext
+@inject IJSRuntime JS
+@implements IDisposable
+
+<PageTitle>Harmonogram – tisk</PageTitle>
+
+@{ var cs = CultureInfo.GetCultureInfo("cs-CZ"); }
+
+<div class="oh-tl-print">
+    <div class="oh-tl-print-hide" style="position:fixed;top:8px;right:8px;display:flex;gap:8px;z-index:99">
+        <button type="button" class="btn btn-primary btn-sm" @onclick="PrintAsync">
+            <i class="bi bi-printer"></i> Tisk
+        </button>
+        <a class="btn btn-outline-secondary btn-sm" href="timeline">
+            <i class="bi bi-x-lg"></i> Zavřít
+        </a>
+    </div>
+
+    <header class="oh-tl-print-head">
+        <h1 class="oh-tl-print-title">Harmonogram hry · @(GameContext.GameName ?? "")</h1>
+        <div class="oh-tl-print-sub">Vytisknuto @DateTime.Now.ToString("d. MMMM yyyy", cs) · pro organizátory</div>
+    </header>
+
+    @if (loading)
+    {
+        <p>Načítám…</p>
+    }
+    else if (slots.Count == 0)
+    {
+        <p>Žádné časové bloky.</p>
+    }
+    else
+    {
+        @foreach (var dayGroup in slots
+            .OrderBy(s => s.StartTime)
+            .GroupBy(s => s.StartTime.ToLocalTime().Date))
+        {
+            <section class="oh-tl-print-day" @key="dayGroup.Key">
+                <h2 class="oh-tl-print-day-head">
+                    @dayGroup.Key.ToString("dddd · d. MMMM yyyy", cs)
+                </h2>
+                @foreach (var s in dayGroup)
+                {
+                    var local = s.StartTime.ToLocalTime();
+                    var endLocal = s.EndTime.ToLocalTime();
+                    <div class="oh-tl-print-slot" @key="s.Id">
+                        <div class="oh-tl-print-slot-head">
+                            <span class="oh-tl-print-slot-time">@local.ToString("HH:mm", cs) – @endLocal.ToString("HH:mm", cs)</span>
+                            <h3 class="oh-tl-print-slot-title">@SlotTitle(s)</h3>
+                            <span class="oh-tl-print-slot-stage">@s.StageDisplay</span>
+                        </div>
+                        @if (s.LinkedEvents.Count > 0 || !string.IsNullOrWhiteSpace(s.BattlefieldBonusName))
+                        {
+                            <div class="oh-tl-print-slot-chips">
+                                @if (s.LinkedEvents.Count > 0)
+                                {
+                                    <span>Události: @string.Join(", ", s.LinkedEvents.Select(e => e.Name))</span>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(s.BattlefieldBonusName))
+                                {
+                                    @if (s.LinkedEvents.Count > 0) { <span> · </span> }
+                                    <span>Bonus: @s.BattlefieldBonusName</span>
+                                }
+                            </div>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(s.Rules))
+                        {
+                            <div class="oh-tl-print-slot-rules">@s.Rules</div>
+                        }
+                    </div>
+                }
+            </section>
+        }
+    }
+</div>
+
+@code {
+    private List<GameTimeSlotDto> slots = [];
+    private bool loading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        GameContext.OnGameChanged += OnGameChanged;
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        var gameId = GameContext.SelectedGameId ?? 0;
+        if (gameId == 0)
+        {
+            slots = [];
+            loading = false;
+            return;
+        }
+        try
+        {
+            slots = await Api.GetListAsync<GameTimeSlotDto>($"/api/timeline/slots/by-game/{gameId}");
+        }
+        catch { slots = []; }
+        loading = false;
+    }
+
+    private async void OnGameChanged()
+    {
+        await LoadAsync();
+        StateHasChanged();
+    }
+
+    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
+
+    private async Task PrintAsync()
+    {
+        try { await JS.InvokeVoidAsync("window.print"); }
+        catch { /* JS unavailable */ }
+    }
+
+    private static string SlotTitle(GameTimeSlotDto s) =>
+        !string.IsNullOrWhiteSpace(s.Rules) && s.Rules.Length <= 60
+            ? s.Rules.Split('\n')[0].Trim()
+            : $"Blok – {s.Stage.GetDisplayName()}";
+}

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2978,3 +2978,167 @@
     border:1px solid rgba(178,98,35,.45);border-left:3px solid #B26223;border-radius:4px;
     font:500 .8125rem/1.45 var(--oh-font-body);color:#6c5212}
 .oh-sacred-banner i{font-size:.95rem;color:#B26223;flex-shrink:0;margin-top:2px}
+
+/* ===========================================================================
+ * Timeline — /timeline cockpit (agenda + Gantt) + /timeline/print
+ * Stage-coloured slot cards over a sequence of game phases. Active-slot
+ * highlight is forest-green (#2D5016) — the same primary used elsewhere.
+ * Stage palette tokens (--oh-stage-*) are declared in the treasures CSS.
+ * Added 2026-04-25 (issue #171).
+ * =========================================================================== */
+
+/* Toolbar */
+.oh-tl-bar{position:sticky;top:0;z-index:10;background:var(--oh-surface);
+    border-bottom:1px solid var(--oh-border);padding:12px 16px;
+    display:flex;flex-direction:column;gap:8px}
+.oh-tl-bar-row{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.oh-tl-bar-title{font:700 1.5rem var(--oh-font-heading);color:var(--oh-text);margin:0}
+.oh-tl-bar-sub{font:400 .85rem 'JetBrains Mono','Fira Code',monospace;color:var(--oh-text-secondary)}
+.oh-tl-bar-spacer{flex:1}
+.oh-tl-act-pill{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;
+    border-radius:99px;font:600 .8rem 'JetBrains Mono','Fira Code',monospace;
+    border:1px solid currentColor}
+.oh-tl-seg{display:inline-flex;border:1px solid var(--oh-border);border-radius:6px;overflow:hidden}
+.oh-tl-seg-btn{background:transparent;border:0;padding:6px 14px;
+    font:500 .85rem var(--oh-font-body);color:var(--oh-text);cursor:pointer}
+.oh-tl-seg-btn.on{background:var(--oh-text);color:#fff}
+.oh-tl-seg-btn:not(.on):hover{background:var(--oh-surface-alt)}
+.oh-tl-filter-row{display:flex;gap:10px;align-items:center;flex-wrap:wrap;
+    padding-top:4px;font-size:.85rem;color:var(--oh-text-secondary)}
+
+/* Agenda */
+.oh-tl-agenda{padding:16px;display:flex;flex-direction:column;gap:10px;
+    max-width:980px;margin:0 auto}
+
+/* Day separator (inline section labels — NOT tabs) */
+.oh-tl-day-sep{display:flex;align-items:baseline;gap:8px;
+    padding:14px 4px 6px;border-bottom:1px solid var(--oh-border);
+    margin-top:6px;font:500 .85rem 'JetBrains Mono','Fira Code',monospace;
+    color:var(--oh-text-secondary);
+    background:linear-gradient(to right,rgba(80,75,37,0.04),transparent 80%)}
+.oh-tl-day-sep:first-child{margin-top:0}
+.oh-tl-day-wkd{font-weight:700;color:var(--oh-text)}
+.oh-tl-day-dt{font-weight:600}
+
+/* Slot card (agenda) */
+.oh-tl-slot{position:relative;background:#FFF8F0;border:1px solid var(--oh-border);
+    border-radius:6px;padding:12px 14px 12px 22px;cursor:pointer;
+    transition:box-shadow .15s,transform .15s}
+.oh-tl-slot:hover{box-shadow:0 2px 6px rgba(0,0,0,.08);transform:translateY(-1px)}
+.oh-tl-slot::before{content:'';position:absolute;left:0;top:0;bottom:0;width:6px;
+    border-radius:6px 0 0 6px;background:var(--oh-stage-start)}
+.oh-tl-slot--start::before{background:var(--oh-stage-start)}
+.oh-tl-slot--early::before{background:var(--oh-stage-early)}
+.oh-tl-slot--midgame::before{background:var(--oh-stage-midgame)}
+.oh-tl-slot--lategame::before{background:var(--oh-stage-lategame)}
+.oh-tl-slot--past{opacity:.7}
+.oh-tl-slot--active{box-shadow:0 0 0 2px #2D5016,0 4px 12px rgba(45,80,22,.25)}
+
+.oh-tl-slot-head{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap}
+.oh-tl-slot-time{font:600 1.05rem 'JetBrains Mono','Fira Code',monospace;
+    color:var(--oh-text);white-space:nowrap}
+.oh-tl-slot-title{font:700 1.15rem var(--oh-font-heading);color:var(--oh-text);
+    margin:0;flex:1 1 200px;min-width:0}
+.oh-tl-slot-pill{display:inline-flex;align-items:center;gap:4px;
+    padding:2px 8px;border-radius:99px;
+    font:600 .75rem 'JetBrains Mono','Fira Code',monospace;
+    background:rgba(45,80,22,.12);color:#2D5016}
+
+.oh-tl-slot-chips{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+.oh-tl-chip{display:inline-flex;align-items:center;gap:4px;
+    padding:2px 8px;border-radius:99px;
+    font:500 .75rem var(--oh-font-body);
+    border:1px solid transparent;line-height:1.4}
+.oh-tl-chip .bi{font-size:.85rem;line-height:1}
+.oh-tl-chip--quest{background:rgba(110,70,130,.1);color:#6E4682;border-color:rgba(110,70,130,.25)}
+.oh-tl-chip--encounter{background:rgba(140,36,35,.1);color:#8C2423;border-color:rgba(140,36,35,.25)}
+.oh-tl-chip--bonus{background:rgba(212,166,60,.15);color:#886a1f;border-color:rgba(212,166,60,.4)}
+.oh-tl-chip--transition{background:transparent;color:var(--oh-text);border-color:var(--oh-border)}
+.oh-tl-chip--other{background:var(--oh-surface-alt);color:var(--oh-text-secondary);border-color:var(--oh-border)}
+
+.oh-tl-slot-rules{margin-top:10px;padding:8px 10px;background:rgba(0,0,0,.03);
+    border-left:3px solid var(--oh-border);
+    font:400 .92rem Georgia,serif;color:var(--oh-text);
+    border-radius:0 4px 4px 0}
+
+/* Empty state */
+.oh-tl-empty{padding:48px 16px;text-align:center;color:var(--oh-text-secondary);
+    max-width:520px;margin:0 auto}
+.oh-tl-empty .bi{font-size:2rem;color:#B26223}
+.oh-tl-empty-title{font:600 1.1rem var(--oh-font-heading);margin:12px 0 6px;color:var(--oh-text)}
+
+/* Gantt */
+.oh-tl-gantt-wrap{padding:16px;max-width:1280px;margin:0 auto}
+.oh-tl-gantt-toolbar{display:flex;align-items:center;gap:8px;padding-bottom:10px;
+    color:var(--oh-text-secondary);font-size:.85rem}
+.oh-tl-gantt-zoom{display:inline-flex;border:1px solid var(--oh-border);border-radius:4px}
+.oh-tl-gantt-zoom button{background:transparent;border:0;padding:4px 10px;
+    font:500 .85rem var(--oh-font-body);color:var(--oh-text);cursor:pointer}
+.oh-tl-gantt-zoom button:hover{background:var(--oh-surface-alt)}
+.oh-tl-gantt-canvas{position:relative;overflow-x:auto;
+    border:1px solid var(--oh-border);border-radius:6px;background:#FFF8F0}
+.oh-tl-gantt-track{position:relative;min-height:240px;padding:34px 0 12px}
+.oh-tl-gx-axis{position:absolute;top:0;left:0;height:30px;
+    border-bottom:1px solid var(--oh-border);font:500 .7rem 'JetBrains Mono','Fira Code',monospace;
+    color:var(--oh-text-secondary)}
+.oh-tl-gx-day{position:absolute;top:0;height:30px;padding-left:6px;line-height:30px;
+    font-weight:600;color:var(--oh-text)}
+.oh-tl-gx-day-bound{position:absolute;top:0;bottom:0;width:0;
+    border-left:1px dashed rgba(80,75,37,.4);pointer-events:none}
+.oh-tl-gx-tick{position:absolute;top:24px;bottom:0;width:0;
+    border-left:1px solid rgba(0,0,0,.05);pointer-events:none}
+.oh-tl-gx-stage-band{position:absolute;top:30px;bottom:0;pointer-events:none}
+.oh-tl-gx-stage-band--start{background:var(--oh-stage-start);opacity:.07}
+.oh-tl-gx-stage-band--early{background:var(--oh-stage-early);opacity:.08}
+.oh-tl-gx-stage-band--midgame{background:var(--oh-stage-midgame);opacity:.07}
+.oh-tl-gx-stage-band--lategame{background:var(--oh-stage-lategame);opacity:.08}
+
+.oh-tl-gbar{position:absolute;height:48px;background:#FFF8F0;
+    border:1px solid var(--oh-border);border-radius:4px;
+    padding:4px 8px 4px 14px;cursor:pointer;overflow:hidden;
+    box-shadow:0 1px 2px rgba(0,0,0,.06)}
+.oh-tl-gbar:hover{box-shadow:0 2px 6px rgba(0,0,0,.12)}
+.oh-tl-gbar::before{content:'';position:absolute;left:0;top:0;bottom:0;width:6px;
+    background:var(--oh-stage-start)}
+.oh-tl-gbar--start::before{background:var(--oh-stage-start)}
+.oh-tl-gbar--early::before{background:var(--oh-stage-early)}
+.oh-tl-gbar--midgame::before{background:var(--oh-stage-midgame)}
+.oh-tl-gbar--lategame::before{background:var(--oh-stage-lategame)}
+.oh-tl-gbar--active{box-shadow:0 0 0 2px #2D5016,0 2px 6px rgba(45,80,22,.25)}
+.oh-tl-gbar--past{opacity:.7}
+.oh-tl-gbar-time{font:600 .68rem 'JetBrains Mono','Fira Code',monospace;
+    color:var(--oh-text-secondary);display:block;line-height:1.2}
+.oh-tl-gbar-title{font:600 .85rem var(--oh-font-heading);color:var(--oh-text);
+    display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:1px}
+.oh-tl-gbar-glyphs{position:absolute;right:6px;bottom:4px;display:flex;gap:3px;
+    font-size:.78rem;color:var(--oh-text-secondary)}
+
+/* Print page (/timeline/print) */
+.oh-tl-print{padding:16px;max-width:760px;margin:0 auto;font-family:var(--oh-font-body);color:#000}
+.oh-tl-print-head{text-align:center;padding-bottom:14px;
+    border-bottom:1px solid #000;margin-bottom:18px}
+.oh-tl-print-title{font:900 1.9rem var(--oh-font-heading);color:#000;margin:0 0 4px}
+.oh-tl-print-sub{font:italic 400 .9rem Georgia,serif;color:#333}
+.oh-tl-print-day{padding-top:6px}
+.oh-tl-print-day + .oh-tl-print-day{page-break-before:always}
+.oh-tl-print-day-head{font:700 1.15rem var(--oh-font-heading);margin:0 0 8px;
+    padding-bottom:4px;border-bottom:1px solid #000}
+.oh-tl-print-slot{padding:8px 0 12px;border-bottom:1px dashed #999;
+    page-break-inside:avoid}
+.oh-tl-print-slot:last-child{border-bottom:0}
+.oh-tl-print-slot-head{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap}
+.oh-tl-print-slot-time{font:600 .95rem 'JetBrains Mono','Fira Code',monospace}
+.oh-tl-print-slot-title{font:700 1.05rem var(--oh-font-heading);margin:0;flex:1}
+.oh-tl-print-slot-stage{font-size:.8rem;color:#555}
+.oh-tl-print-slot-rules{margin-top:6px;font:400 .88rem Georgia,serif;color:#222}
+.oh-tl-print-slot-chips{margin-top:4px;font-size:.8rem;color:#444}
+
+@media print{
+    @page{size:A4 portrait;margin:12mm}
+    body{background:#fff !important}
+    .oh-tl-print-hide,.oh-nav,.oh-page-header,.oh-tl-bar,.oh-tl-filter-row{display:none !important}
+    .oh-tl-print{padding:0}
+    .oh-tl-print-day{page-break-before:always}
+    .oh-tl-print-day:first-child{page-break-before:auto}
+    .oh-tl-print-slot{page-break-inside:avoid}
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/GameTimeSlot.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameTimeSlot.cs
@@ -1,3 +1,5 @@
+using OvcinaHra.Shared.Domain.Enums;
+
 namespace OvcinaHra.Shared.Domain.Entities;
 
 public class GameTimeSlot
@@ -6,6 +8,7 @@ public class GameTimeSlot
     public int? InGameYear { get; set; }
     public DateTime StartTime { get; set; }
     public TimeSpan Duration { get; set; }
+    public TreasureQuestDifficulty Stage { get; set; } = TreasureQuestDifficulty.Start;
     public string? Rules { get; set; }
     public int? BattlefieldBonusId { get; set; }
     public int GameId { get; set; }

--- a/src/OvcinaHra.Shared/Domain/Enums/GameEventKind.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/GameEventKind.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Domain.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum GameEventKind
+{
+    [Display(Name = "Úkol")]
+    Quest,
+
+    [Display(Name = "Setkání")]
+    Encounter,
+
+    [Display(Name = "Jiné")]
+    Other
+}

--- a/src/OvcinaHra.Shared/Dtos/TimelineDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TimelineDtos.cs
@@ -1,10 +1,46 @@
+using System.Text.Json.Serialization;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
+
 namespace OvcinaHra.Shared.Dtos;
 
-public record GameTimeSlotDto(int Id, int? InGameYear, DateTime StartTime, decimal DurationHours, string? Rules, int? BattlefieldBonusId, int GameId);
+public record GameTimeSlotDto(
+    int Id,
+    int? InGameYear,
+    DateTime StartTime,
+    decimal DurationHours,
+    string? Rules,
+    int? BattlefieldBonusId,
+    int GameId,
+    TreasureQuestDifficulty Stage = TreasureQuestDifficulty.Start,
+    string? BattlefieldBonusName = null)
+{
+    public IReadOnlyList<LinkedGameEventDto> LinkedEvents { get; init; } = [];
 
-public record CreateGameTimeSlotDto(int GameId, DateTime StartTime, decimal DurationHours, int? InGameYear = null, string? Rules = null, int? BattlefieldBonusId = null);
+    [JsonIgnore] public string StageDisplay => Stage.GetDisplayName();
+    [JsonIgnore] public DateTime EndTime => StartTime.AddHours((double)DurationHours);
+}
 
-public record UpdateGameTimeSlotDto(DateTime StartTime, decimal DurationHours, int? InGameYear, string? Rules, int? BattlefieldBonusId);
+public record LinkedGameEventDto(int Id, string Name, GameEventKind Kind);
+
+public record CreateGameTimeSlotDto(
+    int GameId,
+    DateTime StartTime,
+    decimal DurationHours,
+    int? InGameYear = null,
+    string? Rules = null,
+    int? BattlefieldBonusId = null,
+    TreasureQuestDifficulty Stage = TreasureQuestDifficulty.Start,
+    IReadOnlyList<int>? LinkedGameEventIds = null);
+
+public record UpdateGameTimeSlotDto(
+    DateTime StartTime,
+    decimal DurationHours,
+    int? InGameYear,
+    string? Rules,
+    int? BattlefieldBonusId,
+    TreasureQuestDifficulty Stage = TreasureQuestDifficulty.Start,
+    IReadOnlyList<int>? LinkedGameEventIds = null);
 
 public record BattlefieldBonusDto(int Id, string? Name, int AttackBonus, int DefenseBonus, string? Description, string? ImagePath, int GameId);
 

--- a/src/OvcinaHra.Shared/Dtos/TimelineDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TimelineDtos.cs
@@ -33,13 +33,16 @@ public record CreateGameTimeSlotDto(
     TreasureQuestDifficulty Stage = TreasureQuestDifficulty.Start,
     IReadOnlyList<int>? LinkedGameEventIds = null);
 
+// Stage is nullable for backward compatibility — older PUT payloads omit it
+// and we don't want to silently overwrite an existing Stage with `Start`.
+// Same semantic as LinkedGameEventIds: null means "don't change".
 public record UpdateGameTimeSlotDto(
     DateTime StartTime,
     decimal DurationHours,
     int? InGameYear,
     string? Rules,
     int? BattlefieldBonusId,
-    TreasureQuestDifficulty Stage = TreasureQuestDifficulty.Start,
+    TreasureQuestDifficulty? Stage = null,
     IReadOnlyList<int>? LinkedGameEventIds = null);
 
 public record BattlefieldBonusDto(int Id, string? Name, int AttackBonus, int DefenseBonus, string? Description, string? ImagePath, int GameId);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TimelineEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TimelineEndpointTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using OvcinaHra.Api.Data;
@@ -324,10 +325,88 @@ public class TimelineEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         Assert.True(await db.GameEvents.AnyAsync(e => e.Id == ev.Id));
     }
 
+    [Fact]
+    public async Task CreateSlot_WithCrossGameEventId_Returns400Problem()
+    {
+        var gameA = await CreateTestGameAsync();
+        var gameB = await CreateTestGameAsync();
+        var foreignEvent = await CreateEventAsync(gameB.Id, "Patří do jiné hry");
+
+        var response = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(
+                GameId: gameA.Id,
+                StartTime: new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc),
+                DurationHours: 2,
+                LinkedGameEventIds: [foreignEvent.Id]));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Uložení selhalo", problem!.Title);
+        Assert.Contains("nepatří", problem.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UpdateSlot_WithCrossGameEventId_Returns400Problem()
+    {
+        var gameA = await CreateTestGameAsync();
+        var gameB = await CreateTestGameAsync();
+        var foreignEvent = await CreateEventAsync(gameB.Id, "Cizí událost");
+
+        var create = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(gameA.Id, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc), 2));
+        var slot = await create.Content.ReadFromJsonAsync<GameTimeSlotDto>();
+
+        var update = await Client.PutAsJsonAsync($"/api/timeline/slots/{slot!.Id}",
+            new UpdateGameTimeSlotDto(
+                StartTime: slot.StartTime,
+                DurationHours: slot.DurationHours,
+                InGameYear: null,
+                Rules: null,
+                BattlefieldBonusId: null,
+                LinkedGameEventIds: [foreignEvent.Id]));
+
+        Assert.Equal(HttpStatusCode.BadRequest, update.StatusCode);
+        var problem = await update.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Uložení selhalo", problem!.Title);
+    }
+
+    [Fact]
+    public async Task UpdateSlot_WithNullStage_PreservesExistingStage()
+    {
+        var game = await CreateTestGameAsync();
+        var create = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(game.Id, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc), 2,
+                Stage: TreasureQuestDifficulty.Midgame));
+        var slot = await create.Content.ReadFromJsonAsync<GameTimeSlotDto>();
+
+        // Older client: no Stage in payload — null means "leave it alone".
+        var update = await Client.PutAsJsonAsync($"/api/timeline/slots/{slot!.Id}",
+            new UpdateGameTimeSlotDto(
+                StartTime: slot.StartTime,
+                DurationHours: slot.DurationHours,
+                InGameYear: 1500,
+                Rules: "Aktualizovaná pravidla",
+                BattlefieldBonusId: null));
+        Assert.Equal(HttpStatusCode.NoContent, update.StatusCode);
+
+        var fetched = await Client.GetFromJsonAsync<List<GameTimeSlotDto>>($"/api/timeline/slots/by-game/{game.Id}");
+        var thisSlot = fetched!.Single(s => s.Id == slot.Id);
+        Assert.Equal(TreasureQuestDifficulty.Midgame, thisSlot.Stage);
+        Assert.Equal(1500, thisSlot.InGameYear);
+        Assert.Equal("Aktualizovaná pravidla", thisSlot.Rules);
+    }
+
+    private int _editionSeq;
+
     private async Task<GameDetailDto> CreateTestGameAsync()
     {
+        // Some tests create multiple games in a single run; use unique
+        // (Name, Edition) pairs so any uniqueness constraint on Edition holds.
+        _editionSeq++;
         var response = await Client.PostAsJsonAsync("/api/games",
-            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+            new CreateGameDto($"Test Hra {_editionSeq}", _editionSeq, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
     }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TimelineEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TimelineEndpointTests.cs
@@ -1,5 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
@@ -182,5 +185,164 @@ public class TimelineEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         var slot = await slotResponse.Content.ReadFromJsonAsync<GameTimeSlotDto>();
         Assert.NotNull(slot);
         Assert.Equal(bonus.Id, slot.BattlefieldBonusId);
+        Assert.Equal("Lesní výhoda", slot.BattlefieldBonusName);
+    }
+
+    [Fact]
+    public async Task CreateSlot_WithoutStage_DefaultsToStart()
+    {
+        var game = await CreateTestGameAsync();
+
+        var response = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(game.Id, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc), 2));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var created = await response.Content.ReadFromJsonAsync<GameTimeSlotDto>();
+        Assert.Equal(TreasureQuestDifficulty.Start, created!.Stage);
+    }
+
+    [Fact]
+    public async Task CreateSlot_WithExplicitStage_RoundTrips()
+    {
+        var game = await CreateTestGameAsync();
+
+        var response = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(
+                GameId: game.Id,
+                StartTime: new DateTime(2026, 5, 2, 14, 0, 0, DateTimeKind.Utc),
+                DurationHours: 3,
+                Stage: TreasureQuestDifficulty.Midgame));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var created = await response.Content.ReadFromJsonAsync<GameTimeSlotDto>();
+        Assert.Equal(TreasureQuestDifficulty.Midgame, created!.Stage);
+
+        var fetched = await Client.GetFromJsonAsync<List<GameTimeSlotDto>>($"/api/timeline/slots/by-game/{game.Id}");
+        Assert.Single(fetched!);
+        Assert.Equal(TreasureQuestDifficulty.Midgame, fetched![0].Stage);
+    }
+
+    [Fact]
+    public async Task UpdateSlot_ChangeStage_Persists()
+    {
+        var game = await CreateTestGameAsync();
+        var create = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(game.Id, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc), 2));
+        var slot = await create.Content.ReadFromJsonAsync<GameTimeSlotDto>();
+
+        var update = await Client.PutAsJsonAsync($"/api/timeline/slots/{slot!.Id}",
+            new UpdateGameTimeSlotDto(
+                StartTime: slot.StartTime,
+                DurationHours: slot.DurationHours,
+                InGameYear: null,
+                Rules: null,
+                BattlefieldBonusId: null,
+                Stage: TreasureQuestDifficulty.Lategame));
+        Assert.Equal(HttpStatusCode.NoContent, update.StatusCode);
+
+        var fetched = await Client.GetFromJsonAsync<List<GameTimeSlotDto>>($"/api/timeline/slots/by-game/{game.Id}");
+        Assert.Equal(TreasureQuestDifficulty.Lategame, fetched!.Single().Stage);
+    }
+
+    [Fact]
+    public async Task CreateSlot_WithLinkedEvents_RoundTrips()
+    {
+        var game = await CreateTestGameAsync();
+        var ev1 = await CreateEventAsync(game.Id, "Bitva u brodu");
+        var ev2 = await CreateEventAsync(game.Id, "Trh v Brodečku");
+
+        var response = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(
+                GameId: game.Id,
+                StartTime: new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc),
+                DurationHours: 2,
+                LinkedGameEventIds: [ev1.Id, ev2.Id]));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var created = await response.Content.ReadFromJsonAsync<GameTimeSlotDto>();
+        Assert.Equal(2, created!.LinkedEvents.Count);
+        Assert.Contains(created.LinkedEvents, e => e.Id == ev1.Id);
+        Assert.Contains(created.LinkedEvents, e => e.Id == ev2.Id);
+
+        // Each event was bootstrapped with its own placeholder slot — filter to the slot under test.
+        var fetched = await Client.GetFromJsonAsync<List<GameTimeSlotDto>>($"/api/timeline/slots/by-game/{game.Id}");
+        var thisSlot = fetched!.Single(s => s.Id == created.Id);
+        Assert.Equal(2, thisSlot.LinkedEvents.Count);
+    }
+
+    [Fact]
+    public async Task UpdateSlot_LinkedEventIds_SyncsAddAndRemove()
+    {
+        var game = await CreateTestGameAsync();
+        var ev1 = await CreateEventAsync(game.Id, "První");
+        var ev2 = await CreateEventAsync(game.Id, "Druhá");
+        var ev3 = await CreateEventAsync(game.Id, "Třetí");
+
+        var create = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(game.Id, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc), 2,
+                LinkedGameEventIds: [ev1.Id, ev2.Id]));
+        var slot = await create.Content.ReadFromJsonAsync<GameTimeSlotDto>();
+
+        // Replace [ev1, ev2] with [ev2, ev3]: ev1 removed, ev3 added, ev2 retained.
+        var update = await Client.PutAsJsonAsync($"/api/timeline/slots/{slot!.Id}",
+            new UpdateGameTimeSlotDto(
+                StartTime: slot.StartTime,
+                DurationHours: slot.DurationHours,
+                InGameYear: null,
+                Rules: null,
+                BattlefieldBonusId: null,
+                LinkedGameEventIds: [ev2.Id, ev3.Id]));
+        Assert.Equal(HttpStatusCode.NoContent, update.StatusCode);
+
+        var fetched = await Client.GetFromJsonAsync<List<GameTimeSlotDto>>($"/api/timeline/slots/by-game/{game.Id}");
+        var thisSlot = fetched!.Single(s => s.Id == slot.Id);
+        var linked = thisSlot.LinkedEvents.Select(e => e.Id).ToHashSet();
+        Assert.Equal(new HashSet<int> { ev2.Id, ev3.Id }, linked);
+    }
+
+    [Fact]
+    public async Task DeleteSlot_RemovesJoinRowsButPreservesLinkedEvent()
+    {
+        var game = await CreateTestGameAsync();
+        var ev = await CreateEventAsync(game.Id, "Smazatelný slot");
+
+        var create = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(game.Id, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc), 2,
+                LinkedGameEventIds: [ev.Id]));
+        var slot = await create.Content.ReadFromJsonAsync<GameTimeSlotDto>();
+
+        var delete = await Client.DeleteAsync($"/api/timeline/slots/{slot!.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
+
+        // Slot is gone.
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        Assert.False(await db.GameTimeSlots.AnyAsync(s => s.Id == slot.Id));
+        // Join rows for the deleted slot are gone.
+        Assert.False(await db.GameEventTimeSlots.AnyAsync(j => j.GameTimeSlotId == slot.Id));
+        // GameEvent itself is preserved (still has the placeholder-slot join row).
+        Assert.True(await db.GameEvents.AnyAsync(e => e.Id == ev.Id));
+    }
+
+    private async Task<GameDetailDto> CreateTestGameAsync()
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    private async Task<GameEventDetailDto> CreateEventAsync(int gameId, string name)
+    {
+        // GameEvents enforce TimeSlotIds.Count >= 1 — bootstrap a placeholder slot for each event.
+        var slotResp = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(gameId, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), 1));
+        slotResp.EnsureSuccessStatusCode();
+        var placeholder = (await slotResp.Content.ReadFromJsonAsync<GameTimeSlotDto>())!;
+
+        var response = await Client.PostAsJsonAsync($"/api/games/{gameId}/events",
+            new CreateGameEventDto(name, null, [placeholder.Id], [], [], []));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameEventDetailDto>())!;
     }
 }


### PR DESCRIPTION
Closes #171.

Replaces the bare DxGrid/timeline scaffolding with the full Harmonogram hry experience the design brief asked for, plus the underpinning Stage field on `GameTimeSlot`.

## What ships

**Server**
- `GameTimeSlot.Stage` (`TreasureQuestDifficulty`, EF stored as string `HasMaxLength(20)`, default `Start`).
- Migration `AddStageToGameTimeSlot` — backfills existing rows with `"Start"`.
- New `GameEventKind` enum (`Quest | Encounter | Other`) classified server-side from each `GameEvent`'s join collections.
- `TimelineEndpoints` slot handlers now round-trip `Stage` and `LinkedGameEventIds`, return enriched `GameTimeSlotDto` (Stage + BattlefieldBonusName + LinkedEvents). `DELETE` cascades the `GameEventTimeSlot` join rows but preserves the linked `GameEvent` itself.
- Existing routes (`/api/timeline/slots/*`, `/api/timeline/bonuses/*`) unchanged — back-compat with any pre-existing callers.

**Client UI**
- `Pages/Timeline/TimelinePage.razor` — full rewrite. Sticky toolbar, agenda/Gantt segmented toggle persisted to `localStorage('oh-timeline-view')`, filter row, empty state, `Aktuálně: {Stage}` pill in *Hra běží* mode, 30-second `IDisposable` timer that re-evaluates active/past slots client-side (no server poll). Bonus management preserved via a side popup so prior CRUD doesn't regress.
- `Pages/Timeline/TimelinePrint.razor` — `/timeline/print` under a chrome-free `PrintLayout`. A4 portrait, page-break per day, JS `window.print()` button.
- `Components/SlotCard.razor` — agenda card: stage strip, time + title + StageChip header, inline chips (Quest/Encounter/Bonus/Stage-transition), collapsible Rules.
- `Components/SlotEditPopup.razor` — `DxPopup` with Identita / Obsah / Vazby groups. Stage `DxComboBox`, BattlefieldBonus `DxComboBox`, multi-select event chip picker. Smazat routes through nested `DxPopup` confirmation per `feedback_ovcinahra_destructive_confirm`.
- `Components/GanttCanvas.razor` + `SlotGanttBar.razor` — horizontal canvas with hour ticks, dashed day boundaries, day labels, low-opacity stage bands, zoom buttons (px/hour clamped 20–180).
- `Layout/PrintLayout.razor` — minimal `@Body`-only wrapper for any print export page.
- `Layout/NavMenu.razor` — relabel `Časová osa` → `Harmonogram` (route unchanged).

**CSS** — `.oh-tl-*` block (~165 lines appended to `ovcinahra-theme.css`). Reuses canonical stage palette (`--oh-stage-start/early/midgame/lategame`). Active highlight `#2D5016`. Print stylesheet hides chrome via `@media print`.

**Czech localization** — weekday/month names via `CultureInfo.GetCultureInfo("cs-CZ")` on day separators, Gantt day labels, and the print page header. No hardcoded Czech dates.

## Tests

- All 9 existing `TimelineEndpointTests` continue to pass.
- 6 new tests:
  - Stage default = `Start` when not specified.
  - Stage explicit value round-trips through GET.
  - Update persists Stage change.
  - LinkedGameEventIds round-trip on POST.
  - Update LinkedGameEventIds adds new + removes stale + retains unchanged.
  - Delete cascade-removes `GameEventTimeSlot` join rows but preserves the linked `GameEvent`.
- **341 / 341 API tests pass locally** (`dotnet test` ran the full Testcontainers suite).
- `dotnet build OvcinaHra.slnx` clean (0 warnings, 0 errors with `TreatWarningsAsErrors=true`).

## Out of scope (follow-ups)

1. Drag-to-resize / drag-to-move in Gantt view.
2. Multi-select slot bulk actions.
3. Server-side Stage progression validation (forward-only soft warning).
4. Day/night shading toggle for night-running games.
5. Optional top stage banner with anchor nav.
6. Playwright E2E (parked per #92 — infra broken).
7. Formal `GameEventKind` enum on `GameEvent` itself (currently derived from joins).

## Notes

- No `<Version>` bump in either csproj — auto-bump CI handles it.
- Bonus management UX preserved via a "Bonusy" toolbar button → popup with simple list + edit/delete. Could move to its own page in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)