### PR TITLE
ci(tests): per-class database isolation enables parallel test execution

### DIFF
--- a/tests/OvcinaHra.Api.Tests/DatabaseMigrationTests.cs
+++ b/tests/OvcinaHra.Api.Tests/DatabaseMigrationTests.cs
@@ -5,7 +5,7 @@ using OvcinaHra.Api.Tests.Fixtures;
 
 namespace OvcinaHra.Api.Tests;
 
-public class DatabaseMigrationTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class DatabaseMigrationTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task Database_HasPendingModelChanges_IsFalse()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/AuthEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/AuthEndpointTests.cs
@@ -6,7 +6,7 @@ using OvcinaHra.Api.Tests.Fixtures;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class AuthEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class AuthEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task DevToken_ReturnsValidToken()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/BuildingEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/BuildingEndpointTests.cs
@@ -6,7 +6,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class BuildingEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class BuildingEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<GameDetailDto> CreateGameAsync()
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/BuildingRecipeEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/BuildingRecipeEndpointTests.cs
@@ -11,7 +11,7 @@ namespace OvcinaHra.Api.Tests.Endpoints;
 // for the Item-side recipe model. Validation rules in lock-step:
 // MoneyCost ≥ 0, IngredientNotes ≤ 2000 chars, prerequisite cannot reference
 // the recipe's own output building, skills must be present in the game.
-public class BuildingRecipeEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class BuildingRecipeEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<GameDetailDto> CreateGameAsync()
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/CharacterEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/CharacterEndpointTests.cs
@@ -5,7 +5,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class CharacterEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class CharacterEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task GetAll_Empty_ReturnsEmptyList()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/CraftingEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/CraftingEndpointTests.cs
@@ -11,7 +11,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class CraftingEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class CraftingEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task GetByGame_Empty_ReturnsEmptyList()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameEndpointTests.cs
@@ -7,7 +7,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class GameEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class GameEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task GetAll_Empty_ReturnsEmptyList()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameEventEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameEventEndpointTests.cs
@@ -6,7 +6,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class GameEventEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class GameEventEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     // ─── Helpers ──────────────────────────────────────────────────────────────
 

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameSkillEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameSkillEndpointsTests.cs
@@ -11,7 +11,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class GameSkillEndpointsTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class GameSkillEndpointsTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<GameDetailDto> CreateGameAsync(string name = "Test Game")
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
@@ -12,7 +12,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class ImageEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class ImageEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     // 1x1 transparent PNG
     private static readonly byte[] ValidPng = Convert.FromBase64String(

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ItemEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ItemEndpointTests.cs
@@ -10,7 +10,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class ItemEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class ItemEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task GetAll_Empty_ReturnsEmptyList()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ItemGameLinkTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ItemGameLinkTests.cs
@@ -12,7 +12,7 @@ namespace OvcinaHra.Api.Tests.Endpoints;
 // MonsterLoot rows survive as silent ghosts. Tests span the three blocking
 // sources (assigned treasure, pool treasure, monster loot) plus a regression
 // happy-path that confirms an unreferenced GameItem still deletes cleanly.
-public class ItemGameLinkTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class ItemGameLinkTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     // ----- helpers -----
 

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ItemInlineEditTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ItemInlineEditTests.cs
@@ -11,7 +11,7 @@ namespace OvcinaHra.Api.Tests.Endpoints;
 // PUT /api/items/{id} and PUT /api/items/game-item/{gameId}/{itemId} are now
 // hit directly from the grid on every blur, so bad inputs must surface as
 // Czech ProblemDetails 400 rather than getting persisted as junk.
-public class ItemInlineEditTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class ItemInlineEditTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<GameDetailDto> CreateGameAsync()
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
@@ -10,7 +10,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class LocationEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class LocationEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task Create_ValidLocation_ReturnsCreated()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MonsterEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MonsterEndpointTests.cs
@@ -9,7 +9,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class MonsterEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class MonsterEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task GetAll_Empty_ReturnsEmptyList()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/NotesFieldTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/NotesFieldTests.cs
@@ -11,7 +11,7 @@ namespace OvcinaHra.Api.Tests.Endpoints;
 // Both are capped at 2000 chars server-side (DxMemo MaxLength is unreliable
 // in DevExpress 25.2.5 — server enforces). Whitespace-only input is trimmed
 // to null on persist so nullable semantics hold downstream.
-public class NotesFieldTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class NotesFieldTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<GameDetailDto> CreateGameAsync()
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/NpcEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/NpcEndpointTests.cs
@@ -6,7 +6,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class NpcEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class NpcEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     // --- Catalog CRUD ---
 

--- a/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/PersonalQuestEndpointTests.cs
@@ -11,7 +11,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class PersonalQuestEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task GetAll_Empty_ReturnsEmptyList()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/QuestCopyTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/QuestCopyTests.cs
@@ -6,7 +6,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class QuestCopyTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class QuestCopyTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<GameDetailDto> CreateGameAsync(string name = "Game")
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/QuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/QuestEndpointTests.cs
@@ -6,7 +6,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class QuestEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class QuestEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task GetByGame_Empty_ReturnsEmptyList()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
@@ -6,7 +6,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<int> GetKingdomIdAsync(string name)
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/SearchEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/SearchEndpointTests.cs
@@ -5,7 +5,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class SearchEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class SearchEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task Search_EmptyQuery_ReturnsEmpty()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/SecretStashEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/SecretStashEndpointTests.cs
@@ -6,7 +6,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class SecretStashEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class SecretStashEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     // --- Catalog CRUD ---
 

--- a/tests/OvcinaHra.Api.Tests/Endpoints/SkillEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/SkillEndpointsTests.cs
@@ -12,7 +12,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class SkillEndpointsTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class SkillEndpointsTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<BuildingDetailDto> CreateBuildingAsync(string name)
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/SpellEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/SpellEndpointTests.cs
@@ -11,7 +11,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class SpellEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class SpellEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task Create_ValidSpell_ReturnsCreated()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TagEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TagEndpointTests.cs
@@ -6,7 +6,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class TagEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class TagEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task Create_ValidTag_ReturnsCreated()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TimelineEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TimelineEndpointTests.cs
@@ -10,7 +10,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class TimelineEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class TimelineEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task GetSlotsByGame_Empty_ReturnsEmptyList()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
@@ -9,7 +9,7 @@ namespace OvcinaHra.Api.Tests.Endpoints;
 // Covers DELETE /api/treasure-planning/pool/{id} per issue #102.
 // The endpoint pre-dates the issue; these tests codify the contract so the
 // UI-facing Odebrat action can trust the 204 / 400 / 404 split.
-public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<GameDetailDto> CreateGameAsync()
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningRefillPoolTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningRefillPoolTests.cs
@@ -15,7 +15,7 @@ namespace OvcinaHra.Api.Tests.Endpoints;
 // treasure-quest), QuestReward, and PersonalQuestItemReward allocations,
 // then appends the unallocated remainder to the pool. MonsterLoot is
 // intentionally ignored (situational drop, not a guaranteed allocation).
-public class TreasurePlanningRefillPoolTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class TreasurePlanningRefillPoolTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<GameDetailDto> CreateGameAsync()
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasureQuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasureQuestEndpointTests.cs
@@ -6,7 +6,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
-public class TreasureQuestEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class TreasureQuestEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<GameDetailDto> CreateGameAsync()
     {

--- a/tests/OvcinaHra.Api.Tests/Fixtures/IntegrationTestBase.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/IntegrationTestBase.cs
@@ -1,59 +1,32 @@
-using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using OvcinaHra.Api.Data;
-using OvcinaHra.Api.Endpoints;
-
 namespace OvcinaHra.Api.Tests.Fixtures;
 
-[Collection("Postgres")]
+/// <summary>
+/// Per-test reset on a per-class fixture.
+///
+/// <see cref="PostgresFixture"/> owns the database, WAF, and authenticated
+/// HttpClient for the whole test class. This base class plugs into xUnit's
+/// per-test lifecycle to TRUNCATE + re-seed before each test, so test order
+/// inside a class doesn't matter.
+///
+/// Test classes look like:
+/// <code>
+/// public class FooTests(PostgresFixture postgres)
+///     : IntegrationTestBase(postgres), IClassFixture&lt;PostgresFixture&gt; { ... }
+/// </code>
+/// </summary>
 public abstract class IntegrationTestBase : IAsyncLifetime
 {
     protected readonly PostgresFixture Postgres;
-    protected ApiWebApplicationFactory Factory = null!;
-    protected HttpClient Client = null!;
+
+    protected ApiWebApplicationFactory Factory => Postgres.Factory;
+    protected HttpClient Client => Postgres.Client;
 
     protected IntegrationTestBase(PostgresFixture postgres)
     {
         Postgres = postgres;
     }
 
-    public async Task InitializeAsync()
-    {
-        Factory = new ApiWebApplicationFactory(Postgres.ConnectionString);
-        Client = Factory.CreateClient();
+    public Task InitializeAsync() => Postgres.ResetDataAsync();
 
-        // Get a dev token and set it on the client
-        var tokenResponse = await Client.PostAsJsonAsync("/api/auth/dev-token",
-            new DevTokenRequest("test-user", "test@ovcina.cz", "Test Organizátor"));
-        var token = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>();
-        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token!.Token);
-
-        using var scope = Factory.Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
-        await db.Database.MigrateAsync();
-
-        // Clean all data between test classes for isolation
-        var tableNames = db.Model.GetEntityTypes().Select(t => t.GetTableName()).Distinct().ToList();
-        var truncateSql = string.Join("; ", tableNames.Select(t => $"TRUNCATE TABLE \"{t}\" CASCADE"));
-        if (truncateSql.Length > 0)
-            await db.Database.ExecuteSqlRawAsync(truncateSql);
-
-        // Re-seed the canonical Kingdom lookup rows the 20260422221753 migration
-        // inserts at apply-time (TRUNCATE CASCADE wipes them between test classes).
-        await db.Database.ExecuteSqlRawAsync("""
-            INSERT INTO "Kingdoms" ("Name", "HexColor", "SortOrder") VALUES
-              ('Aradhryand',      '#2E7D32', 1),
-              ('Azanulinbar-Dum', '#C62828', 2),
-              ('Esgaroth',        '#1565C0', 3),
-              ('Nový Arnor',      '#F9A825', 4)
-            """);
-    }
-
-    public async Task DisposeAsync()
-    {
-        Client.Dispose();
-        await Factory.DisposeAsync();
-    }
+    public Task DisposeAsync() => Task.CompletedTask;
 }

--- a/tests/OvcinaHra.Api.Tests/Fixtures/PostgresCollection.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/PostgresCollection.cs
@@ -1,4 +1,0 @@
-namespace OvcinaHra.Api.Tests.Fixtures;
-
-[CollectionDefinition("Postgres")]
-public class PostgresCollection : ICollectionFixture<PostgresFixture>;

--- a/tests/OvcinaHra.Api.Tests/Fixtures/PostgresFixture.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/PostgresFixture.cs
@@ -1,21 +1,183 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Endpoints;
 using Testcontainers.PostgreSql;
 
 namespace OvcinaHra.Api.Tests.Fixtures;
 
+/// <summary>
+/// Combined per-test-class fixture: provides an isolated Postgres database
+/// AND a single shared <see cref="ApiWebApplicationFactory"/> for that class.
+///
+/// Why one fixture for both:
+/// <list type="bullet">
+///   <item>The WAF entry point can only be wrapped a bounded number of times
+///         per process before its <c>HostFactoryResolver</c> trips with
+///         "entry point exited without ever building an IHost". Sharing one
+///         WAF per class avoids that — tens of factory instances across the
+///         suite, not hundreds.</item>
+///   <item>Per-class DBs (cloned from a migrated template) give parallelism
+///         safety. Each class writes to a disjoint database.</item>
+/// </list>
+///
+/// xUnit instantiates this fixture once per class via
+/// <c>IClassFixture&lt;PostgresFixture&gt;</c>.
+/// Tests within a class share the same WAF + HttpClient + DB and rely on a
+/// per-test <c>TRUNCATE CASCADE</c> in <see cref="IntegrationTestBase"/>
+/// to keep each test starting from the migrated baseline.
+/// </summary>
 public class PostgresFixture : IAsyncLifetime
 {
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:17-alpine")
-        .Build();
+    private const string TemplateDbName = "ovcinahra_template";
 
-    public string ConnectionString => _container.GetConnectionString();
+    private static readonly SemaphoreSlim Gate = new(1, 1);
+    // WebApplicationFactory<TEntryPoint> uses process-static state in
+    // HostFactoryResolver; bootstrapping multiple WAF instances concurrently
+    // trips with "entry point exited without ever building an IHost". Each
+    // class still gets its OWN WAF (and DB), but their construction is
+    // serialized through this gate so the tests themselves run in parallel.
+    private static readonly SemaphoreSlim WafGate = new(1, 1);
+    private static PostgreSqlContainer? _sharedContainer;
+    private static string? _adminConnectionString;
+
+    private readonly string _instanceDbName =
+        $"ovcinahra_test_{Guid.NewGuid().ToString("N")[..12]}";
+
+    public string ConnectionString { get; private set; } = string.Empty;
+    public ApiWebApplicationFactory Factory { get; private set; } = null!;
+    public HttpClient Client { get; private set; } = null!;
 
     public async Task InitializeAsync()
     {
-        await _container.StartAsync();
+        await EnsureSharedAsync();
+
+        // Clone the migrated template into a fresh per-class database.
+        // CREATE DATABASE ... TEMPLATE is a fast file-system clone.
+        await using (var conn = new NpgsqlConnection(_adminConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"CREATE DATABASE \"{_instanceDbName}\" TEMPLATE \"{TemplateDbName}\";";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var b = new NpgsqlConnectionStringBuilder(_adminConnectionString) { Database = _instanceDbName };
+        ConnectionString = b.ConnectionString;
+
+        await WafGate.WaitAsync();
+        try
+        {
+            Factory = new ApiWebApplicationFactory(ConnectionString);
+            Client = Factory.CreateClient();
+        }
+        finally
+        {
+            WafGate.Release();
+        }
+
+        // Authenticate once per class — the dev-token is good for the
+        // whole class lifetime, no need to re-auth per test.
+        var tokenResponse = await Client.PostAsJsonAsync("/api/auth/dev-token",
+            new DevTokenRequest("test-user", "test@ovcina.cz", "Test Organizátor"));
+        var token = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>();
+        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token!.Token);
     }
 
     public async Task DisposeAsync()
     {
-        await _container.DisposeAsync();
+        Client?.Dispose();
+        if (Factory is not null) await Factory.DisposeAsync();
+
+        if (_adminConnectionString is null) return;
+
+        // FORCE terminates pooled sessions — Postgres refuses DROP DATABASE
+        // while sessions exist. WAF disposal above usually clears them, but
+        // the FORCE clause is a belt-and-braces.
+        await using var conn = new NpgsqlConnection(_adminConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"DROP DATABASE IF EXISTS \"{_instanceDbName}\" WITH (FORCE);";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// Truncates every model table and re-seeds the Kingdom lookup rows.
+    /// Called from <see cref="IntegrationTestBase.InitializeAsync"/> per test
+    /// so each test starts at the same migrated baseline.
+    /// </summary>
+    public async Task ResetDataAsync()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+
+        var tableNames = db.Model.GetEntityTypes().Select(t => t.GetTableName()).Distinct().ToList();
+        var truncateSql = string.Join("; ", tableNames.Select(t => $"TRUNCATE TABLE \"{t}\" CASCADE"));
+        if (truncateSql.Length > 0)
+            await db.Database.ExecuteSqlRawAsync(truncateSql);
+
+        await db.Database.ExecuteSqlRawAsync("""
+            INSERT INTO "Kingdoms" ("Name", "HexColor", "SortOrder") VALUES
+              ('Aradhryand',      '#2E7D32', 1),
+              ('Azanulinbar-Dum', '#C62828', 2),
+              ('Esgaroth',        '#1565C0', 3),
+              ('Nový Arnor',      '#F9A825', 4)
+            """);
+    }
+
+    private static async Task EnsureSharedAsync()
+    {
+        if (_sharedContainer is not null) return;
+
+        await Gate.WaitAsync();
+        try
+        {
+            if (_sharedContainer is not null) return;
+
+            var container = new PostgreSqlBuilder("postgres:17-alpine").Build();
+            await container.StartAsync();
+
+            // Testcontainers' default DB is a one-off; use the built-in
+            // `postgres` admin database for CREATE/DROP DATABASE.
+            var adminB = new NpgsqlConnectionStringBuilder(container.GetConnectionString())
+            {
+                Database = "postgres"
+            };
+            var adminConn = adminB.ConnectionString;
+
+            await using (var conn = new NpgsqlConnection(adminConn))
+            {
+                await conn.OpenAsync();
+                await using var cmd = conn.CreateCommand();
+                cmd.CommandText = $"CREATE DATABASE \"{TemplateDbName}\";";
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            // Migrate the template. Pooling=false ensures the connection truly
+            // closes on dispose — CREATE DATABASE ... TEMPLATE refuses to clone
+            // while any session is connected to the source.
+            var migrationB = new NpgsqlConnectionStringBuilder(adminConn)
+            {
+                Database = TemplateDbName,
+                Pooling = false
+            };
+            await using (var ctx = new WorldDbContext(
+                new DbContextOptionsBuilder<WorldDbContext>()
+                    .UseNpgsql(migrationB.ConnectionString)
+                    .Options))
+            {
+                await ctx.Database.MigrateAsync();
+            }
+
+            _sharedContainer = container;
+            _adminConnectionString = adminConn;
+        }
+        finally
+        {
+            Gate.Release();
+        }
     }
 }

--- a/tests/OvcinaHra.Api.Tests/Fixtures/PostgresFixture.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/PostgresFixture.cs
@@ -83,8 +83,11 @@ public class PostgresFixture : IAsyncLifetime
         // whole class lifetime, no need to re-auth per test.
         var tokenResponse = await Client.PostAsJsonAsync("/api/auth/dev-token",
             new DevTokenRequest("test-user", "test@ovcina.cz", "Test Organizátor"));
-        var token = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>();
-        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token!.Token);
+        tokenResponse.EnsureSuccessStatusCode();
+        var token = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>()
+            ?? throw new InvalidOperationException(
+                "Dev-token endpoint returned an empty body — test fixture cannot authenticate.");
+        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
     }
 
     public async Task DisposeAsync()
@@ -140,40 +143,60 @@ public class PostgresFixture : IAsyncLifetime
             var container = new PostgreSqlBuilder("postgres:17-alpine").Build();
             await container.StartAsync();
 
-            // Testcontainers' default DB is a one-off; use the built-in
-            // `postgres` admin database for CREATE/DROP DATABASE.
-            var adminB = new NpgsqlConnectionStringBuilder(container.GetConnectionString())
+            try
             {
-                Database = "postgres"
-            };
-            var adminConn = adminB.ConnectionString;
+                // Testcontainers' default DB is a one-off; use the built-in
+                // `postgres` admin database for CREATE/DROP DATABASE.
+                var adminB = new NpgsqlConnectionStringBuilder(container.GetConnectionString())
+                {
+                    Database = "postgres"
+                };
+                var adminConn = adminB.ConnectionString;
 
-            await using (var conn = new NpgsqlConnection(adminConn))
+                await using (var conn = new NpgsqlConnection(adminConn))
+                {
+                    await conn.OpenAsync();
+                    await using var cmd = conn.CreateCommand();
+                    cmd.CommandText = $"CREATE DATABASE \"{TemplateDbName}\";";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                // Migrate the template. Pooling=false ensures the connection
+                // truly closes on dispose — CREATE DATABASE ... TEMPLATE
+                // refuses to clone while any session is connected to source.
+                var migrationB = new NpgsqlConnectionStringBuilder(adminConn)
+                {
+                    Database = TemplateDbName,
+                    Pooling = false
+                };
+                await using (var ctx = new WorldDbContext(
+                    new DbContextOptionsBuilder<WorldDbContext>()
+                        .UseNpgsql(migrationB.ConnectionString)
+                        .Options))
+                {
+                    await ctx.Database.MigrateAsync();
+                }
+
+                _sharedContainer = container;
+                _adminConnectionString = adminConn;
+            }
+            catch
             {
-                await conn.OpenAsync();
-                await using var cmd = conn.CreateCommand();
-                cmd.CommandText = $"CREATE DATABASE \"{TemplateDbName}\";";
-                await cmd.ExecuteNonQueryAsync();
+                // If template setup fails, dispose the container we just
+                // started so we don't leak it. Re-throw the original error.
+                await container.DisposeAsync();
+                throw;
             }
 
-            // Migrate the template. Pooling=false ensures the connection truly
-            // closes on dispose — CREATE DATABASE ... TEMPLATE refuses to clone
-            // while any session is connected to the source.
-            var migrationB = new NpgsqlConnectionStringBuilder(adminConn)
+            // Belt-and-braces cleanup on process exit — Testcontainers' Ryuk
+            // daemon normally handles this, but if Ryuk is disabled or
+            // unavailable on a CI runner the container would otherwise stick
+            // around until the runner is recycled.
+            AppDomain.CurrentDomain.ProcessExit += async (_, _) =>
             {
-                Database = TemplateDbName,
-                Pooling = false
+                try { await container.DisposeAsync(); }
+                catch { /* best-effort */ }
             };
-            await using (var ctx = new WorldDbContext(
-                new DbContextOptionsBuilder<WorldDbContext>()
-                    .UseNpgsql(migrationB.ConnectionString)
-                    .Options))
-            {
-                await ctx.Database.MigrateAsync();
-            }
-
-            _sharedContainer = container;
-            _adminConnectionString = adminConn;
         }
         finally
         {

--- a/tests/OvcinaHra.Api.Tests/HealthCheckTests.cs
+++ b/tests/OvcinaHra.Api.Tests/HealthCheckTests.cs
@@ -3,7 +3,7 @@ using OvcinaHra.Api.Tests.Fixtures;
 
 namespace OvcinaHra.Api.Tests;
 
-public class HealthCheckTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class HealthCheckTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     [Fact]
     public async Task HealthCheck_ReturnsHealthy()

--- a/tests/OvcinaHra.Api.Tests/xunit.runner.json
+++ b/tests/OvcinaHra.Api.Tests/xunit.runner.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://xunit.net/schema/v3.0/xunit.runner.schema.json",
+  "parallelizeTestCollections": true,
+  "parallelizeAssembly": false,
+  "maxParallelThreads": -1
+}


### PR DESCRIPTION
Closes #180.

Direct continuation of #175 — Lever 3 was deferred there because `[Collection("Postgres")]` serialized all 351 integration tests through a single Postgres database. This PR lifts that barrier by giving every test class its own database (cloned from a migrated template) on the same shared container. xUnit can now parallelize across classes.

## Headline numbers

| | Test step | Notes |
|---|---|---|
| Local sequential (PR #175 baseline) | ~9-10 min | `[Collection("Postgres")]` serialization |
| Local parallel (this PR) | **30s** | 351 / 351 green, 3 consecutive flake-free runs |
| CI before (PR #175 measured) | ~6.5 min | Test step is 88% of `build-and-test` total |
| CI after (expected) | **~2-3 min** | Hits the original ~3 min target from #151 |

## How it works

### `PostgresFixture` (one per class via `IClassFixture<PostgresFixture>`)

- **Process-static lazy init** starts ONE `postgres:17-alpine` container for the whole assembly and creates a migrated `ovcinahra_template` database. The migration connection uses `Pooling=false` so it doesn't linger and block subsequent `CREATE DATABASE ... TEMPLATE` cloning.
- **Per fixture instance**: clones the template via `CREATE DATABASE x TEMPLATE` — fast file-system copy, no per-class re-migration.
- **Owns the WebApplicationFactory + authenticated HttpClient** for the whole class lifetime. WAF construction is gated through a static `SemaphoreSlim` because `WebApplicationFactory<TEntryPoint>`'s `HostFactoryResolver` uses process-static state and trips with `"entry point exited without ever building an IHost"` when many WAF instances bootstrap concurrently. The gate only serializes the ~30 WAF builds; tests themselves run in parallel.
- **`DROP DATABASE WITH (FORCE)`** on dispose terminates pooled sessions cleanly so the cleanup never hangs.

### `IntegrationTestBase` (per-test reset)

- `TRUNCATE CASCADE` all tables + re-seed Kingdoms before each test, so test ordering inside a class doesn't matter. The per-class DB means writes never leak across classes regardless.
- All 29 endpoint test classes converted: `: IntegrationTestBase(postgres)` → `: IntegrationTestBase(postgres), IClassFixture<PostgresFixture>`.

### `xunit.runner.json`

```json
{ "parallelizeTestCollections": true, "parallelizeAssembly": false, "maxParallelThreads": -1 }
```

`PostgresCollection.cs` deleted — `[CollectionDefinition("Postgres")]` is no longer needed because each test class is its own implicit collection.

## Verification

- `dotnet build OvcinaHra.slnx` — clean, 0 warnings (`TreatWarningsAsErrors=true`).
- `dotnet test` — **351 / 351 green** on three consecutive runs, **30s each**, no flakiness.
- No production code touched. Pure test-infra change.

## Notes on the journey

The brief expected Option 1 (per-test transactions) to be the primary path. I spiked it on `TagEndpointTests` and it worked when alone. Mass conversion surfaced two real EF-Core / WAF problems:
1. `WorldDbContext` instances inside the API don't share the test's outer transaction — they try to open their own and Postgres rejects.
2. 10 test classes use `Factory.Services.CreateScope()` to query the DB directly, which would also nest-transaction.

Per the brief's stop-and-ask guidance, fell back to Option 2 (DB isolation) — it sidesteps both EF issues by giving each class its own DB.

A second WAF-specific gotcha surfaced: `HostFactoryResolver`'s process-static state can't be bootstrapped concurrently. Hence the static gate around WAF construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)