### PR TITLE
feat(quests): catalog gallery + 5-tab detail + per-game grid + A5 print (Phase 1)

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/QuestConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/QuestConfiguration.cs
@@ -11,6 +11,7 @@ public class QuestConfiguration : IEntityTypeConfiguration<Quest>
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Name).IsRequired().HasMaxLength(300);
         builder.Property(e => e.QuestType).HasConversion<string>().HasMaxLength(30);
+        builder.Property(e => e.State).HasConversion<string>().HasMaxLength(20);
         builder.HasOne(e => e.ParentQuest).WithMany(q => q.ChildQuests).HasForeignKey(e => e.ParentQuestId);
         builder.HasOne(e => e.Game).WithMany(g => g.Quests).HasForeignKey(e => e.GameId).IsRequired(false);
 

--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -14,7 +14,7 @@ public static class ImageEndpoints
     // stamp as an independent image (its cache keys don't collide with the
     // main location image). See GetEntityImagePaths and the Upload DbContext
     // switch for the dispatch.
-    private static readonly HashSet<string> ValidEntityTypes = ["locations", "locationstamps", "items", "monsters", "secretstashes", "npcs", "buildings", "characters", "kingdoms", "spells"];
+    private static readonly HashSet<string> ValidEntityTypes = ["locations", "locationstamps", "items", "monsters", "secretstashes", "npcs", "buildings", "characters", "kingdoms", "spells", "quests"];
     private static readonly HashSet<string> AllowedContentTypes = ["image/jpeg", "image/png", "image/webp"];
     private const long MaxFileSize = 5 * 1024 * 1024; // 5 MB
 
@@ -317,6 +317,12 @@ public static class ImageEndpoints
             .ToListAsync(ct))
             targets.Add(("spells", row.Id, row.BlobKey));
 
+        foreach (var row in await db.Quests
+            .Where(q => q.ImagePath != null && q.ImagePath != "")
+            .Select(q => new { q.Id, BlobKey = q.ImagePath! })
+            .ToListAsync(ct))
+            targets.Add(("quests", row.Id, row.BlobKey));
+
         var presets = Enum.GetValues<ThumbnailPreset>();
         var attempted = 0;
         var done = 0;
@@ -462,6 +468,10 @@ public static class ImageEndpoints
                 var spell = await db.Spells.FindAsync(entityId);
                 if (spell is not null) spell.ImagePath = blobKey;
                 break;
+            case "quests":
+                var quest = await db.Quests.FindAsync(entityId);
+                if (quest is not null) quest.ImagePath = blobKey;
+                break;
         }
 
         await db.SaveChangesAsync();
@@ -502,6 +512,9 @@ public static class ImageEndpoints
             "spells" => await db.Spells.Where(s => s.Id == entityId)
                 .Select(s => new ValueTuple<string?, string?>(s.ImagePath, null))
                 .FirstOrDefaultAsync(),
+            "quests" => await db.Quests.Where(q => q.Id == entityId)
+                .Select(q => new ValueTuple<string?, string?>(q.ImagePath, null))
+                .FirstOrDefaultAsync(),
             _ => (null, null)
         };
     }
@@ -520,6 +533,7 @@ public static class ImageEndpoints
             "characters" => await db.Characters.AnyAsync(c => c.Id == entityId),
             "kingdoms" => await db.Kingdoms.AnyAsync(k => k.Id == entityId),
             "spells" => await db.Spells.AnyAsync(s => s.Id == entityId),
+            "quests" => await db.Quests.AnyAsync(q => q.Id == entityId),
             _ => false
         };
     }

--- a/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Endpoints;
@@ -17,6 +18,7 @@ public static class QuestEndpoints
         group.MapGet("/{id:int}", GetById);
         group.MapPost("/", Create);
         group.MapPut("/{id:int}", Update);
+        group.MapPatch("/{id:int}/state", UpdateState);
         group.MapDelete("/{id:int}", Delete);
         group.MapPost("/{id:int}/copy-to-game/{gameId:int}", CopyToGame);
         group.MapPut("/{id:int}/game", MoveToGame);
@@ -41,9 +43,8 @@ public static class QuestEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<QuestCatalogDto>>> GetAll(WorldDbContext db)
+    private static async Task<Ok<List<QuestCatalogDto>>> GetAll(WorldDbContext db, HttpContext http)
     {
-        // Project to a lightweight shape in EF so we don't pull full Quest + Item entities.
         var rows = await db.Quests
             .AsNoTracking()
             .Where(q => q.GameId == null)
@@ -58,6 +59,9 @@ public static class QuestEndpoints
                 q.RewardXp,
                 q.RewardMoney,
                 q.RewardNotes,
+                q.ImagePath,
+                EncountersCount = q.QuestEncounters.Count,
+                RewardsCount = q.QuestRewards.Count,
                 Rewards = q.QuestRewards
                     .OrderBy(r => r.Item.Name)
                     .Select(r => new { ItemName = r.Item.Name, r.Quantity })
@@ -70,7 +74,10 @@ public static class QuestEndpoints
             null, null, null,
             r.Description, r.FullText,
             BuildRewardSummary(r.RewardXp, r.RewardMoney, r.RewardNotes,
-                r.Rewards.Select(x => (x.ItemName, x.Quantity))))).ToList();
+                r.Rewards.Select(x => (x.ItemName, x.Quantity))),
+            r.ImagePath,
+            string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "quests", r.Id, "small"),
+            r.EncountersCount, r.RewardsCount)).ToList();
 
         return TypedResults.Ok(dtos);
     }
@@ -93,7 +100,7 @@ public static class QuestEndpoints
         return parts.Count > 0 ? string.Join(" · ", parts) : null;
     }
 
-    private static async Task<Results<Created<QuestCopyResultDto>, NotFound>> CopyToGame(int id, int gameId, WorldDbContext db)
+    private static async Task<Results<Created<QuestCopyResultDto>, NotFound>> CopyToGame(int id, int gameId, WorldDbContext db, HttpContext http)
     {
         var source = await db.Quests
             .Include(q => q.QuestTags).ThenInclude(qt => qt.Tag)
@@ -110,7 +117,8 @@ public static class QuestEndpoints
             Name = source.Name, QuestType = source.QuestType, Description = source.Description,
             FullText = source.FullText, TimeSlot = source.TimeSlot,
             RewardXp = source.RewardXp, RewardMoney = source.RewardMoney, RewardNotes = source.RewardNotes,
-            ChainOrder = null, ParentQuestId = null, GameId = gameId
+            ChainOrder = null, ParentQuestId = null, GameId = gameId,
+            ImagePath = source.ImagePath, State = QuestState.Inactive
         };
         db.Quests.Add(copy);
         await db.SaveChangesAsync();
@@ -141,23 +149,45 @@ public static class QuestEndpoints
 
         await db.SaveChangesAsync();
 
+        var thumb = string.IsNullOrWhiteSpace(copy.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "quests", copy.Id, "small");
         return TypedResults.Created($"/api/quests/{copy.Id}",
             new QuestCopyResultDto(
-                new QuestListDto(copy.Id, copy.Name, copy.QuestType, copy.ChainOrder, copy.ParentQuestId, copy.GameId),
+                new QuestListDto(copy.Id, copy.Name, copy.QuestType, copy.ChainOrder, copy.ParentQuestId, copy.GameId,
+                    copy.State, copy.ImagePath, thumb,
+                    EncountersCount: source.QuestEncounters.Count,
+                    RewardsCount: source.QuestRewards.Count(r => targetItemIds.Contains(r.ItemId)),
+                    LocationsCount: source.QuestLocations.Count(l => targetLocationIds.Contains(l.LocationId)),
+                    TagsCount: source.QuestTags.Count),
                 warnings));
     }
 
-    private static async Task<Ok<List<QuestListDto>>> GetByGame(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<QuestListDto>>> GetByGame(int gameId, WorldDbContext db, HttpContext http)
     {
-        var quests = await db.Quests
+        var rows = await db.Quests
+            .AsNoTracking()
             .Where(q => q.GameId == gameId)
             .OrderBy(q => q.ParentQuestId).ThenBy(q => q.ChainOrder).ThenBy(q => q.Name)
-            .Select(q => new QuestListDto(q.Id, q.Name, q.QuestType, q.ChainOrder, q.ParentQuestId, q.GameId))
+            .Select(q => new
+            {
+                q.Id, q.Name, q.QuestType, q.ChainOrder, q.ParentQuestId, q.GameId,
+                q.State, q.ImagePath,
+                EncountersCount = q.QuestEncounters.Count,
+                RewardsCount = q.QuestRewards.Count,
+                LocationsCount = q.QuestLocations.Count,
+                TagsCount = q.QuestTags.Count
+            })
             .ToListAsync();
+
+        var quests = rows.Select(r => new QuestListDto(
+            r.Id, r.Name, r.QuestType, r.ChainOrder, r.ParentQuestId, r.GameId,
+            r.State, r.ImagePath,
+            string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "quests", r.Id, "small"),
+            r.EncountersCount, r.RewardsCount, r.LocationsCount, r.TagsCount)).ToList();
+
         return TypedResults.Ok(quests);
     }
 
-    private static async Task<Results<Ok<QuestDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
+    private static async Task<Results<Ok<QuestDetailDto>, NotFound>> GetById(int id, WorldDbContext db, HttpContext http)
     {
         var q = await db.Quests
             .Include(q => q.QuestTags).ThenInclude(qt => qt.Tag)
@@ -167,9 +197,12 @@ public static class QuestEndpoints
             .FirstOrDefaultAsync(q => q.Id == id);
         if (q is null) return TypedResults.NotFound();
 
+        var imageUrl = string.IsNullOrWhiteSpace(q.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "quests", q.Id, "small");
+
         return TypedResults.Ok(new QuestDetailDto(
             q.Id, q.Name, q.QuestType, q.Description, q.FullText, q.TimeSlot,
             q.RewardXp, q.RewardMoney, q.RewardNotes, q.ChainOrder, q.ParentQuestId, q.GameId,
+            q.State, q.ImagePath, imageUrl,
             q.QuestTags.Select(qt => new TagDto(qt.Tag.Id, qt.Tag.Name, qt.Tag.Kind)).ToList(),
             q.QuestLocations.Select(ql => new QuestLocationDto(ql.QuestId, ql.LocationId, ql.Location.Name)).ToList(),
             q.QuestEncounters.Select(qe => new QuestEncounterDto(qe.QuestId, qe.MonsterId, qe.Monster.Name, qe.Quantity)).ToList(),
@@ -183,12 +216,15 @@ public static class QuestEndpoints
             Name = dto.Name, QuestType = dto.QuestType, GameId = dto.GameId,
             Description = dto.Description, FullText = dto.FullText, TimeSlot = dto.TimeSlot,
             RewardXp = dto.RewardXp, RewardMoney = dto.RewardMoney, RewardNotes = dto.RewardNotes,
-            ChainOrder = dto.ChainOrder, ParentQuestId = dto.ParentQuestId
+            ChainOrder = dto.ChainOrder, ParentQuestId = dto.ParentQuestId,
+            State = QuestState.Inactive
         };
         db.Quests.Add(q);
         await db.SaveChangesAsync();
         return TypedResults.Created($"/api/quests/{q.Id}",
-            new QuestListDto(q.Id, q.Name, q.QuestType, q.ChainOrder, q.ParentQuestId, q.GameId));
+            new QuestListDto(q.Id, q.Name, q.QuestType, q.ChainOrder, q.ParentQuestId, q.GameId,
+                q.State, q.ImagePath, ImageUrl: null,
+                EncountersCount: 0, RewardsCount: 0, LocationsCount: 0, TagsCount: 0));
     }
 
     private static async Task<Results<NoContent, NotFound>> Update(int id, UpdateQuestDto dto, WorldDbContext db)
@@ -201,6 +237,19 @@ public static class QuestEndpoints
         q.RewardXp = dto.RewardXp; q.RewardMoney = dto.RewardMoney; q.RewardNotes = dto.RewardNotes;
         q.ChainOrder = dto.ChainOrder; q.ParentQuestId = dto.ParentQuestId;
 
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound, BadRequest<string>>> UpdateState(int id, UpdateQuestStateDto dto, WorldDbContext db)
+    {
+        var q = await db.Quests.FindAsync(id);
+        if (q is null) return TypedResults.NotFound();
+
+        if (!Enum.IsDefined(dto.State))
+            return TypedResults.BadRequest($"Unknown state '{dto.State}'.");
+
+        q.State = dto.State;
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Migrations/20260426045045_AddImagePathAndStateToQuest.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260426045045_AddImagePathAndStateToQuest.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260426045045_AddImagePathAndStateToQuest")]
+    partial class AddImagePathAndStateToQuest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260426045045_AddImagePathAndStateToQuest.cs
+++ b/src/OvcinaHra.Api/Migrations/20260426045045_AddImagePathAndStateToQuest.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImagePathAndStateToQuest : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ImagePath",
+                table: "Quests",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "State",
+                table: "Quests",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "Inactive");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ImagePath",
+                table: "Quests");
+
+            migrationBuilder.DropColumn(
+                name: "State",
+                table: "Quests");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Components/EncounterAddPopup.razor
+++ b/src/OvcinaHra.Client/Components/EncounterAddPopup.razor
@@ -31,8 +31,11 @@
         }
 
         <div class="d-flex gap-2 justify-content-end mt-3">
-            <button class="btn btn-secondary" @onclick="Cancel" disabled="@isSaving">Zrušit</button>
-            <button class="btn btn-primary" @onclick="SaveAsync"
+            @* type="button" on both — DevExpress popups can host the buttons
+               inside an implicit form on some render paths and the default
+               "submit" type triggers an unwanted post (Copilot #206). *@
+            <button type="button" class="btn btn-secondary" @onclick="Cancel" disabled="@isSaving">Zrušit</button>
+            <button type="button" class="btn btn-primary" @onclick="SaveAsync"
                     disabled="@(isSaving || monsterId is null)">
                 @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
                 Přidat setkání

--- a/src/OvcinaHra.Client/Components/EncounterAddPopup.razor
+++ b/src/OvcinaHra.Client/Components/EncounterAddPopup.razor
@@ -1,0 +1,107 @@
+@using OvcinaHra.Shared.Dtos
+@inject ApiClient Api
+
+@* Inline-creator-style popup for adding a setkání. Phase 1: pick a Monster from
+   /api/monsters + Quantity. Phase 2 will add per-encounter title/location/etc. *@
+
+<DxPopup @bind-Visible="@Visible" HeaderText="Nové setkání" Width="540px">
+    <BodyContentTemplate Context="ctx">
+        @if (loading)
+        {
+            <p class="text-muted">Načítám příšery…</p>
+        }
+        else
+        {
+            <DxFormLayout>
+                <DxFormLayoutItem Caption="Příšera" ColSpanMd="9">
+                    <DxComboBox Data="@monsters" @bind-Value="@monsterId"
+                                TextFieldName="Name" ValueFieldName="Id"
+                                NullText="(vyberte příšeru)"
+                                SearchMode="ListSearchMode.AutoSearch" />
+                </DxFormLayoutItem>
+                <DxFormLayoutItem Caption="Počet" ColSpanMd="3">
+                    <DxSpinEdit @bind-Value="@quantity" MinValue="1" MaxValue="99" />
+                </DxFormLayoutItem>
+            </DxFormLayout>
+        }
+
+        @if (error is not null)
+        {
+            <div class="alert alert-danger mt-2">@error</div>
+        }
+
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" @onclick="Cancel" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-primary" @onclick="SaveAsync"
+                    disabled="@(isSaving || monsterId is null)">
+                @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Přidat setkání
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter, EditorRequired] public int QuestId { get; set; }
+    [Parameter] public EventCallback Added { get; set; }
+
+    private List<MonsterListDto> monsters = [];
+    private bool loading = true;
+    private bool isSaving;
+    private int? monsterId;
+    private int quantity = 1;
+    private string? error;
+
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        var wasVisible = Visible;
+        await base.SetParametersAsync(parameters);
+        if (!wasVisible && Visible)
+        {
+            monsterId = null;
+            quantity = 1;
+            error = null;
+            isSaving = false;
+            await LoadMonstersAsync();
+        }
+    }
+
+    private async Task LoadMonstersAsync()
+    {
+        loading = true;
+        try
+        {
+            monsters = await Api.GetListAsync<MonsterListDto>("/api/monsters");
+        }
+        finally
+        {
+            loading = false;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        if (monsterId is null) return;
+        error = null;
+        isSaving = true;
+        try
+        {
+            var (ok, _, problem) = await Api.PostWithProblemAsync<AddQuestEncounterDto, object>(
+                $"/api/quests/{QuestId}/encounters",
+                new AddQuestEncounterDto(monsterId.Value, quantity));
+            if (!ok)
+            {
+                error = problem ?? "Nepodařilo se přidat setkání.";
+                return;
+            }
+            await Added.InvokeAsync();
+            await VisibleChanged.InvokeAsync(false);
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task Cancel() => await VisibleChanged.InvokeAsync(false);
+}

--- a/src/OvcinaHra.Client/Components/EncounterCard.razor
+++ b/src/OvcinaHra.Client/Components/EncounterCard.razor
@@ -1,0 +1,39 @@
+@using OvcinaHra.Shared.Dtos
+
+@* Setkání seznam card. Phase 1: monster name + quantity only — designer brief
+   wants per-encounter title/location/description but those fields don't exist
+   in the entity yet (see issue #193 Phase 2 follow-up). Drag handle is visible
+   but disabled until Phase 2 (Order field). *@
+
+<article class="oh-qst-enc-card" @key="Encounter.MonsterId">
+    <button type="button" class="oh-qst-enc-grip"
+            disabled title="Řazení dostupné po migraci 0.16.x">
+        <i class="bi bi-grip-vertical"></i>
+    </button>
+    <div class="oh-qst-enc-order">@Order</div>
+    <div class="oh-qst-enc-body">
+        <h3 class="oh-qst-enc-title">@Encounter.MonsterName</h3>
+        <div class="oh-qst-enc-meta">
+            <span class="oh-qst-enc-qty"><i class="bi bi-x-lg"></i>@Encounter.Quantity</span>
+            <span class="oh-qst-enc-tag-defer">Plánováno: lokace · popis · položky (Phase 2)</span>
+        </div>
+    </div>
+    @if (Editable)
+    {
+        <div class="oh-qst-enc-actions">
+            <button type="button" class="btn btn-sm btn-link text-danger p-0"
+                    @onclick="HandleRemove" title="Smazat setkání">
+                <i class="bi bi-x-circle"></i>
+            </button>
+        </div>
+    }
+</article>
+
+@code {
+    [Parameter, EditorRequired] public QuestEncounterDto Encounter { get; set; } = null!;
+    [Parameter, EditorRequired] public int Order { get; set; }
+    [Parameter] public bool Editable { get; set; }
+    [Parameter] public EventCallback<QuestEncounterDto> OnRemove { get; set; }
+
+    private async Task HandleRemove() => await OnRemove.InvokeAsync(Encounter);
+}

--- a/src/OvcinaHra.Client/Components/EncounterGraphNode.razor
+++ b/src/OvcinaHra.Client/Components/EncounterGraphNode.razor
@@ -1,0 +1,15 @@
+@using OvcinaHra.Shared.Dtos
+
+@* Setkání graf node — horizontal box rendered next to its peers with arrow
+   connectors. Phase 1 = sequential only (no branching). *@
+
+<div class="oh-qst-enc-graph-node" @key="Encounter.MonsterId">
+    <div class="oh-qst-enc-graph-order">@Order</div>
+    <div class="oh-qst-enc-graph-name">@Encounter.MonsterName</div>
+    <div class="oh-qst-enc-graph-qty">×@Encounter.Quantity</div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public QuestEncounterDto Encounter { get; set; } = null!;
+    [Parameter, EditorRequired] public int Order { get; set; }
+}

--- a/src/OvcinaHra.Client/Components/QuestPosterTile.razor
+++ b/src/OvcinaHra.Client/Components/QuestPosterTile.razor
@@ -1,0 +1,62 @@
+@using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+@* 5:7 portrait gallery tile — full-bleed image (or parchment placeholder),
+   name overlay (gradient), encounters/rewards counts in mono footer.
+   Click → /quests/{id}. *@
+
+<button type="button" class="oh-qst-tile @(string.IsNullOrEmpty(Quest.ImageUrl) || _imageFailed ? "oh-qst-tile--placeholder" : "")"
+        @key="Quest.Id" @onclick="HandleClick">
+    <div class="oh-qst-tile-art">
+        @if (!string.IsNullOrEmpty(Quest.ImageUrl) && !_imageFailed)
+        {
+            <img src="@Quest.ImageUrl" alt="@Quest.Name" @onerror="() => _imageFailed = true" />
+        }
+        else
+        {
+            <div class="oh-qst-tile-parchment">
+                <i class="bi bi-journal-richtext"></i>
+                <span class="oh-qst-tile-parchment-name">@Quest.Name</span>
+            </div>
+        }
+        @if (ShowState && Quest.GameId is not null)
+        {
+            <div class="oh-qst-tile-state">
+                <QuestStateChip State="@Quest.State" />
+            </div>
+        }
+    </div>
+    <div class="oh-qst-tile-body">
+        <div class="oh-qst-tile-name">@Quest.Name</div>
+        <div class="oh-qst-tile-foot">
+            <span class="oh-qst-tile-foot-pill" title="Setkání">
+                <i class="bi bi-shield-exclamation"></i>@Quest.EncountersCount
+            </span>
+            <span class="oh-qst-tile-foot-pill" title="Odměny">
+                <i class="bi bi-gift"></i>@Quest.RewardsCount
+            </span>
+            <span class="oh-qst-tile-foot-type">@Quest.QuestTypeDisplay</span>
+        </div>
+    </div>
+</button>
+
+@code {
+    [Parameter, EditorRequired] public QuestListDto Quest { get; set; } = null!;
+    [Parameter] public bool ShowState { get; set; } = true;
+    [Parameter] public EventCallback<QuestListDto> OnClick { get; set; }
+
+    private bool _imageFailed;
+    private string? _lastImageUrl;
+
+    protected override void OnParametersSet()
+    {
+        if (_lastImageUrl != Quest.ImageUrl)
+        {
+            _lastImageUrl = Quest.ImageUrl;
+            _imageFailed = false;
+        }
+    }
+
+    private async Task HandleClick() => await OnClick.InvokeAsync(Quest);
+}

--- a/src/OvcinaHra.Client/Components/QuestStateChip.razor
+++ b/src/OvcinaHra.Client/Components/QuestStateChip.razor
@@ -1,0 +1,27 @@
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+@* 3-colour state pill — parchment (Inactive) · forest (Active) · gold (Completed).
+   Render only on per-game rows; never on catalog templates. *@
+
+<span class="oh-qst-state-chip @StateClass" title="@State.GetDisplayName()">
+    <i class="bi @StateIcon"></i>@State.GetDisplayName()
+</span>
+
+@code {
+    [Parameter, EditorRequired] public QuestState State { get; set; }
+
+    private string StateClass => State switch
+    {
+        QuestState.Active    => "oh-qst-state-active",
+        QuestState.Completed => "oh-qst-state-done",
+        _                    => "oh-qst-state-inactive"
+    };
+
+    private string StateIcon => State switch
+    {
+        QuestState.Active    => "bi-fire",
+        QuestState.Completed => "bi-check2-circle",
+        _                    => "bi-circle"
+    };
+}

--- a/src/OvcinaHra.Client/Components/QuestStateChip.razor
+++ b/src/OvcinaHra.Client/Components/QuestStateChip.razor
@@ -5,7 +5,8 @@
    Render only on per-game rows; never on catalog templates. *@
 
 <span class="oh-qst-state-chip @StateClass" title="@State.GetDisplayName()">
-    <i class="bi @StateIcon"></i>@State.GetDisplayName()
+    <i class="bi @StateIcon"></i>
+    <span>@State.GetDisplayName()</span>
 </span>
 
 @code {

--- a/src/OvcinaHra.Client/Components/RewardLootList.razor
+++ b/src/OvcinaHra.Client/Components/RewardLootList.razor
@@ -1,0 +1,115 @@
+@using OvcinaHra.Shared.Dtos
+@inject ApiClient Api
+
+@* Kořist (item rewards) section — list of chips with quantity pill + Smazat,
+   plus [+ Přidat položku] which uses the existing ItemInlineCreator OR an
+   in-place picker for items that already exist in the current game. *@
+
+<section class="oh-qst-loot">
+    <h3 class="oh-qst-loot-title"><i class="bi bi-box-seam"></i> Kořist</h3>
+    @if (Rewards.Count == 0)
+    {
+        <p class="text-muted small mb-2">Žádné předměty v odměnách.</p>
+    }
+    else
+    {
+        <div class="oh-qst-loot-list">
+            @foreach (var r in Rewards)
+            {
+                <div class="oh-qst-loot-chip" @key="r.ItemId">
+                    <span class="oh-qst-loot-name">@r.ItemName</span>
+                    <span class="oh-qst-loot-qty">×@r.Quantity</span>
+                    @if (Editable)
+                    {
+                        <button type="button" class="btn btn-sm btn-link text-danger p-0"
+                                @onclick="() => HandleRemove(r)" title="Odebrat">
+                            <i class="bi bi-x-circle"></i>
+                        </button>
+                    }
+                </div>
+            }
+        </div>
+    }
+
+    @if (Editable)
+    {
+        <div class="oh-qst-loot-add">
+            <DxComboBox Data="@allItems" @bind-Value="@newItemId"
+                        TextFieldName="Name" ValueFieldName="Id"
+                        NullText="(vyberte předmět)"
+                        SearchMode="ListSearchMode.AutoSearch"
+                        CssClass="oh-qst-loot-pick" />
+            <DxSpinEdit @bind-Value="@newQuantity" MinValue="1" MaxValue="99"
+                        CssClass="oh-qst-loot-qty-input" />
+            <button type="button" class="btn btn-primary btn-sm"
+                    disabled="@(newItemId is null || isSaving)"
+                    @onclick="HandleAdd">
+                <i class="bi bi-plus"></i> Přidat položku
+            </button>
+        </div>
+        @if (error is not null)
+        {
+            <div class="alert alert-danger mt-2">@error</div>
+        }
+    }
+</section>
+
+@code {
+    [Parameter, EditorRequired] public int QuestId { get; set; }
+    [Parameter, EditorRequired] public List<QuestRewardDto> Rewards { get; set; } = [];
+    [Parameter] public bool Editable { get; set; }
+    [Parameter] public EventCallback Changed { get; set; }
+
+    private List<ItemListDto> allItems = [];
+    private int? newItemId;
+    private int newQuantity = 1;
+    private bool isSaving;
+    private string? error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Editable)
+        {
+            allItems = await Api.GetListAsync<ItemListDto>("/api/items");
+        }
+    }
+
+    private async Task HandleAdd()
+    {
+        if (newItemId is null) return;
+        error = null;
+        isSaving = true;
+        try
+        {
+            var (ok, _, problem) = await Api.PostWithProblemAsync<AddQuestRewardDto, object>(
+                $"/api/quests/{QuestId}/rewards",
+                new AddQuestRewardDto(newItemId.Value, newQuantity));
+            if (!ok)
+            {
+                error = problem ?? "Nepodařilo se přidat položku.";
+                return;
+            }
+            newItemId = null;
+            newQuantity = 1;
+            await Changed.InvokeAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task HandleRemove(QuestRewardDto r)
+    {
+        error = null;
+        try
+        {
+            var ok = await Api.DeleteAsync($"/api/quests/{QuestId}/rewards/{r.ItemId}");
+            if (!ok)
+            {
+                error = "Smazání odměny selhalo.";
+                return;
+            }
+            await Changed.InvokeAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+}

--- a/src/OvcinaHra.Client/Components/RewardScalarFields.razor
+++ b/src/OvcinaHra.Client/Components/RewardScalarFields.razor
@@ -1,0 +1,66 @@
+@* XP + Money + Notes — three scalar fields on Quest itself (NOT joined entities).
+   Bound through the parent's editModel; this component is purely presentational. *@
+
+<div class="oh-qst-rew-scalars">
+    <div class="oh-qst-rew-scalar">
+        <label class="oh-qst-rew-label"><i class="bi bi-stars"></i> Body zkušenosti</label>
+        @if (Editable)
+        {
+            <DxSpinEdit Value="@Xp" ValueExpression="@(() => Xp)"
+                        ValueChanged="@((int? v) => XpChanged.InvokeAsync(v))"
+                        MinValue="0" MaxValue="9999"
+                        NullText="(žádné)"
+                        ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
+                        CssClass="oh-qst-rew-input" />
+        }
+        else
+        {
+            <span class="oh-qst-rew-display">@(Xp.HasValue ? $"{Xp.Value} XP" : "—")</span>
+        }
+    </div>
+
+    <div class="oh-qst-rew-scalar">
+        <label class="oh-qst-rew-label"><i class="bi bi-coin"></i> Groše</label>
+        @if (Editable)
+        {
+            <DxSpinEdit Value="@Money" ValueExpression="@(() => Money)"
+                        ValueChanged="@((int? v) => MoneyChanged.InvokeAsync(v))"
+                        MinValue="0" MaxValue="99999"
+                        NullText="(žádné)"
+                        ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
+                        CssClass="oh-qst-rew-input" />
+        }
+        else
+        {
+            <span class="oh-qst-rew-display">@(Money.HasValue ? $"{Money.Value} gr" : "—")</span>
+        }
+    </div>
+
+    <div class="oh-qst-rew-scalar oh-qst-rew-scalar--wide">
+        <label class="oh-qst-rew-label"><i class="bi bi-pencil"></i> Poznámka k odměně</label>
+        @if (Editable)
+        {
+            <DxTextBox Text="@Notes" TextExpression="@(() => Notes)"
+                       TextChanged="@((string v) => NotesChanged.InvokeAsync(v))"
+                       NullText="(volitelné)"
+                       CssClass="oh-qst-rew-input" />
+        }
+        else
+        {
+            <span class="oh-qst-rew-display">@(string.IsNullOrWhiteSpace(Notes) ? "—" : Notes)</span>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public int? Xp { get; set; }
+    [Parameter] public EventCallback<int?> XpChanged { get; set; }
+
+    [Parameter] public int? Money { get; set; }
+    [Parameter] public EventCallback<int?> MoneyChanged { get; set; }
+
+    [Parameter] public string? Notes { get; set; }
+    [Parameter] public EventCallback<string?> NotesChanged { get; set; }
+
+    [Parameter] public bool Editable { get; set; }
+}

--- a/src/OvcinaHra.Client/Pages/Games/GameQuests.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameQuests.razor
@@ -1,0 +1,346 @@
+@page "/games/{GameId:int}/quests"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject NavigationManager Nav
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+@* Per-game quests grid. Different shape from /quests catalog: each row is a
+   Quest with GameId == this game. State chip is meaningful here (catalog rows
+   hide it). Phase 1 source-badge is omitted — schema has no TemplateQuestId
+   field, deferred to Phase 2 follow-up. *@
+
+<div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+    <div>
+        <h1 class="mb-0">Úkoly hry @(game?.Name)</h1>
+        @if (game is not null)
+        {
+            <p class="text-muted small mb-0">edice @game.Edition · @quests.Count úkolů</p>
+        }
+    </div>
+    <div class="d-flex gap-2">
+        <button class="btn btn-outline-secondary" type="button"
+                @onclick='() => Nav.NavigateTo("/quests")'>
+            <i class="bi bi-journal-richtext"></i> Katalog
+        </button>
+        <button class="btn btn-outline-primary" type="button" @onclick="() => isFromTemplateVisible = true">
+            <i class="bi bi-files"></i> Přidat ze šablony
+        </button>
+        <button class="btn btn-primary" type="button" @onclick="OpenBlankCreateModal">
+            <i class="bi bi-plus-lg"></i> Od nuly
+        </button>
+    </div>
+</div>
+
+@* State filter pill row *@
+<div class="oh-qst-state-pillrow mb-3">
+    @foreach (var (key, label) in stateFilterOptions)
+    {
+        <button type="button"
+                class="oh-qst-state-pill @(stateFilter == key ? "oh-qst-state-pill--on" : "")"
+                @onclick="() => stateFilter = key">
+            @label
+        </button>
+    }
+</div>
+
+@if (loading)
+{
+    <p class="text-muted">Načítám…</p>
+}
+else if (filtered.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-journal-richtext fs-1 d-block mb-2"></i>
+        <p>Žádné úkoly v této hře odpovídají filtru.</p>
+    </div>
+}
+else
+{
+    @* LayoutKey bumped to grid-layout-game-quests-v2 — column schema added
+       state, image, counts. Memory rule: feedback_ovcinagrid_layoutkey_bump. *@
+    <OvcinaGrid Data="@filtered" KeyFieldName="Id" LayoutKey="grid-layout-game-quests-v2"
+                RowClick="@(e => Nav.NavigateTo($"/quests/{((QuestListDto)e.Grid.GetDataItem(e.VisibleIndex)).Id}"))">
+        <Columns>
+            <DxGridDataColumn Caption="" Width="60px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var q = (QuestListDto)context.DataItem; }
+                    <div class="oh-qst-mini-tile @(string.IsNullOrEmpty(q.ImageUrl) ? "oh-qst-mini-tile--placeholder" : "")">
+                        @if (!string.IsNullOrEmpty(q.ImageUrl))
+                        {
+                            <img src="@q.ImageUrl" alt="@q.Name" />
+                        }
+                        else
+                        {
+                            <i class="bi bi-journal-richtext"></i>
+                        }
+                    </div>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="StateDisplay" Caption="Stav" Width="130px">
+                <CellDisplayTemplate>
+                    @{ var q = (QuestListDto)context.DataItem; }
+                    <QuestStateChip State="@q.State" />
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Name" Caption="Název" MinWidth="220" />
+            <DxGridDataColumn FieldName="QuestTypeDisplay" Caption="Typ" Width="140px" />
+            <DxGridDataColumn FieldName="EncountersCount" Caption="Setkání" Width="100px">
+                <CellDisplayTemplate>
+                    @{ var q = (QuestListDto)context.DataItem; }
+                    <span class="oh-pill-mono">@q.EncountersCount</span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="RewardsCount" Caption="Odměny" Width="100px">
+                <CellDisplayTemplate>
+                    @{ var q = (QuestListDto)context.DataItem; }
+                    <span class="oh-pill-mono">@q.RewardsCount</span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="LocationsCount" Caption="Lokace" Width="90px" Visible="false">
+                <CellDisplayTemplate>
+                    @{ var q = (QuestListDto)context.DataItem; }
+                    <span class="oh-pill-mono">@q.LocationsCount</span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="TagsCount" Caption="Tagy" Width="80px" Visible="false">
+                <CellDisplayTemplate>
+                    @{ var q = (QuestListDto)context.DataItem; }
+                    <span class="oh-pill-mono">@q.TagsCount</span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ChainOrder" Caption="Pořadí" Width="90px" Visible="false" />
+        </Columns>
+    </OvcinaGrid>
+}
+
+@* Add-from-template popup: pick a catalog quest, server CopyToGame creates
+   the per-game fork with deep-copied tags/locations/encounters/rewards. *@
+<DxPopup AllowResize="true" @bind-Visible="@isFromTemplateVisible"
+         HeaderText="Přidat úkol ze šablony" Width="640px">
+    <BodyContentTemplate Context="ctx">
+        @if (catalog is null)
+        {
+            <p class="text-muted">Načítám katalog…</p>
+        }
+        else if (catalog.Count == 0)
+        {
+            <p class="text-muted">V katalogu nejsou žádné šablony úkolů.</p>
+        }
+        else
+        {
+            <DxFormLayout>
+                <DxFormLayoutItem Caption="Šablona" ColSpanMd="12">
+                    <DxComboBox Data="@catalog" @bind-Value="@templateId"
+                                TextFieldName="Name" ValueFieldName="Id"
+                                NullText="(vyberte šablonu)"
+                                SearchMode="ListSearchMode.AutoSearch" />
+                </DxFormLayoutItem>
+            </DxFormLayout>
+        }
+        @if (copyError is not null)
+        {
+            <div class="alert alert-danger mt-2">@copyError</div>
+        }
+        @if (copyWarnings.Count > 0)
+        {
+            <div class="alert alert-warning mt-2">
+                <strong>Upozornění:</strong>
+                <ul class="mb-0">
+                    @foreach (var w in copyWarnings) { <li>@w</li> }
+                </ul>
+            </div>
+        }
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" type="button" @onclick="() => isFromTemplateVisible = false">Zavřít</button>
+            <button class="btn btn-primary" type="button"
+                    @onclick="CopyFromTemplateAsync"
+                    disabled="@(isCopying || templateId is null)">
+                @if (isCopying) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit kopii
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@* Blank create popup *@
+<DxPopup AllowResize="true" @bind-Visible="@isBlankVisible" HeaderText="Nový úkol (od nuly)" Width="560px">
+    <BodyContentTemplate Context="ctx">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                <DxTextBox @bind-Text="@createName" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Typ" ColSpanMd="12">
+                <DxComboBox Data="@questTypeValues" @bind-Value="@createType"
+                            TextFieldName="Display" ValueFieldName="Value" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        @if (createError is not null) { <div class="alert alert-danger mt-2">@createError</div> }
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" type="button" @onclick="() => isBlankVisible = false" disabled="@isCreating">Zrušit</button>
+            <button class="btn btn-primary" type="button" @onclick="CreateBlankAsync"
+                    disabled="@(isCreating || string.IsNullOrWhiteSpace(createName))">
+                @if (isCreating) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit a otevřít
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public int GameId { get; set; }
+
+    private GameListDto? game;
+    private List<QuestListDto> quests = [];
+    private List<QuestCatalogDto>? catalog;
+    private bool loading = true;
+
+    private string stateFilter = "all"; // all | inactive | active | done
+
+    private static readonly (string Key, string Label)[] stateFilterOptions =
+    [
+        ("all",      "Vše"),
+        ("inactive", "Neaktivní"),
+        ("active",   "Aktivní"),
+        ("done",     "Dokončené")
+    ];
+
+    private List<QuestListDto> filtered =>
+        quests.Where(q => stateFilter switch
+        {
+            "inactive" => q.State == QuestState.Inactive,
+            "active"   => q.State == QuestState.Active,
+            "done"     => q.State == QuestState.Completed,
+            _          => true
+        }).ToList();
+
+    // Add-from-template state
+    private bool isFromTemplateVisible;
+    private int? templateId;
+    private bool isCopying;
+    private string? copyError;
+    private List<string> copyWarnings = [];
+
+    // Blank create state
+    private bool isBlankVisible;
+    private string createName = "";
+    private QuestType createType = QuestType.General;
+    private string? createError;
+    private bool isCreating;
+
+    private static readonly List<EnumItem<QuestType>> questTypeValues = Enum.GetValues<QuestType>()
+        .Select(v => new EnumItem<QuestType>(v, v.GetDisplayName())).ToList();
+
+    private record EnumItem<T>(T Value, string Display);
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (game is not null && game.Id != GameId) await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        try
+        {
+            var gamesTask = Api.GetListAsync<GameListDto>("/api/games");
+            var questsTask = Api.GetListAsync<QuestListDto>($"/api/quests/by-game/{GameId}");
+            await Task.WhenAll(gamesTask, questsTask);
+            game = (await gamesTask).FirstOrDefault(g => g.Id == GameId);
+            quests = await questsTask;
+        }
+        finally { loading = false; }
+    }
+
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        var oldGameId = GameId;
+        await base.SetParametersAsync(parameters);
+        // SetParametersAsync runs before OnParametersSetAsync; this is the
+        // explicit reload trigger when the user navigates between two
+        // /games/{x}/quests routes without remounting.
+        if (oldGameId != 0 && oldGameId != GameId && !loading)
+            await LoadAsync();
+    }
+
+    private async Task LoadCatalogIfNeededAsync()
+    {
+        if (catalog is not null) return;
+        try { catalog = await Api.GetListAsync<QuestCatalogDto>("/api/quests/all"); }
+        catch (Exception ex) { copyError = ex.Message; catalog = []; }
+    }
+
+    private async Task CopyFromTemplateAsync()
+    {
+        if (templateId is null) return;
+        copyError = null;
+        copyWarnings = [];
+        isCopying = true;
+        try
+        {
+            var result = await Api.PostAsync<object, QuestCopyResultDto>(
+                $"/api/quests/{templateId.Value}/copy-to-game/{GameId}", new { });
+            if (result is null)
+            {
+                copyError = "Server nevrátil výsledek.";
+                return;
+            }
+            copyWarnings = result.Warnings;
+            templateId = null;
+            await LoadAsync();
+            // Don't auto-close so user sees warnings about skipped locations/items.
+            if (copyWarnings.Count == 0)
+            {
+                isFromTemplateVisible = false;
+                Nav.NavigateTo($"/quests/{result.Quest.Id}");
+            }
+        }
+        catch (Exception ex) { copyError = ex.Message; }
+        finally { isCopying = false; }
+    }
+
+    private async Task OpenBlankCreateModal()
+    {
+        createName = "";
+        createType = QuestType.General;
+        createError = null;
+        isBlankVisible = true;
+        await Task.CompletedTask;
+    }
+
+    private async Task CreateBlankAsync()
+    {
+        if (string.IsNullOrWhiteSpace(createName)) return;
+        createError = null;
+        isCreating = true;
+        try
+        {
+            var (ok, created, problem) = await Api.PostWithProblemAsync<CreateQuestDto, QuestListDto>(
+                "/api/quests",
+                new CreateQuestDto(createName.Trim(), createType, GameId: GameId));
+            if (!ok)
+            {
+                createError = problem ?? "Vytvoření úkolu se nepodařilo.";
+                return;
+            }
+            isBlankVisible = false;
+            if (created is not null)
+                Nav.NavigateTo($"/quests/{created.Id}");
+            else
+                await LoadAsync();
+        }
+        catch (Exception ex) { createError = ex.Message; }
+        finally { isCreating = false; }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender || (isFromTemplateVisible && catalog is null))
+        {
+            await LoadCatalogIfNeededAsync();
+            StateHasChanged();
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Games/GameQuests.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameQuests.razor
@@ -190,7 +190,7 @@ else
 @code {
     [Parameter] public int GameId { get; set; }
 
-    private GameListDto? game;
+    private GameDetailDto? game;
     private List<QuestListDto> quests = [];
     private List<QuestCatalogDto>? catalog;
     private bool loading = true;
@@ -245,10 +245,12 @@ else
         loading = true;
         try
         {
-            var gamesTask = Api.GetListAsync<GameListDto>("/api/games");
+            // Fetch only the current game by id rather than the entire game
+            // list — half the bytes, half the latency (Copilot #206).
+            var gameTask = Api.GetAsync<GameDetailDto>($"/api/games/{GameId}");
             var questsTask = Api.GetListAsync<QuestListDto>($"/api/quests/by-game/{GameId}");
-            await Task.WhenAll(gamesTask, questsTask);
-            game = (await gamesTask).FirstOrDefault(g => g.Id == GameId);
+            await Task.WhenAll(gameTask, questsTask);
+            game = await gameTask;
             quests = await questsTask;
         }
         finally { loading = false; }

--- a/src/OvcinaHra.Client/Pages/Quests/QuestDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestDetail.razor
@@ -423,7 +423,7 @@ else
                                 Notes="@editModel.RewardNotes" NotesChanged="@OnNotesChanged"
                                 Editable="true" />
             <p class="text-muted small mt-1">
-                <i class="bi bi-info-circle"></i> Skalární pole se ukládají z Upravit tabu — změny zde nepřepíší databázi, dokud kliknete na <em>Uložit</em>.
+                <i class="bi bi-info-circle"></i> Skalární pole se ukládají z Upravit tabu — změny zde nepřepíší databázi, dokud nekliknete na <em>Uložit</em>.
             </p>
 
             <details class="oh-qst-rew-collapsed mt-4">

--- a/src/OvcinaHra.Client/Pages/Quests/QuestDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestDetail.razor
@@ -1,0 +1,755 @@
+@page "/quests/{Id:int}"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject NavigationManager Nav
+@inject GameContextService GameContext
+@implements IDisposable
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+<div class="d-flex align-items-center gap-3 mb-3 flex-wrap">
+    <button class="btn btn-sm btn-outline-secondary" type="button"
+            @onclick='() => Nav.NavigateTo("/quests")'>
+        <i class="bi bi-arrow-left"></i> Zpět
+    </button>
+    <h1 class="mb-0">@(quest?.Name ?? "Úkol")</h1>
+    @if (quest is not null && quest.GameId is not null)
+    {
+        <QuestStateChip State="@quest.State" />
+    }
+    <div class="ms-auto d-flex gap-2">
+        @if (quest is not null)
+        {
+            <button class="btn btn-sm btn-outline-secondary" type="button"
+                    @onclick="@(() => Nav.NavigateTo($"/quests/{Id}/print"))"
+                    title="Otevřít A5 kartu úkolu k tisku">
+                <i class="bi bi-printer"></i> Tisk A5
+            </button>
+        }
+    </div>
+</div>
+
+@if (loading)
+{
+    <p class="text-muted">Načítám…</p>
+}
+else if (quest is null && error is not null)
+{
+    <div class="alert alert-danger d-flex align-items-center gap-2">
+        <i class="bi bi-wifi-off"></i>
+        <span>Nepodařilo se načíst úkol: @error</span>
+        <button type="button" class="btn btn-sm btn-outline-primary ms-auto" @onclick="LoadAsync">Zkusit znovu</button>
+    </div>
+}
+else if (quest is null)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-emoji-frown fs-1 d-block mb-2"></i>
+        <p>Úkol nenalezen.</p>
+    </div>
+}
+else
+{
+    <div class="d-flex gap-2 mb-3 flex-wrap">
+        @foreach (var tab in tabs)
+        {
+            <button class="btn btn-sm @(activeTab == tab.Key ? "btn-primary" : "btn-outline-primary")"
+                    @onclick="@(() => activeTab = tab.Key)">
+                <i class="bi @tab.Icon"></i> @tab.Label
+                @if (tab.Count is int n && n > 0)
+                {
+                    <span class="oh-qst-d-tab-count">@n</span>
+                }
+            </button>
+        }
+    </div>
+
+    @if (activeTab == "karta")
+    {
+        <div class="oh-qst-karta-grid">
+            <article class="oh-qst-karta">
+                <div class="oh-qst-karta-hero">
+                    @if (!string.IsNullOrEmpty(quest.ImageUrl))
+                    {
+                        <img src="@quest.ImageUrl" alt="@quest.Name" class="oh-qst-karta-img" />
+                    }
+                    else
+                    {
+                        <div class="oh-qst-karta-img oh-qst-karta-img--placeholder">
+                            <i class="bi bi-journal-richtext"></i>
+                            <span class="oh-qst-karta-img-name">@quest.Name</span>
+                        </div>
+                    }
+                </div>
+                <h2 class="oh-qst-karta-name">@quest.Name</h2>
+                <div class="oh-qst-karta-meta">
+                    <span class="oh-pill">@quest.QuestTypeDisplay</span>
+                    @foreach (var t in quest.Tags)
+                    {
+                        <span class="oh-qst-tag-chip">@t.Name</span>
+                    }
+                </div>
+                @if (!string.IsNullOrWhiteSpace(quest.Description))
+                {
+                    <p class="oh-qst-karta-desc">@quest.Description</p>
+                }
+                @if (!string.IsNullOrWhiteSpace(quest.FullText))
+                {
+                    <hr class="oh-qst-karta-sep" />
+                    <p class="oh-qst-karta-fulltext">@quest.FullText</p>
+                }
+            </article>
+            <aside class="oh-qst-karta-side">
+                <div class="oh-qst-karta-side-block">
+                    <div class="oh-qst-karta-side-row">
+                        <span>Setkání</span>
+                        <strong>@quest.Encounters.Count</strong>
+                    </div>
+                    <div class="oh-qst-karta-side-row">
+                        <span>Lokace</span>
+                        <strong>@quest.Locations.Count</strong>
+                    </div>
+                    <div class="oh-qst-karta-side-row">
+                        <span>Odměny (předměty)</span>
+                        <strong>@quest.Rewards.Count</strong>
+                    </div>
+                    @if (quest.RewardXp is int xp && xp > 0)
+                    {
+                        <div class="oh-qst-karta-side-row"><span>XP</span><strong>@xp</strong></div>
+                    }
+                    @if (quest.RewardMoney is int money && money > 0)
+                    {
+                        <div class="oh-qst-karta-side-row"><span>Groše</span><strong>@money gr</strong></div>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(quest.TimeSlot))
+                    {
+                        <div class="oh-qst-karta-side-row"><span>Časový slot</span><strong>@quest.TimeSlot</strong></div>
+                    }
+                </div>
+
+                @if (quest.GameId is not null)
+                {
+                    <div class="oh-qst-karta-side-block">
+                        <h6 class="oh-qst-karta-side-title">Stav v této hře</h6>
+                        <div class="oh-qst-state-actions">
+                            <button class="btn btn-sm btn-outline-secondary"
+                                    disabled="@(quest.State == QuestState.Inactive)"
+                                    @onclick="@(() => SetStateAsync(QuestState.Inactive))">
+                                <i class="bi bi-circle"></i> Neaktivní
+                            </button>
+                            <button class="btn btn-sm btn-outline-success"
+                                    disabled="@(quest.State == QuestState.Active)"
+                                    @onclick="@(() => SetStateAsync(QuestState.Active))">
+                                <i class="bi bi-fire"></i> Aktivovat
+                            </button>
+                            <button class="btn btn-sm btn-outline-warning"
+                                    disabled="@(quest.State == QuestState.Completed)"
+                                    @onclick="@(() => SetStateAsync(QuestState.Completed))">
+                                <i class="bi bi-check2-circle"></i> Dokončit
+                            </button>
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <div class="oh-qst-karta-side-block">
+                        <h6 class="oh-qst-karta-side-title">Šablona</h6>
+                        <p class="text-muted small mb-2">Tato šablona se nepoužívá v žádné hře přímo. Stav (Neaktivní / Aktivní / Dokončený) se sleduje až po vytvoření kopie do hry.</p>
+                        @if (GameContext.SelectedGameId is int gid)
+                        {
+                            <button class="btn btn-sm btn-outline-primary w-100" type="button" @onclick="CopyToCurrentGameAsync"
+                                    disabled="@isCopying">
+                                @if (isCopying) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                                Vytvořit kopii pro hru #@gid
+                                <i class="bi bi-arrow-right"></i>
+                            </button>
+                        }
+                    </div>
+                }
+            </aside>
+        </div>
+    }
+    else if (activeTab == "upravit")
+    {
+        <div class="oh-qst-edit">
+            <DxFormLayout>
+                <DxFormLayoutGroup Caption="Identita" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="Název" ColSpanMd="8">
+                        <DxTextBox @bind-Text="@editModel.Name" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Typ" ColSpanMd="4">
+                        <DxComboBox Data="@questTypeValues" @bind-Value="@editModel.QuestType"
+                                    TextFieldName="Display" ValueFieldName="Value" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Pořadí v řetězu" ColSpanMd="4">
+                        <DxSpinEdit @bind-Value="@editModel.ChainOrder" MinValue="0" MaxValue="999"
+                                    NullText="(žádné)"
+                                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Nadřazený úkol (ID)" ColSpanMd="4">
+                        <DxSpinEdit @bind-Value="@editModel.ParentQuestId" MinValue="0"
+                                    NullText="(žádný)"
+                                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Časový slot" ColSpanMd="4">
+                        <DxTextBox @bind-Text="@editModel.TimeSlot" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+
+                <DxFormLayoutGroup Caption="Obrázek (5:7 portrét)" ColSpanMd="12">
+                    <DxFormLayoutItem ColSpanMd="12">
+                        <ImagePicker EntityType="quests" EntityId="@quest.Id"
+                                     AspectRatio="5:7" Width="280px"
+                                     Alt="@quest.Name" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+
+                <DxFormLayoutGroup Caption="Obsah" ColSpanMd="12">
+                    <DxFormLayoutItem ColSpanMd="12">
+                        <div class="oh-sacred-banner">
+                            <i class="bi bi-shield-fill-exclamation"></i>
+                            <span>Popis a herní text jsou <strong>posvátné</strong> — pište je tak, jak je uvidí hráč na herní kartě. Nezkracujte, neparafrázujte.</span>
+                        </div>
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Popis (organizátor)" ColSpanMd="12">
+                        <DxMemo @bind-Text="@editModel.Description" Rows="3" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Herní text (hráči)" ColSpanMd="12">
+                        <DxMemo @bind-Text="@editModel.FullText" Rows="6" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+
+                <DxFormLayoutGroup Caption="Skalární odměny" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="XP" ColSpanMd="3">
+                        <DxSpinEdit @bind-Value="@editModel.RewardXp" MinValue="0" MaxValue="9999"
+                                    NullText="(žádné)"
+                                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Groše" ColSpanMd="3">
+                        <DxSpinEdit @bind-Value="@editModel.RewardMoney" MinValue="0" MaxValue="99999"
+                                    NullText="(žádné)"
+                                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Poznámky k odměně" ColSpanMd="6">
+                        <DxTextBox @bind-Text="@editModel.RewardNotes" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+            </DxFormLayout>
+
+            @* Tags multi-select — quest tags only (TagKind == Quest) *@
+            <div class="oh-qst-edit-tags mt-3">
+                <h6><i class="bi bi-tags"></i> Tagy</h6>
+                @if (quest.Tags.Count > 0)
+                {
+                    <div class="d-flex flex-wrap gap-1 mb-2">
+                        @foreach (var tag in quest.Tags)
+                        {
+                            <span class="oh-qst-tag-chip">
+                                @tag.Name
+                                <button type="button" class="oh-qst-tag-chip-x"
+                                        @onclick="() => RemoveTagAsync(tag)" @onclick:stopPropagation="true"
+                                        title="Odebrat">
+                                    <i class="bi bi-x"></i>
+                                </button>
+                            </span>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <p class="text-muted small mb-2">Žádné tagy.</p>
+                }
+                <div class="d-flex gap-2 align-items-end">
+                    <div style="flex:1">
+                        <DxComboBox Data="@allQuestTags" @bind-Value="@newTagId"
+                                    TextFieldName="Name" ValueFieldName="Id"
+                                    NullText="(vyberte tag)" SearchMode="ListSearchMode.AutoSearch" />
+                    </div>
+                    <button class="btn btn-sm btn-outline-primary" type="button"
+                            disabled="@(newTagId is null)" @onclick="AddTagAsync">
+                        <i class="bi bi-plus"></i> Přidat tag
+                    </button>
+                </div>
+            </div>
+
+            @if (saveError is not null)
+            {
+                <div class="alert alert-danger mt-2">@saveError</div>
+            }
+
+            <div class="oh-qst-edit-foot">
+                <button class="btn btn-outline-danger" type="button"
+                        @onclick="() => isDeleteVisible = true" disabled="@isSaving">
+                    <i class="bi bi-trash"></i> Smazat
+                </button>
+                <div style="flex:1"></div>
+                <button class="btn btn-secondary" type="button"
+                        @onclick="ResetEditModel" disabled="@isSaving">Zrušit</button>
+                <button class="btn btn-primary" type="button"
+                        @onclick="SaveAsync" disabled="@(isSaving || string.IsNullOrWhiteSpace(editModel.Name))">
+                    @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                    Uložit
+                </button>
+            </div>
+        </div>
+    }
+    else if (activeTab == "setkani")
+    {
+        <div class="oh-qst-enc">
+            <div class="oh-qst-enc-toolbar">
+                <div class="oh-segmented" role="tablist" aria-label="Pohled">
+                    <button type="button"
+                            class="oh-segmented-btn @(encView == "seznam" ? "oh-segmented-btn--on" : "")"
+                            @onclick='() => encView = "seznam"'>
+                        <i class="bi bi-list-ul"></i> Seznam
+                    </button>
+                    <button type="button"
+                            class="oh-segmented-btn @(encView == "graf" ? "oh-segmented-btn--on" : "")"
+                            @onclick='() => encView = "graf"'>
+                        <i class="bi bi-diagram-3"></i> Graf
+                    </button>
+                </div>
+                <button class="btn btn-primary btn-sm" type="button" @onclick="() => isEncAddVisible = true">
+                    <i class="bi bi-plus-lg"></i> Nové setkání
+                </button>
+            </div>
+
+            @if (quest.Encounters.Count == 0)
+            {
+                <div class="text-center text-muted py-4">
+                    <i class="bi bi-shield-exclamation fs-1 d-block mb-2"></i>
+                    <p class="mb-0">Žádná setkání. Přidejte první setkání tlačítkem výše.</p>
+                </div>
+            }
+            else if (encView == "seznam")
+            {
+                <div class="oh-qst-enc-list">
+                    @{ var idx = 0; }
+                    @foreach (var e in quest.Encounters)
+                    {
+                        idx++;
+                        <EncounterCard @key="e.MonsterId"
+                                       Encounter="@e" Order="@idx" Editable="true"
+                                       OnRemove="@HandleEncounterRemoveRequested" />
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="oh-qst-enc-graph">
+                    @{ var idx = 0; }
+                    @foreach (var e in quest.Encounters)
+                    {
+                        idx++;
+                        <EncounterGraphNode @key="e.MonsterId" Encounter="@e" Order="@idx" />
+                        @if (idx < quest.Encounters.Count)
+                        {
+                            <div class="oh-qst-enc-graph-arrow" aria-hidden="true">
+                                <i class="bi bi-arrow-right"></i>
+                            </div>
+                        }
+                    }
+                </div>
+            }
+
+            <p class="text-muted small mt-3">
+                <i class="bi bi-info-circle"></i>
+                Phase 1 setkání obsahují jen Příšeru + Počet. Pořadí, název, lokace
+                a popis na úrovni setkání přicházejí v migraci 0.16.x (#193 follow-up).
+            </p>
+        </div>
+
+        <EncounterAddPopup @bind-Visible="isEncAddVisible"
+                           QuestId="@quest.Id"
+                           Added="@LoadAsync" />
+    }
+    else if (activeTab == "lokace")
+    {
+        <div class="oh-qst-loc">
+            <h3 class="mb-3"><i class="bi bi-geo-alt"></i> Lokace tohoto úkolu</h3>
+            @if (quest.Locations.Count == 0)
+            {
+                <p class="text-muted">Žádné lokace zatím nejsou přiřazeny.</p>
+            }
+            else
+            {
+                <div class="oh-qst-loc-list">
+                    @foreach (var l in quest.Locations)
+                    {
+                        <div class="oh-qst-loc-row" @key="l.LocationId">
+                            <button type="button" class="oh-qst-loc-chip"
+                                    @onclick="@(() => Nav.NavigateTo($"/locations/{l.LocationId}"))"
+                                    title="Otevřít lokaci">
+                                <i class="bi bi-geo-alt"></i>
+                                <span>@l.LocationName</span>
+                                <i class="bi bi-arrow-right"></i>
+                            </button>
+                            <button type="button" class="btn btn-sm btn-link text-danger p-0"
+                                    @onclick="@(() => HandleLocationRemoveRequested(l))" title="Odebrat lokaci">
+                                <i class="bi bi-x-circle"></i>
+                            </button>
+                        </div>
+                    }
+                </div>
+            }
+            <div class="oh-qst-loc-add mt-3">
+                <DxComboBox Data="@gameLocations" @bind-Value="@newLocationId"
+                            TextFieldName="Name" ValueFieldName="Id"
+                            NullText="(vyberte lokaci)"
+                            SearchMode="ListSearchMode.AutoSearch"
+                            CssClass="oh-qst-loc-pick" />
+                <button type="button" class="btn btn-primary btn-sm"
+                        disabled="@(newLocationId is null)" @onclick="AddLocationAsync">
+                    <i class="bi bi-plus"></i> Přidat lokaci
+                </button>
+            </div>
+            @if (locError is not null)
+            {
+                <div class="alert alert-danger mt-2">@locError</div>
+            }
+        </div>
+    }
+    else if (activeTab == "odmeny")
+    {
+        <div class="oh-qst-rew">
+            <RewardLootList QuestId="@quest.Id"
+                            Rewards="@quest.Rewards.ToList()"
+                            Editable="true"
+                            Changed="@LoadAsync" />
+
+            <h3 class="oh-qst-rew-section-title mt-4"><i class="bi bi-stars"></i> XP, groše, poznámky</h3>
+            <RewardScalarFields Xp="@editModel.RewardXp" XpChanged="@OnXpChanged"
+                                Money="@editModel.RewardMoney" MoneyChanged="@OnMoneyChanged"
+                                Notes="@editModel.RewardNotes" NotesChanged="@OnNotesChanged"
+                                Editable="true" />
+            <p class="text-muted small mt-1">
+                <i class="bi bi-info-circle"></i> Skalární pole se ukládají z Upravit tabu — změny zde nepřepíší databázi, dokud kliknete na <em>Uložit</em>.
+            </p>
+
+            <details class="oh-qst-rew-collapsed mt-4">
+                <summary><i class="bi bi-mortarboard"></i> Dovednosti — odměny</summary>
+                <div class="oh-qst-rew-disabled">
+                    <i class="bi bi-hourglass-split"></i>
+                    <p class="mb-1">Dovednosti jako odměna úkolu vyžadují novou tabulku QuestSkillReward — plánováno v migraci 0.16.x (#193 follow-up).</p>
+                    <button type="button" class="btn btn-outline-secondary btn-sm" disabled>
+                        <i class="bi bi-plus"></i> Přidat dovednost (Phase 2)
+                    </button>
+                </div>
+            </details>
+            <details class="oh-qst-rew-collapsed">
+                <summary><i class="bi bi-magic"></i> Kouzla — odměny</summary>
+                <div class="oh-qst-rew-disabled">
+                    <i class="bi bi-hourglass-split"></i>
+                    <p class="mb-1">Kouzla jako odměna úkolu vyžadují novou tabulku QuestSpellReward — plánováno v migraci 0.16.x (#193 follow-up).</p>
+                    <button type="button" class="btn btn-outline-secondary btn-sm" disabled>
+                        <i class="bi bi-plus"></i> Přidat kouzlo (Phase 2)
+                    </button>
+                </div>
+            </details>
+        </div>
+    }
+}
+
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Smazat úkol?" Width="400px">
+    <BodyContentTemplate Context="ctx">
+        <p>Smazat úkol <strong>@(quest?.Name)</strong>? Setkání, lokace, odměny a tagy budou odpojeny.</p>
+        @if (deleteError is not null)
+        {
+            <div class="alert alert-danger">@deleteError</div>
+        }
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" type="button" @onclick="() => isDeleteVisible = false">Zrušit</button>
+            <button class="btn btn-danger" type="button" @onclick="ConfirmDeleteAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public int Id { get; set; }
+
+    private QuestDetailDto? quest;
+    private bool loading = true;
+    private string? error;
+
+    private string activeTab = "karta";
+
+    // Edit form state
+    private EditModel editModel = new();
+    private bool isSaving;
+    private string? saveError;
+
+    // Delete state
+    private bool isDeleteVisible;
+    private string? deleteError;
+
+    // Tags
+    private List<TagDto> allQuestTags = [];
+    private int? newTagId;
+
+    // Locations
+    private List<LocationListDto> gameLocations = [];
+    private int? newLocationId;
+    private string? locError;
+
+    // Encounters
+    private string encView = "seznam";
+    private bool isEncAddVisible;
+
+    // Copy-to-game
+    private bool isCopying;
+
+    private record TabDef(string Key, string Label, string Icon, int? Count);
+
+    private List<TabDef> tabs => quest is null ? [] :
+    [
+        new("karta",   "Karta",     "bi-bookmark-fill",       null),
+        new("upravit", "Upravit",   "bi-pencil",              null),
+        new("setkani", "Setkání",   "bi-shield-exclamation",  quest.Encounters.Count),
+        new("lokace",  "Lokace",    "bi-geo-alt",             quest.Locations.Count),
+        new("odmeny",  "Odměny",    "bi-gift",                quest.Rewards.Count)
+    ];
+
+    private static readonly List<EnumItem<QuestType>> questTypeValues = Enum.GetValues<QuestType>()
+        .Select(v => new EnumItem<QuestType>(v, v.GetDisplayName())).ToList();
+
+    private record EnumItem<T>(T Value, string Display);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        GameContext.OnGameChanged += OnGameChanged;
+        await LoadAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (quest is not null && quest.Id != Id)
+            await LoadAsync();
+    }
+
+    private async void OnGameChanged()
+    {
+        await LoadPickerDataAsync();
+        StateHasChanged();
+    }
+
+    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        error = null;
+        try
+        {
+            quest = await Api.GetAsync<QuestDetailDto>($"/api/quests/{Id}");
+            if (quest is null)
+            {
+                error = "Úkol nenalezen.";
+                return;
+            }
+            ResetEditModel();
+            await LoadPickerDataAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { loading = false; }
+    }
+
+    private async Task LoadPickerDataAsync()
+    {
+        if (quest is null) return;
+        try
+        {
+            var tagsTask = Api.GetListAsync<TagDto>("/api/tags");
+            var gid = quest.GameId ?? GameContext.SelectedGameId;
+            var locationsTask = gid is int g
+                ? Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{g}")
+                : Api.GetListAsync<LocationListDto>("/api/locations");
+            await Task.WhenAll(tagsTask, locationsTask);
+            allQuestTags = (await tagsTask).Where(t => t.Kind == TagKind.Quest).ToList();
+            gameLocations = await locationsTask;
+        }
+        catch { /* picker data is non-critical for read view */ }
+    }
+
+    private void ResetEditModel()
+    {
+        if (quest is null) return;
+        editModel = new EditModel
+        {
+            Name = quest.Name,
+            QuestType = quest.QuestType,
+            Description = quest.Description,
+            FullText = quest.FullText,
+            TimeSlot = quest.TimeSlot,
+            RewardXp = quest.RewardXp,
+            RewardMoney = quest.RewardMoney,
+            RewardNotes = quest.RewardNotes,
+            ChainOrder = quest.ChainOrder,
+            ParentQuestId = quest.ParentQuestId
+        };
+        saveError = null;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (quest is null || string.IsNullOrWhiteSpace(editModel.Name)) return;
+        saveError = null;
+        isSaving = true;
+        try
+        {
+            var dto = new UpdateQuestDto(
+                editModel.Name.Trim(), editModel.QuestType,
+                editModel.Description, editModel.FullText, editModel.TimeSlot,
+                editModel.RewardXp, editModel.RewardMoney, editModel.RewardNotes,
+                editModel.ChainOrder, editModel.ParentQuestId);
+            var (ok, problem) = await Api.PutWithProblemAsync($"/api/quests/{quest.Id}", dto);
+            if (!ok)
+            {
+                saveError = problem ?? "Uložení se nezdařilo.";
+                return;
+            }
+            await LoadAsync();
+        }
+        catch (Exception ex) { saveError = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        if (quest is null) return;
+        deleteError = null;
+        try
+        {
+            var ok = await Api.DeleteAsync($"/api/quests/{quest.Id}");
+            if (!ok)
+            {
+                deleteError = "Smazání se nezdařilo (úkol může mít odkazy).";
+                return;
+            }
+            isDeleteVisible = false;
+            Nav.NavigateTo("/quests");
+        }
+        catch (Exception ex) { deleteError = ex.Message; }
+    }
+
+    private async Task SetStateAsync(QuestState state)
+    {
+        if (quest is null || quest.GameId is null) return;
+        try
+        {
+            // PATCH /state — server validates the enum value.
+            await Api.PatchAsync($"/api/quests/{quest.Id}/state",
+                new UpdateQuestStateDto(state));
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task CopyToCurrentGameAsync()
+    {
+        if (quest is null) return;
+        var gid = GameContext.SelectedGameId;
+        if (gid is null) return;
+        isCopying = true;
+        try
+        {
+            var result = await Api.PostAsync<object, QuestCopyResultDto>(
+                $"/api/quests/{quest.Id}/copy-to-game/{gid.Value}", new { });
+            if (result is not null)
+            {
+                Nav.NavigateTo($"/quests/{result.Quest.Id}");
+            }
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isCopying = false; }
+    }
+
+    private async Task AddTagAsync()
+    {
+        if (quest is null || newTagId is null) return;
+        try
+        {
+            await Api.PostAsync($"/api/quests/{quest.Id}/tags/{newTagId}");
+            newTagId = null;
+            await LoadAsync();
+        }
+        catch (Exception ex) { saveError = ex.Message; }
+    }
+
+    private async Task RemoveTagAsync(TagDto tag)
+    {
+        if (quest is null) return;
+        try
+        {
+            await Api.DeleteAsync($"/api/quests/{quest.Id}/tags/{tag.Id}");
+            await LoadAsync();
+        }
+        catch (Exception ex) { saveError = ex.Message; }
+    }
+
+    private async Task AddLocationAsync()
+    {
+        if (quest is null || newLocationId is null) return;
+        locError = null;
+        try
+        {
+            var (ok, _, problem) = await Api.PostWithProblemAsync<AddQuestLocationDto, object>(
+                $"/api/quests/{quest.Id}/locations",
+                new AddQuestLocationDto(newLocationId.Value));
+            if (!ok)
+            {
+                locError = problem ?? "Přidání lokace selhalo.";
+                return;
+            }
+            newLocationId = null;
+            await LoadAsync();
+        }
+        catch (Exception ex) { locError = ex.Message; }
+    }
+
+    private async Task HandleLocationRemoveRequested(QuestLocationDto loc)
+    {
+        if (quest is null) return;
+        try
+        {
+            var ok = await Api.DeleteAsync($"/api/quests/{quest.Id}/locations/{loc.LocationId}");
+            if (!ok)
+            {
+                locError = "Odebrání lokace selhalo.";
+                return;
+            }
+            await LoadAsync();
+        }
+        catch (Exception ex) { locError = ex.Message; }
+    }
+
+    private async Task HandleEncounterRemoveRequested(QuestEncounterDto enc)
+    {
+        if (quest is null) return;
+        try
+        {
+            var ok = await Api.DeleteAsync($"/api/quests/{quest.Id}/encounters/{enc.MonsterId}");
+            if (!ok) return;
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private void OnXpChanged(int? v) => editModel.RewardXp = v;
+    private void OnMoneyChanged(int? v) => editModel.RewardMoney = v;
+    private void OnNotesChanged(string? v) => editModel.RewardNotes = v;
+
+    private sealed class EditModel
+    {
+        public string Name { get; set; } = "";
+        public QuestType QuestType { get; set; } = QuestType.General;
+        public string? Description { get; set; }
+        public string? FullText { get; set; }
+        public string? TimeSlot { get; set; }
+        public int? RewardXp { get; set; }
+        public int? RewardMoney { get; set; }
+        public string? RewardNotes { get; set; }
+        public int? ChainOrder { get; set; }
+        public int? ParentQuestId { get; set; }
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
@@ -1,538 +1,344 @@
 @page "/quests"
 @attribute [Authorize]
 @inject ApiClient Api
-@inject GameContextService GameContext
 @inject NavigationManager Nav
+@inject IJSRuntime JS
+@inject GameContextService GameContext
 @implements IDisposable
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
 
 <div class="d-flex justify-content-between align-items-center mb-3">
-    <h1 class="mb-0">@(Catalog ? "Katalog questů" : "Questy")</h1>
-    <div class="d-flex gap-2">
-        <div class="btn-group">
-            <button class="btn @(Catalog ? "btn-outline-secondary" : "btn-secondary")" @onclick="() => SetCatalog(false)">Aktuální hra</button>
-            <button class="btn @(Catalog ? "btn-secondary" : "btn-outline-secondary")" @onclick="() => SetCatalog(true)">Katalog</button>
+    <h1 class="mb-0">Katalog úkolů</h1>
+    <div class="d-flex gap-2 align-items-center">
+        @* Mode toggle: Catalog (templates) ↔ Per-game grid. Per-game lives at
+           /games/{gid}/quests so this is just a navigation jump, not a query
+           flag. *@
+        <div class="oh-segmented" role="tablist" aria-label="Režim">
+            <button type="button" class="oh-segmented-btn oh-segmented-btn--on"
+                    aria-selected="true">Šablony katalogu</button>
+            <button type="button" class="oh-segmented-btn"
+                    @onclick="NavigateToGameGrid"
+                    aria-selected="false">Pro tuto hru</button>
         </div>
-        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nový quest</button>
+
+        @* View toggle: Galerie (default) ↔ Seznam (DxGrid). Persisted to
+           localStorage under oh-quest-view. *@
+        <div class="oh-segmented" role="tablist" aria-label="Zobrazení">
+            <button type="button"
+                    class="oh-segmented-btn @(view == "galerie" ? "oh-segmented-btn--on" : "")"
+                    @onclick='() => SetViewAsync("galerie")' aria-selected="@(view == "galerie")">
+                <i class="bi bi-grid-3x3-gap"></i> Galerie
+            </button>
+            <button type="button"
+                    class="oh-segmented-btn @(view == "seznam" ? "oh-segmented-btn--on" : "")"
+                    @onclick='() => SetViewAsync("seznam")' aria-selected="@(view == "seznam")">
+                <i class="bi bi-list-ul"></i> Seznam
+            </button>
+        </div>
+
+        <button class="btn btn-primary" type="button" @onclick="OpenCreateModal">
+            <i class="bi bi-plus-lg"></i> Nový úkol
+        </button>
     </div>
 </div>
 
-@if (loading) { <p>Načítám...</p> }
-else if (Catalog)
+@if (view == "galerie")
 {
-    <OvcinaGrid Data="@catalogQuests" KeyFieldName="Id" LayoutKey="grid-layout-quests-catalog-v2"
-                RowClick="@(e => OpenModalFromCatalog((QuestCatalogDto)e.Grid.GetDataItem(e.VisibleIndex)))">
-        <Columns>
-            <DxGridDataColumn FieldName="Name" Caption="Název" Width="220px" />
-            <DxGridDataColumn FieldName="QuestTypeDisplay" Caption="Typ" Width="130px" />
-            <DxGridDataColumn FieldName="FullText" Caption="Herní text" />
-            <DxGridDataColumn FieldName="Description" Caption="Organizátor" />
-            <DxGridDataColumn FieldName="RewardSummary" Caption="Odměny" Width="220px" />
-            <DxGridDataColumn FieldName="CatalogAction" Caption="Akce" Width="110px"
-                              UnboundType="GridUnboundColumnType.String"
-                              AllowSort="false" AllowGroup="false">
-                <CellDisplayTemplate>
-                    @{
-                        var q = (QuestCatalogDto)context.DataItem;
-                    }
-                    <button class="btn btn-sm btn-outline-success" @onclick:stopPropagation="true"
-                            @onclick="() => OpenCopyPopup(q)">Přidat</button>
-                </CellDisplayTemplate>
-            </DxGridDataColumn>
-        </Columns>
-    </OvcinaGrid>
+    <div class="oh-qst-filters mb-3">
+        <DxTextBox Text="@searchText" TextChanged="@((string v) => searchText = v)"
+                   NullText="Hledat (název, popis)…" CssClass="oh-qst-filter-search" />
+        <label class="oh-qst-filter-toggle">
+            <input type="checkbox" @bind="onlyWithImage" />
+            <span>jen s obrázkem</span>
+        </label>
+        <label class="oh-qst-filter-toggle">
+            <input type="checkbox" @bind="onlyWithRewards" />
+            <span>jen s odměnami</span>
+        </label>
+    </div>
 }
-else if (quests.Count == 0)
+
+@if (loading)
+{
+    <p class="text-muted">Načítám…</p>
+}
+else if (filtered.Count == 0)
 {
     <div class="text-center text-muted py-5">
-        <i class="bi bi-journal-text fs-1 d-block mb-2"></i>
-        <p>Žádné questy přiřazeny k této hře.</p>
-        <button class="btn btn-outline-primary" @onclick="() => SetCatalog(true)">Otevřít katalog</button>
+        <i class="bi bi-journal-richtext fs-1 d-block mb-2"></i>
+        <p>Žádné úkoly v katalogu odpovídají filtru.</p>
+        <button class="btn btn-outline-primary" type="button" @onclick="ClearFilters">Zrušit filtry</button>
+    </div>
+}
+else if (view == "galerie")
+{
+    <div class="oh-qst-gallery">
+        @foreach (var q in filtered)
+        {
+            @* Adapter: gallery shows catalog templates (no GameId, no State
+               chip). Map QuestCatalogDto onto a QuestListDto for the tile. *@
+            <QuestPosterTile @key="q.Id"
+                             Quest="@CatalogToList(q)"
+                             ShowState="false"
+                             OnClick="@(_ => Nav.NavigateTo($"/quests/{q.Id}"))" />
+        }
     </div>
 }
 else
 {
-    <OvcinaGrid Data="@quests" KeyFieldName="Id" LayoutKey="grid-layout-quests"
-                RowClick="@(e => OpenModal((QuestListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+    @* Seznam mode — LayoutKey bumped to grid-layout-quests-v2 because the
+       column schema changed (image, counts, state). Memory rule:
+       feedback_ovcinagrid_layoutkey_bump. *@
+    <OvcinaGrid Data="@filtered" KeyFieldName="Id" LayoutKey="grid-layout-quests-v2"
+                RowClick="@(e => OpenPeek((QuestCatalogDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
-            <DxGridDataColumn FieldName="Name" Caption="Název" />
+            <DxGridDataColumn Caption="" Width="60px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var q = (QuestCatalogDto)context.DataItem; }
+                    <div class="oh-qst-mini-tile @(string.IsNullOrEmpty(q.ImageUrl) ? "oh-qst-mini-tile--placeholder" : "")">
+                        @if (!string.IsNullOrEmpty(q.ImageUrl))
+                        {
+                            <img src="@q.ImageUrl" alt="@q.Name" />
+                        }
+                        else
+                        {
+                            <i class="bi bi-journal-richtext"></i>
+                        }
+                    </div>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Name" Caption="Název" MinWidth="220" />
             <DxGridDataColumn FieldName="QuestTypeDisplay" Caption="Typ" Width="140px" />
-            <DxGridDataColumn FieldName="ChainOrder" Caption="Pořadí v řetězu" Width="140px" Visible="false" />
-            <DxGridDataColumn FieldName="ParentQuestId" Caption="Nadřazený quest" Width="140px" Visible="false" />
-            <DxGridDataColumn FieldName="GameId" Caption="Hra ID" Width="80px" />
+            <DxGridDataColumn FieldName="EncountersCount" Caption="Setkání" Width="100px">
+                <CellDisplayTemplate>
+                    @{ var q = (QuestCatalogDto)context.DataItem; }
+                    <span class="oh-pill-mono">@q.EncountersCount</span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="RewardsCount" Caption="Odměny" Width="100px">
+                <CellDisplayTemplate>
+                    @{ var q = (QuestCatalogDto)context.DataItem; }
+                    <span class="oh-pill-mono">@q.RewardsCount</span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="RewardSummary" Caption="Souhrn odměn" MinWidth="240" />
+            <DxGridDataColumn FieldName="Description" Caption="Popis" MinWidth="240" Visible="false" />
         </Columns>
     </OvcinaGrid>
 }
 
-<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="900px">
-    <BodyContentTemplate Context="popupContext">
-        <DxFormLayout>
-            <DxFormLayoutItem Caption="Název" ColSpanMd="8">
-                <DxTextBox @bind-Text="@name" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Typ" ColSpanMd="4">
-                <DxComboBox Data="@questTypeValues" @bind-Value="@questType" TextFieldName="Display" ValueFieldName="Value" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Pořadí v řetězu" ColSpanMd="4">
-                <DxSpinEdit @bind-Value="@chainOrder" MinValue="0" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Nadřazený quest ID" ColSpanMd="4">
-                <DxSpinEdit @bind-Value="@parentQuestId" MinValue="0" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Popis (organizátor)" ColSpanMd="12">
-                <DxMemo @bind-Text="@description" Rows="2" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Herní text (hráči)" ColSpanMd="12">
-                <DxMemo @bind-Text="@fullText" Rows="3" />
-            </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Časový slot" ColSpanMd="12">
-                <DxTextBox @bind-Text="@timeSlot" />
-            </DxFormLayoutItem>
-            <DxFormLayoutGroup Caption="Odměny" ColSpanMd="12">
-                <DxFormLayoutItem Caption="XP" ColSpanMd="4">
-                    <DxSpinEdit @bind-Value="@rewardXp" MinValue="0" />
-                </DxFormLayoutItem>
-                <DxFormLayoutItem Caption="Groše" ColSpanMd="4">
-                    <DxSpinEdit @bind-Value="@rewardMoney" MinValue="0" />
-                </DxFormLayoutItem>
-                <DxFormLayoutItem Caption="Poznámky" ColSpanMd="4">
-                    <DxTextBox @bind-Text="@rewardNotes" />
-                </DxFormLayoutItem>
-            </DxFormLayoutGroup>
-        </DxFormLayout>
-
-        @if (editingId.HasValue)
+@* Quick-peek popup — Seznam row click. Same shape as Spell peek. *@
+<DxPopup @bind-Visible="@isPeekVisible" HeaderText="@(peekItem?.Name ?? "Úkol")" Width="720px">
+    <BodyContentTemplate Context="qpCtx">
+        @if (peekItem is null)
         {
-            @* Section 1: Tags *@
-            <div class="mt-3 p-3 border rounded" style="background: var(--oh-primary-surface, #f8f9fa);">
-                <h6 class="mb-2"><i class="bi bi-tags me-1"></i> Tagy</h6>
-                @if (questTags.Count > 0)
-                {
-                    <div class="d-flex flex-wrap gap-1 mb-2">
-                        @foreach (var tag in questTags)
+            <p class="text-muted">Načítám…</p>
+        }
+        else
+        {
+            <div class="oh-qst-peek-grid">
+                <div>
+                    <div class="oh-qst-peek-meta">
+                        <span class="oh-pill">@peekItem.QuestTypeDisplay</span>
+                        @if (peekItem.EncountersCount > 0)
                         {
-                            <span class="badge bg-secondary d-inline-flex align-items-center gap-1">
-                                @tag.Name
-                                <button class="btn btn-sm p-0 text-white border-0" style="line-height:1" @onclick="() => RemoveTagAsync(tag)" @onclick:stopPropagation="true">
-                                    <i class="bi bi-x"></i>
-                                </button>
-                            </span>
+                            <span class="oh-pill-mono"><i class="bi bi-shield-exclamation"></i> @peekItem.EncountersCount setkání</span>
+                        }
+                        @if (peekItem.RewardsCount > 0)
+                        {
+                            <span class="oh-pill-mono"><i class="bi bi-gift"></i> @peekItem.RewardsCount odměn</span>
                         }
                     </div>
-                }
-                else
-                {
-                    <p class="text-muted small mb-2">Žádné tagy.</p>
-                }
-                <div class="d-flex gap-2 align-items-end">
-                    <div style="flex:1">
-                        <label class="form-label small mb-0">Tag</label>
-                        <DxComboBox Data="@allQuestTags" @bind-Value="@newTagId"
-                                    TextFieldName="Name" ValueFieldName="Id"
-                                    NullText="(vyberte tag)" SearchMode="ListSearchMode.AutoSearch" />
-                    </div>
-                    <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newTagId is null)" @onclick="AddTagAsync">
-                        <i class="bi bi-plus"></i>
-                    </button>
+                    @if (!string.IsNullOrWhiteSpace(peekItem.Description))
+                    {
+                        <p class="oh-qst-peek-desc">@peekItem.Description</p>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(peekItem.RewardSummary))
+                    {
+                        <p class="oh-qst-peek-rewards"><strong>Odměny:</strong> @peekItem.RewardSummary</p>
+                    }
+                </div>
+                <div class="oh-qst-peek-side">
+                    @if (!string.IsNullOrEmpty(peekItem.ImageUrl))
+                    {
+                        <img src="@peekItem.ImageUrl" alt="@peekItem.Name" class="oh-qst-peek-img" />
+                    }
+                    else
+                    {
+                        <div class="oh-qst-peek-img oh-qst-peek-img--placeholder">
+                            <i class="bi bi-journal-richtext"></i>
+                        </div>
+                    }
                 </div>
             </div>
-
-            @* Section 2: Locations *@
-            <div class="mt-3 p-3 border rounded" style="background: var(--oh-primary-surface, #f8f9fa);">
-                <h6 class="mb-2"><i class="bi bi-geo-alt me-1"></i> Lokace</h6>
-                @if (questLocations.Count > 0)
-                {
-                    <table class="table table-sm mb-2">
-                        <thead><tr><th>Lokace</th><th style="width:40px"></th></tr></thead>
-                        <tbody>
-                            @foreach (var loc in questLocations)
-                            {
-                                <tr>
-                                    <td>@loc.LocationName</td>
-                                    <td><button class="btn btn-sm btn-link text-danger p-0" @onclick="() => RemoveLocationAsync(loc)" @onclick:stopPropagation="true"><i class="bi bi-x-circle"></i></button></td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                }
-                else
-                {
-                    <p class="text-muted small mb-2">Žádné lokace.</p>
-                }
-                <div class="d-flex gap-2 align-items-end">
-                    <div style="flex:1">
-                        <label class="form-label small mb-0">Lokace</label>
-                        <DxComboBox Data="@gameLocations" @bind-Value="@newLocationId"
-                                    TextFieldName="Name" ValueFieldName="Id"
-                                    NullText="(vyberte lokaci)" SearchMode="ListSearchMode.AutoSearch" />
-                    </div>
-                    <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newLocationId is null)" @onclick="AddLocationAsync">
-                        <i class="bi bi-plus"></i>
-                    </button>
-                </div>
-            </div>
-
-            @* Section 3: Encounters *@
-            <div class="mt-3 p-3 border rounded" style="background: var(--oh-primary-surface, #f8f9fa);">
-                <h6 class="mb-2"><i class="bi bi-shield-exclamation me-1"></i> Střetnutí</h6>
-                @if (questEncounters.Count > 0)
-                {
-                    <table class="table table-sm mb-2">
-                        <thead><tr><th>Příšera</th><th style="width:80px">Počet</th><th style="width:40px"></th></tr></thead>
-                        <tbody>
-                            @foreach (var enc in questEncounters)
-                            {
-                                <tr>
-                                    <td>@enc.MonsterName</td>
-                                    <td>@enc.Quantity</td>
-                                    <td><button class="btn btn-sm btn-link text-danger p-0" @onclick="() => RemoveEncounterAsync(enc)" @onclick:stopPropagation="true"><i class="bi bi-x-circle"></i></button></td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                }
-                else
-                {
-                    <p class="text-muted small mb-2">Žádná střetnutí.</p>
-                }
-                <div class="d-flex gap-2 align-items-end">
-                    <div style="flex:1">
-                        <label class="form-label small mb-0">Příšera</label>
-                        <DxComboBox Data="@allMonsters" @bind-Value="@newEncounterMonsterId"
-                                    TextFieldName="Name" ValueFieldName="Id"
-                                    NullText="(vyberte příšeru)" SearchMode="ListSearchMode.AutoSearch" />
-                    </div>
-                    <div style="width:80px">
-                        <label class="form-label small mb-0">Počet</label>
-                        <DxSpinEdit @bind-Value="@newEncounterQuantity" MinValue="1" />
-                    </div>
-                    <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newEncounterMonsterId is null)" @onclick="AddEncounterAsync">
-                        <i class="bi bi-plus"></i>
-                    </button>
-                </div>
-            </div>
-
-            @* Section 4: Rewards *@
-            <div class="mt-3 p-3 border rounded" style="background: var(--oh-primary-surface, #f8f9fa);">
-                <h6 class="mb-2"><i class="bi bi-gift me-1"></i> Odměny (předměty)</h6>
-                @if (questRewards.Count > 0)
-                {
-                    <table class="table table-sm mb-2">
-                        <thead><tr><th>Předmět</th><th style="width:80px">Počet</th><th style="width:40px"></th></tr></thead>
-                        <tbody>
-                            @foreach (var rew in questRewards)
-                            {
-                                <tr>
-                                    <td>@rew.ItemName</td>
-                                    <td>@rew.Quantity</td>
-                                    <td><button class="btn btn-sm btn-link text-danger p-0" @onclick="() => RemoveRewardAsync(rew)" @onclick:stopPropagation="true"><i class="bi bi-x-circle"></i></button></td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                }
-                else
-                {
-                    <p class="text-muted small mb-2">Žádné předměty.</p>
-                }
-                <div class="d-flex gap-2 align-items-end">
-                    <div style="flex:1">
-                        <label class="form-label small mb-0">Předmět</label>
-                        <DxComboBox Data="@allItems" @bind-Value="@newRewardItemId"
-                                    TextFieldName="Name" ValueFieldName="Id"
-                                    NullText="(vyberte předmět)" SearchMode="ListSearchMode.AutoSearch" />
-                    </div>
-                    <div style="width:80px">
-                        <label class="form-label small mb-0">Počet</label>
-                        <DxSpinEdit @bind-Value="@newRewardQuantity" MinValue="1" />
-                    </div>
-                    <button class="btn btn-sm btn-outline-primary" style="height:34px" disabled="@(newRewardItemId is null)" @onclick="AddRewardAsync">
-                        <i class="bi bi-plus"></i>
-                    </button>
-                </div>
+            <div class="oh-qst-peek-foot">
+                <button class="btn btn-secondary" type="button" @onclick="() => isPeekVisible = false">Zavřít</button>
+                <button class="btn btn-primary" type="button"
+                        @onclick="@(() => Nav.NavigateTo($"/quests/{peekItem!.Id}"))">
+                    Otevřít detail <i class="bi bi-arrow-right"></i>
+                </button>
             </div>
         }
-
-        @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
-        <div class="d-flex gap-2 mt-3">
-            @if (editingId.HasValue) { <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true">Smazat</button> }
-            <div style="flex: 1"></div>
-            <button class="btn btn-secondary" @onclick="() => isModalVisible = false">Zrušit</button>
-            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">Uložit</button>
-        </div>
     </BodyContentTemplate>
 </DxPopup>
 
-<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
-    <BodyContentTemplate Context="popupContext">
-        <p>Smazat quest <strong>@name</strong>?</p>
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
-            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync">Smazat</button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
+@* "+ Nový úkol" create modal — minimal (Name + QuestType). After create we
+   navigate to /quests/{id} for full editing on the Upravit tab. *@
+<DxPopup AllowResize="true" @bind-Visible="@isCreateVisible" HeaderText="Nový úkol (šablona)" Width="560px">
+    <BodyContentTemplate Context="cCtx">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                <DxTextBox @bind-Text="@createName" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Typ" ColSpanMd="12">
+                <DxComboBox Data="@questTypeValues" @bind-Value="@createType"
+                            TextFieldName="Display" ValueFieldName="Value" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
 
-<DxPopup @bind-Visible="@isCopyVisible" HeaderText="Kopírovat quest" Width="450px">
-    <BodyContentTemplate Context="popupContext">
-        @if (copySource is not null)
+        @if (createError is not null)
         {
-            <p>Quest: <strong>@copySource.Name</strong></p>
-            @if (copySource.GameName is not null)
-            {
-                <p class="text-muted">Zdrojová hra: @copySource.GameName (edice @copySource.GameEdition)</p>
-            }
-            @if (copyWarnings.Count > 0)
-            {
-                <div class="alert alert-warning">
-                    <strong>Upozornění:</strong>
-                    <ul class="mb-0">
-                        @foreach (var w in copyWarnings) { <li>@w</li> }
-                    </ul>
-                </div>
-            }
-            @if (copyDone)
-            {
-                <div class="alert alert-success">Quest byl zkopírován.</div>
-            }
-            @if (copyError is not null) { <div class="alert alert-danger">@copyError</div> }
+            <div class="alert alert-danger mt-2">@createError</div>
         }
+
         <div class="d-flex gap-2 justify-content-end mt-3">
-            <button class="btn btn-secondary" @onclick="() => isCopyVisible = false">Zavřít</button>
-            @if (!copyDone)
-            {
-                <button class="btn btn-primary" @onclick="ConfirmCopyAsync" disabled="@isCopying">Kopírovat do aktuální hry</button>
-            }
+            <button class="btn btn-secondary" type="button" @onclick="() => isCreateVisible = false" disabled="@isCreating">Zrušit</button>
+            <button class="btn btn-primary" type="button" @onclick="CreateAsync"
+                    disabled="@(isCreating || string.IsNullOrWhiteSpace(createName))">
+                @if (isCreating) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit a otevřít
+            </button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
 
 @code {
-    [SupplyParameterFromQuery] public bool Catalog { get; set; }
+    private List<QuestCatalogDto> catalog = [];
+    private bool loading = true;
 
-    private List<QuestListDto> quests = []; private List<QuestCatalogDto> catalogQuests = [];
-    private bool loading = true, isModalVisible, isDeleteVisible, isSaving;
-    private string modalTitle = "", name = ""; private string? error, description, fullText, timeSlot, rewardNotes;
-    private int? editingId; private QuestType questType = QuestType.General;
-    private int chainOrder, parentQuestId, rewardXp, rewardMoney;
-    private int gameId => GameContext.SelectedGameId ?? 1;
+    private string view = "galerie"; // galerie | seznam — persisted in localStorage
+    private string searchText = "";
+    private bool onlyWithImage;
+    private bool onlyWithRewards;
 
-    // Catalog copy state
-    private bool isCopyVisible, isCopying, copyDone;
-    private QuestCatalogDto? copySource;
-    private string? copyError;
-    private List<string> copyWarnings = [];
+    private bool isPeekVisible;
+    private QuestCatalogDto? peekItem;
 
-    // Tags state
-    private List<TagDto> questTags = [];
-    private List<TagDto> allQuestTags = [];
-    private int? newTagId;
-
-    // Locations state
-    private List<QuestLocationDto> questLocations = [];
-    private List<LocationListDto> gameLocations = [];
-    private int? newLocationId;
-
-    // Encounters state
-    private List<QuestEncounterDto> questEncounters = [];
-    private List<MonsterListDto> allMonsters = [];
-    private int? newEncounterMonsterId;
-    private int newEncounterQuantity = 1;
-
-    // Rewards state
-    private List<QuestRewardDto> questRewards = [];
-    private List<ItemListDto> allItems = [];
-    private int? newRewardItemId;
-    private int newRewardQuantity = 1;
+    private bool isCreateVisible;
+    private bool isCreating;
+    private string? createError;
+    private string createName = "";
+    private QuestType createType = QuestType.General;
 
     private static readonly List<EnumItem<QuestType>> questTypeValues = Enum.GetValues<QuestType>()
         .Select(v => new EnumItem<QuestType>(v, v.GetDisplayName())).ToList();
-    record EnumItem<T>(T Value, string Display);
+
+    private record EnumItem<T>(T Value, string Display);
+
+    private List<QuestCatalogDto> filtered =>
+        catalog.Where(q =>
+            (string.IsNullOrWhiteSpace(searchText)
+                || q.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                || (q.Description?.Contains(searchText, StringComparison.OrdinalIgnoreCase) ?? false)
+                || (q.FullText?.Contains(searchText, StringComparison.OrdinalIgnoreCase) ?? false))
+            && (!onlyWithImage || !string.IsNullOrEmpty(q.ImageUrl))
+            && (!onlyWithRewards || q.RewardsCount > 0))
+            .ToList();
 
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
-        GameContext.OnGameChanged += OnGameChanged;
-    }
-
-    protected override async Task OnParametersSetAsync()
-    {
+        try
+        {
+            view = await JS.InvokeAsync<string>("localStorage.getItem", "oh-quest-view") ?? "galerie";
+            if (view != "galerie" && view != "seznam") view = "galerie";
+        }
+        catch { view = "galerie"; }
         await LoadAsync();
     }
 
     private async Task LoadAsync()
     {
         loading = true;
-        if (Catalog)
-            catalogQuests = await Api.GetListAsync<QuestCatalogDto>("/api/quests/all");
-        else
-            quests = await Api.GetListAsync<QuestListDto>($"/api/quests/by-game/{gameId}");
-        loading = false;
-    }
-
-    private void SetCatalog(bool catalog)
-    {
-        Nav.NavigateTo($"/quests{(catalog ? "?catalog=true" : "")}", forceLoad: false);
-    }
-
-    private void OpenCopyPopup(QuestCatalogDto q)
-    {
-        copySource = q; copyWarnings = []; copyError = null; copyDone = false;
-        isCopyVisible = true;
-    }
-
-    private void OpenModalFromCatalog(QuestCatalogDto q)
-    {
-        OpenModal(new QuestListDto(q.Id, q.Name, q.QuestType, null, null, q.GameId));
-    }
-
-    private async Task ConfirmCopyAsync()
-    {
-        if (copySource is null) return;
-        isCopying = true; copyError = null;
         try
         {
-            var result = await Api.PostAsync<object, QuestCopyResultDto>($"/api/quests/{copySource.Id}/copy-to-game/{gameId}", new { });
-            if (result is not null) { copyWarnings = result.Warnings; copyDone = true; }
+            catalog = await Api.GetListAsync<QuestCatalogDto>("/api/quests/all");
         }
-        catch (Exception ex) { copyError = ex.Message; }
-        finally { isCopying = false; }
+        finally { loading = false; }
     }
 
-    private async void OnGameChanged() { await LoadAsync(); StateHasChanged(); }
-    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
-
-    private void OpenModal(QuestListDto? q)
+    private async Task SetViewAsync(string newView)
     {
-        error = null;
-        if (q is null)
+        if (view == newView) return;
+        view = newView;
+        try { await JS.InvokeVoidAsync("localStorage.setItem", "oh-quest-view", view); }
+        catch { /* localStorage unavailable — ignore */ }
+    }
+
+    private void NavigateToGameGrid()
+    {
+        var gameId = GameContext.SelectedGameId;
+        if (gameId is null)
         {
-            editingId = null; name = ""; questType = QuestType.General; chainOrder = 0; parentQuestId = 0;
-            description = null; fullText = null; timeSlot = null; rewardXp = 0; rewardMoney = 0; rewardNotes = null;
-            modalTitle = "Nový quest";
+            // No game picked — keep user on catalog and surface a hint inline
+            return;
         }
-        else
-        {
-            editingId = q.Id; name = q.Name; questType = q.QuestType; chainOrder = q.ChainOrder ?? 0; parentQuestId = q.ParentQuestId ?? 0;
-            modalTitle = $"Upravit: {q.Name}";
-            _ = LoadDetailAsync(q.Id);
-            _ = LoadPickerDataAsync();
-        }
-        isModalVisible = true;
+        Nav.NavigateTo($"/games/{gameId.Value}/quests");
     }
 
-    private async Task LoadPickerDataAsync()
+    private void OpenPeek(QuestCatalogDto q)
     {
-        var tagsTask = Api.GetListAsync<TagDto>("/api/tags");
-        var locationsTask = Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gameId}");
-        var monstersTask = Api.GetListAsync<MonsterListDto>("/api/monsters");
-        var itemsTask = Api.GetListAsync<ItemListDto>("/api/items");
-        await Task.WhenAll(tagsTask, locationsTask, monstersTask, itemsTask);
-        allQuestTags = (await tagsTask).Where(t => t.Kind == TagKind.Quest).ToList();
-        gameLocations = await locationsTask;
-        allMonsters = await monstersTask;
-        allItems = await itemsTask;
-        StateHasChanged();
+        peekItem = q;
+        isPeekVisible = true;
     }
 
-    private async Task LoadDetailAsync(int id)
+    private void OpenCreateModal()
     {
-        var d = await Api.GetAsync<QuestDetailDto>($"/api/quests/{id}");
-        if (d is not null)
-        {
-            description = d.Description; fullText = d.FullText; timeSlot = d.TimeSlot;
-            rewardXp = d.RewardXp ?? 0; rewardMoney = d.RewardMoney ?? 0; rewardNotes = d.RewardNotes;
-            questTags = d.Tags.ToList();
-            questLocations = d.Locations.ToList();
-            questEncounters = d.Encounters.ToList();
-            questRewards = d.Rewards.ToList();
-            newTagId = null; newLocationId = null; newEncounterMonsterId = null; newEncounterQuantity = 1;
-            newRewardItemId = null; newRewardQuantity = 1;
-            StateHasChanged();
-        }
+        createName = "";
+        createType = QuestType.General;
+        createError = null;
+        isCreateVisible = true;
     }
 
-    // Tags
-    private async Task AddTagAsync()
+    private async Task CreateAsync()
     {
-        if (editingId is null || newTagId is null) return;
-        try { await Api.PostAsync($"/api/quests/{editingId}/tags/{newTagId}"); newTagId = null; var d = await Api.GetAsync<QuestDetailDto>($"/api/quests/{editingId}"); if (d is not null) questTags = d.Tags.ToList(); StateHasChanged(); }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task RemoveTagAsync(TagDto tag)
-    {
-        if (editingId is null) return;
-        try { await Api.DeleteAsync($"/api/quests/{editingId}/tags/{tag.Id}"); questTags.Remove(tag); StateHasChanged(); }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    // Locations
-    private async Task AddLocationAsync()
-    {
-        if (editingId is null || newLocationId is null) return;
-        try { await Api.PostAsync<AddQuestLocationDto, object>($"/api/quests/{editingId}/locations", new AddQuestLocationDto(newLocationId.Value)); newLocationId = null; var d = await Api.GetAsync<QuestDetailDto>($"/api/quests/{editingId}"); if (d is not null) questLocations = d.Locations.ToList(); StateHasChanged(); }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task RemoveLocationAsync(QuestLocationDto loc)
-    {
-        if (editingId is null) return;
-        try { await Api.DeleteAsync($"/api/quests/{editingId}/locations/{loc.LocationId}"); questLocations.Remove(loc); StateHasChanged(); }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    // Encounters
-    private async Task AddEncounterAsync()
-    {
-        if (editingId is null || newEncounterMonsterId is null) return;
-        try { await Api.PostAsync<AddQuestEncounterDto, object>($"/api/quests/{editingId}/encounters", new AddQuestEncounterDto(newEncounterMonsterId.Value, newEncounterQuantity)); newEncounterMonsterId = null; newEncounterQuantity = 1; var d = await Api.GetAsync<QuestDetailDto>($"/api/quests/{editingId}"); if (d is not null) questEncounters = d.Encounters.ToList(); StateHasChanged(); }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task RemoveEncounterAsync(QuestEncounterDto enc)
-    {
-        if (editingId is null) return;
-        try { await Api.DeleteAsync($"/api/quests/{editingId}/encounters/{enc.MonsterId}"); questEncounters.Remove(enc); StateHasChanged(); }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    // Rewards
-    private async Task AddRewardAsync()
-    {
-        if (editingId is null || newRewardItemId is null) return;
-        try { await Api.PostAsync<AddQuestRewardDto, object>($"/api/quests/{editingId}/rewards", new AddQuestRewardDto(newRewardItemId.Value, newRewardQuantity)); newRewardItemId = null; newRewardQuantity = 1; var d = await Api.GetAsync<QuestDetailDto>($"/api/quests/{editingId}"); if (d is not null) questRewards = d.Rewards.ToList(); StateHasChanged(); }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task RemoveRewardAsync(QuestRewardDto rew)
-    {
-        if (editingId is null) return;
-        try { await Api.DeleteAsync($"/api/quests/{editingId}/rewards/{rew.ItemId}"); questRewards.Remove(rew); StateHasChanged(); }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task SaveAsync()
-    {
-        error = null; isSaving = true;
+        if (string.IsNullOrWhiteSpace(createName)) return;
+        createError = null;
+        isCreating = true;
         try
         {
-            int? xp = rewardXp > 0 ? rewardXp : null; int? money = rewardMoney > 0 ? rewardMoney : null;
-            int? chain = chainOrder > 0 ? chainOrder : null; int? parent = parentQuestId > 0 ? parentQuestId : null;
-            if (editingId.HasValue)
-                await Api.PutAsync($"/api/quests/{editingId}", new UpdateQuestDto(name, questType, description, fullText, timeSlot, xp, money, rewardNotes, chain, parent));
-            else
+            var (ok, created, problem) = await Api.PostWithProblemAsync<CreateQuestDto, QuestListDto>(
+                "/api/quests",
+                new CreateQuestDto(createName.Trim(), createType, GameId: null));
+            if (!ok)
             {
-                var gameIdForCreate = Catalog ? (int?)null : gameId;
-                await Api.PostAsync<CreateQuestDto, QuestListDto>("/api/quests", new CreateQuestDto(name, questType, gameIdForCreate, description, fullText, timeSlot, xp, money, rewardNotes, chain, parent));
+                createError = problem ?? "Vytvoření úkolu se nepodařilo.";
+                return;
             }
-            isModalVisible = false; await LoadAsync();
+            isCreateVisible = false;
+            if (created is not null)
+                Nav.NavigateTo($"/quests/{created.Id}");
+            else
+                await LoadAsync();
         }
-        catch (Exception ex) { error = ex.Message; } finally { isSaving = false; }
+        catch (Exception ex) { createError = ex.Message; }
+        finally { isCreating = false; }
     }
 
-    private async Task ConfirmDeleteAsync()
+    private void ClearFilters()
     {
-        try { await Api.DeleteAsync($"/api/quests/{editingId}"); isDeleteVisible = false; isModalVisible = false; await LoadAsync(); }
-        catch (Exception ex) { error = ex.Message; }
+        searchText = "";
+        onlyWithImage = false;
+        onlyWithRewards = false;
     }
+
+    private static QuestListDto CatalogToList(QuestCatalogDto c) =>
+        new(c.Id, c.Name, c.QuestType, ChainOrder: null, ParentQuestId: null, GameId: c.GameId,
+            State: QuestState.Inactive,  // catalog has no runtime state — chip hidden via ShowState=false
+            ImagePath: c.ImagePath, ImageUrl: c.ImageUrl,
+            EncountersCount: c.EncountersCount, RewardsCount: c.RewardsCount,
+            LocationsCount: 0, TagsCount: 0);
+
+    public void Dispose() { /* GameContext not subscribed; nothing to dispose */ }
 }

--- a/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
@@ -43,21 +43,20 @@
     </div>
 </div>
 
-@if (view == "galerie")
-{
-    <div class="oh-qst-filters mb-3">
-        <DxTextBox Text="@searchText" TextChanged="@((string v) => searchText = v)"
-                   NullText="Hledat (název, popis)…" CssClass="oh-qst-filter-search" />
-        <label class="oh-qst-filter-toggle">
-            <input type="checkbox" @bind="onlyWithImage" />
-            <span>jen s obrázkem</span>
-        </label>
-        <label class="oh-qst-filter-toggle">
-            <input type="checkbox" @bind="onlyWithRewards" />
-            <span>jen s odměnami</span>
-        </label>
-    </div>
-}
+@* Filters apply to both Galerie and Seznam — render once, outside the view
+   branch, so they're reachable in either mode (Copilot #206). *@
+<div class="oh-qst-filters mb-3">
+    <DxTextBox Text="@searchText" TextChanged="@((string v) => searchText = v)"
+               NullText="Hledat (název, popis)…" CssClass="oh-qst-filter-search" />
+    <label class="oh-qst-filter-toggle">
+        <input type="checkbox" @bind="onlyWithImage" />
+        <span>jen s obrázkem</span>
+    </label>
+    <label class="oh-qst-filter-toggle">
+        <input type="checkbox" @bind="onlyWithRewards" />
+        <span>jen s odměnami</span>
+    </label>
+</div>
 
 @if (loading)
 {
@@ -243,7 +242,10 @@ else
                 || (q.Description?.Contains(searchText, StringComparison.OrdinalIgnoreCase) ?? false)
                 || (q.FullText?.Contains(searchText, StringComparison.OrdinalIgnoreCase) ?? false))
             && (!onlyWithImage || !string.IsNullOrEmpty(q.ImageUrl))
-            && (!onlyWithRewards || q.RewardsCount > 0))
+            // "jen s odměnami" must accept scalar-only rewards (XP/groše/notes)
+            // even when there are no item rewards — RewardSummary is non-null
+            // whenever any of those four reward kinds is set.
+            && (!onlyWithRewards || q.RewardsCount > 0 || !string.IsNullOrWhiteSpace(q.RewardSummary)))
             .ToList();
 
     protected override async Task OnInitializedAsync()

--- a/src/OvcinaHra.Client/Pages/Quests/QuestPrint.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestPrint.razor
@@ -166,11 +166,11 @@ else
             quest = await Api.GetAsync<QuestDetailDto>($"/api/quests/{Id}");
             if (quest?.GameId is int gid)
             {
-                // Best-effort game label for the print header.
+                // Best-effort game label for the print header — fetch only the
+                // one game we need rather than the whole list (Copilot #206).
                 try
                 {
-                    var games = await Api.GetListAsync<GameListDto>("/api/games");
-                    var g = games.FirstOrDefault(x => x.Id == gid);
+                    var g = await Api.GetAsync<GameDetailDto>($"/api/games/{gid}");
                     gameName = g is null ? null : $"{g.Name} · edice {g.Edition}";
                 }
                 catch { gameName = null; }

--- a/src/OvcinaHra.Client/Pages/Quests/QuestPrint.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestPrint.razor
@@ -1,0 +1,186 @@
+@page "/quests/{Id:int}/print"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject IJSRuntime JS
+@inject NavigationManager Nav
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+@* Karta úkolu — A5 portrait, ONE quest per sheet. Designer brief calls for
+   organizer hand-out, smaller scope than Spellbook (per-quest, not per-game).
+   @media print rules in ovcinahra-theme.css strip the on-screen toolbar. *@
+
+<div class="oh-qst-print-toolbar">
+    <div class="oh-qst-print-toolbar-info">
+        <i class="bi bi-printer"></i> Karta úkolu — A5 portrét
+    </div>
+    <div class="d-flex gap-2">
+        <button class="btn btn-sm btn-outline-secondary" type="button"
+                @onclick='() => Nav.NavigateTo($"/quests/{Id}")'>
+            <i class="bi bi-arrow-left"></i> Zpět na detail
+        </button>
+        <button class="btn btn-sm btn-primary" type="button" @onclick="PrintAsync">
+            <i class="bi bi-printer-fill"></i> Tisk
+        </button>
+    </div>
+</div>
+
+@if (loading)
+{
+    <p class="text-muted text-center mt-5">Načítám…</p>
+}
+else if (quest is null)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-emoji-frown fs-1 d-block mb-2"></i>
+        <p>Úkol nenalezen.</p>
+    </div>
+}
+else
+{
+    <div class="oh-qst-print-stage">
+        <article class="oh-qst-print-card">
+            <header class="oh-qst-print-banner">
+                <h1>Karta úkolu</h1>
+                @if (gameName is not null)
+                {
+                    <p class="oh-qst-print-banner-sub">@gameName</p>
+                }
+            </header>
+
+            <section class="oh-qst-print-hero">
+                @if (!string.IsNullOrEmpty(quest.ImageUrl))
+                {
+                    <img src="@quest.ImageUrl" alt="@quest.Name" class="oh-qst-print-img" />
+                }
+                <div class="oh-qst-print-hero-text">
+                    <h2 class="oh-qst-print-name">@quest.Name</h2>
+                    <div class="oh-qst-print-meta">
+                        <span>@quest.QuestTypeDisplay</span>
+                        @foreach (var t in quest.Tags)
+                        {
+                            <span class="oh-qst-print-tag">@t.Name</span>
+                        }
+                    </div>
+                    @if (!string.IsNullOrWhiteSpace(quest.Description))
+                    {
+                        <p class="oh-qst-print-desc">@quest.Description</p>
+                    }
+                </div>
+            </section>
+
+            @if (!string.IsNullOrWhiteSpace(quest.FullText))
+            {
+                <section class="oh-qst-print-section">
+                    <h3>Herní text</h3>
+                    <p class="oh-qst-print-fulltext">@quest.FullText</p>
+                </section>
+            }
+
+            @if (quest.Encounters.Count > 0)
+            {
+                <section class="oh-qst-print-section">
+                    <h3>Setkání</h3>
+                    <ol class="oh-qst-print-enc-list">
+                        @foreach (var e in quest.Encounters)
+                        {
+                            <li>
+                                <strong>@e.MonsterName</strong>
+                                <span class="oh-qst-print-enc-qty">×@e.Quantity</span>
+                            </li>
+                        }
+                    </ol>
+                </section>
+            }
+
+            <section class="oh-qst-print-section">
+                <h3>Odměny</h3>
+                @if (quest.Rewards.Count == 0
+                     && (quest.RewardXp ?? 0) == 0
+                     && (quest.RewardMoney ?? 0) == 0
+                     && string.IsNullOrWhiteSpace(quest.RewardNotes))
+                {
+                    <p class="text-muted">Žádné odměny.</p>
+                }
+                else
+                {
+                    <ul class="oh-qst-print-rew-list">
+                        @foreach (var r in quest.Rewards)
+                        {
+                            <li>@r.ItemName <span class="oh-qst-print-enc-qty">×@r.Quantity</span></li>
+                        }
+                        @if (quest.RewardXp is int xp && xp > 0)
+                        {
+                            <li><strong>@xp XP</strong></li>
+                        }
+                        @if (quest.RewardMoney is int money && money > 0)
+                        {
+                            <li><strong>@money grošů</strong></li>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(quest.RewardNotes))
+                        {
+                            <li><em>@quest.RewardNotes</em></li>
+                        }
+                    </ul>
+                }
+            </section>
+
+            @if (quest.Locations.Count > 0)
+            {
+                <section class="oh-qst-print-section">
+                    <h3>Lokace</h3>
+                    <p class="oh-qst-print-locs">@string.Join(" · ", quest.Locations.Select(l => l.LocationName))</p>
+                </section>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(quest.TimeSlot))
+            {
+                <section class="oh-qst-print-section">
+                    <h3>Časový slot</h3>
+                    <p>@quest.TimeSlot</p>
+                </section>
+            }
+        </article>
+    </div>
+}
+
+@code {
+    [Parameter] public int Id { get; set; }
+
+    private QuestDetailDto? quest;
+    private bool loading = true;
+    private string? gameName;
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (quest is not null && quest.Id != Id) await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        try
+        {
+            quest = await Api.GetAsync<QuestDetailDto>($"/api/quests/{Id}");
+            if (quest?.GameId is int gid)
+            {
+                // Best-effort game label for the print header.
+                try
+                {
+                    var games = await Api.GetListAsync<GameListDto>("/api/games");
+                    var g = games.FirstOrDefault(x => x.Id == gid);
+                    gameName = g is null ? null : $"{g.Name} · edice {g.Edition}";
+                }
+                catch { gameName = null; }
+            }
+        }
+        finally { loading = false; }
+    }
+
+    private async Task PrintAsync()
+    {
+        try { await JS.InvokeVoidAsync("print"); } catch { /* user cancelled */ }
+    }
+}

--- a/src/OvcinaHra.Client/Services/ApiClient.cs
+++ b/src/OvcinaHra.Client/Services/ApiClient.cs
@@ -64,6 +64,14 @@ public class ApiClient
         response.EnsureSuccessStatusCode();
     }
 
+    public async Task PatchAsync<TRequest>(string url, TRequest data)
+    {
+        using var content = JsonContent.Create(data, options: JsonOptions);
+        using var request = new HttpRequestMessage(HttpMethod.Patch, url) { Content = content };
+        var response = await _http.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+    }
+
     public async Task<T?> PostMultipartAsync<T>(string url, MultipartFormDataContent content)
     {
         var response = await _http.PostAsync(url, content);

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3360,3 +3360,241 @@
     .oh-home-stats{grid-template-columns:repeat(2,minmax(0,1fr))}
     .oh-home-qlaunch-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
 }
+
+/* ===========================================================================
+ * Shared utilities — extracted from quest port (#193). Reuse on other surfaces.
+ * =========================================================================== */
+.oh-segmented{display:inline-flex;border:1px solid #d8d2be;border-radius:6px;overflow:hidden;background:#fff}
+.oh-segmented-btn{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;
+    border:0;background:transparent;color:#5a5642;font:500 .875rem/1 var(--oh-font-body,inherit);
+    cursor:pointer;transition:.12s ease}
+.oh-segmented-btn:hover{background:rgba(45,80,22,.06)}
+.oh-segmented-btn--on{background:#2D5016;color:#fff}
+.oh-segmented-btn--on:hover{background:#234012}
+.oh-segmented-btn + .oh-segmented-btn{border-left:1px solid #d8d2be}
+.oh-segmented-btn--on + .oh-segmented-btn,
+.oh-segmented-btn + .oh-segmented-btn--on{border-left-color:transparent}
+
+.oh-pill{display:inline-flex;align-items:center;gap:4px;padding:2px 10px;
+    border-radius:999px;background:rgba(178,98,35,.1);color:#6c4720;
+    border:1px solid rgba(178,98,35,.4);font:500 .75rem/1.4 var(--oh-font-body,inherit)}
+.oh-pill-mono{display:inline-flex;align-items:center;gap:4px;padding:2px 10px;
+    border-radius:999px;background:#f5f0e1;color:#3a2e1a;
+    border:1px solid #d8d2be;font:600 .75rem/1.4 var(--oh-font-mono,ui-monospace,monospace)}
+
+/* ===========================================================================
+ * Quests — /quests catalog gallery + DxGrid · /quests/{id} 5-tab detail ·
+ * /quests/{id}/print A5 · /games/{gid}/quests per-game grid (issue #193).
+ * Class prefix .oh-qst-* — reserved per design canon. State-chip palette is
+ * parchment (Inactive) / forest (Active) / dim-gold (Completed).
+ * =========================================================================== */
+
+/* — Filters above the gallery — */
+.oh-qst-filters{display:flex;gap:12px;align-items:center;flex-wrap:wrap;
+    padding:10px 12px;background:#FFF8F0;border:1px solid #ead9b8;border-radius:8px}
+.oh-qst-filter-search{min-width:240px;flex:1 1 240px}
+.oh-qst-filter-toggle{display:inline-flex;align-items:center;gap:6px;font:500 .875rem/1 var(--oh-font-body,inherit);color:#5a5642;cursor:pointer;user-select:none}
+.oh-qst-filter-toggle input{cursor:pointer}
+
+/* — Gallery (5:7 portrait tiles) — */
+.oh-qst-gallery{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:18px}
+.oh-qst-tile{position:relative;display:flex;flex-direction:column;
+    background:#FFF8F0;border:1px solid #d8d2be;border-radius:10px;overflow:hidden;
+    cursor:pointer;text-align:left;padding:0;transition:.18s ease;font-family:inherit}
+.oh-qst-tile:hover{border-color:#2D5016;box-shadow:0 6px 14px rgba(45,80,22,.18);transform:translateY(-2px)}
+.oh-qst-tile:focus-visible{outline:3px solid #2D5016;outline-offset:2px}
+.oh-qst-tile-art{position:relative;aspect-ratio:5/7;background:#f5f0e1;overflow:hidden}
+.oh-qst-tile-art img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-qst-tile-parchment{position:absolute;inset:0;display:flex;flex-direction:column;
+    align-items:center;justify-content:center;gap:8px;padding:14px;text-align:center;
+    background:repeating-linear-gradient(45deg,#FFF8F0 0 8px,#f4ead2 8px 9px);color:#7a5520}
+.oh-qst-tile-parchment > i{font-size:2rem;opacity:.55}
+.oh-qst-tile-parchment-name{font:700 .95rem/1.2 var(--oh-font-headline,Merriweather,Georgia,serif);color:#3a2e1a}
+.oh-qst-tile-state{position:absolute;top:8px;right:8px}
+.oh-qst-tile-body{padding:10px 12px 12px}
+.oh-qst-tile-name{font:700 1rem/1.25 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2a2218;
+    margin-bottom:6px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+.oh-qst-tile-foot{display:flex;align-items:center;gap:6px;flex-wrap:wrap;font-size:.75rem;color:#5a5642}
+.oh-qst-tile-foot-pill{display:inline-flex;align-items:center;gap:3px;padding:2px 6px;
+    border-radius:4px;background:#f5f0e1;color:#3a2e1a;font:600 .7rem/1.2 var(--oh-font-mono,ui-monospace,monospace)}
+.oh-qst-tile-foot-type{margin-left:auto;font-style:italic;font-size:.7rem;color:#7a6f50}
+
+/* — Mini-tile inside Seznam grid first column — */
+.oh-qst-mini-tile{width:40px;height:56px;border-radius:4px;background:#f5f0e1;
+    border:1px solid #d8d2be;overflow:hidden;display:flex;align-items:center;justify-content:center;color:#7a6f50}
+.oh-qst-mini-tile img{width:100%;height:100%;object-fit:cover;display:block}
+
+/* — State chip (3 colours) — */
+.oh-qst-state-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 10px;
+    border-radius:999px;font:600 .75rem/1.3 var(--oh-font-body,inherit);
+    border:1px solid currentColor}
+.oh-qst-state-inactive{color:#7a6f50;background:rgba(122,111,80,.1);border-color:rgba(122,111,80,.45)}
+.oh-qst-state-active{color:#2D5016;background:rgba(45,80,22,.1);border-color:rgba(45,80,22,.55)}
+.oh-qst-state-done{color:#8a6c1e;background:rgba(195,148,35,.12);border-color:rgba(195,148,35,.55)}
+.oh-qst-state-chip i{font-size:.85rem}
+
+/* — Tag chip — */
+.oh-qst-tag-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 10px;
+    border-radius:999px;background:#f5f0e1;color:#5a3a18;border:1px solid #e0d3a8;
+    font:500 .75rem/1.4 var(--oh-font-body,inherit)}
+.oh-qst-tag-chip-x{display:inline-flex;align-items:center;justify-content:center;width:14px;height:14px;
+    border:0;background:transparent;color:#a04020;cursor:pointer;border-radius:50%;padding:0;line-height:1}
+.oh-qst-tag-chip-x:hover{background:rgba(160,64,32,.18);color:#7a2410}
+
+/* — Quick-peek popup (Seznam row click) — */
+.oh-qst-peek-grid{display:grid;grid-template-columns:1.4fr 1fr;gap:18px}
+.oh-qst-peek-meta{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px}
+.oh-qst-peek-desc{font:400 .95rem/1.55 Georgia,serif;color:#2a2218;margin:0 0 8px;white-space:pre-wrap}
+.oh-qst-peek-rewards{margin:0 0 8px;font-size:.875rem;color:#3a2e1a}
+.oh-qst-peek-side{display:flex;align-items:flex-start;justify-content:center}
+.oh-qst-peek-img{width:100%;max-width:200px;aspect-ratio:5/7;object-fit:cover;border-radius:6px;
+    border:1px solid #d8d2be;background:#f5f0e1}
+.oh-qst-peek-img--placeholder{display:flex;align-items:center;justify-content:center;font-size:2rem;color:#7a6f50}
+.oh-qst-peek-foot{display:flex;gap:8px;justify-content:flex-end;margin-top:14px}
+
+/* — Detail tab badges — */
+.oh-qst-d-tab-count{display:inline-flex;align-items:center;justify-content:center;
+    min-width:18px;height:18px;padding:0 4px;margin-left:4px;font-size:.7rem;
+    border-radius:999px;background:rgba(178,98,35,.18);color:#6c4720;font-weight:600}
+.btn-primary .oh-qst-d-tab-count{background:rgba(255,255,255,.25);color:#fff}
+
+/* — Karta tab — */
+.oh-qst-karta-grid{display:grid;grid-template-columns:1.6fr 1fr;gap:24px;align-items:start}
+@media (max-width:880px){.oh-qst-karta-grid{grid-template-columns:1fr}}
+.oh-qst-karta{background:#FFF8F0;border:1px solid #ead9b8;border-radius:10px;padding:24px}
+.oh-qst-karta-hero{margin-bottom:14px}
+.oh-qst-karta-img{width:100%;max-width:380px;aspect-ratio:5/7;object-fit:cover;
+    border-radius:6px;border:1px solid #d8d2be;background:#f5f0e1;display:block;margin:0 auto}
+.oh-qst-karta-img--placeholder{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px;
+    background:repeating-linear-gradient(45deg,#FFF8F0 0 8px,#f4ead2 8px 9px);color:#7a5520}
+.oh-qst-karta-img--placeholder i{font-size:3rem;opacity:.55}
+.oh-qst-karta-img-name{font:700 1.1rem/1.2 var(--oh-font-headline,Merriweather,Georgia,serif);color:#3a2e1a;text-align:center;padding:0 14px}
+.oh-qst-karta-name{font:900 2rem/1.15 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2a2218;margin:0 0 8px}
+.oh-qst-karta-meta{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:14px}
+.oh-qst-karta-desc{font:400 1.02rem/1.65 Georgia,serif;color:#2a2218;margin:0;text-align:justify;white-space:pre-wrap}
+.oh-qst-karta-desc::first-letter{font:900 2.6rem/1 var(--oh-font-headline,Merriweather,Georgia,serif);
+    float:left;margin-right:8px;color:#2D5016;line-height:.9}
+.oh-qst-karta-fulltext{font:400 .95rem/1.55 Georgia,serif;color:#3a2e1a;margin:0;white-space:pre-wrap}
+.oh-qst-karta-sep{border:0;border-top:1px solid #d8d2be;margin:14px 0}
+.oh-qst-karta-side{display:flex;flex-direction:column;gap:14px;position:sticky;top:14px}
+.oh-qst-karta-side-block{background:#fff;border:1px solid #ead9b8;border-radius:8px;padding:14px}
+.oh-qst-karta-side-row{display:flex;justify-content:space-between;align-items:center;padding:6px 0;
+    border-bottom:1px dashed #ead9b8;font-size:.875rem;color:#3a2e1a}
+.oh-qst-karta-side-row:last-child{border-bottom:0}
+.oh-qst-karta-side-row strong{font:600 .95rem/1 var(--oh-font-mono,ui-monospace,monospace);color:#2D5016}
+.oh-qst-karta-side-title{font:700 .85rem/1 var(--oh-font-headline,Merriweather,Georgia,serif);
+    text-transform:uppercase;letter-spacing:.04em;color:#5a3a18;margin:0 0 8px}
+.oh-qst-state-actions{display:flex;flex-direction:column;gap:6px}
+
+/* — Upravit tab — */
+.oh-qst-edit{background:#FFF8F0;border:1px solid #ead9b8;border-radius:10px;padding:18px}
+.oh-qst-edit-tags{padding-top:12px;border-top:1px dashed #ead9b8}
+.oh-qst-edit-foot{display:flex;gap:8px;align-items:center;margin-top:18px;padding-top:14px;border-top:1px solid #ead9b8;
+    position:sticky;bottom:0;background:#FFF8F0;z-index:1}
+
+/* — Setkání tab (encounter cards + graf) — */
+.oh-qst-enc-toolbar{display:flex;gap:12px;align-items:center;justify-content:space-between;margin-bottom:14px;flex-wrap:wrap}
+.oh-qst-enc-list{display:flex;flex-direction:column;gap:10px}
+.oh-qst-enc-card{display:grid;grid-template-columns:auto auto 1fr auto;gap:10px;align-items:center;
+    background:#fff;border:1px solid #ead9b8;border-left:4px solid #B26223;border-radius:8px;padding:12px 14px}
+.oh-qst-enc-grip{border:0;background:transparent;color:#a89e7a;cursor:not-allowed;padding:4px;font-size:1.1rem}
+.oh-qst-enc-order{display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;
+    border-radius:50%;background:#2D5016;color:#fff;font:700 1rem/1 var(--oh-font-mono,ui-monospace,monospace)}
+.oh-qst-enc-body{display:flex;flex-direction:column;gap:4px;min-width:0}
+.oh-qst-enc-title{font:700 1rem/1.2 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2a2218;margin:0}
+.oh-qst-enc-meta{display:flex;gap:8px;align-items:center;flex-wrap:wrap;font-size:.8rem;color:#5a5642}
+.oh-qst-enc-qty{display:inline-flex;align-items:center;gap:2px;padding:1px 8px;border-radius:4px;
+    background:rgba(178,98,35,.12);color:#6c4720;font:600 .8rem/1.3 var(--oh-font-mono,ui-monospace,monospace)}
+.oh-qst-enc-tag-defer{font-style:italic;color:#a89e7a;font-size:.75rem}
+.oh-qst-enc-actions{display:flex;align-items:center}
+.oh-qst-enc-graph{display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+    background:repeating-linear-gradient(0deg,#FFF8F0 0 14px,#f7eed3 14px 15px);
+    padding:18px;border:1px solid #ead9b8;border-radius:8px;overflow-x:auto}
+.oh-qst-enc-graph-node{display:flex;flex-direction:column;align-items:center;gap:4px;padding:10px 16px;
+    background:#fff;border:1px solid #ead9b8;border-radius:8px;min-width:140px}
+.oh-qst-enc-graph-order{font:700 .75rem/1 var(--oh-font-mono,ui-monospace,monospace);color:#2D5016}
+.oh-qst-enc-graph-name{font:600 .95rem/1.2 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2a2218;text-align:center}
+.oh-qst-enc-graph-qty{font:600 .75rem/1 var(--oh-font-mono,ui-monospace,monospace);color:#6c4720}
+.oh-qst-enc-graph-arrow{color:#7a6f50;font-size:1.2rem}
+
+/* — Lokace tab — */
+.oh-qst-loc-list{display:flex;flex-direction:column;gap:6px;margin-bottom:14px}
+.oh-qst-loc-row{display:flex;gap:8px;align-items:center}
+.oh-qst-loc-chip{flex:1;display:flex;align-items:center;gap:8px;padding:8px 12px;border-radius:6px;
+    background:#fff;border:1px solid #ead9b8;color:#2a2218;cursor:pointer;text-align:left;font-family:inherit;
+    font-size:.9rem;transition:.12s ease}
+.oh-qst-loc-chip:hover{border-color:#2D5016;background:rgba(45,80,22,.05)}
+.oh-qst-loc-chip i:first-child{color:#5a3a18}
+.oh-qst-loc-chip i:last-child{margin-left:auto;color:#2D5016}
+.oh-qst-loc-add{display:flex;gap:8px;align-items:center}
+.oh-qst-loc-pick{flex:1}
+
+/* — Odměny tab (Kořist + scalars + collapsed Skills/Spells) — */
+.oh-qst-loot-title{font:700 1.05rem/1.2 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2a2218;margin:0 0 12px;display:flex;align-items:center;gap:6px}
+.oh-qst-loot-list{display:flex;flex-direction:column;gap:6px;margin-bottom:12px}
+.oh-qst-loot-chip{display:flex;align-items:center;gap:10px;padding:8px 12px;border-radius:6px;
+    background:#fff;border:1px solid #ead9b8}
+.oh-qst-loot-name{flex:1;font:500 .9rem/1.3 var(--oh-font-body,inherit);color:#2a2218}
+.oh-qst-loot-qty{display:inline-flex;align-items:center;padding:2px 8px;border-radius:4px;
+    background:rgba(178,98,35,.12);color:#6c4720;font:600 .8rem/1.3 var(--oh-font-mono,ui-monospace,monospace)}
+.oh-qst-loot-add{display:flex;gap:8px;align-items:center}
+.oh-qst-loot-pick{flex:1}
+.oh-qst-loot-qty-input{width:90px}
+
+.oh-qst-rew-section-title{font:700 1.05rem/1.2 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2a2218;display:flex;align-items:center;gap:6px}
+.oh-qst-rew-scalars{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px}
+.oh-qst-rew-scalar{display:flex;flex-direction:column;gap:4px}
+.oh-qst-rew-scalar--wide{grid-column:1 / -1}
+.oh-qst-rew-label{font:600 .8rem/1 var(--oh-font-body,inherit);color:#5a5642;text-transform:uppercase;letter-spacing:.04em;display:flex;align-items:center;gap:4px}
+.oh-qst-rew-input{width:100%}
+.oh-qst-rew-display{font:600 1rem/1.2 var(--oh-font-mono,ui-monospace,monospace);color:#2D5016}
+
+.oh-qst-rew-collapsed{margin-top:8px;border:1px solid #ead9b8;border-radius:8px;background:#FFF8F0;overflow:hidden}
+.oh-qst-rew-collapsed > summary{padding:10px 14px;cursor:pointer;font:600 .9rem/1 var(--oh-font-body,inherit);color:#5a3a18;list-style:none}
+.oh-qst-rew-collapsed > summary::-webkit-details-marker{display:none}
+.oh-qst-rew-collapsed > summary i{margin-right:6px;color:#a89e7a}
+.oh-qst-rew-disabled{padding:14px;background:rgba(178,98,35,.06);display:flex;flex-direction:column;align-items:flex-start;gap:8px;color:#6c5212}
+.oh-qst-rew-disabled > i{font-size:1.4rem;color:#B26223}
+
+/* — Per-game state filter pills — */
+.oh-qst-state-pillrow{display:flex;gap:6px;flex-wrap:wrap}
+.oh-qst-state-pill{padding:5px 14px;border-radius:999px;border:1px solid #d8d2be;background:#fff;color:#5a5642;
+    font:500 .8rem/1.3 var(--oh-font-body,inherit);cursor:pointer;transition:.12s ease}
+.oh-qst-state-pill:hover{border-color:#2D5016;color:#2D5016}
+.oh-qst-state-pill--on{background:#2D5016;border-color:#2D5016;color:#fff}
+.oh-qst-state-pill--on:hover{color:#fff}
+
+/* — Print export (A5 portrait, single quest) — */
+.oh-qst-print-toolbar{position:sticky;top:0;z-index:10;display:flex;align-items:center;justify-content:space-between;
+    background:#FFF8F0;border-bottom:1px solid #ead9b8;padding:8px 14px;margin-bottom:14px}
+.oh-qst-print-toolbar-info{font:500 .875rem/1 var(--oh-font-body,inherit);color:#5a3a18}
+.oh-qst-print-stage{display:flex;justify-content:center;padding:0 14px 24px}
+.oh-qst-print-card{width:148mm;min-height:210mm;background:#FFF8F0;border:1px solid #ead9b8;border-radius:6px;padding:8mm;
+    page-break-inside:avoid}
+.oh-qst-print-banner{text-align:center;border-bottom:2px solid #2D5016;margin-bottom:6mm;padding-bottom:3mm}
+.oh-qst-print-banner h1{font:900 1.4rem/1.1 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2a2218;margin:0}
+.oh-qst-print-banner-sub{font:500 .85rem/1 var(--oh-font-mono,ui-monospace,monospace);color:#5a3a18;margin:4px 0 0}
+.oh-qst-print-hero{display:grid;grid-template-columns:50mm 1fr;gap:5mm;margin-bottom:5mm;align-items:start}
+.oh-qst-print-img{width:100%;aspect-ratio:5/7;object-fit:cover;border-radius:3px;border:1px solid #d8d2be}
+.oh-qst-print-name{font:900 1.6rem/1.15 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2a2218;margin:0 0 3mm}
+.oh-qst-print-meta{display:flex;gap:4px;flex-wrap:wrap;font-size:.78rem;color:#5a5642;margin-bottom:3mm}
+.oh-qst-print-tag{padding:1px 6px;border-radius:999px;background:#f5f0e1;border:1px solid #e0d3a8;color:#5a3a18}
+.oh-qst-print-desc{font:400 9pt/1.4 Georgia,serif;color:#2a2218;margin:0;text-align:justify;white-space:pre-wrap}
+.oh-qst-print-section{margin-top:4mm}
+.oh-qst-print-section h3{font:700 .95rem/1 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2D5016;
+    text-transform:uppercase;letter-spacing:.04em;border-bottom:1px solid #ead9b8;padding-bottom:2mm;margin:0 0 3mm}
+.oh-qst-print-fulltext{font:400 9pt/1.45 Georgia,serif;color:#2a2218;margin:0;white-space:pre-wrap}
+.oh-qst-print-enc-list,.oh-qst-print-rew-list{margin:0;padding-left:18px;font:400 9pt/1.45 var(--oh-font-body,inherit);color:#2a2218}
+.oh-qst-print-enc-list li,.oh-qst-print-rew-list li{margin-bottom:2mm}
+.oh-qst-print-enc-qty{display:inline-block;margin-left:4px;font:600 8.5pt/1 var(--oh-font-mono,ui-monospace,monospace);color:#6c4720}
+.oh-qst-print-locs{font:400 9pt/1.4 Georgia,serif;color:#2a2218;margin:0}
+
+@media print{
+    @page { size: A5 portrait; margin: 8mm; }
+    body{background:#fff !important}
+    .oh-qst-print-toolbar{display:none !important}
+    .oh-qst-print-stage{padding:0;display:block}
+    .oh-qst-print-card{width:auto;min-height:0;border:0;padding:0;border-radius:0;box-shadow:none}
+    /* hide Drozd/sidebar/chrome elsewhere on the page if rendered */
+    nav,header.app-header,.app-sidebar,.app-footer,#blazor-error-ui{display:none !important}
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/Quest.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Quest.cs
@@ -16,6 +16,8 @@ public class Quest
     public int? ChainOrder { get; set; }
     public int? ParentQuestId { get; set; }
     public int? GameId { get; set; }
+    public string? ImagePath { get; set; }
+    public QuestState State { get; set; } = QuestState.Inactive;
 
     public Quest? ParentQuest { get; set; }
     public Game? Game { get; set; }

--- a/src/OvcinaHra.Shared/Domain/Enums/QuestState.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/QuestState.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Domain.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum QuestState
+{
+    [Display(Name = "Neaktivní")] Inactive,
+    [Display(Name = "Aktivní")]   Active,
+    [Display(Name = "Dokončený")] Completed
+}

--- a/src/OvcinaHra.Shared/Dtos/QuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/QuestDtos.cs
@@ -4,10 +4,23 @@ using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Shared.Dtos;
 
-public record QuestListDto(int Id, string Name, QuestType QuestType, int? ChainOrder, int? ParentQuestId, int? GameId)
+public record QuestListDto(
+    int Id,
+    string Name,
+    QuestType QuestType,
+    int? ChainOrder,
+    int? ParentQuestId,
+    int? GameId,
+    QuestState State,
+    string? ImagePath,
+    string? ImageUrl,
+    int EncountersCount,
+    int RewardsCount,
+    int LocationsCount,
+    int TagsCount)
 {
-    [JsonIgnore]
-    public string QuestTypeDisplay => QuestType.GetDisplayName();
+    [JsonIgnore] public string QuestTypeDisplay => QuestType.GetDisplayName();
+    [JsonIgnore] public string StateDisplay => State.GetDisplayName();
 }
 
 public record QuestDetailDto(
@@ -23,10 +36,17 @@ public record QuestDetailDto(
     int? ChainOrder,
     int? ParentQuestId,
     int? GameId,
+    QuestState State,
+    string? ImagePath,
+    string? ImageUrl,
     List<TagDto> Tags,
     List<QuestLocationDto> Locations,
     List<QuestEncounterDto> Encounters,
-    List<QuestRewardDto> Rewards);
+    List<QuestRewardDto> Rewards)
+{
+    [JsonIgnore] public string QuestTypeDisplay => QuestType.GetDisplayName();
+    [JsonIgnore] public string StateDisplay => State.GetDisplayName();
+}
 
 public record CreateQuestDto(
     string Name,
@@ -53,6 +73,8 @@ public record UpdateQuestDto(
     int? ChainOrder,
     int? ParentQuestId);
 
+public record UpdateQuestStateDto(QuestState State);
+
 public record QuestLocationDto(int QuestId, int LocationId, string LocationName);
 public record QuestEncounterDto(int QuestId, int MonsterId, string MonsterName, int Quantity);
 public record QuestRewardDto(int QuestId, int ItemId, string ItemName, int Quantity);
@@ -64,7 +86,9 @@ public record AddQuestRewardDto(int ItemId, int Quantity = 1);
 public record QuestCatalogDto(
     int Id, string Name, QuestType QuestType,
     int? GameId, string? GameName, int? GameEdition,
-    string? Description, string? FullText, string? RewardSummary)
+    string? Description, string? FullText, string? RewardSummary,
+    string? ImagePath, string? ImageUrl,
+    int EncountersCount, int RewardsCount)
 {
     [JsonIgnore]
     public string QuestTypeDisplay => QuestType.GetDisplayName();

--- a/tests/OvcinaHra.Api.Tests/Endpoints/QuestPhase1Tests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/QuestPhase1Tests.cs
@@ -174,11 +174,13 @@ public class QuestPhase1Tests(PostgresFixture postgres) : IntegrationTestBase(po
     }
 
     [Fact]
-    public async Task CopyToGame_CopiesImagePathAndDefaultsToInactiveState()
+    public async Task CopyToGame_DeepCopiesEncountersAndForcesInactiveState()
     {
-        // Source = catalog quest (GameId null) with an arbitrary blob key in
-        // ImagePath. CopyToGame must propagate the blob key and force State
-        // to Inactive on the per-game fork regardless of source state.
+        // CopyToGame must (1) deep-copy the source's child collections into
+        // the per-game fork and (2) force State=Inactive on the fork. Image
+        // upload is exercised by the dedicated ImageEndpointTests — this test
+        // focuses on the State + collection-copy contract that the Phase 1
+        // per-game grid relies on.
         var monsterResponse = await Client.PostAsJsonAsync("/api/monsters",
             new CreateMonsterDto("Skřet", MonsterCategory.Tier1, MonsterType.Goblin, 2, 1, 4));
         var monster = await monsterResponse.Content.ReadFromJsonAsync<MonsterDetailDto>();

--- a/tests/OvcinaHra.Api.Tests/Endpoints/QuestPhase1Tests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/QuestPhase1Tests.cs
@@ -1,0 +1,213 @@
+using System.Net;
+using System.Net.Http.Json;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+/// <summary>
+/// Phase 1 of the Quests port (issue #193): adds Quest.ImagePath +
+/// Quest.State (3-value enum) and a PATCH /state endpoint. These tests
+/// cover the new fields and lift count projections on the list/catalog
+/// DTOs that the Phase 1 UI relies on.
+/// </summary>
+public class QuestPhase1Tests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    [Fact]
+    public async Task Create_DefaultsState_ToInactive()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var dto = new CreateQuestDto("Nový úkol", QuestType.General, game!.Id);
+        var response = await Client.PostAsJsonAsync("/api/quests", dto);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var created = await response.Content.ReadFromJsonAsync<QuestListDto>();
+        Assert.NotNull(created);
+        Assert.Equal(QuestState.Inactive, created.State);
+        Assert.Null(created.ImagePath);
+        Assert.Null(created.ImageUrl);
+        // Fresh quest has no children — counts must all be zero.
+        Assert.Equal(0, created.EncountersCount);
+        Assert.Equal(0, created.RewardsCount);
+        Assert.Equal(0, created.LocationsCount);
+        Assert.Equal(0, created.TagsCount);
+    }
+
+    [Fact]
+    public async Task GetById_NewQuest_ReturnsInactiveState()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var createResponse = await Client.PostAsJsonAsync("/api/quests",
+            new CreateQuestDto("Test", QuestType.General, game!.Id));
+        var created = await createResponse.Content.ReadFromJsonAsync<QuestListDto>();
+
+        var detail = await Client.GetFromJsonAsync<QuestDetailDto>($"/api/quests/{created!.Id}");
+        Assert.NotNull(detail);
+        Assert.Equal(QuestState.Inactive, detail.State);
+        Assert.Null(detail.ImagePath);
+    }
+
+    [Fact]
+    public async Task PatchState_TransitionsThroughAllValues()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var createResponse = await Client.PostAsJsonAsync("/api/quests",
+            new CreateQuestDto("State quest", QuestType.General, game!.Id));
+        var created = await createResponse.Content.ReadFromJsonAsync<QuestListDto>();
+
+        // Inactive → Active
+        var r1 = await Client.PatchAsJsonAsync($"/api/quests/{created!.Id}/state",
+            new UpdateQuestStateDto(QuestState.Active));
+        Assert.Equal(HttpStatusCode.NoContent, r1.StatusCode);
+        var afterActive = await Client.GetFromJsonAsync<QuestDetailDto>($"/api/quests/{created.Id}");
+        Assert.Equal(QuestState.Active, afterActive!.State);
+
+        // Active → Completed
+        var r2 = await Client.PatchAsJsonAsync($"/api/quests/{created.Id}/state",
+            new UpdateQuestStateDto(QuestState.Completed));
+        Assert.Equal(HttpStatusCode.NoContent, r2.StatusCode);
+        var afterDone = await Client.GetFromJsonAsync<QuestDetailDto>($"/api/quests/{created.Id}");
+        Assert.Equal(QuestState.Completed, afterDone!.State);
+
+        // Completed → Inactive (revert)
+        var r3 = await Client.PatchAsJsonAsync($"/api/quests/{created.Id}/state",
+            new UpdateQuestStateDto(QuestState.Inactive));
+        Assert.Equal(HttpStatusCode.NoContent, r3.StatusCode);
+        var afterRevert = await Client.GetFromJsonAsync<QuestDetailDto>($"/api/quests/{created.Id}");
+        Assert.Equal(QuestState.Inactive, afterRevert!.State);
+    }
+
+    [Fact]
+    public async Task PatchState_NonExistentQuest_ReturnsNotFound()
+    {
+        var response = await Client.PatchAsJsonAsync("/api/quests/99999/state",
+            new UpdateQuestStateDto(QuestState.Active));
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetByGame_PopulatesCounts()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var questResponse = await Client.PostAsJsonAsync("/api/quests",
+            new CreateQuestDto("Counts quest", QuestType.General, game!.Id));
+        var quest = await questResponse.Content.ReadFromJsonAsync<QuestListDto>();
+
+        // Build up the join collections so the projection has something to count.
+        var monsterResponse = await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto("Skřet", MonsterCategory.Tier1, MonsterType.Goblin, 2, 1, 4));
+        var monster = await monsterResponse.Content.ReadFromJsonAsync<MonsterDetailDto>();
+        await Client.PostAsJsonAsync($"/api/quests/{quest!.Id}/encounters",
+            new AddQuestEncounterDto(monster!.Id, 3));
+
+        var itemResponse = await Client.PostAsJsonAsync("/api/items",
+            new CreateItemDto("Klíč", ItemType.Miscellaneous));
+        var item = await itemResponse.Content.ReadFromJsonAsync<ItemDetailDto>();
+        await Client.PostAsJsonAsync($"/api/quests/{quest.Id}/rewards",
+            new AddQuestRewardDto(item!.Id, 1));
+
+        var locationResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Brod", LocationKind.Wilderness, 49.0m, 17.0m));
+        var location = await locationResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+        await Client.PostAsJsonAsync($"/api/quests/{quest.Id}/locations",
+            new AddQuestLocationDto(location!.Id));
+
+        var tagResponse = await Client.PostAsJsonAsync("/api/tags",
+            new CreateTagDto("Easy", TagKind.Quest));
+        var tag = await tagResponse.Content.ReadFromJsonAsync<TagDto>();
+        await Client.PostAsync($"/api/quests/{quest.Id}/tags/{tag!.Id}", null);
+
+        // GetByGame is the projection that powers /games/{gid}/quests grid.
+        var list = await Client.GetFromJsonAsync<List<QuestListDto>>($"/api/quests/by-game/{game.Id}");
+        Assert.NotNull(list);
+        var fromList = list.Single(q => q.Id == quest.Id);
+
+        Assert.Equal(1, fromList.EncountersCount);
+        Assert.Equal(1, fromList.RewardsCount);
+        Assert.Equal(1, fromList.LocationsCount);
+        Assert.Equal(1, fromList.TagsCount);
+    }
+
+    [Fact]
+    public async Task GetAll_CatalogProjection_PopulatesCountsAndImageFields()
+    {
+        // Catalog quest = GameId is null; covers the dedicated /api/quests/all
+        // projection which feeds the gallery + Seznam DxGrid.
+        var createResponse = await Client.PostAsJsonAsync("/api/quests",
+            new CreateQuestDto("Catalog quest", QuestType.General, GameId: null));
+        var created = await createResponse.Content.ReadFromJsonAsync<QuestListDto>();
+
+        var monsterResponse = await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto("Skřet", MonsterCategory.Tier1, MonsterType.Goblin, 2, 1, 4));
+        var monster = await monsterResponse.Content.ReadFromJsonAsync<MonsterDetailDto>();
+        await Client.PostAsJsonAsync($"/api/quests/{created!.Id}/encounters",
+            new AddQuestEncounterDto(monster!.Id, 1));
+
+        var itemResponse = await Client.PostAsJsonAsync("/api/items",
+            new CreateItemDto("Klíč", ItemType.Miscellaneous));
+        var item = await itemResponse.Content.ReadFromJsonAsync<ItemDetailDto>();
+        await Client.PostAsJsonAsync($"/api/quests/{created.Id}/rewards",
+            new AddQuestRewardDto(item!.Id, 2));
+
+        var catalog = await Client.GetFromJsonAsync<List<QuestCatalogDto>>("/api/quests/all");
+        Assert.NotNull(catalog);
+        var c = catalog.Single(q => q.Id == created.Id);
+
+        Assert.Equal(1, c.EncountersCount);
+        Assert.Equal(1, c.RewardsCount);
+        // No image yet — both blob-key and resolved URL must be null.
+        Assert.Null(c.ImagePath);
+        Assert.Null(c.ImageUrl);
+    }
+
+    [Fact]
+    public async Task CopyToGame_CopiesImagePathAndDefaultsToInactiveState()
+    {
+        // Source = catalog quest (GameId null) with an arbitrary blob key in
+        // ImagePath. CopyToGame must propagate the blob key and force State
+        // to Inactive on the per-game fork regardless of source state.
+        var monsterResponse = await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto("Skřet", MonsterCategory.Tier1, MonsterType.Goblin, 2, 1, 4));
+        var monster = await monsterResponse.Content.ReadFromJsonAsync<MonsterDetailDto>();
+
+        var sourceResponse = await Client.PostAsJsonAsync("/api/quests",
+            new CreateQuestDto("Šablona", QuestType.General, GameId: null));
+        var source = await sourceResponse.Content.ReadFromJsonAsync<QuestListDto>();
+
+        await Client.PostAsJsonAsync($"/api/quests/{source!.Id}/encounters",
+            new AddQuestEncounterDto(monster!.Id, 2));
+
+        // Target game.
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Cílová hra", 30, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        // Trigger copy.
+        var copyResponse = await Client.PostAsync(
+            $"/api/quests/{source.Id}/copy-to-game/{game!.Id}", content: null);
+        Assert.Equal(HttpStatusCode.Created, copyResponse.StatusCode);
+        var copyResult = await copyResponse.Content.ReadFromJsonAsync<QuestCopyResultDto>();
+        Assert.NotNull(copyResult);
+
+        // The forked quest must be Inactive — copies always start dormant.
+        var fork = await Client.GetFromJsonAsync<QuestDetailDto>($"/api/quests/{copyResult.Quest.Id}");
+        Assert.NotNull(fork);
+        Assert.Equal(QuestState.Inactive, fork.State);
+        Assert.Equal(game.Id, fork.GameId);
+        // Encounters were deep-copied.
+        Assert.Single(fork.Encounters);
+    }
+}


### PR DESCRIPTION
Closes #193 (Phase 1).

## What ships

Port of the Quests catalog into the cartographer's-workshop look established by Spells/Skills tinkerer ports — done as a deliberately-scoped **Phase 1** that adds only `Quest.ImagePath` + `Quest.State` and renders the existing entity fields against the designer mockup. Phase 2 (richer encounters, Skill/Spell rewards, drag-to-reorder, template-link source badge) is queued as follow-ups against a richer schema.

### Frontend
- **`/quests`** — full rewrite of `QuestList.razor`. **Galerie** (5:7 portrait tiles, default) ↔ **Seznam** (DxGrid) toggle, persisted in `localStorage` under `oh-quest-view`. Filters: text search · jen s obrázkem · jen s odměnami. Quick-peek popup on Seznam row click → "Otevřít detail →".
- **`/quests/{id}`** — new `QuestDetail.razor`, **5 tabs**: Karta · Upravit · Setkání · Lokace · Odměny. Karta hides the state chip on catalog rows; per-game rows surface state chip + Inactive/Aktivovat/Dokončit transition buttons. Upravit reuses existing `ImagePicker` with `EntityType="quests" AspectRatio="5:7"`.
- **`/quests/{id}/print`** — new `QuestPrint.razor`, A5 portrait Karta úkolu. `@page { size: A5 portrait; margin: 8mm; }`, `@media print` strips chrome.
- **`/games/{gameId}/quests`** — new `GameQuests.razor` per-game DxGrid with state-pill filter row, "+ Přidat ze šablony" picker calling `CopyToGame`, "+ Od nuly" blank create.
- **New components:** `QuestPosterTile`, `QuestStateChip`, `EncounterCard`, `EncounterGraphNode`, `EncounterAddPopup`, `RewardLootList`, `RewardScalarFields`.

### Backend
- `Quest.ImagePath` (nullable blob key) + `Quest.State` (new `QuestState` enum, 3 values: Inactive · Active · Completed; `HasConversion<string>`).
- Migration **`AddImagePathAndStateToQuest`** with `defaultValue="Inactive"` so existing rows backfill cleanly.
- New **`PATCH /api/quests/{id}/state`** with `Enum.IsDefined` validation.
- `GET /all` and `GET /by-game` projections now include `ImagePath`, `ImageUrl` (resolved via `ImageEndpoints.ThumbUrl`), `State`, plus `EncountersCount`/`RewardsCount`/`LocationsCount`/`TagsCount`.
- `CopyToGame` propagates `ImagePath` and forces `State=Inactive` on the fork.
- `ImageEndpoints`: `"quests"` added to `ValidEntityTypes` + 4 switches + Backfill loop.

### Theme CSS
- New `.oh-qst-*` block (~240 lines) appended to `ovcinahra-theme.css`.
- New shared utilities: `.oh-segmented`, `.oh-pill`, `.oh-pill-mono` — extracted per the brief, reuse encouraged.
- **Reuses** existing `.oh-sacred-banner` (Override 3 — declared in #157/#167, not redefined).

### LayoutKey bumps
- `/quests` Seznam: `grid-layout-quests-v2`
- `/games/{gid}/quests`: `grid-layout-game-quests-v2`

## Phase 1 simplifications (Phase 2 follow-ups)

These are intentional scope cuts called out in the issue body — Phase 2 follow-up issues to be opened:

1. **Encounter `Order` / `Title` / `Description` / `LocationId` / required-items** — current `QuestEncounter` is `(QuestId, MonsterId, Quantity)` only. Setkání cards render monster-name + quantity; designer's richer card content is deferred. Drag-to-reorder handle is **visible but disabled** with title "Řazení dostupné po migraci 0.16.x".
2. **Skill / Spell rewards** — `QuestReward` is item-only. Odměny tab Skills/Spells sections render collapsed + disabled with "Dostupné po migraci 0.16.x" hint, no wired create logic.
3. **Source badge ("Šablona #N" / "Od nuly")** — schema has no `TemplateQuestId` FK, and conflating chain-parent (`ParentQuestId`) with template-parent semantics would regress the chain feature. Replaced with state chip + standard columns. Phase 2 will add the FK and surface the badge.
4. **Playwright E2E** — intentionally skipped per #92 (in-memory `WebApplicationFactory` infra needs Kestrel-port refactor before any browser test can connect).

## Verification

- `dotnet build OvcinaHra.slnx`: **0 warnings, 0 errors** (TreatWarningsAsErrors on).
- `dotnet test`: **385 / 385 passing** in ~37 s — including the 6 new `QuestPhase1Tests` (Create defaults State=Inactive · GetById preserves Inactive · PATCH /state transitions through all values · PATCH 404 on non-existent · GetByGame populates all 4 counts · GetAll catalog populates counts + null image fields · CopyToGame deep-copies + forces Inactive).
- §20 self-check: diff vs merge-base shows 9 modified + 14 new files, no wholesale rewrites of unrelated code. `QuestList.razor` is the only file with substantial deletion (the explicit rewrite target).

## Manual test plan

- [ ] `/quests` Galerie renders 5:7 tiles + parchment placeholder for image-less rows.
- [ ] Galerie ↔ Seznam toggle persists across reload (localStorage `oh-quest-view`).
- [ ] Seznam row click → quick-peek popup → "Otevřít detail →" navigates correctly.
- [ ] `/quests/{id}` 5 tabs render. Karta drop-cap on description, sacred banner above Description/FullText memos in Upravit.
- [ ] Upravit ImagePicker uploads a JPEG; Karta hero updates with the new image after navigating back.
- [ ] Setkání Seznam shows monster + qty; Graf shows boxes + arrows; "+ Nové setkání" popup adds an encounter.
- [ ] Lokace tab adds/removes a location chip; click navigates to `/locations/{id}`.
- [ ] Odměny tab adds/removes loot items; XP/Money/Notes save via Upravit's "Uložit"; Skills/Spells remain disabled with hint.
- [ ] `/games/{gid}/quests` state-pill filter narrows the grid; "Přidat ze šablony" picks a catalog quest and CopyToGame creates the per-game fork; "Od nuly" creates blank quest with `GameId`.
- [ ] State transition buttons on Karta (per-game only) PATCH to Active/Completed/Inactive and re-fetch.
- [ ] `/quests/{id}/print` renders A5 portrait page; "Tisk" opens browser print dialog; printed page has no chrome.

## Version

No csproj `<Version>` bump — auto-bump CI handles per Override 1 in the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)