### PR TITLE
feat(spells): Spell.ScrollItemId FK + migration + backfill

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/SpellConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/SpellConfiguration.cs
@@ -17,6 +17,16 @@ public class SpellConfiguration : IEntityTypeConfiguration<Spell>
         builder.Property(e => e.Description).HasMaxLength(4000);
         builder.Property(e => e.ImagePath).HasMaxLength(500);
 
+        // Issue #181 — optional FK to the Item that physically represents this
+        // spell when it's a scroll. WithMany() because Item doesn't carry a
+        // back-reference (we don't want to pollute Item DTOs with a parent
+        // spell nav prop). DeleteBehavior.SetNull so deleting the Item just
+        // clears the link; the spell itself survives.
+        builder.HasOne(s => s.ScrollItem)
+               .WithMany()
+               .HasForeignKey(s => s.ScrollItemId)
+               .OnDelete(DeleteBehavior.SetNull);
+
         // Full-text search — shadow property + GIN index. Mirrors Item/Location/Monster/Quest.
         builder.Property<NpgsqlTypes.NpgsqlTsVector>("SearchVector")
             .HasColumnType("tsvector")

--- a/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/SpellEndpoints.cs
@@ -64,13 +64,21 @@ public static class SpellEndpoints
 
     private static async Task<Results<Ok<SpellDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
     {
-        var s = await db.Spells.FindAsync(id);
-        if (s is null) return TypedResults.NotFound();
-
-        return TypedResults.Ok(new SpellDetailDto(
-            s.Id, s.Name, s.Level, s.ManaCost, s.School,
-            s.IsScroll, s.IsReaction, s.IsLearnable, s.MinMageLevel, s.Price,
-            s.Effect, s.Description, s.ImagePath));
+        // Issue #181 — project the ScrollItem join in a single query so the
+        // client can render the "Zobrazit jako předmět" link without a second
+        // round-trip. Left join (s.ScrollItem != null fan-out) handles the
+        // unlinked case naturally.
+        var dto = await db.Spells
+            .Where(s => s.Id == id)
+            .Select(s => new SpellDetailDto(
+                s.Id, s.Name, s.Level, s.ManaCost, s.School,
+                s.IsScroll, s.IsReaction, s.IsLearnable, s.MinMageLevel, s.Price,
+                s.Effect, s.Description, s.ImagePath,
+                ScrollItemId: s.ScrollItemId,
+                ScrollItemName: s.ScrollItem != null ? s.ScrollItem.Name : null))
+            .FirstOrDefaultAsync();
+        if (dto is null) return TypedResults.NotFound();
+        return TypedResults.Ok(dto);
     }
 
     private static async Task<Results<Created<SpellDetailDto>, Conflict<string>>> Create(
@@ -103,7 +111,7 @@ public static class SpellEndpoints
                 s.Effect, s.Description, s.ImagePath));
     }
 
-    private static async Task<Results<NoContent, NotFound, Conflict<string>>> Update(
+    private static async Task<Results<NoContent, NotFound, Conflict<string>, ProblemHttpResult>> Update(
         int id, UpdateSpellDto dto, WorldDbContext db)
     {
         var s = await db.Spells.FindAsync(id);
@@ -111,6 +119,19 @@ public static class SpellEndpoints
 
         if (s.Name != dto.Name && await db.Spells.AnyAsync(x => x.Id != id && x.Name == dto.Name))
             return TypedResults.Conflict($"Kouzlo s názvem '{dto.Name}' už existuje.");
+
+        // Issue #181 — validate ScrollItemId before persisting. EF will throw
+        // an FK violation at SaveChangesAsync otherwise, but that bubbles as
+        // an unfriendly 500. Cleaner to short-circuit with a Czech
+        // ProblemDetails so the client banner shows a useful message.
+        if (dto.ScrollItemId is int scrollItemId &&
+            !await db.Items.AnyAsync(i => i.Id == scrollItemId))
+        {
+            return TypedResults.Problem(
+                title: "Neplatný předmět",
+                detail: $"Položka s ID {scrollItemId} neexistuje.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
 
         s.Name = dto.Name;
         s.Level = dto.Level;
@@ -123,6 +144,10 @@ public static class SpellEndpoints
         s.Price = dto.Price;
         s.Effect = dto.Effect;
         s.Description = dto.Description;
+        // Null clears the link; an int sets it. Non-scroll spells should
+        // always send null (the client side enforces this via the
+        // EffectiveScrollItemId getter).
+        s.ScrollItemId = dto.ScrollItemId;
 
         await db.SaveChangesAsync();
         return TypedResults.NoContent();

--- a/src/OvcinaHra.Api/Migrations/20260425145016_AddScrollItemIdToSpell.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260425145016_AddScrollItemIdToSpell.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425145016_AddScrollItemIdToSpell")]
+    partial class AddScrollItemIdToSpell
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260425145016_AddScrollItemIdToSpell.cs
+++ b/src/OvcinaHra.Api/Migrations/20260425145016_AddScrollItemIdToSpell.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddScrollItemIdToSpell : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ScrollItemId",
+                table: "Spells",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Spells_ScrollItemId",
+                table: "Spells",
+                column: "ScrollItemId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Spells_Items_ScrollItemId",
+                table: "Spells",
+                column: "ScrollItemId",
+                principalTable: "Items",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            // Issue #181 — one-shot backfill. The previous fuzz-match logic in
+            // SpellDetail.razor matched a scroll spell to an Item by
+            // case-insensitive Name. Replicate that join-set as an UPDATE so
+            // existing data picks up the FK without a manual organizer pass.
+            // Idempotent (the WHERE ScrollItemId IS NULL clause makes a
+            // partially-applied migration safe to re-run). LOWER(...) on both
+            // sides matches the previous string.Equals(..., OrdinalIgnoreCase)
+            // semantics. No Down() inverse — reverting the migration drops
+            // the column and the data with it.
+            migrationBuilder.Sql(@"
+                UPDATE ""Spells"" s
+                SET ""ScrollItemId"" = i.""Id""
+                FROM ""Items"" i
+                WHERE s.""IsScroll"" = true
+                  AND LOWER(i.""Name"") = LOWER(s.""Name"")
+                  AND s.""ScrollItemId"" IS NULL;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Spells_Items_ScrollItemId",
+                table: "Spells");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Spells_ScrollItemId",
+                table: "Spells");
+
+            migrationBuilder.DropColumn(
+                name: "ScrollItemId",
+                table: "Spells");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Spells/SpellDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Spells/SpellDetail.razor
@@ -40,7 +40,7 @@ else
             <i class="bi bi-bookmark-fill"></i> Karta
         </button>
         <button class="btn btn-sm @(activeTab == "upravit" ? "btn-primary" : "btn-outline-primary")"
-                @onclick='() => activeTab = "upravit"'>
+                @onclick="OpenUpravitTabAsync">
             <i class="bi bi-pencil"></i> Upravit
         </button>
         <button class="btn btn-sm @(activeTab == "obchod" ? "btn-primary" : "btn-outline-primary")"
@@ -115,25 +115,33 @@ else
                     </div>
                 </div>
 
-                @* Scroll → Item callout (issue #148, follow-up flagged for proper FK).
-                   Fuzz-matches case-insensitive on Name — disabled with explanatory
-                   title when no item matches. *@
+                @* Scroll → Item callout. Issue #181 replaces the previous
+                   case-insensitive name fuzz-match with a proper FK lookup —
+                   ScrollItemId is set explicitly via the Upravit form, so a
+                   spell stays linked even after a Name rename, and unlinked
+                   scrolls render the disabled state without a /api/items
+                   round-trip. *@
                 @if (spell.IsScroll)
                 {
                     <div class="oh-sp-karta-scroll-callout">
                         <h6><i class="bi bi-link-45deg"></i> Svitek je také předmět</h6>
                         <p>Tento svitek existuje i v katalogu předmětů jako <em>Svitek</em>. Detail položky obsahuje cenu, sklad a možnosti prodeje.</p>
-                        <button class="btn btn-sm btn-outline-primary" type="button"
-                                @onclick="OpenAsItemAsync" disabled="@isLookingUpItem">
-                            @if (isLookingUpItem)
-                            {
-                                <span class="spinner-border spinner-border-sm me-1"></span>
-                            }
-                            Zobrazit jako předmět <i class="bi bi-arrow-right"></i>
-                        </button>
-                        @if (!string.IsNullOrEmpty(scrollItemError))
+                        @if (spell.ScrollItemId is int scrollItemId)
                         {
-                            <p class="mt-2 mb-0 text-danger small"><i class="bi bi-exclamation-triangle"></i> @scrollItemError</p>
+                            <a href="/items/@scrollItemId" class="btn btn-sm btn-outline-primary">
+                                Zobrazit jako předmět <i class="bi bi-arrow-right"></i>
+                                @if (!string.IsNullOrWhiteSpace(spell.ScrollItemName))
+                                {
+                                    <span class="ms-1 text-muted small">(@spell.ScrollItemName)</span>
+                                }
+                            </a>
+                        }
+                        else
+                        {
+                            <button class="btn btn-sm btn-outline-secondary" type="button" disabled
+                                    title="Tento svitek zatím není propojen s předmětem v katalogu. Otevřete záložku Upravit a vyberte odpovídající položku.">
+                                <i class="bi bi-link-45deg"></i> Svitek není propojen
+                            </button>
                         }
                     </div>
                 }
@@ -191,6 +199,25 @@ else
                         <DxCheckBox @bind-Checked="@editModel.IsScroll" />
                     </DxFormLayoutItem>
                 </DxFormLayoutGroup>
+
+                @* Issue #181 — link to the catalog Item that physically
+                   represents this scroll. Visible only when IsScroll = true
+                   so non-scroll spells don't surface a meaningless field.
+                   Items list is fetched lazily on first activation of the
+                   Upravit tab (LoadScrollItemPickerAsync). *@
+                @if (editModel.IsScroll)
+                {
+                    <DxFormLayoutGroup Caption="Propojení se svitkem v katalogu" ColSpanMd="12">
+                        <DxFormLayoutItem Caption="Položka (svitek)" ColSpanMd="12">
+                            <DxComboBox Data="@allScrollItems"
+                                        @bind-Value="@editModel.ScrollItemId"
+                                        TextFieldName="Name" ValueFieldName="Id"
+                                        NullText="(žádná — propojení zatím není nastaveno)"
+                                        ClearButton="true"
+                                        SearchMode="ListSearchMode.AutoSearch" />
+                        </DxFormLayoutItem>
+                    </DxFormLayoutGroup>
+                }
 
                 <DxFormLayoutGroup Caption="Obsah" ColSpanMd="12">
                     <DxFormLayoutItem Caption="Efekt (text karty — verbatim)" ColSpanMd="12">
@@ -331,12 +358,13 @@ else
     private bool isDeleteVisible;
     private string? saveError;
 
-    // Scroll → Item callout (issue #148, follow-up #1: replace with proper FK).
-    // Lookup is lazy on button click, NOT eager on detail load — fetching
-    // the entire /api/items catalog just to render one button would scale
-    // poorly as the catalog grows.
-    private bool isLookingUpItem;
-    private string? scrollItemError;
+    // Issue #181 — Items available for the ScrollItem picker. Loaded once
+    // when the Upravit tab is opened on a scroll spell; cached for the
+    // session of this detail view. Pre-PR #181 this was a lazy lookup on
+    // button click against the whole catalog — now we just need it to
+    // populate a single combo box, so a one-shot load is fine.
+    private List<ItemListDto> allScrollItems = [];
+    private bool scrollItemsLoaded;
 
     // Obchod tab — per-game configuration list. Spell-side projection rolled
     // up from /api/spells/by-game/{gameId} hits across all games would be a
@@ -365,7 +393,6 @@ else
             }
             spell = detail;
             editModel = EditForm.FromDetail(detail);
-            scrollItemError = null;
 
             // Obchod data — best-effort. List endpoint per game not provided
             // for spells-by-spellId yet (followup); leave empty for now.
@@ -397,31 +424,40 @@ else
         finally { isSaving = false; }
     }
 
-    /// <summary>
-    /// Lazy fuzz-match by Name against /api/items when the user clicks
-    /// "Zobrazit jako předmět". No eager fetch on detail load — the catalog
-    /// can grow and this lookup is only useful on scroll detail pages.
-    /// Replaced by the proper Spell.ScrollItemId FK in follow-up #1.
-    /// </summary>
-    private async Task OpenAsItemAsync()
+    private async Task OpenUpravitTabAsync()
     {
-        if (spell is null || !spell.IsScroll) return;
-        scrollItemError = null;
-        isLookingUpItem = true;
+        activeTab = "upravit";
+        // Picker only matters for scroll spells. Avoid the catalog fetch on
+        // non-scroll spells until the user toggles IsScroll on.
+        if (editModel.IsScroll) await LoadScrollItemPickerAsync();
+    }
+
+    /// <summary>
+    /// Issue #181 — populate the ScrollItem picker on Upravit tab activation.
+    /// Filters to scroll-type Items only (server-side ?type=Scroll); falls
+    /// back to the full catalog if the API doesn't expose that filter so the
+    /// user can still pick something. Idempotent — only runs once per detail
+    /// page session.
+    /// </summary>
+    private async Task LoadScrollItemPickerAsync()
+    {
+        if (scrollItemsLoaded) return;
         try
         {
-            var items = await Api.GetListAsync<ItemListDto>("/api/items");
-            var hit = items.FirstOrDefault(i =>
-                string.Equals(i.Name?.Trim(), spell.Name.Trim(), StringComparison.OrdinalIgnoreCase));
-            if (hit is null)
-            {
-                scrollItemError = "Položka stejného názvu nenalezena. Vytvořte svitek v katalogu předmětů a propojení vznikne automaticky.";
-                return;
-            }
-            Nav.NavigateTo($"/items/{hit.Id}");
+            // Try the type-filtered endpoint first; fall back to /api/items
+            // if the server doesn't recognise the query string.
+            var filtered = await Api.GetListAsync<ItemListDto>("/api/items?type=Scroll");
+            allScrollItems = filtered.Count > 0
+                ? filtered
+                : await Api.GetListAsync<ItemListDto>("/api/items");
+            scrollItemsLoaded = true;
         }
-        catch (Exception ex) { scrollItemError = $"Nepodařilo se prohledat katalog: {ex.Message}"; }
-        finally { isLookingUpItem = false; }
+        catch
+        {
+            // Best-effort — leave the list empty so the combo at least
+            // renders without crashing the page.
+            scrollItemsLoaded = true;
+        }
     }
 
     private async Task DeleteAsync()
@@ -484,6 +520,12 @@ else
         public int? Price { get; set; }
         public string Effect { get; set; } = "";
         public string? Description { get; set; }
+        // Issue #181 — bound to the ScrollItem picker. Editor accepts a value
+        // even when IsScroll is false (so a user toggling IsScroll off and
+        // back on doesn't lose what they picked); the EffectiveScrollItemId
+        // getter strips it on persist if !IsScroll, mirroring the other
+        // Effective* getters below.
+        public int? ScrollItemId { get; set; }
 
         // ── Effective values — single source of truth for both preview and
         // persistence. MAG-005/006 says scrolls are Level 0, ManaCost 0,
@@ -496,6 +538,7 @@ else
         public int EffectiveMinMageLevel => IsScroll ? 0 : MinMageLevel;
         public bool EffectiveIsLearnable => !IsScroll && IsLearnable;
         public int? EffectivePrice => IsScroll ? null : Price;
+        public int? EffectiveScrollItemId => IsScroll ? ScrollItemId : null;
 
         public static EditForm FromDetail(SpellDetailDto d) => new()
         {
@@ -509,7 +552,8 @@ else
             MinMageLevel = d.MinMageLevel,
             Price = d.Price,
             Effect = d.Effect,
-            Description = d.Description
+            Description = d.Description,
+            ScrollItemId = d.ScrollItemId
         };
 
         public UpdateSpellDto ToUpdateDto() => new(
@@ -523,6 +567,7 @@ else
             EffectiveMinMageLevel,
             EffectivePrice,
             string.IsNullOrWhiteSpace(Effect) ? "—" : Effect.Trim(),
-            string.IsNullOrWhiteSpace(Description) ? null : Description.Trim());
+            string.IsNullOrWhiteSpace(Description) ? null : Description.Trim(),
+            EffectiveScrollItemId);
     }
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/Spell.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Spell.cs
@@ -47,5 +47,14 @@ public class Spell
 
     public string? ImagePath { get; set; }
 
+    /// <summary>
+    /// Optional FK to the catalog <see cref="Item"/> that physically represents
+    /// this spell when it's a scroll (issue #181). Replaces the case-insensitive
+    /// name fuzz-match shipped in PR #157. Null = unlinked. Deleting the Item
+    /// nulls this FK (DeleteBehavior.SetNull) — never cascades into the spell.
+    /// </summary>
+    public int? ScrollItemId { get; set; }
+    public Item? ScrollItem { get; set; }
+
     public ICollection<GameSpell> GameSpells { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Dtos/SpellDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/SpellDtos.cs
@@ -38,7 +38,13 @@ public record SpellDetailDto(
     int? Price,
     string Effect,
     string? Description,
-    string? ImagePath)
+    string? ImagePath,
+    // Issue #181 — proper FK to the catalog Item that physically represents
+    // this scroll spell. Replaces the case-insensitive name fuzz-match shipped
+    // in PR #157. ScrollItemName is a server-side join projection so the
+    // client doesn't have to round-trip /api/items/{id} just to render the link.
+    int? ScrollItemId = null,
+    string? ScrollItemName = null)
 {
     [JsonIgnore] public string SchoolDisplay => School.GetDisplayName();
 }
@@ -67,7 +73,12 @@ public record UpdateSpellDto(
     int MinMageLevel,
     int? Price,
     string Effect,
-    string? Description);
+    string? Description,
+    // Issue #181 — null clears the link, an int sets it. Server validates the
+    // ID against Items before persisting (PUT returns 400 on bogus ID).
+    // Create endpoint deliberately does NOT accept this — set the link as
+    // a follow-up update so the create flow stays narrow.
+    int? ScrollItemId = null);
 
 // ── Per-game spell configuration (mirror GameItem) ────────────────────────
 

--- a/tests/OvcinaHra.Api.Tests/Endpoints/SpellEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/SpellEndpointTests.cs
@@ -1,10 +1,12 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Domain.ValueObjects;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
@@ -166,4 +168,185 @@ public class SpellEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
         Assert.Contains(spells, s => s.Name == "Ohnivá střela (test)");
         Assert.Contains(spells, s => s.Name == "Ohnivá koule (test)");
     }
+
+    // ── Issue #181 — Spell.ScrollItemId FK round-trip + cascade + validation ──
+
+    [Fact]
+    public async Task ScrollItemId_LinkViaUpdate_RoundTripsThroughGet()
+    {
+        var token = Guid.NewGuid().ToString("N")[..6];
+
+        var spellResp = await Client.PostAsJsonAsync("/api/spells",
+            new CreateSpellDto($"Svitek hojení {token}", 0, 0, SpellSchool.Support,
+                IsScroll: true, IsReaction: false, IsLearnable: false, MinMageLevel: 0,
+                Price: null, Effect: "Vyleč 5 ž v kole použití."));
+        spellResp.EnsureSuccessStatusCode();
+        var spell = await spellResp.Content.ReadFromJsonAsync<SpellDetailDto>();
+        Assert.NotNull(spell);
+        Assert.Null(spell.ScrollItemId);
+        Assert.Null(spell.ScrollItemName);
+
+        // Items don't have a public catalog POST in scope here (depends on
+        // ItemEndpoints surface); seed via DbContext to keep this test focused
+        // on the spell side.
+        int itemId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var item = new Item
+            {
+                Name = $"Svitek hojení {token}",
+                ItemType = ItemType.Scroll,
+                ClassRequirements = new ClassRequirements(0, 0, 0, 0)
+            };
+            db.Items.Add(item);
+            await db.SaveChangesAsync();
+            itemId = item.Id;
+        }
+
+        var put = await Client.PutAsJsonAsync($"/api/spells/{spell.Id}",
+            new UpdateSpellDto(spell.Name, 0, 0, SpellSchool.Support,
+                true, false, false, 0, null, spell.Effect, null,
+                ScrollItemId: itemId));
+        Assert.Equal(HttpStatusCode.NoContent, put.StatusCode);
+
+        var get = await Client.GetFromJsonAsync<SpellDetailDto>($"/api/spells/{spell.Id}");
+        Assert.NotNull(get);
+        Assert.Equal(itemId, get.ScrollItemId);
+        Assert.Equal($"Svitek hojení {token}", get.ScrollItemName);
+    }
+
+    [Fact]
+    public async Task ScrollItemId_DeletingItem_NullsTheFk()
+    {
+        var token = Guid.NewGuid().ToString("N")[..6];
+
+        var spellResp = await Client.PostAsJsonAsync("/api/spells",
+            new CreateSpellDto($"Svitek mlhy {token}", 0, 0, SpellSchool.Frost,
+                true, false, false, 0, null, "Mlha skryje cíl."));
+        spellResp.EnsureSuccessStatusCode();
+        var spell = await spellResp.Content.ReadFromJsonAsync<SpellDetailDto>();
+        Assert.NotNull(spell);
+
+        int itemId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var item = new Item
+            {
+                Name = $"Svitek mlhy {token}",
+                ItemType = ItemType.Scroll,
+                ClassRequirements = new ClassRequirements(0, 0, 0, 0)
+            };
+            db.Items.Add(item);
+            await db.SaveChangesAsync();
+            itemId = item.Id;
+        }
+
+        await Client.PutAsJsonAsync($"/api/spells/{spell.Id}",
+            new UpdateSpellDto(spell.Name, 0, 0, SpellSchool.Frost,
+                true, false, false, 0, null, spell.Effect, null,
+                ScrollItemId: itemId));
+
+        // Delete the Item directly via DbContext to exercise the EF cascade
+        // rule (DeleteBehavior.SetNull). Going through /api/items/{id} would
+        // also work but couples this test to the Item endpoint's auth flow.
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var item = await db.Items.FindAsync(itemId);
+            db.Items.Remove(item!);
+            await db.SaveChangesAsync();
+        }
+
+        var get = await Client.GetFromJsonAsync<SpellDetailDto>($"/api/spells/{spell.Id}");
+        Assert.NotNull(get);
+        Assert.Null(get.ScrollItemId);
+        Assert.Null(get.ScrollItemName);
+    }
+
+    [Fact]
+    public async Task ScrollItemId_BogusId_ReturnsBadRequestProblemDetails()
+    {
+        var spellResp = await Client.PostAsJsonAsync("/api/spells",
+            new CreateSpellDto($"Svitek omámení {Guid.NewGuid():N}".Substring(0, 30),
+                0, 0, SpellSchool.Mental, true, false, false, 0, null,
+                "Cíl ztratí akci."));
+        spellResp.EnsureSuccessStatusCode();
+        var spell = await spellResp.Content.ReadFromJsonAsync<SpellDetailDto>();
+        Assert.NotNull(spell);
+
+        var put = await Client.PutAsJsonAsync($"/api/spells/{spell.Id}",
+            new UpdateSpellDto(spell.Name, 0, 0, SpellSchool.Mental,
+                true, false, false, 0, null, spell.Effect, null,
+                ScrollItemId: 999_999));
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+
+        var problem = await put.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Neplatný předmět", problem.Title);
+        Assert.Contains("999999", problem.Detail);
+    }
+
+    [Fact]
+    public async Task ScrollItemId_BackfillSql_LinksMatchingScrollNames()
+    {
+        // The migration's backfill SQL ran when the fixture span up — so for
+        // a deterministic test we re-execute it here against fresh seed data.
+        // The query is idempotent (WHERE ScrollItemId IS NULL clause), so a
+        // second run is safe. This validates the SQL is structurally correct
+        // and matches case-insensitively as the previous fuzz-match did.
+        var token = Guid.NewGuid().ToString("N")[..6];
+        int spellId, itemId;
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+
+            var item = new Item
+            {
+                // Mixed case on purpose — the LOWER() match should find it.
+                Name = $"SVITEK PROMĚNY {token}",
+                ItemType = ItemType.Scroll,
+                ClassRequirements = new ClassRequirements(0, 0, 0, 0)
+            };
+            db.Items.Add(item);
+
+            var spell = new Spell
+            {
+                Name = $"Svitek proměny {token}",
+                Level = 0, ManaCost = 0, School = SpellSchool.Utility,
+                IsScroll = true, IsReaction = false, IsLearnable = false,
+                MinMageLevel = 0, Effect = "Krátká transformace."
+            };
+            db.Spells.Add(spell);
+            await db.SaveChangesAsync();
+
+            spellId = spell.Id;
+            itemId = item.Id;
+
+            // Re-run the backfill SQL verbatim from the migration. PG quoting
+            // matches the migration file character-for-character.
+            await db.Database.ExecuteSqlRawAsync(@"
+                UPDATE ""Spells"" s
+                SET ""ScrollItemId"" = i.""Id""
+                FROM ""Items"" i
+                WHERE s.""IsScroll"" = true
+                  AND LOWER(i.""Name"") = LOWER(s.""Name"")
+                  AND s.""ScrollItemId"" IS NULL;
+            ");
+        }
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var linked = await db.Spells.FindAsync(spellId);
+            Assert.NotNull(linked);
+            Assert.Equal(itemId, linked.ScrollItemId);
+        }
+    }
 }
+
+// Minimal ProblemDetails shape for assertion — System.Text.Json deserialises
+// the standard ASP.NET ProblemDetails payload into these fields.
+internal sealed record ProblemDetails(string? Title, string? Detail, int? Status);


### PR DESCRIPTION
## Summary

Closes **#181**. Replaces the case-insensitive Name fuzz-match shipped in PR #157 with a proper `Spell.ScrollItemId` foreign-key relationship, an idempotent backfill SQL migration so existing data picks up the FK on first deploy, and a UI that lets organizers link/unlink the scroll Item explicitly.

## What changes (per layer)

| Layer | File | Change |
|---|---|---|
| Domain | `Spell.cs` | New `int? ScrollItemId` + `Item? ScrollItem` nav prop |
| EF config | `SpellConfiguration.cs` | `HasOne / WithMany / HasForeignKey / OnDelete.SetNull` (Item carries no back-reference; deleting Item nulls FK, never cascades into the spell) |
| Migration | `20260425145016_AddScrollItemIdToSpell.cs` | AddColumn + CreateIndex + AddForeignKey + idempotent backfill `UPDATE Spells SET ScrollItemId FROM Items WHERE LOWER(Items.Name) = LOWER(Spells.Name) AND IsScroll AND ScrollItemId IS NULL` |
| DTOs | `SpellDtos.cs` | `SpellDetailDto` adds `ScrollItemId` + `ScrollItemName` (server-side join projection); `UpdateSpellDto` adds `ScrollItemId`. `CreateSpellDto` deliberately unchanged — keep create flow narrow. `SpellListDto` unchanged — list cells don't render the callout. |
| Endpoints | `SpellEndpoints.cs` | GET projects the join (`s.ScrollItem != null ? s.ScrollItem.Name : null`); PUT validates `ScrollItemId` and returns 400 ProblemDetails ("Neplatný předmět") if the ID is missing — better UX than EF's raw 500 on FK violation |
| UI — Karta | `SpellDetail.razor` | Callout reads `spell.ScrollItemId`. Linked: anchor `/items/{id}` with optional `ScrollItemName` chip. Unlinked: disabled explanatory button. The lazy `/api/items` fuzz-match is **removed**. |
| UI — Upravit | `SpellDetail.razor` | New "Propojení se svitkem v katalogu" group with `DxComboBox` bound to `editModel.ScrollItemId`, **visible only when `IsScroll = true`**. `EditForm.EffectiveScrollItemId` mirrors the existing `EffectivePrice`/`EffectiveLevel` pattern: returns `null` when `!IsScroll`, so toggling IsScroll off persists `ScrollItemId = null`. |
| UI — picker load | `SpellDetail.razor` | `LoadScrollItemPickerAsync` lazy-loads on Upravit-tab activation for scroll spells only. Tries `/api/items?type=Scroll` first, falls back to the full catalog if the server doesn't expose the filter. |
| Tests | `SpellEndpointTests.cs` | 4 new tests (link round-trip, cascade-null on Item delete, validation 400, backfill SQL smoke) |

## Test plan

- [x] `dotnet build OvcinaHra.slnx` — clean (0 warn / 0 err under `TreatWarningsAsErrors=true`).
- [ ] **Local `dotnet test` could not run** — Docker not available in this dev env, Testcontainers PostgreSQL fixture can't spin up. Deferring to CI's Testcontainers run.
- [ ] Manual: open a scroll spell with no link → callout shows "Svitek není propojen" disabled state. Open Upravit → pick a scroll item → save. Reload Karta → anchor + name chip appear.
- [ ] Manual: toggle `IsScroll` off in Upravit → save → reload → `ScrollItemId` cleared (verified via DB).
- [ ] Manual: try PUT with bogus ScrollItemId via curl → 400 + Czech body `"Neplatný předmět"`.
- [ ] Manual on staging: after deploy, query `SELECT count(*) FROM "Spells" WHERE "ScrollItemId" IS NOT NULL AND "IsScroll" = true` and compare to count of (scroll spell, scroll item) name-pairs to verify backfill landed every previously-fuzz-matched row.

## Migration / deploy notes

- **Single migration** added: `20260425145016_AddScrollItemIdToSpell`.
- Backfill is **idempotent** (`WHERE ScrollItemId IS NULL` clause) — safe to re-run on a partially-applied DB.
- **No `Down()` SQL** — when reverting, the column drops, taking the data with it.
- EF Core 10 strict migration parity gate respected (migration generated **before** any test runs).

## Notes / out-of-scope

- `csproj <Version>` untouched — auto-bump CI handles.
- Kingdom-seal palette unchanged.
- Hra1's `Pages/Games/**` + Hra3's `tests/Fixtures/**` (parallel work) untouched.
- No new entity, no other DTO surfaces touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)