### PR TITLE
hotfix(grid): allow inline edit when EditCell mode is active

### DIFF
--- a/src/OvcinaHra.Client/Components/OvcinaGrid.razor
+++ b/src/OvcinaHra.Client/Components/OvcinaGrid.razor
@@ -22,7 +22,7 @@
 <DxGrid Data="@Data"
         KeyFieldName="@KeyFieldName"
         SelectionMode="@SelectionMode"
-        AllowSelectRowByClick="true"
+        AllowSelectRowByClick="@(EditMode != GridEditMode.EditCell)"
         SelectedDataItems="@SelectedDataItems"
         SelectedDataItemsChanged="@SelectedDataItemsChanged"
         RowClick="@RowClick"


### PR DESCRIPTION
User reported they cannot enter inline-edit on the Items grid despite:
- Effect column visible by default
- CellEditTemplate properly defined with DxTextBox  
- EditMode=GridEditMode.EditCell on the grid
- EditModelSaving handler wired

## Root cause

OvcinaGrid wrapper hardcoded \`AllowSelectRowByClick=\"true\"\`. DxGrid's row-selection-on-click handler fires before the cell-edit activation, swallowing the click. The user clicks → row gets selected → cell never enters edit mode.

The wrapper comment lines 12-13 promised:
> \"In EditCell mode, clicking an editable cell enters edit; clicking elsewhere still fires RowClick\"

…but this never actually worked because of the unconditional selection-by-click.

## Fix

One line. Bind AllowSelectRowByClick to \`EditMode != GridEditMode.EditCell\`:

- Read-only grids + PopupEditForm grids: keep click-to-select (no behavior change)
- EditCell grids (Items catalog + game): clicks reach the cell-edit handler

## Risk

One-line change in the shared wrapper. The 9 read-only grids see no behavior change (their EditMode is null → defaults to PopupEditForm → AllowSelectRowByClick stays true). Only the Items catalog + game grids — the only EditCell consumers — change behavior, and the change is exactly what the wrapper comment promised should already work.

## Manual verification

1. \`/items\` (catalog) — click on Effect cell → DxTextBox appears → type → Tab/blur → save fires.
2. \`/items\` (game view) — click on any inline-editable cell (Cena, Sklad, Effect) → same flow.
3. Other grids (Locations, Monsters, Quests, etc.) — row click still selects/peeks as before.