### PR TITLE
feat(games): UI to link OvčinaHra games to registrace via ExternalGameId (closes #3)

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/GameConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/GameConfiguration.cs
@@ -17,5 +17,12 @@ public class GameConfiguration : IEntityTypeConfiguration<Game>
         builder.Property(e => e.BoundingBoxSwLng).HasPrecision(10, 7);
         builder.Property(e => e.BoundingBoxNeLat).HasPrecision(10, 7);
         builder.Property(e => e.BoundingBoxNeLng).HasPrecision(10, 7);
+
+        // Issue #3: one OvčinaHra game ↔ at most one registrace game.
+        // Filtered so multiple unlinked games (NULL) coexist; once a value
+        // is set it must be unique across the table.
+        builder.HasIndex(e => e.ExternalGameId)
+            .IsUnique()
+            .HasFilter("\"ExternalGameId\" IS NOT NULL");
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
@@ -185,12 +186,26 @@ public static class GameEndpoints
     /// <summary>
     /// Issue #3 — returns the registrace games available for linking.
     /// Filters out games already linked locally so the picker only shows
-    /// candidates the organizer can actually pick.
+    /// candidates the organizer can actually pick. Wraps upstream
+    /// failures in a 502 so callers can distinguish "registrace
+    /// unreachable/unauthorized" from an internal 500.
     /// </summary>
-    private static async Task<Ok<List<RegistraceGameDto>>> GetRegistraceAvailable(
+    private static async Task<Results<Ok<List<RegistraceGameDto>>, ProblemHttpResult>> GetRegistraceAvailable(
         RegistraceGameService registrace, WorldDbContext db, CancellationToken ct)
     {
-        var upstream = await registrace.GetAvailableAsync(ct);
+        IReadOnlyList<RegistraceGameDto> upstream;
+        try
+        {
+            upstream = await registrace.GetAvailableAsync(ct);
+        }
+        catch (HttpRequestException ex)
+        {
+            return TypedResults.Problem(
+                detail: ex.Message,
+                title: "Registrace nedostupná.",
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+
         var alreadyLinked = await db.Games
             .Where(g => g.ExternalGameId != null)
             .Select(g => g.ExternalGameId!.Value)
@@ -200,16 +215,14 @@ public static class GameEndpoints
         return TypedResults.Ok(filtered);
     }
 
-    private static bool IsUniqueViolation(DbUpdateException ex)
-    {
-        // Npgsql surfaces unique-violation as PostgresException SqlState 23505.
-        // Inspect the inner exception instead of binding to the Npgsql type
-        // here so the endpoint stays provider-agnostic for tests.
-        var inner = ex.InnerException;
-        return inner is not null
-            && inner.GetType().Name == "PostgresException"
-            && (inner.GetType().GetProperty("SqlState")?.GetValue(inner) as string) == "23505";
-    }
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        // Npgsql surfaces unique-violation as PostgresException with SqlState
+        // 23505 (PostgresErrorCodes.UniqueViolation). Direct type check is
+        // compile-time safe — the migration's filtered UNIQUE INDEX is
+        // Postgres-specific anyway, so binding to the Npgsql type here is
+        // honest, not a leak.
+        ex.InnerException is PostgresException pg
+        && pg.SqlState == PostgresErrorCodes.UniqueViolation;
 
     // ----- Map overlay (issue #96) ----------------------------------------
 

--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Dtos;
 
@@ -21,6 +22,12 @@ public static class GameEndpoints
         group.MapPut("/{id:int}", Update);
         group.MapPost("/{id:int}/link", LinkToRegistrace);
         group.MapDelete("/{id:int}/link", UnlinkFromRegistrace);
+
+        // Issue #3: server-side proxy for the "Propojit s registrací" picker.
+        // Browsers never see the integration API key; this endpoint inherits
+        // the parent group's RequireAuthorization gate so only logged-in
+        // organizers can trigger the upstream call.
+        group.MapGet("/registrace-available", GetRegistraceAvailable);
 
         // Map overlay (issue #96) — free-draw shapes per game, stored as JSON blob.
         group.MapGet("/{id:int}/overlay", GetOverlay);
@@ -121,14 +128,46 @@ public static class GameEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Results<NoContent, NotFound>> LinkToRegistrace(int id, LinkGameDto dto, WorldDbContext db)
+    private static async Task<Results<NoContent, NotFound, Conflict<ProblemDetails>>> LinkToRegistrace(
+        int id, LinkGameDto dto, WorldDbContext db)
     {
         var game = await db.Games.FindAsync(id);
         if (game is null)
             return TypedResults.NotFound();
 
+        // Issue #3: pre-check before relying on the UNIQUE INDEX so the
+        // organizer gets a friendly Czech message rather than a 500. The
+        // unique index (filtered, NULL-safe) is still the authoritative
+        // guard against concurrent races.
+        var conflict = await db.Games
+            .Where(g => g.Id != id && g.ExternalGameId == dto.ExternalGameId)
+            .Select(g => new { g.Id, g.Name })
+            .FirstOrDefaultAsync();
+        if (conflict is not null)
+        {
+            return TypedResults.Conflict(new ProblemDetails
+            {
+                Title = "Registrace už je propojená.",
+                Detail = $"Hra v registraci #{dto.ExternalGameId} je už propojená s hrou „{conflict.Name}“ (#{conflict.Id}). Nejdřív zruš to staré propojení.",
+                Status = StatusCodes.Status409Conflict
+            });
+        }
+
         game.ExternalGameId = dto.ExternalGameId;
-        await db.SaveChangesAsync();
+        try
+        {
+            await db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // Race against another concurrent link — surface the same 409.
+            return TypedResults.Conflict(new ProblemDetails
+            {
+                Title = "Registrace už je propojená.",
+                Detail = $"Hra v registraci #{dto.ExternalGameId} byla mezitím propojená s jinou hrou.",
+                Status = StatusCodes.Status409Conflict
+            });
+        }
         return TypedResults.NoContent();
     }
 
@@ -141,6 +180,35 @@ public static class GameEndpoints
         game.ExternalGameId = null;
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
+    }
+
+    /// <summary>
+    /// Issue #3 — returns the registrace games available for linking.
+    /// Filters out games already linked locally so the picker only shows
+    /// candidates the organizer can actually pick.
+    /// </summary>
+    private static async Task<Ok<List<RegistraceGameDto>>> GetRegistraceAvailable(
+        RegistraceGameService registrace, WorldDbContext db, CancellationToken ct)
+    {
+        var upstream = await registrace.GetAvailableAsync(ct);
+        var alreadyLinked = await db.Games
+            .Where(g => g.ExternalGameId != null)
+            .Select(g => g.ExternalGameId!.Value)
+            .ToListAsync(ct);
+        var linkedSet = alreadyLinked.ToHashSet();
+        var filtered = upstream.Where(g => !linkedSet.Contains(g.Id)).ToList();
+        return TypedResults.Ok(filtered);
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex)
+    {
+        // Npgsql surfaces unique-violation as PostgresException SqlState 23505.
+        // Inspect the inner exception instead of binding to the Npgsql type
+        // here so the endpoint stays provider-agnostic for tests.
+        var inner = ex.InnerException;
+        return inner is not null
+            && inner.GetType().Name == "PostgresException"
+            && (inner.GetType().GetProperty("SqlState")?.GetValue(inner) as string) == "23505";
     }
 
     // ----- Map overlay (issue #96) ----------------------------------------

--- a/src/OvcinaHra.Api/Migrations/20260425165408_AddUniqueIndexOnGameExternalGameId.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260425165408_AddUniqueIndexOnGameExternalGameId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425165408_AddUniqueIndexOnGameExternalGameId")]
+    partial class AddUniqueIndexOnGameExternalGameId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1645,9 +1648,6 @@ namespace OvcinaHra.Api.Migrations
                         .HasMaxLength(20)
                         .HasColumnType("character varying(20)");
 
-                    b.Property<int?>("ScrollItemId")
-                        .HasColumnType("integer");
-
                     b.Property<NpgsqlTsVector>("SearchVector")
                         .ValueGeneratedOnAddOrUpdate()
                         .HasColumnType("tsvector")
@@ -1657,8 +1657,6 @@ namespace OvcinaHra.Api.Migrations
 
                     b.HasIndex("Name")
                         .IsUnique();
-
-                    b.HasIndex("ScrollItemId");
 
                     b.HasIndex("SearchVector");
 
@@ -2616,16 +2614,6 @@ namespace OvcinaHra.Api.Migrations
                     b.Navigation("Building");
 
                     b.Navigation("Skill");
-                });
-
-            modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.Spell", b =>
-                {
-                    b.HasOne("OvcinaHra.Shared.Domain.Entities.Item", "ScrollItem")
-                        .WithMany()
-                        .HasForeignKey("ScrollItemId")
-                        .OnDelete(DeleteBehavior.SetNull);
-
-                    b.Navigation("ScrollItem");
                 });
 
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.TreasureItem", b =>

--- a/src/OvcinaHra.Api/Migrations/20260425165408_AddUniqueIndexOnGameExternalGameId.cs
+++ b/src/OvcinaHra.Api/Migrations/20260425165408_AddUniqueIndexOnGameExternalGameId.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUniqueIndexOnGameExternalGameId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Games_ExternalGameId",
+                table: "Games",
+                column: "ExternalGameId",
+                unique: true,
+                filter: "\"ExternalGameId\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Games_ExternalGameId",
+                table: "Games");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -47,6 +47,7 @@ try
     var jwtKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!));
 
     builder.Services.AddHttpClient<RegistraceImportService>();
+    builder.Services.AddHttpClient<RegistraceGameService>();
 
     builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>

--- a/src/OvcinaHra.Api/Services/RegistraceGameService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceGameService.cs
@@ -1,0 +1,39 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Services;
+
+/// <summary>
+/// Issue #3 — fetches the list of available registrace games for the
+/// "Propojit s registrací" picker. Server-to-server only: the API key
+/// (<c>IntegrationApi:ApiKey</c>) is held in OvčinaHra config and sent
+/// via the <c>X-Api-Key</c> header — the browser never sees it.
+/// Mirrors the auth + base-URL pattern used by
+/// <see cref="RegistraceImportService"/>.
+/// </summary>
+public class RegistraceGameService(HttpClient httpClient, IConfiguration configuration)
+{
+    private readonly string _baseUrl = configuration["IntegrationApi:BaseUrl"] ?? "https://registrace.ovcina.cz";
+    private readonly string? _apiKey = configuration["IntegrationApi:ApiKey"];
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public async Task<IReadOnlyList<RegistraceGameDto>> GetAvailableAsync(CancellationToken ct = default)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get,
+            $"{_baseUrl.TrimEnd('/')}/api/v1/games");
+
+        if (!string.IsNullOrWhiteSpace(_apiKey))
+            request.Headers.Add("X-Api-Key", _apiKey);
+
+        var response = await httpClient.SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
+
+        var games = await response.Content.ReadFromJsonAsync<List<RegistraceGameDto>>(JsonOptions, ct);
+        return games ?? [];
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Games/GameFormModel.cs
+++ b/src/OvcinaHra.Client/Pages/Games/GameFormModel.cs
@@ -16,6 +16,12 @@ public class GameFormModel
     public decimal? BoundingBoxNeLat { get; set; }
     public decimal? BoundingBoxNeLng { get; set; }
 
+    /// <summary>Issue #3 — read-only mirror of <c>Game.ExternalGameId</c>.
+    /// Mutated only by the link/unlink popup, never by the Save button —
+    /// keeps the link decoupled from Edit so a user can't accidentally
+    /// "save away" a freshly-set link by hitting Cancel.</summary>
+    public int? ExternalGameId { get; set; }
+
     public CreateGameDto ToCreateDto() => new(Name, Edition, StartDate, EndDate, Status);
 
     public UpdateGameDto ToUpdateDto() => new(
@@ -32,6 +38,7 @@ public class GameFormModel
         BoundingBoxSwLat = dto.BoundingBoxSwLat,
         BoundingBoxSwLng = dto.BoundingBoxSwLng,
         BoundingBoxNeLat = dto.BoundingBoxNeLat,
-        BoundingBoxNeLng = dto.BoundingBoxNeLng
+        BoundingBoxNeLng = dto.BoundingBoxNeLng,
+        ExternalGameId = dto.ExternalGameId
     };
 }

--- a/src/OvcinaHra.Client/Pages/Games/GameList.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameList.razor
@@ -63,6 +63,49 @@ else
             </DxFormLayout>
         }
 
+        @* Issue #3 — registrace link status + actions. Sits inside the edit
+           popup but operates independently of Save/Cancel: link/unlink call
+           dedicated endpoints so the user can manage the link without
+           mutating other fields. *@
+        @if (editingId.HasValue)
+        {
+            <div class="d-flex align-items-center gap-2 mt-3 pt-3 border-top oh-registrace-link-row">
+                @if (model.ExternalGameId.HasValue)
+                {
+                    <span class="text-success">
+                        <i class="bi bi-link-45deg me-1"></i>
+                        Propojeno s registrací #@model.ExternalGameId
+                    </span>
+                    <button class="btn btn-outline-danger btn-sm ms-auto"
+                            @onclick="() => isUnlinkConfirmVisible = true"
+                            disabled="@isLinkBusy">
+                        <i class="bi bi-link-45deg me-1"></i>Zrušit propojení
+                    </button>
+                }
+                else
+                {
+                    <span class="text-muted">
+                        <i class="bi bi-link-45deg me-1"></i>
+                        Nepropojeno
+                    </span>
+                    <button class="btn btn-outline-primary btn-sm ms-auto"
+                            @onclick="() => isLinkPickerVisible = true"
+                            disabled="@isLinkBusy">
+                        <i class="bi bi-link-45deg me-1"></i>Propojit s registrací
+                    </button>
+                }
+            </div>
+            @if (linkActionError is not null)
+            {
+                <div class="alert alert-danger mt-2 mb-0 d-flex align-items-center gap-2">
+                    <i class="bi bi-exclamation-triangle"></i>
+                    <span>@linkActionError</span>
+                    <button type="button" class="btn-close ms-auto" aria-label="Zavřít"
+                            @onclick="() => linkActionError = null"></button>
+                </div>
+            }
+        }
+
         @if (error is not null)
         {
             <div class="alert alert-danger mt-2">@error</div>
@@ -80,6 +123,35 @@ else
                     <span class="spinner-border spinner-border-sm me-1"></span>
                 }
                 Uložit
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@* Issue #3 — picker popup for "Propojit s registrací" *@
+@if (editingId.HasValue)
+{
+    <LinkToRegistracePopup @bind-Visible="@isLinkPickerVisible"
+                           GameId="@editingId.Value"
+                           Linked="OnLinkedAsync" />
+}
+
+@* Issue #3 — unlink destructive-action confirmation *@
+<DxPopup @bind-Visible="@isUnlinkConfirmVisible" HeaderText="Zrušit propojení s registrací?" Width="400px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete zrušit propojení této hry s registrací #@model.ExternalGameId?</p>
+        <p class="text-muted small">
+            Hru můžete kdykoli znovu propojit. Žádná data v registraci se nezmění.
+        </p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary"
+                    @onclick="() => isUnlinkConfirmVisible = false"
+                    disabled="@isLinkBusy">Zrušit</button>
+            <button class="btn btn-danger"
+                    @onclick="ConfirmUnlinkAsync"
+                    disabled="@isLinkBusy">
+                @if (isLinkBusy) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Zrušit propojení
             </button>
         </div>
     </BodyContentTemplate>
@@ -110,6 +182,12 @@ else
     private int? editingId;
     private GameFormModel model = new();
     private BoundingBoxPicker.BboxValue bboxValue = BoundingBoxPicker.BboxValue.Empty;
+
+    // Issue #3 — registrace link state
+    private bool isLinkPickerVisible;
+    private bool isUnlinkConfirmVisible;
+    private bool isLinkBusy;
+    private string? linkActionError;
 
     // DateEdit works with DateTime, not DateOnly
     private DateTime startDate
@@ -217,5 +295,34 @@ else
         }
         catch (Exception ex) { error = ex.Message; }
         finally { isSaving = false; }
+    }
+
+    // Issue #3 — link/unlink handlers
+    private async Task OnLinkedAsync(int externalGameId)
+    {
+        model.ExternalGameId = externalGameId;
+        await LoadDataAsync();
+        StateHasChanged();
+    }
+
+    private async Task ConfirmUnlinkAsync()
+    {
+        if (!editingId.HasValue) return;
+        linkActionError = null;
+        isLinkBusy = true;
+        try
+        {
+            var (ok, problem) = await Api.DeleteWithProblemAsync($"/api/games/{editingId.Value}/link");
+            if (!ok)
+            {
+                linkActionError = problem ?? "Server odmítl požadavek bez podrobností.";
+                return;
+            }
+            model.ExternalGameId = null;
+            isUnlinkConfirmVisible = false;
+            await LoadDataAsync();
+        }
+        catch (Exception ex) { linkActionError = ex.Message; }
+        finally { isLinkBusy = false; }
     }
 }

--- a/src/OvcinaHra.Client/Pages/Games/LinkToRegistracePopup.razor
+++ b/src/OvcinaHra.Client/Pages/Games/LinkToRegistracePopup.razor
@@ -1,0 +1,159 @@
+@* Issue #3 — picker popup for "Propojit s registrací". Loads the
+   server-side proxy /api/games/registrace-available (which already filters
+   out games linked to other local games), lets the organizer pick one,
+   and POSTs to /api/games/{GameId}/link. Surfaces 409 ProblemDetails
+   verbatim so the user sees exactly which existing link is in the way. *@
+
+@inject ApiClient Api
+
+<DxPopup AllowResize="true" Visible="@Visible"
+         VisibleChanged="@OnVisibleChanged"
+         HeaderText="Propojit s registrací" Width="640px">
+    <BodyContentTemplate Context="popupContext">
+        @if (loading)
+        {
+            <p class="text-muted small mb-0">Načítám hry z registrace…</p>
+        }
+        else if (loadError is not null)
+        {
+            <div class="alert alert-danger mb-2">
+                <i class="bi bi-wifi-off me-1"></i>
+                @loadError
+            </div>
+        }
+        else if (_games.Count == 0)
+        {
+            <p class="text-muted small fst-italic mb-0">
+                V registraci nejsou žádné publikované hry, které by ještě nebyly propojené.
+            </p>
+        }
+        else
+        {
+            <p class="text-muted small mb-2">Vyberte hru z registrace, ke které se má tato hra připojit:</p>
+            <div class="oh-registrace-picker" role="listbox">
+                @foreach (var g in _games)
+                {
+                    var isSelected = _selectedId == g.Id;
+                    <button type="button"
+                            class="oh-registrace-picker-row @(isSelected ? "is-on" : "")"
+                            role="option" aria-selected="@isSelected"
+                            @onclick="() => _selectedId = g.Id">
+                        <div class="oh-registrace-picker-row-name">
+                            <strong>@g.Name</strong>
+                            <span class="text-muted small ms-2">#@g.Id</span>
+                        </div>
+                        <div class="oh-registrace-picker-row-meta text-muted small">
+                            @g.StartsAtUtc.ToLocalTime().ToString("d.M.yyyy") –
+                            @g.EndsAtUtc.ToLocalTime().ToString("d.M.yyyy")
+                            @if (!string.IsNullOrWhiteSpace(g.Description))
+                            {
+                                <span class="ms-2">· @g.Description</span>
+                            }
+                        </div>
+                    </button>
+                }
+            </div>
+        }
+
+        @if (linkError is not null)
+        {
+            <div class="alert alert-danger mt-2 mb-0">
+                <i class="bi bi-exclamation-triangle me-1"></i>
+                @linkError
+            </div>
+        }
+
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" @onclick="Close" disabled="@isLinking">Zrušit</button>
+            <button class="btn btn-primary"
+                    @onclick="LinkAsync"
+                    disabled="@(isLinking || _selectedId is null)">
+                @if (isLinking) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Propojit
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter] public int GameId { get; set; }
+    [Parameter] public EventCallback<int> Linked { get; set; }
+
+    private bool loading;
+    private string? loadError;
+    private bool isLinking;
+    private string? linkError;
+    private List<RegistraceGameDto> _games = new();
+    private int? _selectedId;
+    private bool _wasVisible;
+
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        var prev = Visible;
+        await base.SetParametersAsync(parameters);
+        if (Visible && !_wasVisible)
+        {
+            _selectedId = null;
+            linkError = null;
+            await LoadAsync();
+        }
+        _wasVisible = Visible;
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        loadError = null;
+        try
+        {
+            var fetched = await Api.GetListAsync<RegistraceGameDto>("/api/games/registrace-available");
+            _games = fetched
+                .OrderBy(g => g.StartsAtUtc)
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _games = new();
+            loadError = $"Nepodařilo se načíst hry z registrace: {ex.Message}";
+        }
+        finally { loading = false; }
+    }
+
+    private async Task LinkAsync()
+    {
+        if (_selectedId is null) return;
+        linkError = null;
+        isLinking = true;
+        try
+        {
+            var (ok, _, problem) = await Api.PostWithProblemAsync<LinkGameDto, object>(
+                $"/api/games/{GameId}/link",
+                new LinkGameDto(_selectedId.Value));
+            if (!ok)
+            {
+                linkError = problem ?? "Server odmítl požadavek bez podrobností.";
+                return;
+            }
+            await Linked.InvokeAsync(_selectedId.Value);
+            await Close();
+        }
+        catch (Exception ex) { linkError = ex.Message; }
+        finally { isLinking = false; }
+    }
+
+    private async Task Close()
+    {
+        Visible = false;
+        await VisibleChanged.InvokeAsync(false);
+    }
+
+    private async Task OnVisibleChanged(bool next)
+    {
+        // DxPopup raises this when the user hits the X / Escape. Forward the
+        // change to the parent so the [Parameter] mirror stays in sync.
+        Visible = next;
+        await VisibleChanged.InvokeAsync(next);
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Games/LinkToRegistracePopup.razor
+++ b/src/OvcinaHra.Client/Pages/Games/LinkToRegistracePopup.razor
@@ -91,7 +91,6 @@
 
     public override async Task SetParametersAsync(ParameterView parameters)
     {
-        var prev = Visible;
         await base.SetParametersAsync(parameters);
         if (Visible && !_wasVisible)
         {

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3142,3 +3142,18 @@
     .oh-tl-print-day:first-child{page-break-before:auto}
     .oh-tl-print-slot{page-break-inside:avoid}
 }
+
+/* Issue #3 — registrace game picker (LinkToRegistracePopup) */
+.oh-registrace-link-row{font-size:.875rem}
+.oh-registrace-picker{display:flex;flex-direction:column;gap:6px;
+    padding:6px;background:var(--oh-surface-alt,#f5f0e1);
+    border:1px solid var(--oh-border,#d8d2be);border-radius:6px;
+    max-height:340px;overflow-y:auto}
+.oh-registrace-picker-row{display:flex;flex-direction:column;gap:2px;
+    text-align:left;padding:8px 12px;border-radius:5px;
+    border:1px solid var(--oh-border,#d8d2be);
+    background:var(--oh-surface,#fff);color:var(--oh-text,#2a2a2a);
+    cursor:pointer;transition:.12s ease}
+.oh-registrace-picker-row:hover{border-color:#2D5016}
+.oh-registrace-picker-row.is-on{background:#2D5016;border-color:#2D5016;color:#fff}
+.oh-registrace-picker-row.is-on .text-muted{color:rgba(255,255,255,.78) !important}

--- a/src/OvcinaHra.Shared/Dtos/GameDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/GameDtos.cs
@@ -47,6 +47,23 @@ public record UpdateGameDto(
 /// </summary>
 public record LinkGameDto(int ExternalGameId);
 
+/// <summary>
+/// Issue #3 — picker payload for the "Propojit s registrací" UI. Shape
+/// matches registrace's <c>/api/v1/games</c> response verbatim so future
+/// fields are forward-compatible without re-mapping. Registrace already
+/// filters this list to <c>IsPublished == true</c>; the flag is included
+/// for UI labelling only.
+/// </summary>
+public record RegistraceGameDto(
+    int Id,
+    string Name,
+    string? Description,
+    DateTime StartsAtUtc,
+    DateTime EndsAtUtc,
+    DateTime? RegistrationClosesAtUtc,
+    int? TargetPlayerCountTotal,
+    bool IsPublished);
+
 public record GameSkillDto(
     int Id,
     int GameId,

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameLinkEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameLinkEndpointTests.cs
@@ -11,7 +11,8 @@ namespace OvcinaHra.Api.Tests.Endpoints;
 // /api/games/registrace-available endpoint is a thin proxy over the
 // registrace integration API; covering it here would require mocking
 // HttpClient — out of scope, that path is integration-tested by hand.
-public class GameLinkEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+public class GameLinkEndpointTests(PostgresFixture postgres)
+    : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
     private async Task<GameDetailDto> CreateGameAsync(string name)
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameLinkEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameLinkEndpointTests.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+// Issue #3 — POST/DELETE /api/games/{id}/link contract.
+// Codifies the round-trip + the new UNIQUE INDEX 409 path. The matching
+// /api/games/registrace-available endpoint is a thin proxy over the
+// registrace integration API; covering it here would require mocking
+// HttpClient — out of scope, that path is integration-tested by hand.
+public class GameLinkEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres)
+{
+    private async Task<GameDetailDto> CreateGameAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto(name, 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    [Fact]
+    public async Task Link_FreshExternalId_SetsAndReturnsNoContent()
+    {
+        var game = await CreateGameAsync("Štafeta II");
+
+        var response = await Client.PostAsJsonAsync($"/api/games/{game.Id}/link",
+            new LinkGameDto(42));
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var detail = await Client.GetFromJsonAsync<GameDetailDto>($"/api/games/{game.Id}");
+        Assert.NotNull(detail);
+        Assert.Equal(42, detail.ExternalGameId);
+    }
+
+    [Fact]
+    public async Task Link_NonExistentGame_ReturnsNotFound()
+    {
+        var response = await Client.PostAsJsonAsync("/api/games/999999/link",
+            new LinkGameDto(7));
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Link_RelinkSameGameToDifferentExternalId_Updates()
+    {
+        var game = await CreateGameAsync("Hra na opravu");
+        await Client.PostAsJsonAsync($"/api/games/{game.Id}/link", new LinkGameDto(11));
+
+        var response = await Client.PostAsJsonAsync($"/api/games/{game.Id}/link",
+            new LinkGameDto(22));
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var detail = await Client.GetFromJsonAsync<GameDetailDto>($"/api/games/{game.Id}");
+        Assert.Equal(22, detail!.ExternalGameId);
+    }
+
+    [Fact]
+    public async Task Link_ExternalIdAlreadyTaken_Returns409WithProblemDetails()
+    {
+        var first = await CreateGameAsync("První");
+        var second = await CreateGameAsync("Druhá");
+
+        var ok = await Client.PostAsJsonAsync($"/api/games/{first.Id}/link",
+            new LinkGameDto(99));
+        ok.EnsureSuccessStatusCode();
+
+        var conflict = await Client.PostAsJsonAsync($"/api/games/{second.Id}/link",
+            new LinkGameDto(99));
+        Assert.Equal(HttpStatusCode.Conflict, conflict.StatusCode);
+
+        var problem = await conflict.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal((int)HttpStatusCode.Conflict, problem.Status);
+        Assert.NotNull(problem.Detail);
+        Assert.Contains("První", problem.Detail);
+
+        // Second game must still be unlinked — no partial mutation.
+        var detail = await Client.GetFromJsonAsync<GameDetailDto>($"/api/games/{second.Id}");
+        Assert.Null(detail!.ExternalGameId);
+    }
+
+    [Fact]
+    public async Task Unlink_LinkedGame_ClearsExternalId()
+    {
+        var game = await CreateGameAsync("Pro odpojení");
+        await Client.PostAsJsonAsync($"/api/games/{game.Id}/link", new LinkGameDto(55));
+
+        var response = await Client.DeleteAsync($"/api/games/{game.Id}/link");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var detail = await Client.GetFromJsonAsync<GameDetailDto>($"/api/games/{game.Id}");
+        Assert.Null(detail!.ExternalGameId);
+    }
+
+    [Fact]
+    public async Task Unlink_AlreadyUnlinked_ReturnsNoContent()
+    {
+        // Idempotent — unlinking an unlinked game is not an error; the
+        // operation just clears an already-null field. Mirrors the
+        // existing handler contract before issue #3.
+        var game = await CreateGameAsync("Nikdy nebyla propojená");
+
+        var response = await Client.DeleteAsync($"/api/games/{game.Id}/link");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Unlink_NonExistentGame_ReturnsNotFound()
+    {
+        var response = await Client.DeleteAsync("/api/games/999999/link");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Link_ReleasesExternalIdAfterUnlink_AllowingAnotherGameToTakeIt()
+    {
+        // Verifies the filtered UNIQUE INDEX gating on NULL — once we
+        // unlink, the external id frees up for a different local game.
+        var first = await CreateGameAsync("Drží 77");
+        var second = await CreateGameAsync("Bere 77");
+
+        await Client.PostAsJsonAsync($"/api/games/{first.Id}/link", new LinkGameDto(77));
+        await Client.DeleteAsync($"/api/games/{first.Id}/link");
+
+        var response = await Client.PostAsJsonAsync($"/api/games/{second.Id}/link",
+            new LinkGameDto(77));
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3 — adds the missing UI for linking an OvčinaHra game to its registrace counterpart.

**Phase 0 design decisions confirmed by orchestrator:**
- Q2 sync direction: **A** — manual link only, no automatic data pull
- Q3 conflict resolution: **(i)** keep local Name/EditionDate
- Q4 uniqueness: **filtered UNIQUE INDEX** on `Game.ExternalGameId IS NOT NULL`
- Q5 auth model: **server-side proxy** with `X-Api-Key` (key never reaches the browser; mirrors `RegistraceImportService`)
- Q6 Czech label: **„Propojit s registrací"**
- Q7 DTO shape: matches registrace's `GameDto` verbatim for forward-compatibility

## Backend
- `GameConfiguration` — filtered UNIQUE INDEX on `ExternalGameId` (NULL coexists; once set must be unique). Migration `AddUniqueIndexOnGameExternalGameId`.
- `LinkToRegistrace` handler — pre-checks for taken external id → returns **409 ProblemDetails** naming the existing local game; race-safe `DbUpdateException` catch on Postgres `SqlState 23505`.
- New **`GET /api/games/registrace-available`** — proxies to registrace's `/api/v1/games`. Uses existing `IntegrationApi:BaseUrl` + `ApiKey` config. Filters out external ids already linked locally.
- `RegistraceGameService` — typed `HttpClient`, sends `X-Api-Key`.

## Shared
- `RegistraceGameDto` matches registrace's `GameDto` shape verbatim — `(Id, Name, Description, StartsAtUtc, EndsAtUtc, RegistrationClosesAtUtc, TargetPlayerCountTotal, IsPublished)`.

## UI (GameList edit popup)
- "Propojit s registrací" / "Zrušit propojení" row gated on `editingId`, independent of Save/Cancel — link state mutates only via the dedicated endpoints.
- Destructive unlink routes through `DxPopup` confirm.
- Picker popup loads `/api/games/registrace-available` and surfaces 409 ProblemDetails verbatim.

## Tests (8 new in `GameLinkEndpointTests`)
- Round-trip link, relink to a different external id, link to non-existent game → 404
- UNIQUE 409 with `ProblemDetail` naming the conflicting game
- Unlink linked + unlink already-unlinked + unlink non-existent → 404
- Filtered UNIQUE releases the id after unlink (another game can take it)

## Test plan
- [x] `dotnet build OvcinaHra.slnx` clean (0W/0E)
- [x] `dotnet test tests/OvcinaHra.Api.Tests` — **365 passed, 0 failed** (9m35s)
- [x] New `GameLinkEndpointTests` — 8/8
- [ ] Manual smoke once `IntegrationApi:ApiKey` is set in deployed env: open `/games`, edit a game, click "Propojit s registrací", verify list, pick one, unlink, verify state round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)