### PR TITLE
fix(import): use Game.ExternalGameId for registrace fetches; 400 when unlinked (closes #191)

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
@@ -264,14 +264,21 @@ public static class CharacterEndpoints
             var result = await importService.ImportAsync(gameId);
             return TypedResults.Ok(result);
         }
+        catch (GameNotFoundException)
+        {
+            return TypedResults.Problem(
+                detail: RegistraceImportProblems.NotFoundDetail(gameId),
+                title: RegistraceImportProblems.NotFoundTitle,
+                statusCode: StatusCodes.Status404NotFound);
+        }
         catch (GameNotLinkedToRegistraceException)
         {
             // Issue #191 — pre-empt the upstream call when the local game
             // has no registrace counterpart. The Czech detail string is
             // surfaced verbatim by ApiClient.PostWithProblemAsync.
             return TypedResults.Problem(
-                detail: "Tato hra ještě není propojená s registrací. Otevřete Správu her, otevřete tuto hru a klikněte na tlačítko Propojit s registrací.",
-                title: "Hra není propojená s registrací.",
+                detail: RegistraceImportProblems.NotLinkedDetail,
+                title: RegistraceImportProblems.NotLinkedTitle,
                 statusCode: StatusCodes.Status400BadRequest);
         }
     }

--- a/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
@@ -256,10 +256,23 @@ public static class CharacterEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Ok<ImportResultDto>> ImportFromRegistrace(
+    private static async Task<Results<Ok<ImportResultDto>, ProblemHttpResult>> ImportFromRegistrace(
         int gameId, RegistraceImportService importService)
     {
-        var result = await importService.ImportAsync(gameId);
-        return TypedResults.Ok(result);
+        try
+        {
+            var result = await importService.ImportAsync(gameId);
+            return TypedResults.Ok(result);
+        }
+        catch (GameNotLinkedToRegistraceException)
+        {
+            // Issue #191 — pre-empt the upstream call when the local game
+            // has no registrace counterpart. The Czech detail string is
+            // surfaced verbatim by ApiClient.PostWithProblemAsync.
+            return TypedResults.Problem(
+                detail: "Tato hra ještě není propojená s registrací. Otevřete Správu her, otevřete tuto hru a klikněte na tlačítko Propojit s registrací.",
+                title: "Hra není propojená s registrací.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
@@ -39,6 +39,14 @@ public static class NpcEndpoints
             var adults = await registrace.FetchAdultsAsync(gameId);
             return TypedResults.Ok(adults);
         }
+        catch (GameNotLinkedToRegistraceException)
+        {
+            // Issue #191 — same shape as the character import 400 path.
+            return TypedResults.Problem(
+                detail: "Tato hra ještě není propojená s registrací. Otevřete Správu her, otevřete tuto hru a klikněte na tlačítko Propojit s registrací.",
+                title: "Hra není propojená s registrací.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
         catch (HttpRequestException ex)
         {
             return TypedResults.Problem(

--- a/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
@@ -39,12 +39,20 @@ public static class NpcEndpoints
             var adults = await registrace.FetchAdultsAsync(gameId);
             return TypedResults.Ok(adults);
         }
+        catch (GameNotFoundException)
+        {
+            return TypedResults.Problem(
+                detail: RegistraceImportProblems.NotFoundDetail(gameId),
+                title: RegistraceImportProblems.NotFoundTitle,
+                statusCode: StatusCodes.Status404NotFound);
+        }
         catch (GameNotLinkedToRegistraceException)
         {
-            // Issue #191 — same shape as the character import 400 path.
+            // Issue #191 — same shape as the character import 400 path,
+            // sourced from the shared helper to avoid copy drift.
             return TypedResults.Problem(
-                detail: "Tato hra ještě není propojená s registrací. Otevřete Správu her, otevřete tuto hru a klikněte na tlačítko Propojit s registrací.",
-                title: "Hra není propojená s registrací.",
+                detail: RegistraceImportProblems.NotLinkedDetail,
+                title: RegistraceImportProblems.NotLinkedTitle,
                 statusCode: StatusCodes.Status400BadRequest);
         }
         catch (HttpRequestException ex)

--- a/src/OvcinaHra.Api/Services/RegistraceImportService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceImportService.cs
@@ -21,6 +21,34 @@ public sealed class GameNotLinkedToRegistraceException(int localGameId)
     public int LocalGameId { get; } = localGameId;
 }
 
+/// <summary>
+/// Thrown when the import service is asked to operate on a local game
+/// that doesn't exist (#191). Distinct from
+/// <see cref="GameNotLinkedToRegistraceException"/> so endpoints can
+/// return 404 vs 400 — Copilot flagged the original conflation.
+/// </summary>
+public sealed class GameNotFoundException(int localGameId)
+    : Exception($"Local game {localGameId} does not exist.")
+{
+    public int LocalGameId { get; } = localGameId;
+}
+
+/// <summary>
+/// Issue #191 — single source of truth for the Czech ProblemDetails
+/// strings the import endpoints surface. Lets us tweak copy or wire a
+/// new CTA without hunting both endpoints.
+/// </summary>
+public static class RegistraceImportProblems
+{
+    public const string NotLinkedTitle = "Hra není propojená s registrací.";
+    public const string NotLinkedDetail =
+        "Tato hra ještě není propojená s registrací. Otevřete Správu her, otevřete tuto hru a klikněte na tlačítko Propojit s registrací.";
+
+    public const string NotFoundTitle = "Hra nenalezena.";
+    public static string NotFoundDetail(int localGameId) =>
+        $"Hra s ID {localGameId} v této instanci OvčinaHra neexistuje.";
+}
+
 public class RegistraceImportService(HttpClient httpClient, IConfiguration configuration, WorldDbContext db)
 {
     private readonly string _baseUrl = configuration["IntegrationApi:BaseUrl"] ?? "https://registrace.ovcina.cz";
@@ -28,18 +56,30 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
 
     /// <summary>
     /// Issue #191 — resolve the registrace counterpart id for a local game.
-    /// Throws <see cref="GameNotLinkedToRegistraceException"/> when not linked
-    /// rather than silently using the wrong id (the pre-#191 behavior).
+    /// Three outcomes:
+    /// <list type="bullet">
+    ///   <item>game exists + linked → returns <c>ExternalGameId</c></item>
+    ///   <item>game exists + unlinked → throws <see cref="GameNotLinkedToRegistraceException"/></item>
+    ///   <item>game does not exist → throws <see cref="GameNotFoundException"/></item>
+    /// </list>
+    /// The two exception types let endpoints return 400 vs 404 distinctly
+    /// — pre-fixup the missing-game case was masquerading as not-linked.
     /// </summary>
     private async Task<int> ResolveExternalGameIdAsync(int localGameId)
     {
-        var externalId = await db.Games
+        // Fetch a wrapper struct so a null ExternalGameId on an existing
+        // game doesn't collapse to the same "no row" sentinel. Without
+        // this projection the FirstOrDefault would return 0/null both
+        // when the game is missing and when it's unlinked.
+        var row = await db.Games
             .Where(g => g.Id == localGameId)
-            .Select(g => g.ExternalGameId)
+            .Select(g => new { g.ExternalGameId })
             .FirstOrDefaultAsync();
-        if (externalId is null)
+        if (row is null)
+            throw new GameNotFoundException(localGameId);
+        if (row.ExternalGameId is null)
             throw new GameNotLinkedToRegistraceException(localGameId);
-        return externalId.Value;
+        return row.ExternalGameId.Value;
     }
 
     /// <summary>

--- a/src/OvcinaHra.Api/Services/RegistraceImportService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceImportService.cs
@@ -9,13 +9,48 @@ using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Api.Services;
 
+/// <summary>
+/// Thrown when a caller asks the import service to do work for a local
+/// OvčinaHra Game that has no <c>ExternalGameId</c> (#191). Endpoints
+/// translate this into a 400 ProblemDetails so the UI can surface a
+/// "není propojená s registrací" CTA pointing at the link picker (#187).
+/// </summary>
+public sealed class GameNotLinkedToRegistraceException(int localGameId)
+    : Exception($"Game {localGameId} is not linked to a registrace game (Game.ExternalGameId is null).")
+{
+    public int LocalGameId { get; } = localGameId;
+}
+
 public class RegistraceImportService(HttpClient httpClient, IConfiguration configuration, WorldDbContext db)
 {
     private readonly string _baseUrl = configuration["IntegrationApi:BaseUrl"] ?? "https://registrace.ovcina.cz";
     private readonly string? _apiKey = configuration["IntegrationApi:ApiKey"];
 
-    public async Task<ImportResultDto> ImportAsync(int gameId)
+    /// <summary>
+    /// Issue #191 — resolve the registrace counterpart id for a local game.
+    /// Throws <see cref="GameNotLinkedToRegistraceException"/> when not linked
+    /// rather than silently using the wrong id (the pre-#191 behavior).
+    /// </summary>
+    private async Task<int> ResolveExternalGameIdAsync(int localGameId)
     {
+        var externalId = await db.Games
+            .Where(g => g.Id == localGameId)
+            .Select(g => g.ExternalGameId)
+            .FirstOrDefaultAsync();
+        if (externalId is null)
+            throw new GameNotLinkedToRegistraceException(localGameId);
+        return externalId.Value;
+    }
+
+    /// <summary>
+    /// Imports player characters for the local OvčinaHra game with id
+    /// <paramref name="localGameId"/>. Resolves the registrace counterpart
+    /// from <c>Game.ExternalGameId</c> internally — callers no longer need
+    /// to (and should not) hand over a registrace id directly.
+    /// </summary>
+    public async Task<ImportResultDto> ImportAsync(int localGameId)
+    {
+        var externalGameId = await ResolveExternalGameIdAsync(localGameId);
         var created = 0;
         var updated = 0;
         var skipped = 0;
@@ -24,7 +59,7 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
         List<RegistraceCharacterRecord> records;
         try
         {
-            records = await FetchCharactersAsync(gameId);
+            records = await FetchCharactersAsync(externalGameId);
         }
         catch (Exception ex)
         {
@@ -82,9 +117,13 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
                         character.IsDeleted = false;
                 }
 
-                // Look up assignment by GameId + ExternalPersonId
+                // Look up assignment by local GameId + ExternalPersonId.
+                // Pre-#191 this used the same `gameId` variable that was
+                // also passed to the registrace fetch URL — broken if the
+                // local id and registrace id ever diverge. Now resolved
+                // separately at the top of ImportAsync.
                 var assignment = await db.CharacterAssignments
-                    .FirstOrDefaultAsync(a => a.GameId == gameId && a.ExternalPersonId == record.PersonId);
+                    .FirstOrDefaultAsync(a => a.GameId == localGameId && a.ExternalPersonId == record.PersonId);
 
                 PlayerClass? playerClass = null;
                 if (!string.IsNullOrWhiteSpace(record.ClassOrType))
@@ -103,7 +142,7 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
                     assignment = new CharacterAssignment
                     {
                         CharacterId = character.Id,
-                        GameId = gameId,
+                        GameId = localGameId,
                         ExternalPersonId = record.PersonId,
                         RegistraceCharacterId = record.CharacterId,
                         Class = playerClass,
@@ -134,10 +173,10 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
         return new ImportResultDto(created, updated, skipped, errors);
     }
 
-    private async Task<List<RegistraceCharacterRecord>> FetchCharactersAsync(int gameId)
+    private async Task<List<RegistraceCharacterRecord>> FetchCharactersAsync(int externalGameId)
     {
         var request = new HttpRequestMessage(HttpMethod.Get,
-            $"{_baseUrl.TrimEnd('/')}/api/v1/games/{gameId}/characters");
+            $"{_baseUrl.TrimEnd('/')}/api/v1/games/{externalGameId}/characters");
 
         if (!string.IsNullOrWhiteSpace(_apiKey))
             request.Headers.Add("X-Api-Key", _apiKey);
@@ -150,10 +189,19 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
     }
 
-    public async Task<List<RegistraceAdultDto>> FetchAdultsAsync(int gameId)
+    /// <summary>
+    /// Fetches the registrace "adults" list for the local game with id
+    /// <paramref name="localGameId"/>. Used by the NPC picker to let
+    /// organizers attach a real-world person to an NPC. Resolves
+    /// <c>Game.ExternalGameId</c> internally — see <see cref="ImportAsync"/>
+    /// for the same #191 contract.
+    /// </summary>
+    public async Task<List<RegistraceAdultDto>> FetchAdultsAsync(int localGameId)
     {
+        var externalGameId = await ResolveExternalGameIdAsync(localGameId);
+
         var request = new HttpRequestMessage(HttpMethod.Get,
-            $"{_baseUrl.TrimEnd('/')}/api/v1/games/{gameId}/adults");
+            $"{_baseUrl.TrimEnd('/')}/api/v1/games/{externalGameId}/adults");
 
         if (!string.IsNullOrWhiteSpace(_apiKey))
             request.Headers.Add("X-Api-Key", _apiKey);

--- a/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
+++ b/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
@@ -464,11 +464,21 @@ else
     private async Task ImportAsync()
     {
         if (!GameContext.SelectedGameId.HasValue) return;
-        isImporting = true; importResult = null;
+        isImporting = true; importResult = null; error = null;
         try
         {
-            importResult = await Api.PostAsync<object, ImportResultDto>(
+            // Issue #191 — server may return 400 ProblemDetails when the
+            // local game is not yet linked to registrace. PostWithProblemAsync
+            // surfaces the Czech detail string verbatim ("…klikněte na
+            // „Propojit s registrací"") so the organizer knows what to do.
+            var (ok, value, problem) = await Api.PostWithProblemAsync<object, ImportResultDto>(
                 $"/api/characters/import/{GameContext.SelectedGameId}", new { });
+            if (!ok)
+            {
+                error = problem ?? "Server odmítl požadavek bez podrobností.";
+                return;
+            }
+            importResult = value;
             await LoadAsync();
             await LoadParentSourceAsync();
         }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/RegistraceImportNotLinkedTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/RegistraceImportNotLinkedTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+// Issue #191 — when a local OvčinaHra game has no ExternalGameId, both
+// import surfaces (POST /api/characters/import/{id} and the NPC picker
+// GET /api/npcs/available-players/{id}) must return 400 ProblemDetails
+// before ever reaching out to registrace. This codifies the contract.
+//
+// Happy-path import is intentionally not tested here — it would require a
+// live registrace integration API or a stubbed HttpMessageHandler, both
+// outside the test fixture's scope. The 400 path runs entirely against
+// the local DB so it's deterministic.
+public class RegistraceImportNotLinkedTests(PostgresFixture postgres)
+    : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    private async Task<GameDetailDto> CreateGameAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto(name, 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    [Fact]
+    public async Task Import_GameNotLinked_Returns400ProblemDetails()
+    {
+        var game = await CreateGameAsync("Bez registrace");
+
+        var response = await Client.PostAsJsonAsync(
+            $"/api/characters/import/{game.Id}", new { });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal((int)HttpStatusCode.BadRequest, problem.Status);
+        Assert.NotNull(problem.Detail);
+        Assert.Contains("propojená s registrací", problem.Detail);
+    }
+
+    [Fact]
+    public async Task AvailablePlayers_GameNotLinked_Returns400ProblemDetails()
+    {
+        var game = await CreateGameAsync("NPC bez registrace");
+
+        var response = await Client.GetAsync($"/api/npcs/available-players/{game.Id}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal((int)HttpStatusCode.BadRequest, problem.Status);
+        Assert.NotNull(problem.Detail);
+        Assert.Contains("propojená s registrací", problem.Detail);
+    }
+
+    [Fact]
+    public async Task Import_GameLinkedButRegistraceUnreachable_DoesNotShortCircuitWith400()
+    {
+        // When ExternalGameId is set we expect the service to reach the
+        // upstream HTTP call. In the test environment registrace is
+        // unreachable, so ImportAsync's catch-block returns an empty
+        // ImportResultDto with the network error string in `Errors`.
+        // Importantly, the response body is NOT a 400 — the "not linked"
+        // short-circuit must not fire when ExternalGameId is non-null.
+        var game = await CreateGameAsync("Propojená");
+        var link = await Client.PostAsJsonAsync($"/api/games/{game.Id}/link",
+            new LinkGameDto(424242));
+        link.EnsureSuccessStatusCode();
+
+        var response = await Client.PostAsJsonAsync(
+            $"/api/characters/import/{game.Id}", new { });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ImportResultDto>();
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Created);
+        Assert.Equal(0, result.Updated);
+        Assert.NotEmpty(result.Errors); // network failure surfaced, not a 400
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OvcinaHra.Api.Data;
@@ -19,6 +20,22 @@ public class ApiWebApplicationFactory : WebApplicationFactory<Program>
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        // Issue #191 — pin the registrace integration base URL to a known
+        // unreachable loopback so any RegistraceImportService HTTP call in
+        // tests fails deterministically instead of depending on whether
+        // the dev/CI environment can reach https://registrace.ovcina.cz.
+        // Tests that need the upstream "linked but unreachable" path
+        // assert on the resulting Errors list; tests that gate on the
+        // "not linked" 400 short-circuit never reach the network anyway.
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["IntegrationApi:BaseUrl"] = "http://127.0.0.1:1",
+                ["IntegrationApi:ApiKey"] = "test-key-not-used"
+            });
+        });
+
         builder.ConfigureServices(services =>
         {
             // Remove the existing DbContext registration


### PR DESCRIPTION
## Summary

Closes #191. **Correctness fix**, not just a UX cleanup.

Pre-#191 `RegistraceImportService.ImportAsync` overloaded a single `gameId` parameter for two different purposes:
- registrace fetch URL `https://registrace.ovcina.cz/api/v1/games/{gameId}/characters` (expects **registrace** id)
- `CharacterAssignment.GameId = gameId` (local FK)

These match in production today only by coincidence. As soon as a local `Game.Id` ever diverges from its registrace counterpart, the import fetched the wrong roster from registrace while writing rows under the right local id. Same conflation in `FetchAdultsAsync` (NPC picker).

After this PR: the service resolves `Game.ExternalGameId` from the local id once, uses it ONLY for upstream URLs, keeps the local id for FKs. Unlinked games short-circuit with **400 ProblemDetails** ("Tato hra ještě není propojená s registrací …") so the organizer is sent to the link picker added in #187.

## Backend

- New `GameNotLinkedToRegistraceException` (in the import service file).
- `RegistraceImportService.ImportAsync(int localGameId)` and `FetchAdultsAsync(int localGameId)` now go through a private `ResolveExternalGameIdAsync` helper.
- `POST /api/characters/import/{gameId}` returns 400 ProblemDetails when not linked.
- `GET /api/npcs/available-players/{gameId}` gets the same 400 path on top of its existing 502 fallback.

## Client

- `CharacterList.ImportAsync` switched to `Api.PostWithProblemAsync` so the Czech detail string surfaces verbatim in the existing error banner. No new UI surface added.

## Scope clarification

Per the existing memory rule, import is **players only**. Adults / NPC picker still works the same way feature-wise — only the underlying id-conflation bug got fixed there.

## Tests (3 new in `RegistraceImportNotLinkedTests`)

- Import on a game without `ExternalGameId` → 400 with ProblemDetail mentioning `propojená s registrací`.
- NPC available-players on a game without `ExternalGameId` → 400 with the same Czech detail.
- Import on a **linked** game still attempts the upstream call (registrace unreachable in test env, surfaces in `ImportResultDto.Errors` rather than 400) — verifies the short-circuit only fires when truly unlinked.

## Test plan
- [x] `dotnet build OvcinaHra.slnx` clean (0W/0E)
- [x] `dotnet test tests/OvcinaHra.Api.Tests` — 374/374 passed (34s)
- [x] New `RegistraceImportNotLinkedTests` — 3/3
- [ ] Manual smoke once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)