### PR TITLE
fix(skills): rename Přidat ze šablony → Přidat z katalogu (closes #194)

### DIFF
--- a/src/OvcinaHra.Client/Pages/Games/GameSkills.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameSkills.razor
@@ -14,7 +14,7 @@
            the entry points lead straight to the right step. *@
         <button class="btn btn-primary" type="button" @onclick="OpenFromTemplateStep"
                 title="Vytvořit kopii z existující šablony">
-            <i class="bi bi-stack"></i> Přidat ze šablony
+            <i class="bi bi-stack"></i> Přidat z katalogu
         </button>
         <button class="btn btn-outline-primary" type="button" @onclick="OpenCustomEdit"
                 title="Vytvořit dovednost úplně od nuly">
@@ -506,7 +506,7 @@ else
         xpCost = 0;
         levelRequirement = null;
 
-        editTitle = $"Přidat ze šablony: {tpl.Name}";
+        editTitle = $"Přidat z katalogu: {tpl.Name}";
         isEditVisible = true;
     }
 


### PR DESCRIPTION
**Report @ 22:45 (UTC+2)** — trivial Czech-label rename.

## Scope

Two user-facing strings in `Pages/Games/GameSkills.razor`:
- Line 17 — primary button label
- Line 509 — edit popup title format string `editTitle = $"Přidat z katalogu: {tpl.Name}"`

Rationale: button used internal jargon ("šablona" / template); user mental model is the catalog they see in the UI.

## Conservative scope per brief — flagged for follow-up

Following brief's "err on the side of NOT renaming and ask in PR description" — these "šablon" hits are still in the file. If you want a broader sweep, just say so and I'll do a follow-up:

| Line | String | Why I left it |
|---|---|---|
| 16 | `title="Vytvořit kopii z existující šablony"` | tooltip on the renamed button — likely should match, but brief said be conservative |
| 146 / 150 / 154 | Chooser popup body + "Ze šablony" choice button | parallel to "Vlastní" — domain semantic, action-label call |
| 167 | Picker popup `HeaderText="Vybrat šablonu"` | popup header for the inner template-pick step |
| 172 / 182 | Empty state + ComboBox NullText | template-pick popup internals |
| 57 | Source badge `Šablona #N` | brief explicitly says leave (domain concept) |
| 73 | Drift hint `Pole se liší od šablony` | brief explicitly says leave (domain concept) |

## §20 self-check

```
src/OvcinaHra.Client/Pages/Games/GameSkills.razor | 4 ++--
1 file changed, 2 insertions(+), 2 deletions(-)
```

One file, two line swaps. Residual scan for `Přidat ze šablony` returns no matches.

## Test plan

- [x] `dotnet build src/OvcinaHra.Client/OvcinaHra.Client.csproj` — 0W/0E
- [ ] Manual smoke once deployed: `/games/{id}/skills` button reads "Přidat z katalogu"; clicking opens the picker; picking a template opens the edit popup with header "Přidat z katalogu: {name}"

🤖 Generated with [Claude Code](https://claude.com/claude-code)