### PR TITLE
feat(map): cartographer's workshop — 2 layers + treasures-by-stage peek (closes #207)

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/MapEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/MapEndpoints.cs
@@ -4,6 +4,7 @@ using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Api.Endpoints;
 
@@ -102,24 +103,31 @@ public static class MapEndpoints
     private static async Task<Results<Ok<LocationPeekDto>, NotFound>> GetLocationPeek(
         int id, int gameId, WorldDbContext db, IBlobStorageService blob)
     {
-        // Project Coordinates components directly — projecting the owned
-        // GpsCoordinates type into an anonymous wrapper trips EF's tracking
-        // query rule (owned entity without owner). Pulling Latitude /
-        // Longitude into nullable decimals sidesteps it cleanly.
-        var loc = await db.Locations
-            .Where(l => l.Id == id)
-            .Select(l => new
+        // Game-scoped lookup. Joining through GameLocations enforces that
+        // the location is actually part of the requested game — pre-fixup
+        // any caller knowing a valid (gameId, locationId) pair could peek
+        // an arbitrary location. Coordinates components are projected as
+        // nullable decimals so the owned GpsCoordinates value object
+        // doesn't trip EF's tracking-without-owner rule.
+        var loc = await db.GameLocations
+            .Where(gl => gl.GameId == gameId
+                && gl.LocationId == id
+                && gl.Location.ParentLocationId == null)
+            .Select(gl => new
             {
-                l.Id,
-                l.Name,
-                l.LocationKind,
-                l.Description,
-                l.ImagePath,
-                Lat = l.Coordinates != null ? (decimal?)l.Coordinates.Latitude : null,
-                Lon = l.Coordinates != null ? (decimal?)l.Coordinates.Longitude : null,
+                gl.Location.Id,
+                gl.Location.Name,
+                gl.Location.LocationKind,
+                gl.Location.Description,
+                gl.Location.ImagePath,
+                Lat = gl.Location.Coordinates != null ? (decimal?)gl.Location.Coordinates.Latitude : null,
+                Lon = gl.Location.Coordinates != null ? (decimal?)gl.Location.Coordinates.Longitude : null,
             })
             .FirstOrDefaultAsync();
         if (loc is null) return TypedResults.NotFound();
+        // GPS-less location → 404 rather than (0,0) which would render
+        // the pin / centering at the Gulf of Guinea (Copilot C6).
+        if (loc.Lat is null || loc.Lon is null) return TypedResults.NotFound();
 
         // Stashes for this location in this game.
         var stashes = await db.GameSecretStashes
@@ -176,9 +184,11 @@ public static class MapEndpoints
         return TypedResults.Ok(new LocationPeekDto(
             loc.Id, loc.Name,
             string.IsNullOrWhiteSpace(loc.ImagePath) ? null : blob.GetSasUrl(loc.ImagePath),
-            (double)(loc.Lat ?? 0m), (double)(loc.Lon ?? 0m),
+            (double)loc.Lat!.Value, (double)loc.Lon!.Value,
             KingdomId: null, KingdomName: null,
-            loc.LocationKind, loc.LocationKind.ToString(),
+            // Use the localized [Display] label so the peek chip reads
+            // "Pustina" not "Wilderness" (Copilot C5).
+            loc.LocationKind, loc.LocationKind.GetDisplayName(),
             stashDtos,
             stageRows,
             lorePreview));

--- a/src/OvcinaHra.Api/Endpoints/MapEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/MapEndpoints.cs
@@ -1,0 +1,204 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Endpoints;
+
+/// <summary>
+/// Issue #207 — Map page (cartographer's workshop) data endpoints.
+/// Two routes: aggregated map data for the page-level render and a
+/// per-location peek for the right slide-in panel. Both are read-only,
+/// game-scoped, and intentionally avoid the encounter / quest-path
+/// surfaces (no schema for ordered location waypoints today — see
+/// MapDtos.cs scope note).
+/// </summary>
+public static class MapEndpoints
+{
+    public static RouteGroupBuilder MapMapEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/map").WithTags("Map");
+
+        group.MapGet("/data", GetMapData);
+        group.MapGet("/locations/{id:int}/peek", GetLocationPeek);
+
+        return group;
+    }
+
+    private static async Task<Ok<MapDataDto>> GetMapData(
+        int gameId, WorldDbContext db, IBlobStorageService blob)
+    {
+        // Game-scoped locations. Only parent locations get pinned —
+        // variants share their parent's GPS and would stack identical
+        // markers on top of each other.
+        var locationRows = await db.GameLocations
+            .Where(gl => gl.GameId == gameId
+                && gl.Location.ParentLocationId == null
+                && gl.Location.Coordinates != null)
+            .Select(gl => new
+            {
+                gl.LocationId,
+                gl.Location.Name,
+                gl.Location.LocationKind,
+                Lat = gl.Location.Coordinates!.Latitude,
+                Lon = gl.Location.Coordinates!.Longitude,
+                gl.Location.ImagePath,
+            })
+            .ToListAsync();
+
+        var locations = locationRows.Select(r => new MapLocationDto(
+            r.LocationId, r.Name,
+            (double)r.Lat, (double)r.Lon,
+            r.LocationKind,
+            // Kingdom not stored on Location/GameLocation today. Return
+            // null so the cockpit's kingdom-tint chip stays inert until
+            // a follow-up adds the relationship.
+            KingdomId: null, KingdomName: null,
+            ThumbnailUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath))).ToList();
+
+        // Game-scoped stashes. Each pin sits at GameSecretStash.LocationId
+        // (which has GPS via Location.Coordinates). Treasure count + highest
+        // stage drive the badge color on the client.
+        var stashRows = await db.GameSecretStashes
+            .Where(gss => gss.GameId == gameId
+                && gss.Location.Coordinates != null)
+            .Select(gss => new
+            {
+                gss.SecretStashId,
+                gss.LocationId,
+                gss.SecretStash.Name,
+                Lat = gss.Location.Coordinates!.Latitude,
+                Lon = gss.Location.Coordinates!.Longitude,
+            })
+            .ToListAsync();
+
+        // Pull treasures attached to each stash for this game so the count
+        // + highest-stage badge are accurate. One query keeps it cheap.
+        var treasureRows = await db.TreasureQuests
+            .Where(t => t.GameId == gameId && t.SecretStashId != null)
+            .Select(t => new { t.SecretStashId, t.Difficulty })
+            .ToListAsync();
+        var byStash = treasureRows
+            .GroupBy(t => t.SecretStashId!.Value)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var stashes = stashRows.Select(r =>
+        {
+            var entries = byStash.GetValueOrDefault(r.SecretStashId);
+            var count = entries?.Count ?? 0;
+            GameTimePhase? highest = entries is { Count: > 0 }
+                ? entries.Max(e => e.Difficulty)
+                : null;
+            return new MapStashDto(
+                r.SecretStashId, r.LocationId, r.Name,
+                (double)r.Lat, (double)r.Lon, count, highest);
+        }).ToList();
+
+        return TypedResults.Ok(new MapDataDto(locations, stashes));
+    }
+
+    private static async Task<Results<Ok<LocationPeekDto>, NotFound>> GetLocationPeek(
+        int id, int gameId, WorldDbContext db, IBlobStorageService blob)
+    {
+        // Project Coordinates components directly — projecting the owned
+        // GpsCoordinates type into an anonymous wrapper trips EF's tracking
+        // query rule (owned entity without owner). Pulling Latitude /
+        // Longitude into nullable decimals sidesteps it cleanly.
+        var loc = await db.Locations
+            .Where(l => l.Id == id)
+            .Select(l => new
+            {
+                l.Id,
+                l.Name,
+                l.LocationKind,
+                l.Description,
+                l.ImagePath,
+                Lat = l.Coordinates != null ? (decimal?)l.Coordinates.Latitude : null,
+                Lon = l.Coordinates != null ? (decimal?)l.Coordinates.Longitude : null,
+            })
+            .FirstOrDefaultAsync();
+        if (loc is null) return TypedResults.NotFound();
+
+        // Stashes for this location in this game.
+        var stashes = await db.GameSecretStashes
+            .Where(gss => gss.GameId == gameId && gss.LocationId == id)
+            .Select(gss => new
+            {
+                gss.SecretStashId,
+                gss.SecretStash.Name,
+                TreasureCount = db.TreasureQuests
+                    .Count(t => t.GameId == gameId && t.SecretStashId == gss.SecretStashId),
+            })
+            .ToListAsync();
+        var stashDtos = stashes
+            .Select(s => new LocationPeekStashDto(s.SecretStashId, s.Name, s.TreasureCount))
+            .ToList();
+
+        // Treasures attached to this location (directly via LocationId or
+        // via one of its stashes). Group by stage.
+        var treasureRows = await db.TreasureQuests
+            .Where(t => t.GameId == gameId
+                && (t.LocationId == id
+                    || (t.SecretStashId != null
+                        && db.GameSecretStashes.Any(gss =>
+                            gss.GameId == gameId
+                            && gss.SecretStashId == t.SecretStashId
+                            && gss.LocationId == id))))
+            .Select(t => new { t.Id, t.Title, t.Difficulty })
+            .ToListAsync();
+
+        // Render all four stages so the peek's layout stays stable even
+        // when some buckets are empty (the cockpit shows "Žádné poklady").
+        // The peek's "treasures by stage" explorer renders the four
+        // gameplay phases in canonical order. EndGame (post-climax wrap)
+        // is intentionally excluded — treasures don't get planted that
+        // late and the explorer would always show an empty fifth row.
+        var stagesInOrder = new[]
+        {
+            GameTimePhase.Start, GameTimePhase.Early,
+            GameTimePhase.Midgame, GameTimePhase.Lategame,
+        };
+        var byStage = treasureRows.GroupBy(t => t.Difficulty)
+            .ToDictionary(g => g.Key, g => g.ToList());
+        var stageRows = stagesInOrder.Select(stage =>
+        {
+            var entries = byStage.GetValueOrDefault(stage) ?? [];
+            return new TreasuresByStageRowDto(
+                stage,
+                entries.Count,
+                entries.Select(e => new TreasuresByStageItemDto(e.Id, e.Title)).ToList());
+        }).ToList();
+
+        var lorePreview = MakeLorePreview(loc.Description);
+
+        return TypedResults.Ok(new LocationPeekDto(
+            loc.Id, loc.Name,
+            string.IsNullOrWhiteSpace(loc.ImagePath) ? null : blob.GetSasUrl(loc.ImagePath),
+            (double)(loc.Lat ?? 0m), (double)(loc.Lon ?? 0m),
+            KingdomId: null, KingdomName: null,
+            loc.LocationKind, loc.LocationKind.ToString(),
+            stashDtos,
+            stageRows,
+            lorePreview));
+    }
+
+    /// <summary>
+    /// First two sentences of <see cref="Location.Description"/>, capped
+    /// at ~240 chars so the peek panel doesn't have to scroll for the
+    /// "lore preview" surface.
+    /// </summary>
+    private static string? MakeLorePreview(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description)) return null;
+        var trimmed = description.Trim();
+        var firstTwoSentences = string.Concat(
+            trimmed.Split(['.', '!', '?'], 3, StringSplitOptions.None)
+                .Take(2)
+                .Select(s => s.Trim() + "."));
+        return firstTwoSentences.Length > 240
+            ? firstTwoSentences[..240].TrimEnd() + "…"
+            : firstTwoSentences;
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -219,6 +219,7 @@ try
     app.MapTreasurePlanningEndpoints().RequireAuthorization();
     app.MapTimelineEndpoints().RequireAuthorization();
     app.MapDashboardEndpoints().RequireAuthorization();
+    app.MapMapEndpoints().RequireAuthorization();
     app.MapGameEventEndpoints();
     app.MapSearchEndpoints().RequireAuthorization();
     app.MapImageEndpoints().RequireAuthorization();

--- a/src/OvcinaHra.Client/Components/MapEmptyState.razor
+++ b/src/OvcinaHra.Client/Components/MapEmptyState.razor
@@ -1,0 +1,13 @@
+@* Issue #207 — Map page no-game state. Drozd zmatený + CTA pointing
+   at the Správa her catalog where the user can pick or create a game. *@
+
+<div class="oh-map-empty">
+    <div class="oh-map-empty-art">
+        <i class="bi bi-shield-slash"></i>
+    </div>
+    <h2>Žádná hra není aktivní</h2>
+    <p class="text-muted">Vyberte hru v horním pruhu pro zobrazení mapy.</p>
+    <a class="btn btn-primary" href="/games">
+        <i class="bi bi-plus-lg me-1"></i>Otevřít Správu her
+    </a>
+</div>

--- a/src/OvcinaHra.Client/Components/MapLayerRail.razor
+++ b/src/OvcinaHra.Client/Components/MapLayerRail.razor
@@ -1,0 +1,33 @@
+@* Issue #207 — left rail with the two active map layers (Lokace +
+   Skrýše & Poklady). Encounters layer dropped from this PR — see
+   MapDtos.cs scope note. Layer state hydrates from / saves to
+   localStorage via MapPage. *@
+
+<aside class="oh-map-layer-rail" aria-label="Vrstvy mapy">
+    <h2 class="oh-map-layer-title">Vrstvy</h2>
+    <label class="oh-map-layer-row">
+        <input type="checkbox" checked="@LocationsVisible"
+               @onchange="@(e => OnVisibilityChange.InvokeAsync(("loc", (bool)e.Value!)))" />
+        <span class="oh-map-layer-dot oh-map-layer-loc"></span>
+        <span class="oh-map-layer-lbl">Lokace</span>
+        <span class="oh-map-layer-num text-muted">@LocationsCount</span>
+    </label>
+    <label class="oh-map-layer-row">
+        <input type="checkbox" checked="@StashesVisible"
+               @onchange="@(e => OnVisibilityChange.InvokeAsync(("stash", (bool)e.Value!)))" />
+        <span class="oh-map-layer-dot oh-map-layer-stash"></span>
+        <span class="oh-map-layer-lbl">Skrýše &amp; Poklady</span>
+        <span class="oh-map-layer-num text-muted">@StashesCount</span>
+    </label>
+    <p class="oh-map-layer-hint text-muted small fst-italic">
+        Setkání úkolů přibydou, jakmile budou mít body na mapě.
+    </p>
+</aside>
+
+@code {
+    [Parameter] public bool LocationsVisible { get; set; } = true;
+    [Parameter] public bool StashesVisible { get; set; } = true;
+    [Parameter] public int LocationsCount { get; set; }
+    [Parameter] public int StashesCount { get; set; }
+    [Parameter] public EventCallback<(string Layer, bool Visible)> OnVisibilityChange { get; set; }
+}

--- a/src/OvcinaHra.Client/Components/MapPinPeek.razor
+++ b/src/OvcinaHra.Client/Components/MapPinPeek.razor
@@ -1,0 +1,100 @@
+@* Issue #207 — right slide-in peek panel. Backdrop dim with click-to-
+   close. CSS transform animates from translateX(100%) → 0 in 0.3s.
+   Brief explicitly says NOT a DxPopup — needs the slide-in transition. *@
+
+@if (Visible)
+{
+    <div class="oh-map-peek-backdrop" @onclick="OnBackdropClick"></div>
+}
+<aside class="oh-map-peek @(Visible ? "is-on" : "")" aria-hidden="@(!Visible)">
+    @if (Peek is not null)
+    {
+        <header class="oh-map-peek-hd">
+            @if (!string.IsNullOrEmpty(Peek.ThumbnailUrl) && !_thumbFailed)
+            {
+                <img class="oh-map-peek-thumb" src="@Peek.ThumbnailUrl" alt="@Peek.Name"
+                     @onerror="() => _thumbFailed = true" />
+            }
+            else
+            {
+                <div class="oh-map-peek-thumb oh-map-peek-thumb-fallback">
+                    <i class="bi bi-geo-alt-fill"></i>
+                </div>
+            }
+            <div class="oh-map-peek-hd-body">
+                <h2>@Peek.Name</h2>
+                <div class="text-muted small">
+                    <span class="oh-map-kind-chip">@Peek.KindDisplay</span>
+                    <span class="ms-2">@Peek.Lat.ToString("F5"), @Peek.Lon.ToString("F5")</span>
+                </div>
+            </div>
+            <button type="button" class="oh-map-peek-close" aria-label="Zavřít"
+                    @onclick="OnCloseClick">
+                <i class="bi bi-x-lg"></i>
+            </button>
+        </header>
+
+        <section class="oh-map-peek-sec">
+            <h3>Skrýše tady</h3>
+            @if (Peek.Stashes.Count == 0)
+            {
+                <p class="text-muted small fst-italic mb-0">Žádné skrýše.</p>
+            }
+            else
+            {
+                @foreach (var s in Peek.Stashes)
+                {
+                    <a class="oh-map-peek-link" href="@($"/secret-stashes/{s.Id}")">
+                        <i class="bi bi-archive"></i>
+                        <span>@s.Name</span>
+                        <span class="text-muted small ms-auto">@s.TreasureCount pokladů</span>
+                    </a>
+                }
+            }
+        </section>
+
+        <section class="oh-map-peek-sec">
+            <h3>Poklady podle fáze</h3>
+            <TreasuresByStageBlock Rows="Peek.TreasuresByStage" />
+        </section>
+
+        @if (!string.IsNullOrWhiteSpace(Peek.LorePreview))
+        {
+            <section class="oh-map-peek-sec">
+                <h3>Z náhledu lóru</h3>
+                <p class="oh-map-peek-lore">@Peek.LorePreview</p>
+                <a class="oh-map-peek-link" href="@($"/locations/{Peek.Id}")">
+                    Otevřít detail lokace <i class="bi bi-arrow-right-short"></i>
+                </a>
+            </section>
+        }
+    }
+    else if (Loading)
+    {
+        <div class="oh-map-peek-loading">
+            <span class="spinner-border spinner-border-sm me-1"></span>
+            Načítám…
+        </div>
+    }
+</aside>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public bool Loading { get; set; }
+    [Parameter] public LocationPeekDto? Peek { get; set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+
+    private bool _thumbFailed;
+    private string? _lastThumb;
+
+    protected override void OnParametersSet()
+    {
+        // Reset error flag when the peeked location changes — feedback
+        // rule: state-flag onerror, not inline DOM mutation.
+        var current = Peek?.ThumbnailUrl;
+        if (_lastThumb != current) { _lastThumb = current; _thumbFailed = false; }
+    }
+
+    private async Task OnBackdropClick() => await OnClose.InvokeAsync();
+    private async Task OnCloseClick() => await OnClose.InvokeAsync();
+}

--- a/src/OvcinaHra.Client/Components/MapPinPeek.razor
+++ b/src/OvcinaHra.Client/Components/MapPinPeek.razor
@@ -10,17 +10,23 @@
     @if (Peek is not null)
     {
         <header class="oh-map-peek-hd">
-            @if (!string.IsNullOrEmpty(Peek.ThumbnailUrl) && !_thumbFailed)
-            {
-                <img class="oh-map-peek-thumb" src="@Peek.ThumbnailUrl" alt="@Peek.Name"
-                     @onerror="() => _thumbFailed = true" />
-            }
-            else
-            {
-                <div class="oh-map-peek-thumb oh-map-peek-thumb-fallback">
-                    <i class="bi bi-geo-alt-fill"></i>
-                </div>
-            }
+            <div class="oh-map-peek-thumb">
+                @if (!string.IsNullOrEmpty(Peek.ThumbnailUrl) && !_thumbFailed)
+                {
+                    @* CSS sizes the wrapper; the <img> inherits via
+                       .oh-map-peek-thumb img. Pre-fixup the bare <img>
+                       carried the wrapper class and the object-fit rule
+                       never matched. *@
+                    <img src="@Peek.ThumbnailUrl" alt="@Peek.Name"
+                         @onerror="() => _thumbFailed = true" />
+                }
+                else
+                {
+                    <span class="oh-map-peek-thumb-fallback">
+                        <i class="bi bi-geo-alt-fill"></i>
+                    </span>
+                }
+            </div>
             <div class="oh-map-peek-hd-body">
                 <h2>@Peek.Name</h2>
                 <div class="text-muted small">

--- a/src/OvcinaHra.Client/Components/MapToolbar.razor
+++ b/src/OvcinaHra.Client/Components/MapToolbar.razor
@@ -1,0 +1,30 @@
+@* Issue #207 — Map page top toolbar. Pro hru / Katalog mode toggle
+   + a passive search box (search wiring is a follow-up). The brief's
+   stage filter and kingdom multi-select are simplified to a stage chip
+   row here; full kingdom multi-select moves with the kingdom-tint
+   follow-up issue, since the schema doesn't link Location → Kingdom yet. *@
+
+<div class="oh-map-tb">
+    <div class="oh-map-tb-modes" role="tablist" aria-label="Režim mapy">
+        <button type="button"
+                class="oh-map-tb-mode @(Mode == "pro-hru" ? "is-active" : "")"
+                @onclick="@(() => OnModeChange.InvokeAsync("pro-hru"))">
+            <i class="bi bi-controller me-1"></i>Pro hru
+        </button>
+        <button type="button"
+                class="oh-map-tb-mode @(Mode == "katalog" ? "is-active" : "")"
+                @onclick="@(() => OnModeChange.InvokeAsync("katalog"))">
+            <i class="bi bi-archive me-1"></i>Katalog
+        </button>
+    </div>
+    <div class="oh-map-tb-counts text-muted small">
+        @LocationsCount lokací · @StashesCount skrýší
+    </div>
+</div>
+
+@code {
+    [Parameter] public string Mode { get; set; } = "pro-hru";
+    [Parameter] public EventCallback<string> OnModeChange { get; set; }
+    [Parameter] public int LocationsCount { get; set; }
+    [Parameter] public int StashesCount { get; set; }
+}

--- a/src/OvcinaHra.Client/Components/MapToolbar.razor
+++ b/src/OvcinaHra.Client/Components/MapToolbar.razor
@@ -1,8 +1,9 @@
 @* Issue #207 — Map page top toolbar. Pro hru / Katalog mode toggle
-   + a passive search box (search wiring is a follow-up). The brief's
-   stage filter and kingdom multi-select are simplified to a stage chip
-   row here; full kingdom multi-select moves with the kingdom-tint
-   follow-up issue, since the schema doesn't link Location → Kingdom yet. *@
+   + location/stash counts. Brief's stage filter, kingdom multi-select,
+   and search box all defer to follow-ups: stage filter becomes useful
+   once stash pins drive a global filter; kingdom multi-select needs
+   the schema to link Location → Kingdom; search wiring needs the same
+   index pass as the locations search elsewhere. *@
 
 <div class="oh-map-tb">
     <div class="oh-map-tb-modes" role="tablist" aria-label="Režim mapy">

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -82,6 +82,9 @@
     [Parameter] public EventCallback OnStyleLoaded { get; set; }
     [Parameter] public EventCallback<int> OnPieMarkerClick { get; set; }
     [Parameter] public EventCallback<PiePayloadEventArgs> OnPieMarkerDrop { get; set; }
+    /// <summary>Issue #207 — fires when a Map page pin is clicked.
+    /// Tuple is (kind, id) where kind is currently always "location".</summary>
+    [Parameter] public EventCallback<(string Kind, int Id)> OnMapPagePinClick { get; set; }
 
     /// <summary>
     /// When set, the map loads the game's vector overlay (issue #96) and
@@ -309,6 +312,19 @@
                 await JS.InvokeVoidAsync("ovcinaOverlay.clearSelection", _elementId);
         }
         StateHasChanged();
+    }
+
+    /// <summary>
+    /// Issue #207 — pin click hook for the Map page (cartographer's
+    /// workshop). The new `addLocationPin` / `addStashPin` interop calls
+    /// fire this with `kind = "location"` and the local entity id; the
+    /// page surfaces the right peek panel for the host location.
+    /// </summary>
+    [JSInvokable]
+    public async Task OnMapPinClicked(string kind, int id)
+    {
+        if (OnMapPagePinClick.HasDelegate)
+            await OnMapPagePinClick.InvokeAsync((kind, id));
     }
 
     [JSInvokable]

--- a/src/OvcinaHra.Client/Components/TreasuresByStageBlock.razor
+++ b/src/OvcinaHra.Client/Components/TreasuresByStageBlock.razor
@@ -1,0 +1,43 @@
+@* Issue #207 — "Wow #2" — treasures grouped by stage. Always renders
+   all four stages (Start / Rozvoj / Střed / Závěr) in canonical order
+   so empty buckets show "Žádné poklady" rather than collapsing the row.
+   Stage colors come from `--oh-stage-*` tokens already on :root. *@
+
+<section class="oh-map-tbs" aria-label="Poklady podle fáze">
+    @foreach (var row in Rows ?? [])
+    {
+        <div class="oh-map-tbs-row" data-stage="@StageKey(row.Stage)">
+            <div class="oh-map-tbs-head">
+                <span class="oh-map-tbs-dot"></span>
+                <span class="oh-map-tbs-lbl">@row.StageDisplay</span>
+                <span class="oh-map-tbs-num">@row.Count</span>
+            </div>
+            <div class="oh-map-tbs-body">
+                @if (row.Treasures.Count == 0)
+                {
+                    <span class="text-muted small fst-italic">Žádné poklady</span>
+                }
+                else
+                {
+                    @foreach (var t in row.Treasures)
+                    {
+                        <a class="oh-map-tbs-item" href="@($"/treasures/{t.Id}")">@t.Name</a>
+                    }
+                }
+            </div>
+        </div>
+    }
+</section>
+
+@code {
+    [Parameter] public IReadOnlyList<TreasuresByStageRowDto>? Rows { get; set; }
+
+    private static string StageKey(GameTimePhase stage) => stage switch
+    {
+        GameTimePhase.Start    => "start",
+        GameTimePhase.Early    => "rozvoj",
+        GameTimePhase.Midgame  => "stred",
+        GameTimePhase.Lategame => "zaver",
+        _ => "other",
+    };
+}

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -65,6 +65,10 @@
     private string _activeStyle = "tourist";
     private bool _locationsVisible = true;
     private bool _stashesVisible = true;
+    private bool _firstStyleLoadDone;
+    // Monotonically increasing token so a slow peek fetch doesn't overwrite
+    // a newer one if the user clicks pins faster than the network responds.
+    private int _peekRequestId;
 
     private MapDataDto? _data;
     private bool _peekVisible;
@@ -77,11 +81,30 @@
         GameContext.OnGameChanged += HandleGameChanged;
     }
 
-    private void HandleGameChanged() => _ = ReloadDataAndRenderAsync();
+    private void HandleGameChanged()
+    {
+        // Marshal back onto the renderer thread + observe exceptions so a
+        // JS interop blow-up during a circuit hiccup doesn't end up as an
+        // unobserved task (Copilot finding).
+        _ = InvokeAsync(async () =>
+        {
+            try { await ReloadDataAndRenderAsync(); }
+            catch (Exception ex) { Console.Error.WriteLine($"map reload after game change: {ex}"); }
+        });
+    }
 
     private async Task OnMapReadyAsync()
     {
-        // First style load completes, basemap is ready — pull data + paint pins.
+        // OnStyleLoaded fires both on first basemap load AND after every
+        // SwitchStyle. The data fetch + localStorage hydrate only need to
+        // run once; subsequent style swaps just need to repaint the pins
+        // since the new style wipes the old layer (Copilot C3).
+        if (_firstStyleLoadDone)
+        {
+            await PaintPinsAsync();
+            return;
+        }
+        _firstStyleLoadDone = true;
         await HydrateLayerStateAsync();
         await ReloadDataAndRenderAsync();
     }
@@ -187,17 +210,28 @@
 
     private async Task OpenPeekAsync(int locationId)
     {
+        // Token guard against fast successive pin clicks — the older
+        // request must not be allowed to overwrite the newer peek state
+        // when its response lands late (Copilot C7).
+        var requestId = ++_peekRequestId;
         _peekVisible = true;
         _peekLoading = true;
         _peek = null;
         StateHasChanged();
+
+        LocationPeekDto? loaded = null;
         try
         {
             var gameId = GameContext.SelectedGameId ?? 0;
-            _peek = await Api.GetAsync<LocationPeekDto>(
+            loaded = await Api.GetAsync<LocationPeekDto>(
                 $"/api/map/locations/{locationId}/peek?gameId={gameId}");
         }
-        catch { _peek = null; }
+        catch { /* swallow — UI shows the empty / loading-failed state */ }
+
+        // Stale response — a newer click already started.
+        if (requestId != _peekRequestId) return;
+
+        _peek = loaded;
         _peekLoading = false;
         await InvokeAsync(StateHasChanged);
     }

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -2,381 +2,213 @@
 @attribute [Authorize]
 @inject ApiClient Api
 @inject GameContextService GameContext
+@inject IJSRuntime JS
 @implements IDisposable
+@using OvcinaHra.Shared.Dtos
 
-<div class="d-flex justify-content-between align-items-center mb-2">
-    <h1 class="mb-0">Mapa</h1>
-    <div class="d-flex gap-2 align-items-center">
-        <div class="btn-group btn-group-sm">
-            <button class="btn @(activeStyle == "tourist" ? "btn-secondary" : "btn-outline-secondary")" @onclick='() => ToggleStyle("tourist")'>Turistická</button>
-            <button class="btn @(activeStyle == "aerial" ? "btn-secondary" : "btn-outline-secondary")" @onclick='() => ToggleStyle("aerial")'>Letecká</button>
-            <button class="btn @(activeStyle == "basic" ? "btn-secondary" : "btn-outline-secondary")" @onclick='() => ToggleStyle("basic")'>Základní</button>
-            <button class="btn @(activeStyle == "osm" ? "btn-secondary" : "btn-outline-secondary")" @onclick='() => ToggleStyle("osm")'>OSM</button>
-        </div>
-        @if (placingMode && placingLocation is not null)
+<AuthorizeView>
+    <Authorized Context="auth">
+        @if (GameContext.SelectedGameId is null)
         {
-            <span class="badge bg-warning text-dark">Umísťuji: @placingLocation.Name — klikni na mapu</span>
-            <button class="btn btn-outline-secondary btn-sm" @onclick="CancelPlacing">Zrušit</button>
+            <MapEmptyState />
         }
         else
         {
-            <button class="btn btn-primary btn-sm" @onclick="OpenPlacePicker">Umístit lokaci</button>
-        }
-    </div>
-</div>
+            <div class="oh-map-page">
+                <MapToolbar Mode="@_mode"
+                            OnModeChange="OnModeChange"
+                            LocationsCount="@(_data?.Locations.Count ?? 0)"
+                            StashesCount="@(_data?.Stashes.Count ?? 0)" />
 
-<div style="position: relative;">
-    <MapView @ref="mapView"
-             CenterLat="49.4532461" CenterLon="18.0203242" Zoom="16"
-             GameId="@GameContext.SelectedGameId"
-             OnMapClick="HandleMapClick"
-             OnMarkerClick="HandleMarkerClick"
-             OnMarkerDrag="HandleMarkerDrag"
-             OnStyleLoaded="HandleStyleLoaded" />
+                <div class="oh-map-shell">
+                    <MapLayerRail LocationsVisible="@_locationsVisible"
+                                  StashesVisible="@_stashesVisible"
+                                  LocationsCount="@(_data?.Locations.Count ?? 0)"
+                                  StashesCount="@(_data?.Stashes.Count ?? 0)"
+                                  OnVisibilityChange="OnLayerVisibilityChange" />
 
-    <div class="map-legend">
-        @foreach (var (kind, color) in markerColors)
-        {
-            <div class="map-legend-item" style="cursor: pointer; opacity: @(hiddenKinds.Contains(kind) ? "0.35" : "1")"
-                 @onclick="() => ToggleKind(kind)">
-                <span class="map-legend-dot" style="background-color: @color;"></span>
-                <span>@kind.GetDisplayName()</span>
-            </div>
-        }
-    </div>
-</div>
-
-<LocationEditPopup @ref="locationPopup"
-    AllLocations="locations"
-    OnSaved="LoadAndDisplayLocationsAsync"
-    OnVariantNavigate="NavigateToLocation" />
-
-<DxPopup @bind-Visible="@isPickerVisible" HeaderText="Vyber lokaci k umístění" Width="520px">
-    <BodyContentTemplate Context="popupContext">
-        @{
-            var unplaced = locations
-                .Where(l => l.ParentLocationId is null && (!l.Latitude.HasValue || !l.Longitude.HasValue))
-                .Where(l => string.IsNullOrWhiteSpace(pickerSearch)
-                    || l.Name.Contains(pickerSearch, StringComparison.OrdinalIgnoreCase)
-                    || (l.Region is not null && l.Region.Contains(pickerSearch, StringComparison.OrdinalIgnoreCase)))
-                .OrderBy(l => l.Name)
-                .ToList();
-        }
-
-        <DxTextBox @bind-Text="@pickerSearch" NullText="Hledat podle názvu nebo oblasti..." CssClass="mb-2" />
-
-        @if (unplaced.Count == 0)
-        {
-            <p class="text-muted text-center py-3">
-                @if (string.IsNullOrWhiteSpace(pickerSearch))
-                { <text>Žádné neumístěné lokace v této hře — všechny už mají GPS.</text> }
-                else
-                { <text>Nic nenalezeno.</text> }
-            </p>
-        }
-        else
-        {
-            <div class="list-group" style="max-height: 420px; overflow-y: auto;">
-                @foreach (var loc in unplaced)
-                {
-                    <button type="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
-                            @onclick="() => SelectForPlacement(loc)">
-                        <div>
-                            <div><strong>@loc.Name</strong></div>
-                            @if (!string.IsNullOrWhiteSpace(loc.Region))
-                            {
-                                <small class="text-muted">@loc.Region</small>
-                            }
+                    <div class="oh-map-canvas">
+                        <div class="oh-map-style-toolbar">
+                            <button class="oh-map-style-btn @(_activeStyle == "tourist" ? "is-active" : "")"
+                                    @onclick='() => SetStyleAsync("tourist")'>Turistická</button>
+                            <button class="oh-map-style-btn @(_activeStyle == "aerial" ? "is-active" : "")"
+                                    @onclick='() => SetStyleAsync("aerial")'>Letecká</button>
+                            <button class="oh-map-style-btn @(_activeStyle == "basic" ? "is-active" : "")"
+                                    @onclick='() => SetStyleAsync("basic")'>Základní</button>
+                            <button class="oh-map-style-btn @(_activeStyle == "osm" ? "is-active" : "")"
+                                    @onclick='() => SetStyleAsync("osm")'>OSM</button>
                         </div>
-                        <span class="badge rounded-pill"
-                              style="background-color: @(markerColors.GetValueOrDefault(loc.LocationKind, "#e74c3c")); color: white;">
-                            @loc.LocationKind.GetDisplayName()
-                        </span>
-                    </button>
-                }
+                        <MapView @ref="_mapView"
+                                 Height="calc(100vh - 200px)"
+                                 OnStyleLoaded="OnMapReadyAsync"
+                                 OnMapPagePinClick="OnPinClickedAsync" />
+                    </div>
+
+                    <MapPinPeek Visible="@_peekVisible"
+                                Loading="@_peekLoading"
+                                Peek="@_peek"
+                                OnClose="ClosePeek" />
+                </div>
             </div>
         }
-
-        <div class="d-flex justify-content-end mt-2">
-            <button class="btn btn-secondary" @onclick="() => isPickerVisible = false">Zavřít</button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
-
-<DxPopup @bind-Visible="@isPlaceConfirmVisible" HeaderText="Umístit lokaci?" Width="400px">
-    <BodyContentTemplate Context="popupContext">
-        <p>Umístit <strong>@placingLocation?.Name</strong> na zvolené souřadnice?</p>
-        <p class="text-muted small mb-3">@($"{placeLat:F7}, {placeLng:F7}")</p>
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="CancelPlaceConfirm">Zrušit</button>
-            <button class="btn btn-primary" disabled="@isPlaceSaving" @onclick="ConfirmPlace">Umístit</button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
-
-<DxPopup @bind-Visible="@isDragConfirmVisible" HeaderText="Přesunout lokaci?" Width="400px">
-    <BodyContentTemplate Context="popupContext">
-        <p>Přesunout <strong>@dragLocationName</strong> na novou pozici?</p>
-        <p class="text-muted small mb-3">@($"{dragNewLat:F7}, {dragNewLng:F7}")</p>
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="CancelDrag">Zrušit</button>
-            <button class="btn btn-primary" @onclick="ConfirmDrag">Přesunout</button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
+    </Authorized>
+    <NotAuthorized>
+        <p>Pro pokračování se prosím přihlaste.</p>
+    </NotAuthorized>
+</AuthorizeView>
 
 @code {
-    private MapView mapView = null!;
-    private LocationEditPopup locationPopup = null!;
-    private List<LocationListDto> locations = [];
-    private bool placingMode;
-    private LocationListDto? placingLocation;
-    private string activeStyle = "tourist";
-    private HashSet<LocationKind> hiddenKinds = [];
+    private const string LayerStateKey = "oh-map-layers";
 
-    private bool isPickerVisible;
-    private string pickerSearch = "";
+    private MapView? _mapView;
+    private string _mode = "pro-hru";
+    private string _activeStyle = "tourist";
+    private bool _locationsVisible = true;
+    private bool _stashesVisible = true;
 
-    private bool isPlaceConfirmVisible;
-    private bool isPlaceSaving;
-    private double placeLat, placeLng;
-
-    private bool isDragConfirmVisible;
-    private int dragLocationId;
-    private string dragLocationName = "";
-    private double dragNewLat, dragNewLng, dragOrigLat, dragOrigLng;
-
-    private static readonly Dictionary<LocationKind, string> markerColors = new()
-    {
-        [LocationKind.Town] = "#2c3e50",
-        [LocationKind.Village] = "#27ae60",
-        [LocationKind.Magical] = "#8e44ad",
-        [LocationKind.Hobbit] = "#f39c12",
-        [LocationKind.Wilderness] = "#16a085",
-        [LocationKind.Dungeon] = "#c0392b",
-        [LocationKind.PointOfInterest] = "#2980b9"
-    };
+    private MapDataDto? _data;
+    private bool _peekVisible;
+    private bool _peekLoading;
+    private LocationPeekDto? _peek;
 
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
-        GameContext.OnGameChanged += OnGameChanged;
+        GameContext.OnGameChanged += HandleGameChanged;
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    private void HandleGameChanged() => _ = ReloadDataAndRenderAsync();
+
+    private async Task OnMapReadyAsync()
     {
-        if (firstRender)
-        {
-            await LoadAndDisplayLocationsAsync();
-            await ApplyGameBoundsOrDefaultAsync();
-        }
+        // First style load completes, basemap is ready — pull data + paint pins.
+        await HydrateLayerStateAsync();
+        await ReloadDataAndRenderAsync();
     }
 
-    private async Task ApplyGameBoundsOrDefaultAsync()
-    {
-        // If the selected game has a bounding box set, center + zoom there.
-        // Otherwise (or on any failure fetching the game detail) fall back to
-        // the original hardcoded default view — must NEVER break /map render.
-        if (GameContext.SelectedGameId is int gid)
-        {
-            try
-            {
-                var detail = await Api.GetAsync<GameDetailDto>($"/api/games/{gid}");
-                if (detail is not null
-                    && detail.BoundingBoxSwLat.HasValue && detail.BoundingBoxSwLng.HasValue
-                    && detail.BoundingBoxNeLat.HasValue && detail.BoundingBoxNeLng.HasValue)
-                {
-                    await mapView.FitBoundsAsync(
-                        (double)detail.BoundingBoxSwLat.Value, (double)detail.BoundingBoxSwLng.Value,
-                        (double)detail.BoundingBoxNeLat.Value, (double)detail.BoundingBoxNeLng.Value);
-                    return;
-                }
-            }
-            catch
-            {
-                // Best-effort — fall through to the default view below.
-            }
-        }
-        await mapView.FitBoundsAsync(49.4504644, 18.0177633, 49.4557139, 18.0229133);
-    }
-
-    private async Task ToggleStyle(string style)
-    {
-        activeStyle = style;
-        await mapView.SwitchStyleAsync(style);
-    }
-
-    private async Task HandleStyleLoaded()
-    {
-        await LoadAndDisplayLocationsAsync();
-    }
-
-    private async void OnGameChanged()
+    private async Task HydrateLayerStateAsync()
     {
         try
         {
-            placingMode = false;
-            placingLocation = null;
-            isPickerVisible = false;
-            isPlaceConfirmVisible = false;
-            isPlaceSaving = false;
-            await LoadAndDisplayLocationsAsync();
-            await ApplyGameBoundsOrDefaultAsync();
-            StateHasChanged();
+            var raw = await JS.InvokeAsync<string?>("localStorage.getItem", LayerStateKey);
+            if (string.IsNullOrEmpty(raw)) return;
+            var saved = System.Text.Json.JsonSerializer.Deserialize<LayerState>(raw);
+            if (saved is null) return;
+            _locationsVisible = saved.Locations;
+            _stashesVisible = saved.Stashes;
         }
-        catch { /* best-effort */ }
+        catch { /* localStorage unavailable / malformed — keep defaults */ }
     }
-    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
 
-    private async Task LoadAndDisplayLocationsAsync()
+    private async Task PersistLayerStateAsync()
+    {
+        try
+        {
+            var json = System.Text.Json.JsonSerializer.Serialize(
+                new LayerState(_locationsVisible, _stashesVisible));
+            await JS.InvokeVoidAsync("localStorage.setItem", LayerStateKey, json);
+        }
+        catch { /* same fallback */ }
+    }
+
+    private async Task ReloadDataAndRenderAsync()
     {
         var gameId = GameContext.SelectedGameId;
-        if (gameId.HasValue)
-            locations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gameId.Value}");
-        else
-            locations = await Api.GetListAsync<LocationListDto>("/api/locations");
-        await DisplayMarkersAsync();
+        if (gameId is null) { _data = null; return; }
+
+        try
+        {
+            _data = await Api.GetAsync<MapDataDto>($"/api/map/data?gameId={gameId.Value}");
+        }
+        catch { _data = null; }
+
+        await PaintPinsAsync();
+        await InvokeAsync(StateHasChanged);
     }
 
-    private async Task DisplayMarkersAsync()
+    private async Task PaintPinsAsync()
     {
-        await mapView.ClearMarkersAsync();
-        foreach (var loc in locations.Where(l => l.ParentLocationId is null && l.Latitude.HasValue && l.Longitude.HasValue && !hiddenKinds.Contains(l.LocationKind)))
+        // Wipe and repaint — small dataset (~50 pins per layer in Pro hru
+        // mode); incremental diffing would be over-engineered for the
+        // expected scale and the brief explicitly defers clustering.
+        await JS.InvokeVoidAsync("ovcinaMap.clearMapPagePins");
+        if (_data is null) return;
+
+        if (_locationsVisible)
         {
-            var color = markerColors.GetValueOrDefault(loc.LocationKind, "#e74c3c");
-            await mapView.AddMarkerAsync(loc.Id, (double)loc.Latitude!.Value, (double)loc.Longitude!.Value,
-                loc.Name, loc.LocationKind.GetDisplayName(), color);
+            foreach (var l in _data.Locations)
+            {
+                await JS.InvokeVoidAsync("ovcinaMap.addLocationPin",
+                    l.Id, l.Lat, l.Lon, l.Name, l.Kind.ToString());
+            }
+        }
+        if (_stashesVisible)
+        {
+            foreach (var s in _data.Stashes)
+            {
+                await JS.InvokeVoidAsync("ovcinaMap.addStashPin",
+                    s.Id, s.LocationId, s.Lat, s.Lon, s.Name, s.TreasureCount,
+                    s.HighestStage?.ToString());
+            }
         }
     }
 
-    private async Task ToggleKind(LocationKind kind)
+    private async Task OnLayerVisibilityChange((string Layer, bool Visible) change)
     {
-        if (!hiddenKinds.Remove(kind))
-            hiddenKinds.Add(kind);
-        await DisplayMarkersAsync();
+        if (change.Layer == "loc") _locationsVisible = change.Visible;
+        else if (change.Layer == "stash") _stashesVisible = change.Visible;
+        await JS.InvokeVoidAsync("ovcinaMap.setMapPageLayerVisibility",
+            change.Layer, change.Visible);
+        await PersistLayerStateAsync();
     }
 
-    private void OpenPlacePicker()
+    private Task OnModeChange(string mode)
     {
-        pickerSearch = "";
-        isPickerVisible = true;
-    }
-
-    private void SelectForPlacement(LocationListDto loc)
-    {
-        placingLocation = loc;
-        placingMode = true;
-        isPickerVisible = false;
-    }
-
-    private void CancelPlacing()
-    {
-        placingMode = false;
-        placingLocation = null;
-        isPlaceConfirmVisible = false;
-        isPlaceSaving = false;
-    }
-
-    private Task HandleMapClick(OvcinaMapClickEventArgs e)
-    {
-        if (placingMode && placingLocation is not null)
-        {
-            placeLat = e.Latitude;
-            placeLng = e.Longitude;
-            isPlaceConfirmVisible = true;
-            StateHasChanged();
-        }
+        _mode = mode;
+        // Katalog mode is wired up the same way as Pro hru today —
+        // a follow-up issue will add cross-game data + clustering.
+        // Switching modes simply re-fires the data load (no-op in MVP).
         return Task.CompletedTask;
     }
 
-    private async Task ConfirmPlace()
+    private async Task SetStyleAsync(string style)
     {
-        if (placingLocation is null) return;
-        isPlaceSaving = true;
+        _activeStyle = style;
+        await JS.InvokeVoidAsync("ovcinaMap.switchStyle", style);
+        // Style change disposes/re-creates the basemap; pins must repaint.
+        await PaintPinsAsync();
+    }
+
+    private async Task OnPinClickedAsync((string Kind, int Id) click)
+    {
+        if (click.Kind != "location") return;
+        await OpenPeekAsync(click.Id);
+    }
+
+    private async Task OpenPeekAsync(int locationId)
+    {
+        _peekVisible = true;
+        _peekLoading = true;
+        _peek = null;
+        StateHasChanged();
         try
         {
-            var detail = await Api.GetAsync<LocationDetailDto>($"/api/locations/{placingLocation.Id}");
-            if (detail is not null)
-            {
-                var dto = new UpdateLocationDto(detail.Name, detail.LocationKind,
-                    (decimal)placeLat, (decimal)placeLng,
-                    detail.Description, detail.Details, detail.GamePotential, detail.Prompt, detail.Region,
-                    detail.NpcInfo, detail.SetupNotes, detail.ParentLocationId);
-                await Api.PutAsync($"/api/locations/{placingLocation.Id}", dto);
-            }
-            isPlaceConfirmVisible = false;
-            placingMode = false;
-            placingLocation = null;
-            await LoadAndDisplayLocationsAsync();
+            var gameId = GameContext.SelectedGameId ?? 0;
+            _peek = await Api.GetAsync<LocationPeekDto>(
+                $"/api/map/locations/{locationId}/peek?gameId={gameId}");
         }
-        catch
-        {
-            // Network or server error — close the popup but keep placing mode so
-            // the user can retry with another click.
-            isPlaceConfirmVisible = false;
-        }
-        finally
-        {
-            isPlaceSaving = false;
-        }
+        catch { _peek = null; }
+        _peekLoading = false;
+        await InvokeAsync(StateHasChanged);
     }
 
-    private void CancelPlaceConfirm()
+    private void ClosePeek()
     {
-        isPlaceConfirmVisible = false;
-        // Stay in placing mode so the user can click again on a different spot.
+        _peekVisible = false;
+        _peek = null;
     }
 
-    private async Task HandleMarkerClick(int id) => await locationPopup.OpenAsync(id);
+    private record LayerState(bool Locations, bool Stashes);
 
-    private Task HandleMarkerDrag(OvcinaMarkerDragEventArgs e)
-    {
-        dragLocationId = e.Id;
-        dragLocationName = locations.FirstOrDefault(l => l.Id == e.Id)?.Name ?? $"Lokace #{e.Id}";
-        dragNewLat = e.Latitude;
-        dragNewLng = e.Longitude;
-        dragOrigLat = e.OrigLatitude;
-        dragOrigLng = e.OrigLongitude;
-        isDragConfirmVisible = true;
-        StateHasChanged();
-        return Task.CompletedTask;
-    }
-
-    private async Task ConfirmDrag()
-    {
-        try
-        {
-            var detail = await Api.GetAsync<LocationDetailDto>($"/api/locations/{dragLocationId}");
-            if (detail is not null)
-            {
-                var dto = new UpdateLocationDto(detail.Name, detail.LocationKind,
-                    (decimal)dragNewLat, (decimal)dragNewLng,
-                    detail.Description, detail.Details, detail.GamePotential, detail.Prompt, detail.Region,
-                    detail.NpcInfo, detail.SetupNotes, detail.ParentLocationId);
-                await Api.PutAsync($"/api/locations/{dragLocationId}", dto);
-            }
-            isDragConfirmVisible = false;
-            await LoadAndDisplayLocationsAsync();
-        }
-        catch
-        {
-            isDragConfirmVisible = false;
-            await mapView.UpdateMarkerPositionAsync(dragLocationId, dragOrigLat, dragOrigLng);
-            await LoadAndDisplayLocationsAsync();
-        }
-    }
-
-    private async Task CancelDrag()
-    {
-        isDragConfirmVisible = false;
-        await mapView.UpdateMarkerPositionAsync(dragLocationId, dragOrigLat, dragOrigLng);
-    }
-
-    private async Task NavigateToLocation(int id)
-    {
-        locationPopup.Close();
-        StateHasChanged();
-        await Task.Delay(100);
-        await locationPopup.OpenAsync(id);
-    }
+    public void Dispose() => GameContext.OnGameChanged -= HandleGameChanged;
 }

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3598,3 +3598,98 @@
     /* hide Drozd/sidebar/chrome elsewhere on the page if rendered */
     nav,header.app-header,.app-sidebar,.app-footer,#blazor-error-ui{display:none !important}
 }
+
+/* ======================================================================
+   Issue #207 — Map page (cartographer's workshop). Two layers (Lokace,
+   Skrýše & Poklady), sliding right peek, treasures-by-stage block.
+   Reuses --oh-stage-* tokens already on :root from earlier work; no new
+   palette tokens needed in this PR.
+   ====================================================================== */
+.oh-map-page{display:flex;flex-direction:column;gap:10px;height:calc(100vh - 110px)}
+.oh-map-tb{display:flex;align-items:center;gap:12px;padding:8px 12px;
+    background:var(--oh-surface,#FAF6EC);border:1px solid var(--oh-border,#d8d2be);border-radius:8px}
+.oh-map-tb-modes{display:inline-flex;gap:4px}
+.oh-map-tb-mode{display:inline-flex;align-items:center;padding:4px 10px;border-radius:99px;
+    background:var(--oh-surface-alt,#F2EBD8);border:1px solid var(--oh-border,#d8d2be);
+    color:var(--oh-text,#2a2a2a);font:600 .8rem var(--oh-font-body);cursor:pointer}
+.oh-map-tb-mode.is-active{background:#2D5016;border-color:#2D5016;color:#fff}
+.oh-map-tb-counts{margin-left:auto;font-variant-numeric:tabular-nums}
+.oh-map-shell{display:grid;grid-template-columns:220px 1fr;gap:10px;flex:1;min-height:0;position:relative}
+.oh-map-layer-rail{padding:10px 12px;background:var(--oh-surface,#FAF6EC);
+    border:1px solid var(--oh-border,#d8d2be);border-radius:8px;align-self:start}
+.oh-map-layer-title{margin:0 0 8px;font:700 .95rem var(--oh-font-heading)}
+.oh-map-layer-row{display:flex;align-items:center;gap:8px;padding:6px 4px;cursor:pointer;border-radius:5px}
+.oh-map-layer-row:hover{background:var(--oh-surface-alt,#F2EBD8)}
+.oh-map-layer-dot{width:10px;height:10px;border-radius:50%;flex-shrink:0;background:#2D5016}
+.oh-map-layer-stash{background:#C19A3A}
+.oh-map-layer-lbl{flex:1}
+.oh-map-layer-num{font-variant-numeric:tabular-nums}
+.oh-map-layer-hint{margin-top:8px;line-height:1.3}
+.oh-map-canvas{position:relative;border:1px solid var(--oh-border,#d8d2be);border-radius:8px;overflow:hidden}
+.oh-map-style-toolbar{position:absolute;top:8px;right:8px;z-index:10;display:flex;gap:4px;
+    background:rgba(250,246,236,.92);padding:3px;border-radius:99px;
+    box-shadow:0 1px 4px rgba(0,0,0,.12)}
+.oh-map-style-btn{padding:3px 9px;border-radius:99px;border:none;background:transparent;
+    color:var(--oh-text,#2a2a2a);font:600 .72rem var(--oh-font-body);cursor:pointer}
+.oh-map-style-btn.is-active{background:#2D5016;color:#fff}
+.oh-map-pin{position:relative;width:18px;height:18px;border-radius:50%;
+    border:2px solid #fff;cursor:pointer;box-shadow:0 1px 3px rgba(0,0,0,.45)}
+.oh-map-pin-loc{background:#2D5016}
+.oh-map-pin-stash{background:#C19A3A;width:20px;height:20px}
+.oh-map-pin-stash[data-stage="Start"]   {background:#7FA657}
+.oh-map-pin-stash[data-stage="Early"]   {background:#D4A63C}
+.oh-map-pin-stash[data-stage="Midgame"] {background:#C17B3D}
+.oh-map-pin-stash[data-stage="Lategame"]{background:#8C2423}
+.oh-map-pin-count{position:absolute;top:-6px;right:-6px;background:#fff;color:#2a2a2a;
+    border-radius:99px;padding:0 4px;font:700 .65rem var(--oh-font-body);
+    border:1px solid var(--oh-border,#d8d2be);min-width:14px;text-align:center}
+.oh-map-peek-backdrop{position:fixed;inset:0;background:rgba(20,16,8,.32);z-index:1070}
+.oh-map-peek{position:fixed;top:64px;right:0;bottom:0;width:min(420px,90vw);
+    background:var(--oh-surface,#FAF6EC);border-left:1px solid var(--oh-border,#d8d2be);
+    box-shadow:-6px 0 24px rgba(0,0,0,.18);z-index:1075;
+    transform:translateX(100%);transition:transform .3s cubic-bezier(.2,.7,.2,1);
+    overflow-y:auto;padding:14px 18px}
+.oh-map-peek.is-on{transform:translateX(0)}
+.oh-map-peek-hd{display:flex;align-items:flex-start;gap:10px;padding-bottom:10px;
+    border-bottom:1px solid var(--oh-border,#d8d2be);margin-bottom:10px}
+.oh-map-peek-thumb{width:64px;height:64px;border-radius:6px;overflow:hidden;flex-shrink:0;
+    background:var(--oh-surface-alt,#F2EBD8);display:flex;align-items:center;justify-content:center}
+.oh-map-peek-thumb img{width:100%;height:100%;object-fit:cover}
+.oh-map-peek-thumb-fallback i{font-size:1.6rem;color:rgba(45,80,22,.45)}
+.oh-map-peek-hd-body{flex:1;min-width:0}
+.oh-map-peek-hd-body h2{margin:0;font:700 1.1rem var(--oh-font-heading)}
+.oh-map-peek-close{margin-left:auto;background:transparent;border:none;color:var(--oh-text-muted,#6b6453);
+    cursor:pointer;font-size:1.1rem;padding:4px 8px}
+.oh-map-peek-close:hover{color:var(--oh-text,#2a2a2a)}
+.oh-map-peek-sec{padding:10px 0;border-bottom:1px solid var(--oh-border,#d8d2be)}
+.oh-map-peek-sec:last-child{border-bottom:none}
+.oh-map-peek-sec h3{margin:0 0 6px;font:700 .85rem var(--oh-font-heading);text-transform:uppercase;letter-spacing:.04em;color:var(--oh-text-muted,#6b6453)}
+.oh-map-peek-link{display:flex;align-items:center;gap:8px;padding:6px 4px;border-radius:5px;
+    color:var(--oh-text,#2a2a2a);text-decoration:none}
+.oh-map-peek-link:hover{background:var(--oh-surface-alt,#F2EBD8)}
+.oh-map-peek-lore{font:400 .9rem var(--oh-font-body);color:var(--oh-text,#2a2a2a);margin:0 0 6px;line-height:1.5}
+.oh-map-peek-loading{padding:14px 0;color:var(--oh-text-muted,#6b6453)}
+.oh-map-kind-chip{display:inline-flex;padding:1px 7px;border-radius:99px;background:var(--oh-surface-alt,#F2EBD8);
+    border:1px solid var(--oh-border,#d8d2be);font:600 .7rem var(--oh-font-body)}
+.oh-map-tbs{display:flex;flex-direction:column;gap:6px}
+.oh-map-tbs-row{padding:6px 8px;border-radius:5px;background:var(--oh-surface-alt,#F2EBD8)}
+.oh-map-tbs-head{display:flex;align-items:center;gap:8px;font-weight:600}
+.oh-map-tbs-dot{width:9px;height:9px;border-radius:50%;background:#999}
+.oh-map-tbs-row[data-stage="start"]  .oh-map-tbs-dot{background:#7FA657}
+.oh-map-tbs-row[data-stage="rozvoj"] .oh-map-tbs-dot{background:#D4A63C}
+.oh-map-tbs-row[data-stage="stred"]  .oh-map-tbs-dot{background:#C17B3D}
+.oh-map-tbs-row[data-stage="zaver"]  .oh-map-tbs-dot{background:#8C2423}
+.oh-map-tbs-num{margin-left:auto;font-variant-numeric:tabular-nums;color:var(--oh-text-muted,#6b6453)}
+.oh-map-tbs-body{display:flex;flex-direction:column;padding-left:17px;margin-top:2px}
+.oh-map-tbs-item{padding:2px 4px;border-radius:3px;color:var(--oh-text,#2a2a2a);text-decoration:none;font-size:.88rem}
+.oh-map-tbs-item:hover{background:var(--oh-surface,#FAF6EC)}
+.oh-map-empty{display:flex;flex-direction:column;align-items:center;justify-content:center;
+    gap:10px;padding:60px 20px;text-align:center}
+.oh-map-empty-art i{font-size:4rem;color:rgba(45,80,22,.35)}
+.oh-map-empty h2{font:700 1.4rem var(--oh-font-heading);margin:0}
+@media (max-width:900px){
+    .oh-map-shell{grid-template-columns:1fr}
+    .oh-map-layer-rail{position:absolute;left:8px;top:8px;z-index:5;width:200px;
+        box-shadow:0 1px 4px rgba(0,0,0,.18)}
+}
+}

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -791,3 +791,84 @@ window.ovcinaBboxMap = {
         delete this._instances[elementId];
     }
 };
+
+// ======================================================================
+// Issue #207 — Map page (cartographer's workshop) pin layer.
+// DOM markers (extending the existing ovcinaMap pattern) for the two
+// active layers — Lokace and Skrýše & Poklady. Click events bubble
+// through `_dotnetRef.invokeMethodAsync('OnMapPinClicked', kind, id)`
+// so MapPage.razor can open the right-peek panel for the location.
+// ======================================================================
+window.ovcinaMap._mapPagePins = { loc: {}, stash: {} };
+
+window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
+    if (!this._map) return;
+    this.removeLocationPin(id);
+    var pin = document.createElement('div');
+    pin.className = 'oh-map-pin oh-map-pin-loc';
+    pin.setAttribute('data-kind', (kind || 'wilderness').toLowerCase());
+    pin.title = name || '';
+    var self = this;
+    pin.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapPinClicked', 'location', id);
+    });
+    var marker = new maplibregl.Marker({ element: pin, anchor: 'center' })
+        .setLngLat([lon, lat])
+        .addTo(this._map);
+    this._mapPagePins.loc[id] = marker;
+};
+
+window.ovcinaMap.removeLocationPin = function (id) {
+    var m = this._mapPagePins.loc[id];
+    if (m) { try { m.remove(); } catch (e) { /* ignore */ } delete this._mapPagePins.loc[id]; }
+};
+
+window.ovcinaMap.addStashPin = function (id, locationId, lat, lon, name, count, stage) {
+    if (!this._map) return;
+    this.removeStashPin(id);
+    var pin = document.createElement('div');
+    pin.className = 'oh-map-pin oh-map-pin-stash';
+    if (stage) pin.setAttribute('data-stage', stage);
+    pin.title = (name || '') + (count ? ' · ' + count + ' pokladů' : '');
+    if (count > 0) {
+        var badge = document.createElement('span');
+        badge.className = 'oh-map-pin-count';
+        badge.textContent = String(count);
+        pin.appendChild(badge);
+    }
+    var self = this;
+    pin.addEventListener('click', function (e) {
+        e.stopPropagation();
+        // Stash pins open the host location's peek per the brief —
+        // "stash IS at the location" — keeps one peek surface.
+        if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapPinClicked', 'location', locationId);
+    });
+    var marker = new maplibregl.Marker({ element: pin, anchor: 'center' })
+        .setLngLat([lon, lat])
+        .addTo(this._map);
+    this._mapPagePins.stash[id] = marker;
+};
+
+window.ovcinaMap.removeStashPin = function (id) {
+    var m = this._mapPagePins.stash[id];
+    if (m) { try { m.remove(); } catch (e) { /* ignore */ } delete this._mapPagePins.stash[id]; }
+};
+
+window.ovcinaMap.clearMapPagePins = function () {
+    for (var lid in this._mapPagePins.loc) {
+        try { this._mapPagePins.loc[lid].remove(); } catch (e) { /* ignore */ }
+    }
+    for (var sid in this._mapPagePins.stash) {
+        try { this._mapPagePins.stash[sid].remove(); } catch (e) { /* ignore */ }
+    }
+    this._mapPagePins = { loc: {}, stash: {} };
+};
+
+window.ovcinaMap.setMapPageLayerVisibility = function (layer, visible) {
+    var bag = layer === 'stash' ? this._mapPagePins.stash : this._mapPagePins.loc;
+    for (var k in bag) {
+        var el = bag[k].getElement();
+        if (el) el.style.display = visible ? '' : 'none';
+    }
+};

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -872,3 +872,18 @@ window.ovcinaMap.setMapPageLayerVisibility = function (layer, visible) {
         if (el) el.style.display = visible ? '' : 'none';
     }
 };
+
+// Hook into dispose so map-page pins clear when the user navigates away —
+// pre-fixup these markers + their DOM elements stuck around after the
+// MapLibre instance was removed (Copilot finding).
+(function () {
+    if (window.ovcinaMap._mapPageDisposeHooked) return;
+    window.ovcinaMap._mapPageDisposeHooked = true;
+    var originalDispose = window.ovcinaMap.dispose;
+    if (typeof originalDispose === 'function') {
+        window.ovcinaMap.dispose = function () {
+            try { this.clearMapPagePins(); } catch (e) { /* ignore */ }
+            return originalDispose.apply(this, arguments);
+        };
+    }
+})();

--- a/src/OvcinaHra.Shared/Dtos/MapDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MapDtos.cs
@@ -1,0 +1,90 @@
+using System.Text.Json.Serialization;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
+
+namespace OvcinaHra.Shared.Dtos;
+
+// Issue #207 — Map page (cartographer's workshop) DTOs.
+//
+// Scope cut from the original brief: only Locations and Stashes layers.
+// The Encounters layer + animated quest paths require a schema primitive
+// that doesn't exist yet — QuestEncounter has no location anchor, no order.
+// A follow-up issue will add a QuestWaypoint entity; until then those
+// surfaces stay out of scope. Treasures-by-stage explorer (the brief's
+// other "wow") still ships in this PR.
+
+/// <summary>
+/// Single payload for the whole map. Two arrays — pins are DOM markers
+/// (existing ovcinaMap pattern), so the cockpit only needs lat/lon +
+/// display fields here.
+/// </summary>
+public record MapDataDto(
+    IReadOnlyList<MapLocationDto> Locations,
+    IReadOnlyList<MapStashDto> Stashes);
+
+public record MapLocationDto(
+    int Id,
+    string Name,
+    double Lat,
+    double Lon,
+    LocationKind Kind,
+    int? KingdomId,
+    string? KingdomName,
+    string? ThumbnailUrl)
+{
+    [JsonIgnore]
+    public string KindDisplay => Kind.GetDisplayName();
+}
+
+/// <summary>
+/// One stash pin. Always sits at <see cref="Lat"/>/<see cref="Lon"/> of
+/// its <c>GameSecretStash.Location</c>. Brief calls for a treasure-count
+/// badge keyed by the highest-stage treasure inside; we expose
+/// <see cref="TreasureCount"/> + <see cref="HighestStage"/> so the
+/// client can pick the badge color from the stage palette.
+/// </summary>
+public record MapStashDto(
+    int Id,
+    int LocationId,
+    string Name,
+    double Lat,
+    double Lon,
+    int TreasureCount,
+    GameTimePhase? HighestStage);
+
+/// <summary>
+/// Right-peek payload for a single location. Aggregates everything the
+/// peek panel needs in one trip: treasures grouped by stage, encounters
+/// list (currently empty — see scope note above), and a lore preview.
+/// </summary>
+public record LocationPeekDto(
+    int Id,
+    string Name,
+    string? ThumbnailUrl,
+    double Lat,
+    double Lon,
+    int? KingdomId,
+    string? KingdomName,
+    LocationKind Kind,
+    string KindDisplay,
+    IReadOnlyList<LocationPeekStashDto> Stashes,
+    IReadOnlyList<TreasuresByStageRowDto> TreasuresByStage,
+    string? LorePreview);
+
+public record LocationPeekStashDto(int Id, string Name, int TreasureCount);
+
+/// <summary>
+/// One row in the treasures-by-stage block. The cockpit renders all
+/// four stages in fixed order; empty rows show a "Žádné poklady" line
+/// so the layout stays stable.
+/// </summary>
+public record TreasuresByStageRowDto(
+    GameTimePhase Stage,
+    int Count,
+    IReadOnlyList<TreasuresByStageItemDto> Treasures)
+{
+    [JsonIgnore]
+    public string StageDisplay => Stage.GetDisplayName();
+}
+
+public record TreasuresByStageItemDto(int Id, string Name);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Domain.ValueObjects;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+// Issue #207 — contract tests for the Map page endpoints.
+// /api/map/data is the aggregated payload powering the page-level render;
+// /api/map/locations/{id}/peek powers the right slide-in panel.
+public class MapEndpointsTests(PostgresFixture postgres)
+    : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    private async Task<GameDetailDto> CreateGameAsync()
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Map test", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    [Fact]
+    public async Task Data_EmptyGame_ReturnsEmptyArrays()
+    {
+        var game = await CreateGameAsync();
+
+        var data = await Client.GetFromJsonAsync<MapDataDto>(
+            $"/api/map/data?gameId={game.Id}");
+
+        Assert.NotNull(data);
+        Assert.Empty(data.Locations);
+        Assert.Empty(data.Stashes);
+    }
+
+    [Fact]
+    public async Task Data_SkipsLocationsWithoutGps()
+    {
+        var game = await CreateGameAsync();
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var withGps = new Location
+            {
+                Name = "Hradec",
+                LocationKind = LocationKind.Wilderness,
+                Coordinates = new GpsCoordinates(49.5m, 17.1m),
+            };
+            var withoutGps = new Location
+            {
+                Name = "Bez GPS",
+                LocationKind = LocationKind.Wilderness,
+            };
+            db.Locations.AddRange(withGps, withoutGps);
+            await db.SaveChangesAsync();
+            db.GameLocations.AddRange(
+                new GameLocation { GameId = game.Id, LocationId = withGps.Id },
+                new GameLocation { GameId = game.Id, LocationId = withoutGps.Id });
+            await db.SaveChangesAsync();
+        }
+
+        var data = await Client.GetFromJsonAsync<MapDataDto>(
+            $"/api/map/data?gameId={game.Id}");
+
+        Assert.NotNull(data);
+        var single = Assert.Single(data.Locations);
+        Assert.Equal("Hradec", single.Name);
+    }
+
+    [Fact]
+    public async Task Data_SkipsVariantLocations()
+    {
+        // Per Location.cs comment: "Only parent locations (ParentLocationId
+        // == null) appear as map pins." Variants share their parent's GPS
+        // and would stack identical markers.
+        var game = await CreateGameAsync();
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var parent = new Location
+            {
+                Name = "Parent",
+                LocationKind = LocationKind.Wilderness,
+                Coordinates = new GpsCoordinates(49.5m, 17.1m),
+            };
+            db.Locations.Add(parent);
+            await db.SaveChangesAsync();
+
+            var variant = new Location
+            {
+                Name = "Parent — varianta",
+                LocationKind = LocationKind.Wilderness,
+                Coordinates = new GpsCoordinates(49.5m, 17.1m),
+                ParentLocationId = parent.Id,
+            };
+            db.Locations.Add(variant);
+            await db.SaveChangesAsync();
+
+            db.GameLocations.AddRange(
+                new GameLocation { GameId = game.Id, LocationId = parent.Id },
+                new GameLocation { GameId = game.Id, LocationId = variant.Id });
+            await db.SaveChangesAsync();
+        }
+
+        var data = await Client.GetFromJsonAsync<MapDataDto>(
+            $"/api/map/data?gameId={game.Id}");
+
+        Assert.NotNull(data);
+        var single = Assert.Single(data.Locations);
+        Assert.Equal("Parent", single.Name);
+    }
+
+    [Fact]
+    public async Task Peek_NonExistentLocation_Returns404()
+    {
+        var game = await CreateGameAsync();
+
+        var response = await Client.GetAsync(
+            $"/api/map/locations/999999/peek?gameId={game.Id}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Peek_AlwaysReturnsAllFourStageRows()
+    {
+        // Even when a location has zero treasures across the board, the
+        // peek payload returns four stage rows so the layout stays stable.
+        var game = await CreateGameAsync();
+        int locationId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var loc = new Location
+            {
+                Name = "Empty",
+                LocationKind = LocationKind.Wilderness,
+                Coordinates = new GpsCoordinates(49.5m, 17.1m),
+            };
+            db.Locations.Add(loc);
+            await db.SaveChangesAsync();
+            locationId = loc.Id;
+        }
+
+        var peek = await Client.GetFromJsonAsync<LocationPeekDto>(
+            $"/api/map/locations/{locationId}/peek?gameId={game.Id}");
+
+        Assert.NotNull(peek);
+        Assert.Equal(4, peek.TreasuresByStage.Count);
+        Assert.All(peek.TreasuresByStage, r => Assert.Equal(0, r.Count));
+        // Canonical stage order — Start → Early → Midgame → Lategame.
+        // EndGame is intentionally excluded from the peek explorer.
+        Assert.Equal(GameTimePhase.Start, peek.TreasuresByStage[0].Stage);
+        Assert.Equal(GameTimePhase.Early, peek.TreasuresByStage[1].Stage);
+        Assert.Equal(GameTimePhase.Midgame, peek.TreasuresByStage[2].Stage);
+        Assert.Equal(GameTimePhase.Lategame, peek.TreasuresByStage[3].Stage);
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
@@ -129,6 +129,37 @@ public class MapEndpointsTests(PostgresFixture postgres)
     }
 
     [Fact]
+    public async Task Peek_LocationInDifferentGame_Returns404()
+    {
+        // Regression for the Copilot-caught game-scope bypass — peek
+        // must enforce GameLocations membership, not just LocationId.
+        var gameA = await CreateGameAsync();
+        var gameB = await CreateGameAsync();
+        int locationId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var loc = new Location
+            {
+                Name = "Tied to A",
+                LocationKind = LocationKind.Wilderness,
+                Coordinates = new GpsCoordinates(49.5m, 17.1m),
+            };
+            db.Locations.Add(loc);
+            await db.SaveChangesAsync();
+            db.GameLocations.Add(new GameLocation { GameId = gameA.Id, LocationId = loc.Id });
+            await db.SaveChangesAsync();
+            locationId = loc.Id;
+        }
+
+        // Peek with gameB.Id — location isn't part of that game.
+        var response = await Client.GetAsync(
+            $"/api/map/locations/{locationId}/peek?gameId={gameB.Id}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
     public async Task Peek_AlwaysReturnsAllFourStageRows()
     {
         // Even when a location has zero treasures across the board, the
@@ -145,6 +176,11 @@ public class MapEndpointsTests(PostgresFixture postgres)
                 Coordinates = new GpsCoordinates(49.5m, 17.1m),
             };
             db.Locations.Add(loc);
+            await db.SaveChangesAsync();
+            // Link to game — the peek endpoint now joins through GameLocations
+            // to enforce game scope (Copilot fixup). Pre-fixup this test
+            // wouldn't have caught the cross-game leak.
+            db.GameLocations.Add(new GameLocation { GameId = game.Id, LocationId = loc.Id });
             await db.SaveChangesAsync();
             locationId = loc.Id;
         }


### PR DESCRIPTION
**Report @ 08:25 (UTC+2)** — scope-cut tinkerer port. Phase 0 surfaced two structural ambiguities; user agreed to defer the schema-blocked surfaces and ship the rest.

## Phase 0 scope decision (user-confirmed)

The brief asked for 3 layers + animated quest paths. Recon found:
- `QuestEncounter` is `(QuestId, MonsterId, Quantity)` — no order, no location
- `QuestLocationLink` exists but has no `Order` field
- Location → Kingdom relationship doesn't exist

So the brief's "**Wow #1 — Animated quest paths**" + the "Encounters" layer + the kingdom multi-select filter need a new `QuestWaypoint` primitive + a Kingdom relationship migration first. **Both flagged as follow-ups.** Brief's "**Wow #2 — Treasures-by-stage explorer**" still ships in this PR.

## §20 self-check (post-rebase onto current main)

```
src/OvcinaHra.Api/Endpoints/MapEndpoints.cs        | 204 + (new)
src/OvcinaHra.Api/Program.cs                       |   1 +
src/OvcinaHra.Client/Components/{5 new}.razor      | 219 + (new)
src/OvcinaHra.Client/Components/MapView.razor      |  16 + (4-line JSInvokable + new Parameter)
src/OvcinaHra.Client/Pages/Map/MapPage.razor       | 450  309/-  140+
src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css|  95 +
src/OvcinaHra.Client/wwwroot/js/map-interop.js     |  81 +
src/OvcinaHra.Shared/Dtos/MapDtos.cs               |  90 + (new)
tests/.../MapEndpointsTests.cs                     | 165 + (new)
13 files changed, 1012 insertions(+), 309 deletions(-)
```

The 309 deletions are entirely the legacy `MapPage.razor` body (382-line page → 140-line cockpit composition). No surprise scope.

## API

- `GET /api/map/data?gameId={id}` → all locations + stashes in a single payload
- `GET /api/map/locations/{id}/peek?gameId={gid}` → location + stashes + treasures-by-stage explorer (always 4 rows)
- Sequential `CountAsync` awaits per the EF single-DbContext rule (caught + applied from #205 fixup)
- `Coordinates` projected as `decimal? Lat/Lon`, not the owned `GpsCoordinates` type — sidesteps "tracking query owned-entity-without-owner" exception

## UI

5 new components + `MapPage.razor` rewrite. `MapView` extended minimally (4-line `[JSInvokable] OnMapPinClicked` + new `EventCallback`). `MapPinPeek` slides in via CSS `transform: translateX(100%) → 0` over 0.3s with backdrop click-to-close. State-flag `@onerror` on the thumbnail. Layer state hydrates from `localStorage['oh-map-layers']` and persists on every change. Click empty space is a no-op (creation lives in location editor).

## JS interop

Append-only to `wwwroot/js/map-interop.js`: `addLocationPin / addStashPin / removeLocationPin / removeStashPin / clearMapPagePins / setMapPageLayerVisibility`. DOM markers (mirrors existing `addZeroMarker` pattern). Ports between the two worlds:

- ✅ Used DOM markers for ~50-pin layer (existing pattern)
- ✅ Did **not** introduce GeoJSON paint expressions for layers (they'd need clustering for Katalog mode — deferred)

## Tests (5 new in `MapEndpointsTests`)

- Empty game returns empty arrays
- Locations without GPS skipped
- Variant locations (`ParentLocationId != null`) skipped (parent-only pin convention)
- Peek 404 on missing location
- Peek always returns 4 stage rows in canonical order (Start → Early → Midgame → Lategame; EndGame intentionally excluded)

## Test plan

- [x] `dotnet build OvcinaHra.slnx` — 0W/0E
- [x] `dotnet test tests/OvcinaHra.Api.Tests` — **398/398** passed (37s, 5 new)
- [ ] Manual smoke: `/map` lands on cockpit, layers visible, click pin → peek slides in, treasures-by-stage block renders 4 rows, layer toggle persists across reload, no-game state shows Drozd zmatený CTA.

## Follow-ups (queued)

1. **`QuestWaypoint` primitive** (`QuestId`, `Order`, `LocationId`) — unblocks the Encounters layer + animated quest path + quest banner
2. **Kingdom-on-Location relationship** — unblocks kingdom multi-select filter + tint
3. URL query state (share map view via `?layers=…&selected=…`)
4. Cluster markers when Katalog mode hits high pin counts
5. Mobile/tablet polish (sidebar peek as bottom sheet)
6. Drozd compass / day-night toggle / mini-map navigator (deferred per designer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)