### PR TITLE
feat(treasures): bbox zoom + location markers + bulk pool refill (closes #160)

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
@@ -299,6 +300,13 @@ public static class TreasurePlanningEndpoints
     /// </summary>
     private static async Task<Ok<RefillPoolResponse>> RefillPool(int gameId, WorldDbContext db)
     {
+        // Wrap the read-then-write in SERIALIZABLE so two concurrent refills
+        // can't both compute `remaining` from the same allocation snapshot
+        // and double-append. Postgres will retry-fail one of the txns; the
+        // caller can press the button again. Cost is negligible — refill is
+        // organizer-triggered, not on a hot path.
+        await using var tx = await db.Database.BeginTransactionAsync(IsolationLevel.Serializable);
+
         // 1. Fetch findable items with stock for this game.
         var gameItems = await db.GameItems
             .Where(gi => gi.GameId == gameId && gi.IsFindable && gi.StockCount != null)
@@ -307,6 +315,7 @@ public static class TreasurePlanningEndpoints
 
         if (gameItems.Count == 0)
         {
+            await tx.CommitAsync();
             return TypedResults.Ok(new RefillPoolResponse(0,
                 Array.Empty<RefillPoolItemDto>(), Array.Empty<RefillPoolOverAllocationDto>()));
         }
@@ -344,6 +353,18 @@ public static class TreasurePlanningEndpoints
             .Select(g => new { ItemId = g.Key, Used = g.Sum(r => r.Quantity) })
             .ToDictionaryAsync(x => x.ItemId, x => x.Used);
 
+        // Pre-load all pool rows for this game in one shot so the per-item
+        // append below is dictionary lookup, not a DB roundtrip per item.
+        // The /pool POST endpoint can leave multiple unstacked rows per
+        // item (legacy behavior), so reduce to a single representative row
+        // per ItemId — the refill endpoint always stacks remainder onto one.
+        var existingPoolByItem = (await db.TreasureItems
+                .Where(ti => ti.GameId == gameId && ti.TreasureQuestId == null
+                    && itemIds.Contains(ti.ItemId))
+                .ToListAsync())
+            .GroupBy(ti => ti.ItemId)
+            .ToDictionary(g => g.Key, g => g.First());
+
         // 3. For each findable game-item: compute remaining; allocate or report.
         var added = new List<RefillPoolItemDto>();
         var overAllocated = new List<RefillPoolOverAllocationDto>();
@@ -366,12 +387,11 @@ public static class TreasurePlanningEndpoints
             var remaining = stock - allocated;
             if (remaining <= 0) continue;
 
-            // Stack onto an existing pool row if one exists for this item;
-            // brief #3 confirmed pool entries are stacks (one TreasureItem
-            // with Count=N), not N distinct rows.
-            var existingPool = await db.TreasureItems.FirstOrDefaultAsync(ti =>
-                ti.GameId == gameId && ti.ItemId == gi.ItemId && ti.TreasureQuestId == null);
-            if (existingPool is not null)
+            // Refill always consolidates remainder onto a single per-item
+            // pool row (stacks via Count +=). The /pool POST endpoint
+            // currently creates fresh rows on every call — refill smooths
+            // that over so re-running this action is idempotent.
+            if (existingPoolByItem.TryGetValue(gi.ItemId, out var existingPool))
             {
                 existingPool.Count += remaining;
             }
@@ -389,6 +409,7 @@ public static class TreasurePlanningEndpoints
         }
 
         await db.SaveChangesAsync();
+        await tx.CommitAsync();
 
         return TypedResults.Ok(new RefillPoolResponse(
             ItemsAdded: added.Sum(a => a.Added),

--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -18,6 +18,9 @@ public static class TreasurePlanningEndpoints
         group.MapPost("/pool", AddToPool);
         group.MapDelete("/pool/{id:int}", RemoveFromPool);
 
+        // Issue #160: bulk refill — append unallocated stock to the pool.
+        group.MapPost("/refill-pool/{gameId:int}", RefillPool);
+
         // Unlimited items (always available, derived from GameItem)
         group.MapGet("/unlimited/{gameId:int}", GetUnlimitedItems);
 
@@ -272,5 +275,124 @@ public static class TreasurePlanningEndpoints
                 loaded.Id, loaded.Title, loaded.Clue, loaded.Difficulty,
                 loaded.LocationId, loaded.Location?.Name, loaded.SecretStashId, loaded.SecretStash?.Name, loaded.GameId,
                 loaded.TreasureItems.Select(ti => new TreasureItemDto(ti.Id, ti.ItemId, ti.Item.Name, ti.Count, ti.TreasureQuestId)).ToList()));
+    }
+
+    // ── Issue #160: bulk refill ───────────────────────────────────────────
+
+    /// <summary>
+    /// Sweeps every <c>GameItem</c> with <c>IsFindable=true</c> and a non-null
+    /// <c>StockCount</c> for the active game, computes the unallocated remainder
+    /// against three reward channels (per the user's confirmed inventory):
+    /// <list type="bullet">
+    ///   <item><c>TreasureItem</c> (pool + treasure-quest, both legs)</item>
+    ///   <item><c>QuestReward</c> (regular quest rewards scoped by Quest.GameId)</item>
+    ///   <item><c>PersonalQuestItemReward</c> on PersonalQuest templates that
+    ///         this game has linked via <c>GamePersonalQuest</c></item>
+    /// </list>
+    /// MonsterLoot intentionally excluded (situational, encounter-dependent
+    /// — confirmed with the user).
+    ///
+    /// For each item where <c>StockCount &gt; allocated</c>, the remainder is
+    /// appended to the existing pool TreasureItem (stack via <c>Count +=</c>)
+    /// or a fresh pool row is created. Items where allocations already exceed
+    /// stock are skipped and listed in <see cref="RefillPoolResponse.OverAllocated"/>.
+    /// </summary>
+    private static async Task<Ok<RefillPoolResponse>> RefillPool(int gameId, WorldDbContext db)
+    {
+        // 1. Fetch findable items with stock for this game.
+        var gameItems = await db.GameItems
+            .Where(gi => gi.GameId == gameId && gi.IsFindable && gi.StockCount != null)
+            .Include(gi => gi.Item)
+            .ToListAsync();
+
+        if (gameItems.Count == 0)
+        {
+            return TypedResults.Ok(new RefillPoolResponse(0,
+                Array.Empty<RefillPoolItemDto>(), Array.Empty<RefillPoolOverAllocationDto>()));
+        }
+
+        var itemIds = gameItems.Select(gi => gi.ItemId).ToHashSet();
+
+        // 2. Sum allocations across the three reward channels.
+
+        // Channel A: TreasureItem — covers BOTH the pool (TreasureQuestId == null)
+        // and items already placed inside a treasure quest. Existing /available-items
+        // endpoint sums them the same way; staying consistent.
+        var treasureUsed = await db.TreasureItems
+            .Where(ti => ti.GameId == gameId && itemIds.Contains(ti.ItemId))
+            .GroupBy(ti => ti.ItemId)
+            .Select(g => new { ItemId = g.Key, Used = g.Sum(ti => ti.Count) })
+            .ToDictionaryAsync(x => x.ItemId, x => x.Used);
+
+        // Channel B: QuestReward — Quest.GameId is nullable on the entity, but
+        // for stock allocation we only care about quests pinned to THIS game.
+        var questRewardUsed = await db.QuestRewards
+            .Where(qr => qr.Quest.GameId == gameId && itemIds.Contains(qr.ItemId))
+            .GroupBy(qr => qr.ItemId)
+            .Select(g => new { ItemId = g.Key, Used = g.Sum(qr => qr.Quantity) })
+            .ToDictionaryAsync(x => x.ItemId, x => x.Used);
+
+        // Channel C: PersonalQuestItemReward — PersonalQuest is a catalog
+        // template; per-game linkage via GamePersonalQuest. Each template's
+        // ItemRewards count once per game-link (planning view; the actual
+        // per-character payout depends on claims).
+        var pqRewardUsed = await db.GamePersonalQuests
+            .Where(gpq => gpq.GameId == gameId)
+            .SelectMany(gpq => gpq.PersonalQuest.ItemRewards)
+            .Where(r => itemIds.Contains(r.ItemId))
+            .GroupBy(r => r.ItemId)
+            .Select(g => new { ItemId = g.Key, Used = g.Sum(r => r.Quantity) })
+            .ToDictionaryAsync(x => x.ItemId, x => x.Used);
+
+        // 3. For each findable game-item: compute remaining; allocate or report.
+        var added = new List<RefillPoolItemDto>();
+        var overAllocated = new List<RefillPoolOverAllocationDto>();
+
+        foreach (var gi in gameItems)
+        {
+            var t = treasureUsed.GetValueOrDefault(gi.ItemId, 0);
+            var q = questRewardUsed.GetValueOrDefault(gi.ItemId, 0);
+            var p = pqRewardUsed.GetValueOrDefault(gi.ItemId, 0);
+            var allocated = t + q + p;
+            var stock = gi.StockCount!.Value;
+
+            if (allocated > stock)
+            {
+                overAllocated.Add(new RefillPoolOverAllocationDto(
+                    gi.ItemId, gi.Item.Name, stock, allocated, allocated - stock));
+                continue;
+            }
+
+            var remaining = stock - allocated;
+            if (remaining <= 0) continue;
+
+            // Stack onto an existing pool row if one exists for this item;
+            // brief #3 confirmed pool entries are stacks (one TreasureItem
+            // with Count=N), not N distinct rows.
+            var existingPool = await db.TreasureItems.FirstOrDefaultAsync(ti =>
+                ti.GameId == gameId && ti.ItemId == gi.ItemId && ti.TreasureQuestId == null);
+            if (existingPool is not null)
+            {
+                existingPool.Count += remaining;
+            }
+            else
+            {
+                db.TreasureItems.Add(new TreasureItem
+                {
+                    GameId = gameId,
+                    ItemId = gi.ItemId,
+                    TreasureQuestId = null,
+                    Count = remaining
+                });
+            }
+            added.Add(new RefillPoolItemDto(gi.ItemId, gi.Item.Name, remaining));
+        }
+
+        await db.SaveChangesAsync();
+
+        return TypedResults.Ok(new RefillPoolResponse(
+            ItemsAdded: added.Sum(a => a.Added),
+            Added: added,
+            OverAllocated: overAllocated));
     }
 }

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -11,9 +11,20 @@
 
 <div class="d-flex justify-content-between align-items-center mb-2">
     <h1 class="mb-0">Rozmístění pokladů</h1>
-    <button class="btn btn-primary btn-sm" @onclick="OpenAddToPoolModal">
-        <i class="bi bi-plus-circle me-1"></i> Přidat do zásobníku
-    </button>
+    <div class="d-flex gap-2">
+        @* Issue #160 sub-task C: bulk refill — sweeps stock - allocations
+           per findable item and tops up the pool. Routes through DxPopup
+           confirmation per feedback_ovcinahra_destructive_confirm; this
+           isn't destructive but it IS bulk + irreversible-without-cleanup. *@
+        <button class="btn btn-outline-primary btn-sm" type="button"
+                @onclick="() => isRefillConfirmVisible = true" disabled="@isRefilling"
+                title="Spočítá zbývající stock pro každý nalézatelný předmět a doplní zásobník.">
+            <i class="bi bi-arrow-down-circle me-1"></i> Doplnit vše zbývající k schování do zásobníku
+        </button>
+        <button class="btn btn-primary btn-sm" type="button" @onclick="OpenAddToPoolModal">
+            <i class="bi bi-plus-circle me-1"></i> Přidat do zásobníku
+        </button>
+    </div>
 </div>
 
 @if (loading)
@@ -77,6 +88,29 @@ else
                                 @onclick="() => ToggleStage(s.Key)">@s.Label</button>
                     }
                 </div>
+                @* Issue #160 sub-task B: surface an explicit hint when the
+                   game has assigned locations but none have GPS coordinates
+                   yet — without this the map looks empty and the user can't
+                   tell whether it's a bug or a data state. *@
+                @if (locations.Count > 0 && locations.All(l => !l.Latitude.HasValue || !l.Longitude.HasValue))
+                {
+                    <div class="alert alert-info small mb-2 d-flex align-items-center gap-2">
+                        <i class="bi bi-geo-alt"></i>
+                        <span>
+                            Žádná z @locations.Count přiřazených lokací nemá nastavené GPS souřadnice.
+                            Otevři detail lokace a nastav je, aby se zobrazila na mapě.
+                        </span>
+                    </div>
+                }
+                else if (locations.Count == 0)
+                {
+                    <div class="alert alert-warning small mb-2 d-flex align-items-center gap-2">
+                        <i class="bi bi-exclamation-triangle"></i>
+                        <span>
+                            Tato hra nemá přiřazené žádné lokace. Přidej je v sekci „Lokace" a vrať se sem.
+                        </span>
+                    </div>
+                }
                 <div class="oh-tp-map-host" id="oh-tp-map-host">
                     <MapView @ref="mapView"
                              Height="100%"
@@ -385,6 +419,75 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+@* Issue #160 sub-task C — bulk refill confirm. *@
+<DxPopup @bind-Visible="@isRefillConfirmVisible" HeaderText="Doplnit zásobník?" Width="540px">
+    <BodyContentTemplate Context="popupContext">
+        <p>
+            Spočítáme zbývající stock pro každý předmět s <strong>nalézatelným</strong> příznakem
+            (<em>IsFindable</em>) a doplníme rozdíl do zásobníku.
+        </p>
+        <ul class="small text-muted mb-3">
+            <li>Stock se počítá per-hru z <code>GameItem.StockCount</code>.</li>
+            <li>Alokace = <strong>zásobník + skryté poklady + odměny questů + osobní questy</strong>.</li>
+            <li>Předměty s alokacemi nad rámec stocku se přeskočí a označí pro manuální revizi.</li>
+        </ul>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" type="button"
+                    @onclick="() => isRefillConfirmVisible = false" disabled="@isRefilling">Zrušit</button>
+            <button class="btn btn-primary" type="button"
+                    @onclick="RefillPoolAsync" disabled="@isRefilling">
+                @if (isRefilling) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Doplnit
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@* Result banner — rendered after the API call returns. Dismissible via the
+   button. Shows over-allocated items as a follow-up note. *@
+@if (_refillResult is not null)
+{
+    <div class="alert @( _refillResult.OverAllocated.Count > 0 ? "alert-warning" : "alert-success") d-flex align-items-start gap-2 mt-2">
+        <i class="bi @( _refillResult.OverAllocated.Count > 0 ? "bi-exclamation-triangle" : "bi-check2-circle") fs-5"></i>
+        <div class="flex-fill">
+            <strong>Doplněno @_refillResult.ItemsAdded předmětů do zásobníku.</strong>
+            @if (_refillResult.Added.Count > 0)
+            {
+                <details class="mt-1">
+                    <summary class="small text-muted">Detail (@_refillResult.Added.Count položek)</summary>
+                    <ul class="small mb-0 mt-1">
+                        @foreach (var a in _refillResult.Added)
+                        {
+                            <li>@a.ItemName: <strong>+@a.Added</strong></li>
+                        }
+                    </ul>
+                </details>
+            }
+            @if (_refillResult.OverAllocated.Count > 0)
+            {
+                <div class="mt-2 small">
+                    <strong>Pozor: @_refillResult.OverAllocated.Count předmětů má více alokací než stock — vyžadují manuální revizi:</strong>
+                    <ul class="mb-0 mt-1">
+                        @foreach (var o in _refillResult.OverAllocated)
+                        {
+                            <li>@o.ItemName: stock @o.StockCount, alokováno @o.Allocated (přebytek @o.Excess)</li>
+                        }
+                    </ul>
+                </div>
+            }
+        </div>
+        <button type="button" class="btn-close" aria-label="Zavřít" @onclick="() => _refillResult = null"></button>
+    </div>
+}
+@if (_refillError is not null)
+{
+    <div class="alert alert-danger d-flex align-items-center gap-2 mt-2">
+        <i class="bi bi-wifi-off"></i>
+        <span>Doplnění se nepodařilo: @_refillError</span>
+        <button type="button" class="btn-close ms-auto" @onclick="() => _refillError = null"></button>
+    </div>
+}
+
 @code {
     // ===== Data =====
     private List<TreasurePoolItemDto> poolItems = [];
@@ -450,6 +553,12 @@ else
 
     // ===== Add-to-pool popup =====
     private bool isAddPoolVisible, poolSaving;
+
+    // Issue #160 sub-task C — bulk refill state.
+    private bool isRefillConfirmVisible;
+    private bool isRefilling;
+    private RefillPoolResponse? _refillResult;
+    private string? _refillError;
     private int? poolItemId;
     private int poolItemCount = 1;
     private string? poolError;
@@ -567,12 +676,13 @@ else
             .SelectMany(l => new[] { l.StartCount, l.EarlyCount, l.MidgameCount, l.LategameCount })
             .DefaultIfEmpty(0).Max());
 
-        // Issue #103: map centers on the game's bounding box when set, else
-        // falls back to a Czech-countryside default. Fetch failures must not
-        // break the treasures page render — best-effort try/catch.
-        await FitMapToGameBoundsOrDefaultAsync();
-
+        // Issue #160 / #103: prefer the LOCATION-EXTENT bbox over the saved
+        // game bbox so the map starts tight on what the organizer actually
+        // placed. Saved bbox stays as a fallback (and CZ countryside as a
+        // last resort) so games without placements still render somewhere
+        // sensible.
         var placed = locations.Where(l => l.Latitude.HasValue && l.Longitude.HasValue).ToList();
+        await FitMapToLocationExtentOrFallbackAsync(placed);
         foreach (var loc in placed)
         {
             var card = locationCards.FirstOrDefault(c => c.LocationId == loc.Id);
@@ -594,17 +704,46 @@ else
         await mapView.SetStageFilterAsync(activeStages);
     }
 
-    // Cached bbox per gameId so we don't refetch /api/games/{id} on every
-    // FitMapToGameBoundsOrDefaultAsync call (Copilot noticed — marker rebuilds
-    // + style reloads were triggering an extra roundtrip each time). Cache
-    // invalidates automatically when the bound gameId changes (game switch).
+    /// <summary>Cached saved-bbox per gameId, used as a fallback when no
+    /// placed locations exist. Invalidates on game switch.</summary>
     private int? _cachedBoundsGameId;
     private (double SwLat, double SwLng, double NeLat, double NeLng)? _cachedBounds;
 
-    private async Task FitMapToGameBoundsOrDefaultAsync()
+    /// <summary>
+    /// Issue #160: zoom the Treasures map tight on the smallest box that
+    /// contains every placed <see cref="LocationListDto"/> for the active
+    /// game. Three-tier fallback so the map renders cleanly even on
+    /// freshly-created games:
+    ///   1. ≥ 2 placed locations → fitBounds to their extent (40px padding
+    ///      already baked into <c>ovcinaMap.fitBounds</c>).
+    ///   2. exactly 1 placed location → SetCenter at zoom 14
+    ///      (zero-area fitBounds doesn't render correctly in MapLibre).
+    ///   3. 0 placed locations → fall back to the game's saved bbox if
+    ///      set, else the CZ-countryside default the BoundingBoxPicker uses.
+    /// Saved-bbox fetch is best-effort: a 5xx must not break the page.
+    /// </summary>
+    private async Task FitMapToLocationExtentOrFallbackAsync(IReadOnlyList<LocationListDto> placed)
     {
         if (mapView is null) return;
 
+        if (placed.Count >= 2)
+        {
+            var minLat = placed.Min(l => (double)l.Latitude!.Value);
+            var maxLat = placed.Max(l => (double)l.Latitude!.Value);
+            var minLng = placed.Min(l => (double)l.Longitude!.Value);
+            var maxLng = placed.Max(l => (double)l.Longitude!.Value);
+            await mapView.FitBoundsAsync(minLat, minLng, maxLat, maxLng);
+            return;
+        }
+
+        if (placed.Count == 1)
+        {
+            var only = placed[0];
+            await mapView.SetCenterAsync((double)only.Latitude!.Value, (double)only.Longitude!.Value, 14);
+            return;
+        }
+
+        // No placed locations — try the game's saved bbox (cached per game).
         if (_cachedBoundsGameId != gameId)
         {
             _cachedBoundsGameId = gameId;
@@ -630,8 +769,7 @@ else
             return;
         }
 
-        // Fall back to CZ countryside — mirrors BoundingBoxPicker's default.
-        // SetCenterAsync signature is (lat, lon, zoom), NOT MapLibre's [lng,lat] order.
+        // Last resort — CZ countryside, mirrors BoundingBoxPicker's default.
         await mapView.SetCenterAsync(49.8, 15.4, 7);
     }
 
@@ -724,6 +862,40 @@ else
         }
         catch (Exception ex) { poolError = ex.Message; }
         finally { poolSaving = false; }
+    }
+
+    // ===== Bulk refill (issue #160) =====
+    // Sums every IsFindable GameItem's StockCount against current allocations
+    // (TreasureItem pool + treasure-quest, QuestReward, PersonalQuestItemReward),
+    // then appends the unallocated remainder to the pool. Items already over-
+    // allocated are skipped and surfaced for manual review.
+    private async Task RefillPoolAsync()
+    {
+        _refillError = null;
+        _refillResult = null;
+        isRefilling = true;
+        try
+        {
+            var (ok, value, problem) = await Api.PostWithProblemAsync<object, RefillPoolResponse>(
+                $"/api/treasure-planning/refill-pool/{gameId}",
+                new { });
+            if (!ok)
+            {
+                _refillError = problem ?? "Server odmítl požadavek bez podrobností.";
+            }
+            else
+            {
+                _refillResult = value;
+                isRefillConfirmVisible = false;
+                await LoadAllAsync();
+            }
+        }
+        catch (Exception ex) { _refillError = ex.Message; }
+        finally
+        {
+            isRefilling = false;
+            StateHasChanged();
+        }
     }
 
     // ===== Pool-remove flow =====

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -484,7 +484,7 @@ else
     <div class="alert alert-danger d-flex align-items-center gap-2 mt-2">
         <i class="bi bi-wifi-off"></i>
         <span>Doplnění se nepodařilo: @_refillError</span>
-        <button type="button" class="btn-close ms-auto" @onclick="() => _refillError = null"></button>
+        <button type="button" class="btn-close ms-auto" aria-label="Zavřít" @onclick="() => _refillError = null"></button>
     </div>
 }
 
@@ -886,13 +886,16 @@ else
             else
             {
                 _refillResult = value;
-                isRefillConfirmVisible = false;
                 await LoadAllAsync();
             }
         }
         catch (Exception ex) { _refillError = ex.Message; }
         finally
         {
+            // Always dismiss the confirm popup so the top-level result/
+            // error banner is visible underneath. Leaving the popup open
+            // on failure hides the error banner behind the modal.
+            isRefillConfirmVisible = false;
             isRefilling = false;
             StateHasChanged();
         }

--- a/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
@@ -62,3 +62,27 @@ public record TreasureSummaryDto(
 public record UnlimitedItemDto(int ItemId, string ItemName, ItemType ItemType);
 
 public record AvailablePoolItemDto(int ItemId, string DisplayName, int Remaining, int StockCount);
+
+// ── Issue #160: bulk pool refill ──────────────────────────────────────────
+
+/// <summary>
+/// Result of <c>POST /api/treasure-planning/refill-pool/{gameId}</c>.
+/// Sums every <c>GameItem.IsFindable</c> item's stock against allocations on
+/// TreasureItem (pool + treasure-quest), QuestReward, and PersonalQuestItemReward,
+/// then appends the unallocated remainder to the treasure pool. Items where
+/// allocations already exceed stock are skipped and listed in
+/// <see cref="OverAllocated"/> for manual review.
+/// </summary>
+public record RefillPoolResponse(
+    int ItemsAdded,
+    IReadOnlyList<RefillPoolItemDto> Added,
+    IReadOnlyList<RefillPoolOverAllocationDto> OverAllocated);
+
+public record RefillPoolItemDto(int ItemId, string ItemName, int Added);
+
+public record RefillPoolOverAllocationDto(
+    int ItemId,
+    string ItemName,
+    int StockCount,
+    int Allocated,
+    int Excess);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningRefillPoolTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningRefillPoolTests.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+// Issue #160 sub-task C: POST /api/treasure-planning/refill-pool/{gameId}.
+// Sums every IsFindable GameItem.StockCount against TreasureItem (pool +
+// treasure-quest), QuestReward, and PersonalQuestItemReward allocations,
+// then appends the unallocated remainder to the pool. MonsterLoot is
+// intentionally ignored (situational drop, not a guaranteed allocation).
+public class TreasurePlanningRefillPoolTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    private async Task<GameDetailDto> CreateGameAsync()
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Refill Test", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    private async Task<ItemDetailDto> CreateItemAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/items",
+            new CreateItemDto(name, ItemType.Potion));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<ItemDetailDto>())!;
+    }
+
+    private async Task AssignItemToGameAsync(int gameId, int itemId, int? stock, bool findable)
+    {
+        var response = await Client.PostAsJsonAsync("/api/items/game-item",
+            new CreateGameItemDto(gameId, itemId, StockCount: stock, IsFindable: findable));
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<TreasurePoolItemDto> AddPoolItemAsync(int gameId, int itemId, int count = 1)
+    {
+        var response = await Client.PostAsJsonAsync("/api/treasure-planning/pool",
+            new CreateTreasurePoolItemDto(itemId, gameId, count));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<TreasurePoolItemDto>())!;
+    }
+
+    private async Task<RefillPoolResponse> RefillAsync(int gameId)
+    {
+        var response = await Client.PostAsync($"/api/treasure-planning/refill-pool/{gameId}", null);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        return (await response.Content.ReadFromJsonAsync<RefillPoolResponse>())!;
+    }
+
+    private async Task<List<TreasurePoolItemDto>> GetPoolAsync(int gameId)
+    {
+        var pool = await Client.GetFromJsonAsync<List<TreasurePoolItemDto>>(
+            $"/api/treasure-planning/pool/{gameId}");
+        return pool!;
+    }
+
+    [Fact]
+    public async Task Refill_NoAllocations_AppendsFullStockToPool()
+    {
+        var game = await CreateGameAsync();
+        var item = await CreateItemAsync("Lektvar zdraví");
+        await AssignItemToGameAsync(game.Id, item.Id, stock: 10, findable: true);
+
+        var result = await RefillAsync(game.Id);
+
+        Assert.Equal(10, result.ItemsAdded);
+        Assert.Single(result.Added);
+        Assert.Empty(result.OverAllocated);
+
+        var pool = await GetPoolAsync(game.Id);
+        var row = Assert.Single(pool, p => p.ItemId == item.Id);
+        Assert.Equal(10, row.Count);
+    }
+
+    [Fact]
+    public async Task Refill_WithExistingPoolStack_TopsUpRemainder()
+    {
+        var game = await CreateGameAsync();
+        var item = await CreateItemAsync("Šíp");
+        await AssignItemToGameAsync(game.Id, item.Id, stock: 10, findable: true);
+        await AddPoolItemAsync(game.Id, item.Id, count: 3);
+
+        var result = await RefillAsync(game.Id);
+
+        // 10 stock − 3 already in pool = 7 added.
+        Assert.Equal(7, result.ItemsAdded);
+        Assert.Empty(result.OverAllocated);
+
+        // Pool should now hold a single stacked row at Count=10.
+        var pool = await GetPoolAsync(game.Id);
+        var row = Assert.Single(pool, p => p.ItemId == item.Id);
+        Assert.Equal(10, row.Count);
+    }
+
+    [Fact]
+    public async Task Refill_CalledTwice_SecondCallIsNoop()
+    {
+        var game = await CreateGameAsync();
+        var item = await CreateItemAsync("Pochodeň");
+        await AssignItemToGameAsync(game.Id, item.Id, stock: 5, findable: true);
+
+        var first = await RefillAsync(game.Id);
+        var second = await RefillAsync(game.Id);
+
+        Assert.Equal(5, first.ItemsAdded);
+        Assert.Equal(0, second.ItemsAdded);
+        Assert.Empty(second.Added);
+        Assert.Empty(second.OverAllocated);
+
+        var pool = await GetPoolAsync(game.Id);
+        var row = Assert.Single(pool, p => p.ItemId == item.Id);
+        Assert.Equal(5, row.Count);
+    }
+
+    [Fact]
+    public async Task Refill_OverAllocated_SkipsItemAndReportsExcess()
+    {
+        var game = await CreateGameAsync();
+        var item = await CreateItemAsync("Vzácný amulet");
+        await AssignItemToGameAsync(game.Id, item.Id, stock: 5, findable: true);
+        // Forge an over-allocation directly in the DB. The public
+        // /api/treasure-planning/pool POST validates count <= stock so we
+        // can't reach this state through the API by design — but production
+        // can drift here via QuestReward / PersonalQuestItemReward edits
+        // after the pool is populated. Bypass the guard with a direct insert
+        // so we exercise the endpoint's "skip + report" branch.
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            db.TreasureItems.Add(new TreasureItem
+            {
+                GameId = game.Id,
+                ItemId = item.Id,
+                Count = 7,
+                TreasureQuestId = null,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var result = await RefillAsync(game.Id);
+
+        Assert.Equal(0, result.ItemsAdded);
+        Assert.Empty(result.Added);
+        var over = Assert.Single(result.OverAllocated);
+        Assert.Equal(item.Id, over.ItemId);
+        Assert.Equal(5, over.StockCount);
+        Assert.Equal(7, over.Allocated);
+        Assert.Equal(2, over.Excess);
+
+        // Pool unchanged — still the single 7-stack.
+        var pool = await GetPoolAsync(game.Id);
+        var row = Assert.Single(pool, p => p.ItemId == item.Id);
+        Assert.Equal(7, row.Count);
+    }
+
+    [Fact]
+    public async Task Refill_NonFindableItem_IsIgnored()
+    {
+        var game = await CreateGameAsync();
+        var item = await CreateItemAsync("Soukromý relikt");
+        await AssignItemToGameAsync(game.Id, item.Id, stock: 4, findable: false);
+
+        var result = await RefillAsync(game.Id);
+
+        Assert.Equal(0, result.ItemsAdded);
+        Assert.Empty(result.Added);
+        Assert.Empty(result.OverAllocated);
+
+        var pool = await GetPoolAsync(game.Id);
+        Assert.DoesNotContain(pool, p => p.ItemId == item.Id);
+    }
+
+    [Fact]
+    public async Task Refill_NullStock_IsTreatedAsZero()
+    {
+        var game = await CreateGameAsync();
+        var item = await CreateItemAsync("Bez počtu");
+        await AssignItemToGameAsync(game.Id, item.Id, stock: null, findable: true);
+
+        var result = await RefillAsync(game.Id);
+
+        Assert.Equal(0, result.ItemsAdded);
+        Assert.Empty(result.Added);
+        Assert.Empty(result.OverAllocated);
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningRefillPoolTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningRefillPoolTests.cs
@@ -179,8 +179,12 @@ public class TreasurePlanningRefillPoolTests(PostgresFixture postgres) : Integra
     }
 
     [Fact]
-    public async Task Refill_NullStock_IsTreatedAsZero()
+    public async Task Refill_NullStock_IsIgnoredAsUnlimited()
     {
+        // Null StockCount means "unlimited" elsewhere in the app
+        // (GetUnlimitedItems filters on StockCount == null). Refill has
+        // nothing concrete to allocate for an unlimited item — no upper
+        // bound to top up against — so it skips them entirely.
         var game = await CreateGameAsync();
         var item = await CreateItemAsync("Bez počtu");
         await AssignItemToGameAsync(game.Id, item.Id, stock: null, findable: true);


### PR DESCRIPTION
## Summary

Closes #160 — three sub-fixes for the Treasures planning page.

- **Sub-fix A — bbox zoom**: map opens fitted to the placed locations' extent (≥2 → fitBounds, 1 → SetCenter z=14, 0 → cached saved-bbox → CZ default), instead of the whole world.
- **Sub-fix B — markers visible**: empty-state info banners above the map for "no GPS coords on placed locations" and "no game locations assigned at all", so an empty map is no longer mistaken for a bug.
- **Sub-fix C — bulk pool refill**: new header button **„Doplnit vše zbývající k schování do zásobníku"**. `POST /api/treasure-planning/refill-pool/{gameId}` sums every findable `GameItem.StockCount` against allocations on `TreasureItem` (pool + treasure-quest), `QuestReward`, and `PersonalQuestItemReward`, then appends the unallocated remainder to the pool. `MonsterLoot` is intentionally ignored (situational drop, not a guaranteed allocation per organizer). Items where allocations already exceed stock are skipped and listed in `RefillPoolResponse.OverAllocated` for manual review. Confirm popup + result banner with success / over-allocation states.

## Test plan

- [x] Backend: 6 Testcontainers tests in `TreasurePlanningRefillPoolTests` — empty-pool full append, top-up over existing pool stack, idempotent second call, over-allocation skip+report, non-findable ignored, null stock treated as zero.
- [x] `dotnet build OvcinaHra.slnx` clean (0W/0E).
- [x] `dotnet test tests/OvcinaHra.Api.Tests` full suite green.
- [ ] Manual smoke: open `/treasures/{gameId}` on a game with locations + items, confirm map fits the extent, click „Doplnit vše zbývající k schování do zásobníku", verify pool stacks update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)