### PR TITLE
feat(locations): edit Razítko image from Location detail

### DIFF
--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -248,6 +248,17 @@ else
                         <ImagePicker EntityType="locations" EntityId="@Id" Field="placement"
                                      AspectRatio="4:3" Width="280px" Alt="Fotka umístění" />
                     </div>
+                    @* Issue #172 — Razítko (rubber stamp) editor. Goes through
+                       the `locationstamps` image-pipeline alias so the cache
+                       namespace stays separate from the main location image
+                       (per feedback_ovcinahra_secondary_image_entity_alias).
+                       Same picker config as the LocationEditPopup so the two
+                       editing surfaces stay consistent. *@
+                    <div class="oh-lc-mv-col">
+                        <small class="text-muted d-block mb-1">Razítko (1:1)</small>
+                        <ImagePicker EntityType="locationstamps" EntityId="@Id"
+                                     AspectRatio="1:1" Width="180px" Alt="Razítko lokace" />
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

Closes **#172**. Adds a `Razítko` (rubber stamp) image picker to the Location detail page so organizers can edit the stamp from the same surface they use for Hlavní obrázek + Fotka umístění — instead of having to open the LocationList edit popup.

**Layout A** — same row, third column. The existing `.oh-lc-mv-row` flex container already declares `flex-wrap: wrap` (`ovcinahra-theme.css:1081`), so the new column drops to a second line cleanly on narrow viewports. No CSS change needed.

## What this PR is NOT

The backend pipeline was already complete from a prior PR — `Location.StampImagePath` field, `LocationDetailDto.StampImageUrl`, `/api/images/locationstamps/{id}` endpoint, the `locationstamps` entity-type alias in `ValidEntityTypes`, and the `LocationEditPopup` already wires the same picker. This PR is UI-only on the detail page.

## Files (1 changed, +11 / 0)

- `src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor` — adds one `<div class="oh-lc-mv-col">` with the ImagePicker. Width=180px and AspectRatio=1:1 match the LocationEditPopup config so both editing surfaces stay consistent.

## Test plan

- [x] `dotnet build src/OvcinaHra.Client` — clean (0 warn / 0 err under `TreatWarningsAsErrors=true`).
- [x] No new API tests — backend pipeline pre-existed; existing integration tests cover the PUT round-trip.
- [ ] Manual: open `/locations/{id}` for a Location without a stamp → empty 1:1 picker visible to the right of "Fotka umístění".
- [ ] Manual: upload a stamp → persists, displays.
- [ ] Manual: refresh the page → still there.
- [ ] Manual: click remove → DxPopup confirm fires (ImagePicker's existing destructive-confirm), then clears.
- [ ] Manual: shrink to ~600px viewport → row wraps, no overflow / broken alignment.
- [ ] Manual: `/locations` grid tile still renders the read-only stamp thumbnail (no regression).

## Notes

- No `csproj <Version>` bump (auto-bump CI handles).
- No new component — straight ImagePicker reuse.
- The picker's destructive-confirm DxPopup on remove is preserved (`feedback_ovcinahra_destructive_confirm`).
- Detail surface uses the full SAS URL via the picker's `ImageUrlsDto` fetch — not the thumbnail endpoint (`feedback_ovcinahra_image_sourcing_rule`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)