### PR TITLE
feat(treasures): preview-then-confirm UX on bulk pool refill

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -298,8 +298,13 @@ public static class TreasurePlanningEndpoints
     /// or a fresh pool row is created. Items where allocations already exceed
     /// stock are skipped and listed in <see cref="RefillPoolResponse.OverAllocated"/>.
     /// </summary>
-    private static async Task<Ok<RefillPoolResponse>> RefillPool(int gameId, WorldDbContext db)
+    private static async Task<Ok<RefillPoolResponse>> RefillPool(int gameId, bool? dryRun, WorldDbContext db)
     {
+        // Optional preview mode — compute the same response shape without
+        // persisting. UI fetches a preview before showing the confirm popup
+        // so the user reviews exactly what will be added before committing.
+        var preview = dryRun == true;
+
         // Wrap the read-then-write in SERIALIZABLE so two concurrent refills
         // can't both compute `remaining` from the same allocation snapshot
         // and double-append. Postgres will retry-fail one of the txns; the
@@ -391,25 +396,35 @@ public static class TreasurePlanningEndpoints
             // pool row (stacks via Count +=). The /pool POST endpoint
             // currently creates fresh rows on every call — refill smooths
             // that over so re-running this action is idempotent.
-            if (existingPoolByItem.TryGetValue(gi.ItemId, out var existingPool))
+            if (!preview)
             {
-                existingPool.Count += remaining;
-            }
-            else
-            {
-                db.TreasureItems.Add(new TreasureItem
+                if (existingPoolByItem.TryGetValue(gi.ItemId, out var existingPool))
                 {
-                    GameId = gameId,
-                    ItemId = gi.ItemId,
-                    TreasureQuestId = null,
-                    Count = remaining
-                });
+                    existingPool.Count += remaining;
+                }
+                else
+                {
+                    db.TreasureItems.Add(new TreasureItem
+                    {
+                        GameId = gameId,
+                        ItemId = gi.ItemId,
+                        TreasureQuestId = null,
+                        Count = remaining
+                    });
+                }
             }
             added.Add(new RefillPoolItemDto(gi.ItemId, gi.Item.Name, remaining));
         }
 
-        await db.SaveChangesAsync();
-        await tx.CommitAsync();
+        if (preview)
+        {
+            await tx.RollbackAsync();
+        }
+        else
+        {
+            await db.SaveChangesAsync();
+            await tx.CommitAsync();
+        }
 
         return TypedResults.Ok(new RefillPoolResponse(
             ItemsAdded: added.Sum(a => a.Added),

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -17,8 +17,9 @@
            confirmation per feedback_ovcinahra_destructive_confirm; this
            isn't destructive but it IS bulk + irreversible-without-cleanup. *@
         <button class="btn btn-outline-primary btn-sm" type="button"
-                @onclick="() => isRefillConfirmVisible = true" disabled="@isRefilling"
-                title="Spočítá zbývající stock pro každý nalézatelný předmět a doplní zásobník.">
+                @onclick="OpenRefillPreviewAsync" disabled="@(isRefilling || _isLoadingPreview)"
+                title="Spočítá zbývající stock pro každý nalézatelný předmět a zobrazí náhled toho, co se doplní.">
+            @if (_isLoadingPreview) { <span class="spinner-border spinner-border-sm me-1"></span> }
             <i class="bi bi-arrow-down-circle me-1"></i> Doplnit vše zbývající k schování do zásobníku
         </button>
         <button class="btn btn-primary btn-sm" type="button" @onclick="OpenAddToPoolModal">
@@ -419,27 +420,86 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
-@* Issue #160 sub-task C — bulk refill confirm. *@
-<DxPopup @bind-Visible="@isRefillConfirmVisible" HeaderText="Doplnit zásobník?" Width="540px">
+@* Issue #160 sub-task C — bulk refill preview + confirm. Preview fetched
+   on open via dryRun=true so user sees exactly what will be added before
+   committing. *@
+<DxPopup @bind-Visible="@isRefillConfirmVisible" HeaderText="Náhled doplnění zásobníku" Width="640px">
     <BodyContentTemplate Context="popupContext">
-        <p>
-            Spočítáme zbývající stock pro každý předmět s <strong>nalézatelným</strong> příznakem
-            (<em>IsFindable</em>) a doplníme rozdíl do zásobníku.
-        </p>
-        <ul class="small text-muted mb-3">
-            <li>Stock se počítá per-hru z <code>GameItem.StockCount</code>.</li>
-            <li>Alokace = <strong>zásobník + skryté poklady + odměny questů + osobní questy</strong>.</li>
-            <li>Předměty s alokacemi nad rámec stocku se přeskočí a označí pro manuální revizi.</li>
-        </ul>
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" type="button"
-                    @onclick="() => isRefillConfirmVisible = false" disabled="@isRefilling">Zrušit</button>
-            <button class="btn btn-primary" type="button"
-                    @onclick="RefillPoolAsync" disabled="@isRefilling">
-                @if (isRefilling) { <span class="spinner-border spinner-border-sm me-1"></span> }
-                Doplnit
-            </button>
-        </div>
+        @if (_refillPreview is null)
+        {
+            <p class="text-muted mb-0"><span class="spinner-border spinner-border-sm me-2"></span>Počítám náhled…</p>
+        }
+        else if (_refillPreview.Added.Count == 0 && _refillPreview.OverAllocated.Count == 0)
+        {
+            <p class="mb-3">
+                <i class="bi bi-check2-circle text-success me-1"></i>
+                <strong>Žádné předměty k doplnění.</strong> Všechny nalézatelné položky jsou už alokované do limitu stocku.
+            </p>
+            <div class="d-flex gap-2 justify-content-end">
+                <button class="btn btn-secondary" type="button" @onclick="CloseRefillPreview">Zavřít</button>
+            </div>
+        }
+        else
+        {
+            <p class="small text-muted mb-2">
+                Po potvrzení se do zásobníku doplní následující předměty (rozdíl mezi stockem a všemi alokacemi).
+            </p>
+            @if (_refillPreview.Added.Count > 0)
+            {
+                <div class="table-responsive mb-3" style="max-height: 320px; overflow-y: auto;">
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>Předmět</th>
+                                <th class="text-end" style="width: 90px;">Doplnit</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var a in _refillPreview.Added)
+                            {
+                                <tr>
+                                    <td>@a.ItemName</td>
+                                    <td class="text-end"><strong>+@a.Added</strong></td>
+                                </tr>
+                            }
+                        </tbody>
+                        <tfoot>
+                            <tr class="table-light">
+                                <td><strong>Celkem</strong></td>
+                                <td class="text-end"><strong>+@_refillPreview.Added.Sum(a => a.Added)</strong></td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            }
+            @if (_refillPreview.OverAllocated.Count > 0)
+            {
+                <div class="alert alert-warning small mb-3">
+                    <strong>
+                        <i class="bi bi-exclamation-triangle me-1"></i>
+                        @_refillPreview.OverAllocated.Count předmětů má více alokací než stock — přeskočí se:
+                    </strong>
+                    <ul class="mb-0 mt-1">
+                        @foreach (var oa in _refillPreview.OverAllocated)
+                        {
+                            <li>@oa.ItemName: stock @oa.StockCount, alokovaných @oa.Allocated (přebytek @oa.Excess)</li>
+                        }
+                    </ul>
+                </div>
+            }
+            <div class="d-flex gap-2 justify-content-end">
+                <button class="btn btn-secondary" type="button"
+                        @onclick="CloseRefillPreview" disabled="@isRefilling">Zrušit</button>
+                @if (_refillPreview.Added.Count > 0)
+                {
+                    <button class="btn btn-primary" type="button"
+                            @onclick="RefillPoolAsync" disabled="@isRefilling">
+                        @if (isRefilling) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                        Doplnit (@_refillPreview.Added.Sum(a => a.Added) předmětů)
+                    </button>
+                }
+            </div>
+        }
     </BodyContentTemplate>
 </DxPopup>
 
@@ -557,6 +617,8 @@ else
     // Issue #160 sub-task C — bulk refill state.
     private bool isRefillConfirmVisible;
     private bool isRefilling;
+    private bool _isLoadingPreview;
+    private RefillPoolResponse? _refillPreview;
     private RefillPoolResponse? _refillResult;
     private string? _refillError;
     private int? poolItemId;
@@ -869,6 +931,49 @@ else
     // (TreasureItem pool + treasure-quest, QuestReward, PersonalQuestItemReward),
     // then appends the unallocated remainder to the pool. Items already over-
     // allocated are skipped and surfaced for manual review.
+
+    // Open the popup and fetch a dry-run preview so the user reviews exactly
+    // what will be added before committing. Bulk + irreversible-without-cleanup
+    // → preview-then-confirm beats a single confirm dialog.
+    private async Task OpenRefillPreviewAsync()
+    {
+        _refillError = null;
+        _refillPreview = null;
+        _isLoadingPreview = true;
+        isRefillConfirmVisible = true;
+        try
+        {
+            var (ok, value, problem) = await Api.PostWithProblemAsync<object, RefillPoolResponse>(
+                $"/api/treasure-planning/refill-pool/{gameId}?dryRun=true",
+                new { });
+            if (!ok)
+            {
+                _refillError = problem ?? "Server odmítl požadavek bez podrobností.";
+                isRefillConfirmVisible = false;
+            }
+            else
+            {
+                _refillPreview = value;
+            }
+        }
+        catch (Exception ex)
+        {
+            _refillError = ex.Message;
+            isRefillConfirmVisible = false;
+        }
+        finally
+        {
+            _isLoadingPreview = false;
+            StateHasChanged();
+        }
+    }
+
+    private void CloseRefillPreview()
+    {
+        isRefillConfirmVisible = false;
+        _refillPreview = null;
+    }
+
     private async Task RefillPoolAsync()
     {
         _refillError = null;
@@ -897,6 +1002,7 @@ else
             // on failure hides the error banner behind the modal.
             isRefillConfirmVisible = false;
             isRefilling = false;
+            _refillPreview = null;
             StateHasChanged();
         }
     }


### PR DESCRIPTION
## What

The "Doplnit vše zbývající k schování do zásobníku" button now shows a **preview** of items + counts before the user confirms.

## Why

Bulk + irreversible-without-cleanup actions deserve real preview, not a static "are you sure?" dialog. The organizer needs to know exactly what's about to land in the pool.

## How

**Backend** — optional `?dryRun=true` on `POST /api/treasure-planning/refill-pool/{gameId}`. Same allocation math, response shape unchanged, but the transaction rolls back instead of committing.

**Frontend** — button click fetches preview first, popup renders three states:
- Loading spinner while preview fetches
- Empty: "Žádné předměty k doplnění" if all stock is allocated
- Preview: table of items + per-item +N counts + total, plus over-allocated warning section if any items exceed stock. Buttons: `Zrušit` / `Doplnit (N předmětů)`.

## Manual verification

1. `/treasures` with a game that has IsFindable items + remaining stock → click button
2. Popup loads preview, shows table
3. Cancel → no DB writes, popup closes, preview state cleared
4. Confirm → real POST runs, items land in pool, popup closes, success banner appears
5. Re-click on already-balanced game → popup shows empty state, no items to add

## Risk

Low — adds a new query param (no breaking change to existing callers; default behaviour unchanged when `dryRun` is absent or `false`). UI changes are scoped to one popup body.