### PR TITLE
feat(treasures): Karty view + region grouping + kind filter

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -190,7 +190,8 @@ public static class TreasurePlanningEndpoints
                 CountByDifficulty(GameTimePhase.Lategame),
                 allQuests.SelectMany(q => q.TreasureItems).Sum(ti => ti.Count),
                 loc.GameSecretStashes.Count, 3,
-                stashSummaries);
+                stashSummaries,
+                Region: loc.Region);
         }).ToList();
 
         return TypedResults.Ok(result);

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -112,23 +112,111 @@ else
                         </span>
                     </div>
                 }
-                <div class="oh-tp-map-host" id="oh-tp-map-host">
-                    <MapView @ref="mapView"
-                             Height="100%"
-                             CenterLat="49.4532461" CenterLon="18.0203242" Zoom="12"
-                             OnPieMarkerClick="HandlePieClick"
-                             OnPieMarkerDrop="HandlePieDrop"
-                             OnStyleLoaded="HandleStyleLoaded" />
-                </div>
-                <div class="oh-tp-map-toolbar">
-                    <span>Legenda:</span>
-                    @foreach (var s in stageKeys)
+                @* Issue #200: view toggle Mapa ↔ Karty. Cards mode is the
+                   organizer-friendly fallback when locations don't have GPS
+                   yet — group by Region, filter by LocationKind, click a
+                   card to open the same focus/assign flow as the map markers. *@
+                <div class="oh-tp-view-toggle">
+                    <div class="oh-tl-seg" role="tablist" aria-label="Pohled">
+                        <button type="button" class="oh-tl-seg-btn @(treasuresView == "map" ? "on" : "")"
+                                role="tab" aria-selected="@(treasuresView == "map")"
+                                @onclick='() => SetTreasuresViewAsync("map")'>
+                            <i class="bi bi-map"></i> Mapa
+                        </button>
+                        <button type="button" class="oh-tl-seg-btn @(treasuresView == "cards" ? "on" : "")"
+                                role="tab" aria-selected="@(treasuresView == "cards")"
+                                @onclick='() => SetTreasuresViewAsync("cards")'>
+                            <i class="bi bi-grid"></i> Karty
+                        </button>
+                    </div>
+                    @if (treasuresView == "cards" && locationCards.Count > 0)
                     {
-                        <span class="oh-tp-focus-stats"><span class="sw" style="background:var(--oh-stage-@s.SoftKey)"></span>@s.Label</span>
+                        <div class="oh-tp-kind-filter">
+                            <span class="text-muted small">Typ:</span>
+                            <button type="button"
+                                    class="oh-tp-kind-pill @(treasuresKindFilter is null ? "on" : "")"
+                                    @onclick="() => treasuresKindFilter = null">vše</button>
+                            @foreach (var kind in locationCards.Select(l => l.LocationKind).Distinct().OrderBy(k => k.GetDisplayName()))
+                            {
+                                var k = kind;
+                                <button type="button"
+                                        class="oh-tp-kind-pill @(treasuresKindFilter == k ? "on" : "")"
+                                        @onclick="() => treasuresKindFilter = k">@k.GetDisplayName()</button>
+                            }
+                        </div>
                     }
-                    <div class="oh-tp-map-toolbar-spacer"></div>
-                    <span class="oh-tp-map-count">@locationCards.Count lokací · @(summary?.Placed ?? 0) umístěno</span>
                 </div>
+                @if (treasuresView == "cards")
+                {
+                    @* Cards view: groups by Region, click a card → focus/assign flow *@
+                    var filtered = treasuresKindFilter.HasValue
+                        ? locationCards.Where(l => l.LocationKind == treasuresKindFilter.Value).ToList()
+                        : locationCards.ToList();
+                    var grouped = filtered
+                        .GroupBy(l => string.IsNullOrWhiteSpace(l.Region) ? "(bez regionu)" : l.Region!)
+                        .OrderBy(g => g.Key)
+                        .ToList();
+                    if (grouped.Count == 0)
+                    {
+                        <p class="text-muted small">Žádné lokace neodpovídají filtru.</p>
+                    }
+                    else
+                    {
+                        <div class="oh-tp-cards-host">
+                            @foreach (var grp in grouped)
+                            {
+                                <div class="oh-tp-cards-region" @key="grp.Key">
+                                    <h6 class="oh-tp-cards-region-hdr">@grp.Key <span class="text-muted small">· @grp.Count() lokací</span></h6>
+                                    <div class="oh-tp-cards-grid">
+                                        @foreach (var loc in grp.OrderBy(l => l.LocationName))
+                                        {
+                                            var isFocused = focusedLocationId == loc.LocationId;
+                                            <button type="button"
+                                                    class="oh-tp-card @(isFocused ? "is-focused" : "")"
+                                                    @key="loc.LocationId"
+                                                    @onclick="() => HandlePieClick(loc.LocationId)">
+                                                <div class="oh-tp-card-hdr">
+                                                    <span class="oh-tp-card-kind">@loc.LocationKind.GetDisplayName()</span>
+                                                    @if (loc.TotalItems > 0)
+                                                    {
+                                                        <span class="oh-tp-card-count">@loc.TotalItems pokladů</span>
+                                                    }
+                                                </div>
+                                                <div class="oh-tp-card-name">@loc.LocationName</div>
+                                                @if (loc.StashCount > 0)
+                                                {
+                                                    <div class="oh-tp-card-stash">
+                                                        <i class="bi bi-archive"></i> @loc.StashCount / @loc.MaxStashes skrýší
+                                                    </div>
+                                                }
+                                            </button>
+                                        }
+                                    </div>
+                                </div>
+                            }
+                        </div>
+                    }
+                }
+                else
+                {
+                    <div class="oh-tp-map-host" id="oh-tp-map-host">
+                        <MapView @ref="mapView"
+                                 Height="100%"
+                                 CenterLat="49.4532461" CenterLon="18.0203242" Zoom="12"
+                                 OnPieMarkerClick="HandlePieClick"
+                                 OnPieMarkerDrop="HandlePieDrop"
+                                 OnStyleLoaded="HandleStyleLoaded" />
+                    </div>
+                    <div class="oh-tp-map-toolbar">
+                        <span>Legenda:</span>
+                        @foreach (var s in stageKeys)
+                        {
+                            <span class="oh-tp-focus-stats"><span class="sw" style="background:var(--oh-stage-@s.SoftKey)"></span>@s.Label</span>
+                        }
+                        <div class="oh-tp-map-toolbar-spacer"></div>
+                        <span class="oh-tp-map-count">@locationCards.Count lokací · @(summary?.Placed ?? 0) umístěno</span>
+                    </div>
+                }
             </div>
 
             @* RIGHT: assignment panel *@
@@ -593,6 +681,13 @@ else
     // ===== Focus state =====
     private int? focusedLocationId;
     private string focusTab = "prehled";
+
+    // Issue #200: Mapa ↔ Karty toggle. Cards view groups by Region with a
+    // LocationKind filter — works without GPS coords. Persisted via
+    // localStorage key `oh-tp-view`.
+    private const string TreasuresViewKey = "oh-tp-view";
+    private string treasuresView = "map";
+    private OvcinaHra.Shared.Domain.Enums.LocationKind? treasuresKindFilter;
     private GameTimePhase lastUsedDifficulty = GameTimePhase.Start;
 
     // ===== Game context =====
@@ -713,7 +808,32 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            // Issue #200: restore preferred view from localStorage. Falls
+            // through to default "map" if storage is unavailable / empty.
+            try
+            {
+                var stored = await JS.InvokeAsync<string?>("localStorage.getItem", TreasuresViewKey);
+                if ((stored == "map" || stored == "cards") && stored != treasuresView)
+                {
+                    treasuresView = stored;
+                    StateHasChanged();
+                }
+            }
+            catch { /* prerender / JS unavailable */ }
+        }
         await PlaceMarkersIfReadyAsync();
+    }
+
+    // Issue #200: persist Mapa ↔ Karty selection. Same shape as Timeline's
+    // SetViewAsync from #189.
+    private async Task SetTreasuresViewAsync(string next)
+    {
+        if (treasuresView == next) return;
+        treasuresView = next;
+        try { await JS.InvokeVoidAsync("localStorage.setItem", TreasuresViewKey, next); }
+        catch { /* non-fatal */ }
     }
 
     private async Task PlaceMarkersIfReadyAsync()

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3192,3 +3192,26 @@
 .oh-tl-list-title{font-weight:600;margin-bottom:.15rem}
 .oh-tl-list-rules{color:var(--oh-text-secondary,#666);font-size:.85rem;white-space:pre-wrap}
 .oh-tl-list-chips{display:flex;flex-wrap:wrap;gap:.3rem}
+
+/* Treasures — Mapa ↔ Karty toggle + Cards view (issue #200). */
+.oh-tp-view-toggle{display:flex;align-items:center;gap:.6rem;flex-wrap:wrap;margin-bottom:.5rem}
+.oh-tp-kind-filter{display:flex;align-items:center;gap:.3rem;flex-wrap:wrap}
+.oh-tp-kind-pill{background:var(--oh-surface,#FAF6EC);border:1px solid var(--oh-border,#D9CFB6);
+    border-radius:999px;padding:.15rem .55rem;font-size:.78rem;cursor:pointer;color:var(--oh-text,#2a2a2a);
+    transition:.12s ease}
+.oh-tp-kind-pill:hover{background:#F2EBD8;border-color:#B8A87A}
+.oh-tp-kind-pill.on{background:#2D5016;border-color:#2D5016;color:#fff}
+.oh-tp-cards-host{display:flex;flex-direction:column;gap:1rem;max-height:600px;overflow-y:auto;padding-right:.25rem}
+.oh-tp-cards-region-hdr{font-family:'Merriweather',serif;font-weight:600;font-size:.95rem;
+    margin:0 0 .4rem 0;padding-bottom:.25rem;border-bottom:1px dashed var(--oh-border,#D9CFB6)}
+.oh-tp-cards-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:.5rem}
+.oh-tp-card{background:var(--oh-surface,#FAF6EC);border:1px solid var(--oh-border,#D9CFB6);
+    border-radius:8px;padding:.6rem .7rem;text-align:left;cursor:pointer;
+    transition:.12s ease;display:flex;flex-direction:column;gap:.25rem}
+.oh-tp-card:hover{background:#F2EBD8;border-color:#2D5016}
+.oh-tp-card.is-focused{border-color:#2D5016;box-shadow:0 0 0 2px rgba(45,80,22,.18)}
+.oh-tp-card-hdr{display:flex;justify-content:space-between;align-items:center;gap:.4rem;font-size:.75rem;color:var(--oh-text-secondary,#666)}
+.oh-tp-card-kind{text-transform:capitalize;font-family:'JetBrains Mono',monospace}
+.oh-tp-card-count{background:#2D5016;color:#fff;border-radius:999px;padding:.05rem .4rem;font-size:.7rem}
+.oh-tp-card-name{font-weight:600;color:var(--oh-text,#2a2a2a);font-size:.95rem}
+.oh-tp-card-stash{font-size:.75rem;color:var(--oh-text-secondary,#666);display:flex;align-items:center;gap:.3rem}

--- a/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
@@ -43,7 +43,8 @@ public record TreasurePlanningLocationDto(
     int LocationId, string LocationName, LocationKind LocationKind,
     int StartCount, int EarlyCount, int MidgameCount, int LategameCount,
     int TotalItems, int StashCount, int MaxStashes,
-    List<StashSummaryDto> Stashes);
+    List<StashSummaryDto> Stashes,
+    string? Region = null);
 
 public record StashSummaryDto(int Id, string Name, int ItemCount);
 


### PR DESCRIPTION
Closes #200 phase 1.

## What lands

Alternative **Karty** view alongside the existing **Mapa** on `/treasures`. User can now assign treasures to locations even when those locations don't have GPS coords yet — same focus/assign flow, just opened by clicking a card instead of a map pin.

- **View toggle** Mapa ↔ Karty (persists in `localStorage['oh-tp-view']`)
- **Region grouping** — cards group by `Location.Region` with a "(bez regionu)" bucket for unset regions
- **Kind filter** — pills above cards (vše / specific LocationKind)
- **Cards show** kind / name / treasure count / stash count
- **Click → focus** uses the existing `HandlePieClick` handler, so TreasureAssignForm works unchanged

## Backend

Extends `TreasurePlanningLocationDto` with optional `Region string?` (default null → wire-compatible). Endpoint projection passes `loc.Region`.

## Deferred to follow-up

- **Multi-item treasures (#200 ask 5)** — user noted 80-85% are single items; suggested using a custom-note item as the workaround, which the existing `OpenAddToPoolModal` already supports. Not worth the entity-model expansion right now.

## Verification

- `dotnet build OvcinaHra.slnx` clean (0/0)
- `dotnet test tests/OvcinaHra.Api.Tests` — **378 / 378** passed in 37 s
- `git diff origin/main --stat`: 4 files, +161 / −16

## Manual smoke test

1. `/treasures` on a game with locations that have no GPS — switch to **Karty** → cards render grouped by region.
2. Click a kind pill → list filters by that kind.
3. Click a card → focus panel opens on the right, **Přidat poklad** tab → assign works.
4. Refresh page → view preference persists.