### PR TITLE
feat(buildings): 3-mode catalog + 2-tab detail + recipe pair (Cost → Effect)

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/BuildingEndpoints.cs
@@ -40,14 +40,23 @@ public static class BuildingEndpoints
                 b.LocationId,
                 LocationName = b.Location != null ? b.Location.Name : null,
                 b.IsPrebuilt,
-                b.ImagePath
+                b.ImagePath,
+                b.CostMoney,
+                b.Effect,
+                CraftingRecipesCount = b.CraftingRequirements.Count,
+                GamesCount = b.GameBuildings.Count
             })
             .ToListAsync();
         var buildings = rows.Select(r => new BuildingListDto(
             r.Id, r.Name, r.Description, r.Notes,
             r.LocationId, r.LocationName, r.IsPrebuilt,
             ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "buildings", r.Id, "small"))).ToList();
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "buildings", r.Id, "small"),
+            RecipeSummary: null,
+            CostMoney: r.CostMoney,
+            Effect: r.Effect,
+            CraftingRecipesCount: r.CraftingRecipesCount,
+            GamesCount: r.GamesCount)).ToList();
         return TypedResults.Ok(buildings);
     }
 
@@ -65,7 +74,11 @@ public static class BuildingEndpoints
                 gb.Building.LocationId,
                 LocationName = gb.Building.Location != null ? gb.Building.Location.Name : null,
                 gb.Building.IsPrebuilt,
-                gb.Building.ImagePath
+                gb.Building.ImagePath,
+                gb.Building.CostMoney,
+                gb.Building.Effect,
+                CraftingRecipesCount = gb.Building.CraftingRequirements.Count,
+                GamesCount = gb.Building.GameBuildings.Count
             })
             .ToListAsync();
 
@@ -91,15 +104,43 @@ public static class BuildingEndpoints
             r.LocationId, r.LocationName, r.IsPrebuilt,
             ImagePath: r.ImagePath,
             ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "buildings", r.Id, "small"),
-            RecipeSummary: summaryByBuildingId.GetValueOrDefault(r.Id))).ToList();
+            RecipeSummary: summaryByBuildingId.GetValueOrDefault(r.Id),
+            CostMoney: r.CostMoney,
+            Effect: r.Effect,
+            CraftingRecipesCount: r.CraftingRecipesCount,
+            GamesCount: r.GamesCount)).ToList();
         return TypedResults.Ok(buildings);
     }
 
-    private static async Task<Results<Ok<BuildingDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
+    private static async Task<Results<Ok<BuildingDetailDto>, NotFound>> GetById(int id, WorldDbContext db, HttpContext http)
     {
-        var b = await db.Buildings.FindAsync(id);
-        if (b is null) return TypedResults.NotFound();
-        return TypedResults.Ok(new BuildingDetailDto(b.Id, b.Name, b.Description, b.Notes, b.ImagePath, b.LocationId, b.IsPrebuilt));
+        var row = await db.Buildings
+            .Where(b => b.Id == id)
+            .Select(b => new
+            {
+                b.Id, b.Name, b.Description, b.Notes, b.ImagePath,
+                b.LocationId,
+                LocationName = b.Location != null ? b.Location.Name : null,
+                b.IsPrebuilt,
+                b.CostMoney, b.Effect,
+                CraftingRecipesCount = b.CraftingRequirements.Count,
+                GamesCount = b.GameBuildings.Count
+            })
+            .FirstOrDefaultAsync();
+        if (row is null) return TypedResults.NotFound();
+
+        var imageUrl = string.IsNullOrWhiteSpace(row.ImagePath)
+            ? null
+            : ImageEndpoints.ThumbUrl(http, "buildings", row.Id, "small");
+
+        return TypedResults.Ok(new BuildingDetailDto(
+            row.Id, row.Name, row.Description, row.Notes, row.ImagePath,
+            row.LocationId, row.LocationName, row.IsPrebuilt,
+            ImageUrl: imageUrl,
+            CostMoney: row.CostMoney,
+            Effect: row.Effect,
+            CraftingRecipesCount: row.CraftingRecipesCount,
+            GamesCount: row.GamesCount));
     }
 
     private static async Task<Created<BuildingDetailDto>> Create(CreateBuildingDto dto, HttpContext http, WorldDbContext db)
@@ -110,7 +151,9 @@ public static class BuildingEndpoints
             Description = dto.Description,
             Notes = dto.Notes,
             LocationId = dto.LocationId,
-            IsPrebuilt = dto.IsPrebuilt
+            IsPrebuilt = dto.IsPrebuilt,
+            CostMoney = dto.CostMoney,
+            Effect = dto.Effect
         };
         db.Buildings.Add(b);
         await db.SaveChangesAsync();
@@ -123,15 +166,35 @@ public static class BuildingEndpoints
             await db.SaveChangesAsync();
         }
 
+        // Resolve LocationName for the freshly-created entity so the client
+        // gets the same shape as GetById without an extra round-trip.
+        string? locationName = null;
+        if (b.LocationId is int locId)
+        {
+            locationName = await db.Locations
+                .Where(l => l.Id == locId)
+                .Select(l => l.Name)
+                .FirstOrDefaultAsync();
+        }
+
         return TypedResults.Created($"/api/buildings/{b.Id}",
-            new BuildingDetailDto(b.Id, b.Name, b.Description, b.Notes, b.ImagePath, b.LocationId, b.IsPrebuilt));
+            new BuildingDetailDto(
+                b.Id, b.Name, b.Description, b.Notes, b.ImagePath,
+                b.LocationId, locationName, b.IsPrebuilt,
+                ImageUrl: null,
+                CostMoney: b.CostMoney,
+                Effect: b.Effect,
+                CraftingRecipesCount: 0,
+                GamesCount: http.Request.Query.ContainsKey("gameId") ? 1 : 0));
     }
 
     private static async Task<Results<NoContent, NotFound>> Update(int id, UpdateBuildingDto dto, WorldDbContext db)
     {
         var b = await db.Buildings.FindAsync(id);
         if (b is null) return TypedResults.NotFound();
-        b.Name = dto.Name; b.Description = dto.Description; b.Notes = dto.Notes; b.LocationId = dto.LocationId; b.IsPrebuilt = dto.IsPrebuilt;
+        b.Name = dto.Name; b.Description = dto.Description; b.Notes = dto.Notes;
+        b.LocationId = dto.LocationId; b.IsPrebuilt = dto.IsPrebuilt;
+        b.CostMoney = dto.CostMoney; b.Effect = dto.Effect;
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Migrations/20260426073855_AddCostMoneyAndEffectToBuilding.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260426073855_AddCostMoneyAndEffectToBuilding.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260426073855_AddCostMoneyAndEffectToBuilding")]
+    partial class AddCostMoneyAndEffectToBuilding
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260426073855_AddCostMoneyAndEffectToBuilding.cs
+++ b/src/OvcinaHra.Api/Migrations/20260426073855_AddCostMoneyAndEffectToBuilding.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCostMoneyAndEffectToBuilding : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CostMoney",
+                table: "Buildings",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Effect",
+                table: "Buildings",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CostMoney",
+                table: "Buildings");
+
+            migrationBuilder.DropColumn(
+                name: "Effect",
+                table: "Buildings");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Components/BuildingCardRow.razor
+++ b/src/OvcinaHra.Client/Components/BuildingCardRow.razor
@@ -1,0 +1,73 @@
+@using OvcinaHra.Shared.Dtos
+
+@* Karty mode — horizontal card-row (~120px tall). 86×120 5:7 thumb on
+   left, name + description preview center, recipe block right with
+   stats cluster. Click navigates to detail. *@
+
+<button type="button" class="oh-bld-cardrow" @key="Building.Id" @onclick="HandleClick">
+    <div class="oh-bld-cardrow-thumb @(string.IsNullOrEmpty(Building.ImageUrl) || _imageFailed ? "oh-bld-cardrow-thumb--placeholder" : "")">
+        @if (!string.IsNullOrEmpty(Building.ImageUrl) && !_imageFailed)
+        {
+            <img src="@Building.ImageUrl" alt="@Building.Name" @onerror="() => _imageFailed = true" />
+        }
+        else
+        {
+            <i class="bi bi-house-fill"></i>
+        }
+    </div>
+    <div class="oh-bld-cardrow-body">
+        <h3 class="oh-bld-cardrow-name">
+            @Building.Name
+            @if (Building.IsPrebuilt)
+            {
+                <span class="oh-bld-cardrow-prebuilt" title="Představěná">
+                    <i class="bi bi-flag"></i>
+                </span>
+            }
+        </h3>
+        @if (!string.IsNullOrWhiteSpace(Building.Description))
+        {
+            <p class="oh-bld-cardrow-desc">@Building.Description</p>
+        }
+        <BuildingRecipeBlock CostMoney="@Building.CostMoney" Effect="@Building.Effect" />
+    </div>
+    <div class="oh-bld-cardrow-stats">
+        @if (Building.CraftingRecipesCount > 0)
+        {
+            <span class="oh-pill-mono" title="Recepty vyžadující tuto stavbu">
+                <i class="bi bi-hammer"></i>@Building.CraftingRecipesCount receptů
+            </span>
+        }
+        @if (Building.GamesCount > 0)
+        {
+            <span class="oh-pill-mono" title="Hry používající tuto stavbu">
+                <i class="bi bi-controller"></i>@Building.GamesCount her
+            </span>
+        }
+        @if (!string.IsNullOrWhiteSpace(Building.LocationName))
+        {
+            <span class="oh-pill" title="Lokace">
+                <i class="bi bi-geo-alt"></i>@Building.LocationName
+            </span>
+        }
+    </div>
+</button>
+
+@code {
+    [Parameter, EditorRequired] public BuildingListDto Building { get; set; } = null!;
+    [Parameter] public EventCallback<BuildingListDto> OnClick { get; set; }
+
+    private bool _imageFailed;
+    private string? _lastImageUrl;
+
+    protected override void OnParametersSet()
+    {
+        if (_lastImageUrl != Building.ImageUrl)
+        {
+            _lastImageUrl = Building.ImageUrl;
+            _imageFailed = false;
+        }
+    }
+
+    private async Task HandleClick() => await OnClick.InvokeAsync(Building);
+}

--- a/src/OvcinaHra.Client/Components/BuildingRecipeBlock.razor
+++ b/src/OvcinaHra.Client/Components/BuildingRecipeBlock.razor
@@ -1,0 +1,24 @@
+@* The "build recipe" formula: cost → effect. Reused on tile, card-row,
+   Karta hero, and Seznam cell. Effect is sacred prose — never truncate or
+   decorate; CSS handles wrapping. Null Effect → muted "Bez efektu". *@
+
+<div class="oh-bld-rec @(Compact ? "oh-bld-rec--compact" : "")">
+    <CoinPill Cost="@CostMoney" />
+    <span class="oh-bld-rec-arrow" aria-hidden="true">
+        <i class="bi bi-arrow-right"></i>
+    </span>
+    @if (string.IsNullOrWhiteSpace(Effect))
+    {
+        <span class="oh-bld-rec-effect oh-bld-rec-effect--empty">Bez efektu</span>
+    }
+    else
+    {
+        <span class="oh-bld-rec-effect">@Effect</span>
+    }
+</div>
+
+@code {
+    [Parameter] public int? CostMoney { get; set; }
+    [Parameter] public string? Effect { get; set; }
+    [Parameter] public bool Compact { get; set; }
+}

--- a/src/OvcinaHra.Client/Components/BuildingTile.razor
+++ b/src/OvcinaHra.Client/Components/BuildingTile.razor
@@ -1,0 +1,73 @@
+@using OvcinaHra.Shared.Dtos
+
+@* Galerie 5:7 portrait tile. Full-bleed image with bottom-fade gradient
+   carrying the name overlay; recipe block below. Parchment placeholder
+   when no image. State-flag `_imageFailed` reset on URL change so a
+   reused tile (filtered list) tries the new image. *@
+
+<button type="button" class="oh-bld-tile @(string.IsNullOrEmpty(Building.ImageUrl) || _imageFailed ? "oh-bld-tile--placeholder" : "")"
+        @key="Building.Id" @onclick="HandleClick">
+    <div class="oh-bld-tile-art">
+        @if (!string.IsNullOrEmpty(Building.ImageUrl) && !_imageFailed)
+        {
+            <img src="@Building.ImageUrl" alt="@Building.Name" @onerror="() => _imageFailed = true" />
+            <div class="oh-bld-tile-fade"></div>
+            <div class="oh-bld-tile-name-on-img">@Building.Name</div>
+        }
+        else
+        {
+            <div class="oh-bld-tile-parchment">
+                <i class="bi bi-house-fill"></i>
+                <span class="oh-bld-tile-parchment-name">@Building.Name</span>
+            </div>
+        }
+        @if (Building.IsPrebuilt)
+        {
+            <span class="oh-bld-tile-prebuilt" title="Představěná organizátory">
+                <i class="bi bi-flag-fill"></i>
+            </span>
+        }
+    </div>
+    <div class="oh-bld-tile-body">
+        <BuildingRecipeBlock CostMoney="@Building.CostMoney" Effect="@Building.Effect" Compact="true" />
+        <div class="oh-bld-tile-foot">
+            @if (Building.CraftingRecipesCount > 0)
+            {
+                <span class="oh-pill-mono" title="Receptů které tuto stavbu vyžadují">
+                    <i class="bi bi-hammer"></i>@Building.CraftingRecipesCount
+                </span>
+            }
+            @if (Building.GamesCount > 0)
+            {
+                <span class="oh-pill-mono" title="Her používajících tuto stavbu">
+                    <i class="bi bi-controller"></i>@Building.GamesCount
+                </span>
+            }
+            @if (!string.IsNullOrWhiteSpace(Building.LocationName))
+            {
+                <span class="oh-bld-tile-foot-loc" title="Lokace">
+                    <i class="bi bi-geo-alt"></i>@Building.LocationName
+                </span>
+            }
+        </div>
+    </div>
+</button>
+
+@code {
+    [Parameter, EditorRequired] public BuildingListDto Building { get; set; } = null!;
+    [Parameter] public EventCallback<BuildingListDto> OnClick { get; set; }
+
+    private bool _imageFailed;
+    private string? _lastImageUrl;
+
+    protected override void OnParametersSet()
+    {
+        if (_lastImageUrl != Building.ImageUrl)
+        {
+            _lastImageUrl = Building.ImageUrl;
+            _imageFailed = false;
+        }
+    }
+
+    private async Task HandleClick() => await OnClick.InvokeAsync(Building);
+}

--- a/src/OvcinaHra.Client/Components/CoinPill.razor
+++ b/src/OvcinaHra.Client/Components/CoinPill.razor
@@ -1,0 +1,23 @@
+@* Shared coin/groše pill — reuse on Items + Recipes catalogs in follow-ups.
+   `Cost` null or 0 → render muted "Zdarma" pill. Otherwise renders the
+   coin icon + "{N} gr" in mono. Forest-green accent on the coin glyph. *@
+
+<span class="oh-coin-pill @(IsFree ? "oh-coin-pill--free" : "")"
+      title="@(IsFree ? "Zdarma" : $"{Cost} grošů")">
+    @if (IsFree)
+    {
+        <i class="bi bi-circle"></i>
+        <span>Zdarma</span>
+    }
+    else
+    {
+        <i class="bi bi-coin"></i>
+        <span>@Cost gr</span>
+    }
+</span>
+
+@code {
+    [Parameter] public int? Cost { get; set; }
+
+    private bool IsFree => Cost is null or 0;
+}

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingDetail.razor
@@ -1,0 +1,373 @@
+@page "/buildings/{Id:int}"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject NavigationManager Nav
+@inject GameContextService GameContext
+@implements IDisposable
+
+@* Issue #208 — 2-tab building detail page (Karta · Upravit). Karta hero
+   shows the recipe block (cost → effect) + "Použito v" cluster. Upravit
+   3 sections: Identita / Recept (sacred banner over Effect memo) / Obsah.
+   Smazat blocked when CraftingRecipesCount > 0. *@
+
+<div class="d-flex align-items-center gap-3 mb-3 flex-wrap">
+    <button class="btn btn-sm btn-outline-secondary" type="button"
+            @onclick='() => Nav.NavigateTo("/buildings")'>
+        <i class="bi bi-arrow-left"></i> Zpět
+    </button>
+    <h1 class="mb-0">@(building?.Name ?? "Stavba")</h1>
+    @if (building is not null && building.IsPrebuilt)
+    {
+        <span class="oh-pill" title="Představěná organizátory">
+            <i class="bi bi-flag-fill"></i> Představěná
+        </span>
+    }
+</div>
+
+@if (loading)
+{
+    <p class="text-muted">Načítám…</p>
+}
+else if (building is null && error is not null)
+{
+    <div class="alert alert-danger d-flex align-items-center gap-2">
+        <i class="bi bi-wifi-off"></i>
+        <span>Nepodařilo se načíst stavbu: @error</span>
+        <button type="button" class="btn btn-sm btn-outline-primary ms-auto" @onclick="LoadAsync">Zkusit znovu</button>
+    </div>
+}
+else if (building is null)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-emoji-frown fs-1 d-block mb-2"></i>
+        <p>Stavba nenalezena.</p>
+    </div>
+}
+else
+{
+    <div class="d-flex gap-2 mb-3">
+        <button class="btn btn-sm @(activeTab == "karta" ? "btn-primary" : "btn-outline-primary")"
+                @onclick='() => activeTab = "karta"'>
+            <i class="bi bi-bookmark-fill"></i> Karta
+        </button>
+        <button class="btn btn-sm @(activeTab == "upravit" ? "btn-primary" : "btn-outline-primary")"
+                @onclick='() => activeTab = "upravit"'>
+            <i class="bi bi-pencil"></i> Upravit
+        </button>
+    </div>
+
+    @if (activeTab == "karta")
+    {
+        <div class="oh-bld-karta">
+            <div class="oh-bld-karta-hero">
+                <div class="oh-bld-karta-img-wrap @(string.IsNullOrEmpty(building.ImageUrl) ? "oh-bld-karta-img-wrap--placeholder" : "")">
+                    @if (!string.IsNullOrEmpty(building.ImageUrl))
+                    {
+                        <img src="@building.ImageUrl" alt="@building.Name" class="oh-bld-karta-img" />
+                    }
+                    else
+                    {
+                        <div class="oh-bld-karta-img oh-bld-karta-img--placeholder">
+                            <i class="bi bi-house-fill"></i>
+                            <span class="oh-bld-karta-img-name">@building.Name</span>
+                        </div>
+                    }
+                </div>
+                <div class="oh-bld-karta-side">
+                    <h2 class="oh-bld-karta-name">@building.Name</h2>
+                    <BuildingRecipeBlock CostMoney="@building.CostMoney" Effect="@building.Effect" />
+
+                    <div class="oh-bld-karta-stats">
+                        @if (!string.IsNullOrWhiteSpace(building.LocationName))
+                        {
+                            <div class="oh-bld-karta-stat-row">
+                                <span><i class="bi bi-geo-alt"></i> Lokace</span>
+                                <strong>@building.LocationName</strong>
+                            </div>
+                        }
+                        <div class="oh-bld-karta-stat-row">
+                            <span><i class="bi bi-flag"></i> Představěná</span>
+                            <strong>@(building.IsPrebuilt ? "Ano" : "Ne")</strong>
+                        </div>
+                    </div>
+
+                    @if (building.CraftingRecipesCount > 0 || building.GamesCount > 0)
+                    {
+                        <h6 class="oh-bld-karta-cluster-title">Použito v</h6>
+                        <div class="oh-bld-karta-cluster">
+                            @if (building.CraftingRecipesCount > 0)
+                            {
+                                <span class="oh-pill-mono" title="Recepty vyžadující tuto stavbu">
+                                    <i class="bi bi-hammer"></i>
+                                    <strong>@building.CraftingRecipesCount</strong>
+                                    receptů
+                                </span>
+                            }
+                            @if (building.GamesCount > 0)
+                            {
+                                <span class="oh-pill-mono" title="Hry používající tuto stavbu">
+                                    <i class="bi bi-controller"></i>
+                                    <strong>@building.GamesCount</strong>
+                                    @(building.GamesCount == 1 ? "hra" : (building.GamesCount < 5 ? "hry" : "her"))
+                                </span>
+                            }
+                        </div>
+                    }
+                </div>
+            </div>
+
+            @if (!string.IsNullOrWhiteSpace(building.Description))
+            {
+                <p class="oh-bld-karta-desc">@building.Description</p>
+            }
+            @if (!string.IsNullOrWhiteSpace(building.Notes))
+            {
+                <p class="oh-bld-karta-notes"><em>@building.Notes</em></p>
+            }
+        </div>
+    }
+    else if (activeTab == "upravit")
+    {
+        <div class="oh-bld-edit">
+            <DxFormLayout>
+                <DxFormLayoutGroup Caption="Identita" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="Název" ColSpanMd="8">
+                        <DxTextBox @bind-Text="@editModel.Name" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Lokace" ColSpanMd="4">
+                        <DxComboBox Data="@allLocations" @bind-Value="@editModel.LocationId"
+                                    TextFieldName="Name" ValueFieldName="Id"
+                                    NullText="Bez lokace"
+                                    SearchMode="ListSearchMode.AutoSearch"
+                                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                    </DxFormLayoutItem>
+                    @* "Představěná" is the intentional Czech label per
+                       feedback_ovcinahra_predstavena_term — not a typo. *@
+                    <DxFormLayoutItem Caption="Představěná" ColSpanMd="12">
+                        <DxCheckBox @bind-Checked="@editModel.IsPrebuilt">Představěná organizátory (existuje od začátku hry)</DxCheckBox>
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+
+                <DxFormLayoutGroup Caption="Obrázek (5:7 portrét)" ColSpanMd="12">
+                    <DxFormLayoutItem ColSpanMd="12">
+                        <ImagePicker EntityType="buildings" EntityId="@building.Id"
+                                     AspectRatio="5:7" Width="240px"
+                                     Alt="@building.Name" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+
+                <DxFormLayoutGroup Caption="Recept (cena → efekt)" ColSpanMd="12">
+                    <DxFormLayoutItem ColSpanMd="12">
+                        <div class="oh-sacred-banner">
+                            <i class="bi bi-shield-fill-exclamation"></i>
+                            <span>Efekt je <strong>posvátný text</strong> — pište ho tak, jak ho uvidí hráč na herní kartě. Nezkracujte, neparafrázujte.</span>
+                        </div>
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Cena (groše)" ColSpanMd="4">
+                        <DxSpinEdit @bind-Value="@editModel.CostMoney" MinValue="0" MaxValue="999999"
+                                    NullText="Zdarma"
+                                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
+                                    CssClass="oh-coin-input" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Efekt" ColSpanMd="12">
+                        <DxMemo @bind-Text="@editModel.Effect" Rows="3" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+
+                <DxFormLayoutGroup Caption="Obsah" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="Popis (organizátor)" ColSpanMd="12">
+                        <DxMemo @bind-Text="@editModel.Description" Rows="3" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
+                        <DxMemo @bind-Text="@editModel.Notes" Rows="3" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+            </DxFormLayout>
+
+            @if (saveError is not null)
+            {
+                <div class="alert alert-danger mt-2">@saveError</div>
+            }
+
+            <div class="oh-bld-edit-foot">
+                @if (building.CraftingRecipesCount > 0)
+                {
+                    <span class="oh-bld-delete-blocked" title="Stavba je odkazovaná recepty — nelze smazat">
+                        <i class="bi bi-lock-fill"></i>
+                        Smazat zablokováno — používá se v <strong>@building.CraftingRecipesCount</strong> receptech
+                    </span>
+                }
+                else
+                {
+                    <button class="btn btn-outline-danger" type="button"
+                            @onclick="() => isDeleteVisible = true" disabled="@isSaving">
+                        <i class="bi bi-trash"></i> Smazat
+                    </button>
+                }
+                <div style="flex:1"></div>
+                <button class="btn btn-secondary" type="button"
+                        @onclick="ResetEditModel" disabled="@isSaving">Zrušit</button>
+                <button class="btn btn-primary" type="button"
+                        @onclick="SaveAsync" disabled="@(isSaving || string.IsNullOrWhiteSpace(editModel.Name))">
+                    @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                    Uložit
+                </button>
+            </div>
+        </div>
+    }
+}
+
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Smazat stavbu?" Width="420px">
+    <BodyContentTemplate Context="ctx">
+        <p>Smazat stavbu <strong>@(building?.Name)</strong>? Akce je nevratná.</p>
+        @if (deleteError is not null)
+        {
+            <div class="alert alert-danger">@deleteError</div>
+        }
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" type="button" @onclick="() => isDeleteVisible = false">Zrušit</button>
+            <button class="btn btn-danger" type="button" @onclick="ConfirmDeleteAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public int Id { get; set; }
+
+    private BuildingDetailDto? building;
+    private bool loading = true;
+    private string? error;
+
+    private string activeTab = "karta";
+
+    private EditModel editModel = new();
+    private bool isSaving;
+    private string? saveError;
+
+    private bool isDeleteVisible;
+    private string? deleteError;
+
+    private List<LocationListDto> allLocations = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        GameContext.OnGameChanged += OnGameChanged;
+        await LoadAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (building is not null && building.Id != Id)
+            await LoadAsync();
+    }
+
+    private async void OnGameChanged()
+    {
+        // Location combo is keyed by the current game; refresh.
+        await LoadLocationsAsync();
+        StateHasChanged();
+    }
+
+    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        error = null;
+        try
+        {
+            building = await Api.GetAsync<BuildingDetailDto>($"/api/buildings/{Id}");
+            if (building is null)
+            {
+                error = "Stavba nenalezena.";
+                return;
+            }
+            ResetEditModel();
+            await LoadLocationsAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { loading = false; }
+    }
+
+    private async Task LoadLocationsAsync()
+    {
+        try
+        {
+            var gid = GameContext.SelectedGameId;
+            allLocations = gid is int g
+                ? await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{g}")
+                : await Api.GetListAsync<LocationListDto>("/api/locations");
+        }
+        catch { /* picker is non-critical for read view */ }
+    }
+
+    private void ResetEditModel()
+    {
+        if (building is null) return;
+        editModel = new EditModel
+        {
+            Name = building.Name,
+            Description = building.Description,
+            Notes = building.Notes,
+            LocationId = building.LocationId,
+            IsPrebuilt = building.IsPrebuilt,
+            CostMoney = building.CostMoney,
+            Effect = building.Effect
+        };
+        saveError = null;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (building is null || string.IsNullOrWhiteSpace(editModel.Name)) return;
+        saveError = null;
+        isSaving = true;
+        try
+        {
+            var dto = new UpdateBuildingDto(
+                editModel.Name.Trim(),
+                editModel.Description, editModel.Notes,
+                editModel.LocationId, editModel.IsPrebuilt,
+                editModel.CostMoney, editModel.Effect);
+            var (ok, problem) = await Api.PutWithProblemAsync($"/api/buildings/{building.Id}", dto);
+            if (!ok)
+            {
+                saveError = problem ?? "Uložení se nezdařilo.";
+                return;
+            }
+            await LoadAsync();
+        }
+        catch (Exception ex) { saveError = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        if (building is null) return;
+        deleteError = null;
+        try
+        {
+            var ok = await Api.DeleteAsync($"/api/buildings/{building.Id}");
+            if (!ok)
+            {
+                deleteError = "Smazání se nezdařilo (stavba může mít odkazy).";
+                return;
+            }
+            isDeleteVisible = false;
+            Nav.NavigateTo("/buildings");
+        }
+        catch (Exception ex) { deleteError = ex.Message; }
+    }
+
+    private sealed class EditModel
+    {
+        public string Name { get; set; } = "";
+        public string? Description { get; set; }
+        public string? Notes { get; set; }
+        public int? LocationId { get; set; }
+        public bool IsPrebuilt { get; set; }
+        public int? CostMoney { get; set; }
+        public string? Effect { get; set; }
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingDetail.razor
@@ -3,6 +3,7 @@
 @inject ApiClient Api
 @inject NavigationManager Nav
 @inject GameContextService GameContext
+@inject SkillService SkillSvc
 @implements IDisposable
 
 @* Issue #208 — 2-tab building detail page (Karta · Upravit). Karta hero
@@ -184,6 +185,75 @@ else
                 </DxFormLayoutGroup>
             </DxFormLayout>
 
+            @* Issue #142 — per-game construction recipe editor. Only meaningful
+               when a game is selected. Ported verbatim from the legacy
+               BuildingList popup so organizers don't lose access to the recipe
+               CRUD when this page replaces it. Sits outside the DxFormLayout
+               because its leaf-pickers manage their own state (issue #163). *@
+            @if (GameContext.SelectedGameId.HasValue)
+            {
+                <div class="mt-3 p-3 border rounded oh-bld-recpanel">
+                    <h6 class="mb-2"><i class="bi bi-hammer me-1"></i> Konstrukce v této hře (Cena výstavby)</h6>
+                    @if (recipe is not null)
+                    {
+                        <div class="mb-2">
+                            <strong class="small">Cena v zlaťácích:</strong>
+                            <div class="d-flex gap-2 align-items-end mt-1">
+                                <div style="width:140px">
+                                    <DxSpinEdit @bind-Value="@recipeMoneyCost" MinValue="0" NullText="(žádná)"
+                                                ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                                </div>
+                                <button type="button" class="btn btn-sm btn-outline-primary"
+                                        disabled="@(recipeMoneyCost == recipe.MoneyCost)"
+                                        @onclick="SaveRecipeMoneyAsync">
+                                    Uložit cenu
+                                </button>
+                            </div>
+                        </div>
+                        <RecipeIngredientPicker
+                            Ingredients="@_ingredientRows"
+                            AvailableItems="@allItems"
+                            OnAdd="@AddIngredientAsync"
+                            OnRemove="@RemoveIngredientAsync" />
+
+                        <RecipeNotesEditor
+                            PersistedValue="@recipe.IngredientNotes"
+                            OnSave="@SaveRecipeNotesAsync" />
+
+                        <RecipeBuildingPicker
+                            Caption="Předpoklady (jiné budovy)"
+                            AddPlaceholder="(přidat předpoklad)"
+                            Buildings="@_prerequisiteRows"
+                            AvailableBuildings="@AvailablePrereqBuildings"
+                            OnAdd="@AddPrereqAsync"
+                            OnRemove="@RemovePrereqAsync" />
+
+                        <RecipeSkillPicker
+                            SelectedSkillIds="@recipe.RequiredSkillIds"
+                            AllGameSkills="@gameSkills"
+                            AvailableSkills="@AvailableGameSkills"
+                            OnAdd="@AddSkillAsync"
+                            OnRemove="@RemoveSkillAsync" />
+
+                        <button type="button" class="btn btn-sm btn-outline-danger"
+                                @onclick="() => isDeleteRecipeVisible = true">
+                            Smazat recept
+                        </button>
+                    }
+                    else
+                    {
+                        <p class="text-muted small mb-2">Tato budova nemá nastavenou cenu výstavby pro tuto hru.</p>
+                        <button type="button" class="btn btn-sm btn-outline-primary" @onclick="CreateRecipeAsync">
+                            <i class="bi bi-plus-circle me-1"></i>Vytvořit cenu
+                        </button>
+                    }
+                    @if (recipeError is not null)
+                    {
+                        <div class="alert alert-danger mt-2">@recipeError</div>
+                    }
+                </div>
+            }
+
             @if (saveError is not null)
             {
                 <div class="alert alert-danger mt-2">@saveError</div>
@@ -231,6 +301,18 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+@* Issue #142 — destructive recipe-delete confirmation, per the
+   destructive-action-confirm memory rule. *@
+<DxPopup @bind-Visible="@isDeleteRecipeVisible" HeaderText="Smazat recept?" Width="420px">
+    <BodyContentTemplate Context="ctx">
+        <p>Opravdu chcete smazat cenu výstavby pro budovu <strong>@(building?.Name)</strong>? Ingredience, předpoklady a požadované dovednosti se odeberou společně s receptem.</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" type="button" @onclick="() => isDeleteRecipeVisible = false">Zrušit</button>
+            <button class="btn btn-danger" type="button" @onclick="ConfirmDeleteRecipeAsync">Smazat recept</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @code {
     [Parameter] public int Id { get; set; }
 
@@ -249,6 +331,35 @@ else
 
     private List<LocationListDto> allLocations = [];
 
+    // ----- Per-game construction recipe state (issue #142) -----
+    // Ported from the legacy BuildingList popup so the recipe CRUD survives
+    // the move to a 2-tab detail page. Only loaded/rendered when a game is
+    // selected (the recipe is per-game). Leaf pickers own their input state
+    // (issue #163) — _ingredientRows / _prerequisiteRows are pre-projected
+    // once per recipe load to avoid re-allocating each render.
+    private BuildingRecipeDetailDto? recipe;
+    private List<ItemListDto> allItems = [];
+    private List<BuildingListDto> allCatalogBuildings = [];
+    private List<GameSkillDto> gameSkills = [];
+    private int? recipeMoneyCost;
+    private bool isDeleteRecipeVisible;
+    private string? recipeError;
+    private IReadOnlyList<RecipeIngredientPicker.IngredientRow> _ingredientRows = [];
+    private IReadOnlyList<RecipeBuildingPicker.BuildingRow> _prerequisiteRows = [];
+
+    private List<GameSkillDto> AvailableGameSkills =>
+        recipe is null
+            ? []
+            : gameSkills.Where(gs => !recipe.RequiredSkillIds.Contains(gs.Id)).ToList();
+
+    private List<BuildingListDto> AvailablePrereqBuildings =>
+        recipe is null
+            ? []
+            : allCatalogBuildings
+                .Where(b => b.Id != building?.Id
+                    && !recipe.PrerequisiteBuildings.Any(pb => pb.BuildingId == b.Id))
+                .ToList();
+
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
@@ -264,8 +375,10 @@ else
 
     private async void OnGameChanged()
     {
-        // Location combo is keyed by the current game; refresh.
+        // Location combo + recipe panel are keyed by the current game; refresh.
         await LoadLocationsAsync();
+        await LoadRecipePickerDataAsync();
+        await LoadRecipeAsync();
         StateHasChanged();
     }
 
@@ -285,9 +398,204 @@ else
             }
             ResetEditModel();
             await LoadLocationsAsync();
+            await LoadRecipePickerDataAsync();
+            await LoadRecipeAsync();
         }
         catch (Exception ex) { error = ex.Message; }
         finally { loading = false; }
+    }
+
+    private async Task LoadRecipePickerDataAsync()
+    {
+        if (GameContext.SelectedGameId is not int gid) return;
+        try
+        {
+            var itemsTask = Api.GetListAsync<ItemListDto>("/api/items");
+            var catalogTask = Api.GetListAsync<BuildingListDto>("/api/buildings");
+            var skillsTask = SkillSvc.GetGameSkillsAsync(gid);
+            await Task.WhenAll(itemsTask, catalogTask, skillsTask);
+            allItems = await itemsTask;
+            allCatalogBuildings = await catalogTask;
+            gameSkills = (await skillsTask).ToList();
+        }
+        catch { /* picker data is non-critical */ }
+    }
+
+    private async Task LoadRecipeAsync()
+    {
+        recipe = null;
+        recipeMoneyCost = null;
+        _ingredientRows = [];
+        _prerequisiteRows = [];
+        recipeError = null;
+        if (building is null || GameContext.SelectedGameId is not int gid) return;
+
+        try
+        {
+            // /api/building-recipes/by-game/{gid} returns one entry per recipe,
+            // plus the OutputBuildingId so we can pick the one for THIS building.
+            var recipes = await Api.GetListAsync<BuildingRecipeListDto>($"/api/building-recipes/by-game/{gid}");
+            var match = recipes.FirstOrDefault(r => r.OutputBuildingId == building.Id);
+            if (match is not null)
+            {
+                recipe = await Api.GetAsync<BuildingRecipeDetailDto>($"/api/building-recipes/{match.Id}");
+                recipeMoneyCost = recipe?.MoneyCost;
+                if (recipe is not null)
+                {
+                    _ingredientRows = recipe.Ingredients
+                        .Select(i => new RecipeIngredientPicker.IngredientRow(i.ItemId, i.ItemName, i.Quantity))
+                        .ToList();
+                    _prerequisiteRows = recipe.PrerequisiteBuildings
+                        .Select(pb => new RecipeBuildingPicker.BuildingRow(pb.BuildingId, pb.BuildingName))
+                        .ToList();
+                }
+            }
+        }
+        catch (Exception ex) { recipeError = ex.Message; }
+    }
+
+    private async Task CreateRecipeAsync()
+    {
+        if (building is null || GameContext.SelectedGameId is not int gid) return;
+        recipeError = null;
+        try
+        {
+            await Api.PostAsync<CreateBuildingRecipeDto, BuildingRecipeDetailDto>("/api/building-recipes",
+                new CreateBuildingRecipeDto(gid, building.Id));
+            await LoadRecipeAsync();
+        }
+        catch (Exception ex) { recipeError = ex.Message; }
+    }
+
+    private async Task ConfirmDeleteRecipeAsync()
+    {
+        if (recipe is null) return;
+        recipeError = null;
+        try
+        {
+            await Api.DeleteAsync($"/api/building-recipes/{recipe.Id}");
+            recipe = null;
+            recipeMoneyCost = null;
+            isDeleteRecipeVisible = false;
+        }
+        catch (Exception ex) { recipeError = ex.Message; isDeleteRecipeVisible = false; }
+    }
+
+    private async Task AddIngredientAsync((int ItemId, int Quantity) ev)
+    {
+        if (recipe is null) return;
+        recipeError = null;
+        try
+        {
+            await Api.PostAsync<AddBuildingRecipeIngredientDto, object>($"/api/building-recipes/{recipe.Id}/ingredients",
+                new AddBuildingRecipeIngredientDto(ev.ItemId, ev.Quantity));
+            await LoadRecipeAsync();
+        }
+        catch (Exception ex) { recipeError = ex.Message; }
+    }
+
+    private async Task RemoveIngredientAsync(int itemId)
+    {
+        if (recipe is null) return;
+        recipeError = null;
+        try
+        {
+            await Api.DeleteAsync($"/api/building-recipes/{recipe.Id}/ingredients/{itemId}");
+            await LoadRecipeAsync();
+        }
+        catch (Exception ex) { recipeError = ex.Message; }
+    }
+
+    private async Task AddPrereqAsync(int buildingId)
+    {
+        if (recipe is null) return;
+        recipeError = null;
+        try
+        {
+            await Api.PostAsync<AddBuildingRecipePrerequisiteDto, object>($"/api/building-recipes/{recipe.Id}/prerequisites",
+                new AddBuildingRecipePrerequisiteDto(buildingId));
+            await LoadRecipeAsync();
+        }
+        catch (Exception ex) { recipeError = ex.Message; }
+    }
+
+    private async Task RemovePrereqAsync(int buildingId)
+    {
+        if (recipe is null) return;
+        recipeError = null;
+        try
+        {
+            await Api.DeleteAsync($"/api/building-recipes/{recipe.Id}/prerequisites/{buildingId}");
+            await LoadRecipeAsync();
+        }
+        catch (Exception ex) { recipeError = ex.Message; }
+    }
+
+    private async Task AddSkillAsync(int skillId)
+    {
+        if (recipe is null) return;
+        var next = recipe.RequiredSkillIds.ToList();
+        if (next.Contains(skillId)) return;
+        next.Add(skillId);
+        await PutRecipeAsync(
+            moneyCost: recipe.MoneyCost,
+            skillIds: next,
+            ingredientNotes: recipe.IngredientNotes);
+    }
+
+    private async Task RemoveSkillAsync(int skillId)
+    {
+        if (recipe is null) return;
+        var next = recipe.RequiredSkillIds.Where(s => s != skillId).ToList();
+        await PutRecipeAsync(
+            moneyCost: recipe.MoneyCost,
+            skillIds: next,
+            ingredientNotes: recipe.IngredientNotes);
+    }
+
+    private async Task SaveRecipeMoneyAsync()
+    {
+        if (recipe is null) return;
+        // Pass `recipeMoneyCost` verbatim — null clears the field.
+        await PutRecipeAsync(
+            moneyCost: recipeMoneyCost,
+            skillIds: recipe.RequiredSkillIds.ToList(),
+            ingredientNotes: recipe.IngredientNotes);
+    }
+
+    private async Task SaveRecipeNotesAsync(string? newValue)
+    {
+        if (recipe is null) return;
+        var normalized = string.IsNullOrWhiteSpace(newValue) ? null : newValue.Trim();
+        await PutRecipeAsync(
+            moneyCost: recipe.MoneyCost,
+            skillIds: recipe.RequiredSkillIds.ToList(),
+            ingredientNotes: normalized);
+    }
+
+    /// <summary>
+    /// Single PUT helper that requires explicit values for every mutable
+    /// field. Callers pass the recipe's current server-side values for
+    /// fields they don't want to change — without that contract a null
+    /// param meant "preserve" and clearing a field silently no-op'd
+    /// (Copilot review on the original PR #164).
+    /// </summary>
+    private async Task PutRecipeAsync(
+        int? moneyCost, IReadOnlyList<int> skillIds, string? ingredientNotes)
+    {
+        if (recipe is null) return;
+        recipeError = null;
+        try
+        {
+            var dto = new UpdateBuildingRecipeDto(
+                recipe.OutputBuildingId,
+                MoneyCost: moneyCost,
+                RequiredSkillIds: skillIds,
+                IngredientNotes: ingredientNotes);
+            await Api.PutAsync($"/api/building-recipes/{recipe.Id}", dto);
+            await LoadRecipeAsync();
+        }
+        catch (Exception ex) { recipeError = ex.Message; }
     }
 
     private async Task LoadLocationsAsync()

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
@@ -1,527 +1,268 @@
 @page "/buildings"
 @attribute [Authorize]
 @inject ApiClient Api
-@inject GameContextService GameContext
 @inject NavigationManager Nav
-@inject SkillService SkillSvc
-@implements IDisposable
+@inject IJSRuntime JS
 
-<div class="d-flex justify-content-between align-items-center mb-3">
-    <h1 class="mb-0">@(Catalog ? "Katalog budov" : "Budovy")</h1>
-    <div class="d-flex gap-2">
-        <div class="d-flex gap-2">
-            <button class="btn btn-sm @(Catalog ? "btn-outline-primary" : "btn-primary")"
-                    @onclick='() => Nav.NavigateTo("/buildings")'>Jen tato hra</button>
-            <button class="btn btn-sm @(Catalog ? "btn-primary" : "btn-outline-primary")"
-                    @onclick='() => Nav.NavigateTo("/buildings?catalog=true")'>Katalog</button>
+@* Issue #208 — single-catalog Buildings list with 3-mode toggle:
+   Galerie (5:7 tiles, default) ↔ Karty (horizontal card-rows) ↔ Seznam
+   (DxGrid). The legacy per-game / catalog mode toggle is gone — the
+   building catalog is global per the design brief, and the per-game
+   construction-recipe editor lives at /recipes (BuildingRecipe entity,
+   issue #142, untouched). View choice persists in localStorage. *@
+
+<div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+    <h1 class="mb-0">Stavby</h1>
+    <div class="d-flex gap-2 align-items-center">
+        <div class="oh-segmented" role="tablist" aria-label="Zobrazení">
+            <button type="button"
+                    class="oh-segmented-btn @(view == "galerie" ? "oh-segmented-btn--on" : "")"
+                    @onclick='() => SetViewAsync("galerie")' aria-selected="@(view == "galerie")">
+                <i class="bi bi-grid-3x3-gap"></i> Galerie
+            </button>
+            <button type="button"
+                    class="oh-segmented-btn @(view == "karty" ? "oh-segmented-btn--on" : "")"
+                    @onclick='() => SetViewAsync("karty")' aria-selected="@(view == "karty")">
+                <i class="bi bi-card-list"></i> Karty
+            </button>
+            <button type="button"
+                    class="oh-segmented-btn @(view == "seznam" ? "oh-segmented-btn--on" : "")"
+                    @onclick='() => SetViewAsync("seznam")' aria-selected="@(view == "seznam")">
+                <i class="bi bi-list-ul"></i> Seznam
+            </button>
         </div>
-        <button class="btn btn-primary" @onclick="() => OpenModal(null)">+ Nová budova</button>
+        <button class="btn btn-primary" type="button" @onclick="OpenCreateModal">
+            <i class="bi bi-plus-lg"></i> Nová stavba
+        </button>
     </div>
 </div>
 
-@if (loading) { <p>Načítám...</p> }
-else if (!Catalog && buildings.Count == 0)
+<div class="oh-bld-filters mb-3">
+    <DxTextBox Text="@searchText" TextChanged="@((string v) => searchText = v)"
+               NullText="Hledat (název, popis, efekt)…" CssClass="oh-bld-filter-search" />
+    <label class="oh-bld-filter-toggle">
+        <input type="checkbox" @bind="onlyWithImage" />
+        <span>jen s obrázkem</span>
+    </label>
+    <label class="oh-bld-filter-toggle">
+        <input type="checkbox" @bind="onlyWithRecipes" />
+        <span>jen s recepty</span>
+    </label>
+    <label class="oh-bld-filter-toggle">
+        <input type="checkbox" @bind="onlyWithEffect" />
+        <span>jen s efektem</span>
+    </label>
+</div>
+
+@if (loading)
+{
+    <p class="text-muted">Načítám…</p>
+}
+else if (filtered.Count == 0)
 {
     <div class="text-center text-muted py-5">
         <i class="bi bi-house fs-1 d-block mb-2"></i>
-        <p>Žádné budovy přiřazeny k této hře.</p>
-        <button class="btn btn-outline-primary" @onclick='() => Nav.NavigateTo("/buildings?catalog=true")'>Otevřít katalog</button>
+        <p>Žádné stavby zatím nejsou.</p>
+        <button class="btn btn-outline-primary" type="button"
+                @onclick="ClearFilters">Zrušit filtry</button>
+    </div>
+}
+else if (view == "galerie")
+{
+    <div class="oh-bld-gallery">
+        @foreach (var b in filtered)
+        {
+            <BuildingTile @key="b.Id" Building="@b"
+                          OnClick="@(_ => Nav.NavigateTo($"/buildings/{b.Id}"))" />
+        }
+    </div>
+}
+else if (view == "karty")
+{
+    <div class="oh-bld-cardrow-wrap">
+        @foreach (var b in filtered)
+        {
+            <BuildingCardRow @key="b.Id" Building="@b"
+                             OnClick="@(_ => Nav.NavigateTo($"/buildings/{b.Id}"))" />
+        }
     </div>
 }
 else
 {
-    <OvcinaGrid Data="@buildings" KeyFieldName="Id" LayoutKey="grid-layout-buildings-v3"
-                RowClick="@(e => OpenModal((BuildingListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+    @* Seznam mode — LayoutKey bumped to grid-layout-buildings-v2 because
+       column schema changed (image, recipe pair, counts).
+       Memory rule: feedback_ovcinagrid_layoutkey_bump. *@
+    <OvcinaGrid Data="@filtered" KeyFieldName="Id" LayoutKey="grid-layout-buildings-v2"
+                RowClick="@(e => Nav.NavigateTo($"/buildings/{((BuildingListDto)e.Grid.GetDataItem(e.VisibleIndex)).Id}"))">
         <Columns>
-            <DxGridDataColumn FieldName="Name" Caption="Název" />
-            <DxGridDataColumn FieldName="LocationName" Caption="Lokace" Width="180px" />
+            <DxGridDataColumn Caption="" Width="60px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var b = (BuildingListDto)context.DataItem; }
+                    <div class="oh-bld-mini-tile @(string.IsNullOrEmpty(b.ImageUrl) ? "oh-bld-mini-tile--placeholder" : "")">
+                        @if (!string.IsNullOrEmpty(b.ImageUrl))
+                        {
+                            <img src="@b.ImageUrl" alt="@b.Name" />
+                        }
+                        else
+                        {
+                            <i class="bi bi-house-fill"></i>
+                        }
+                    </div>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Name" Caption="Název" MinWidth="220" />
+            <DxGridDataColumn FieldName="CostMoney" Caption="Cena" Width="120px">
+                <CellDisplayTemplate>
+                    @{ var b = (BuildingListDto)context.DataItem; }
+                    <CoinPill Cost="@b.CostMoney" />
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Effect" Caption="Efekt" MinWidth="280">
+                <CellDisplayTemplate>
+                    @{ var b = (BuildingListDto)context.DataItem; }
+                    @if (string.IsNullOrWhiteSpace(b.Effect))
+                    {
+                        <span class="text-muted fst-italic">Bez efektu</span>
+                    }
+                    else
+                    {
+                        @* Sacred prose — full text in DOM (line-clamp via CSS); never truncated server-side. *@
+                        <span class="oh-bld-effect-cell" title="@b.Effect">@b.Effect</span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="LocationName" Caption="Lokace" Width="160px" />
+            <DxGridDataColumn FieldName="CraftingRecipesCount" Caption="Recepty" Width="100px">
+                <CellDisplayTemplate>
+                    @{ var b = (BuildingListDto)context.DataItem; }
+                    <span class="oh-pill-mono">@b.CraftingRecipesCount</span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
             <DxGridDataColumn FieldName="IsPrebuilt" Caption="Představěná" Width="120px">
                 <CellDisplayTemplate>@(((bool)context.Value) ? "Ano" : "Ne")</CellDisplayTemplate>
             </DxGridDataColumn>
-            @* Issue #142 — per-game crafting cost summary. Catalog mode leaves
-               the field null (no recipes there); game mode populates a compact
-               "3× ingrediencí · 50 zlaťáků · 1 dovednost" via the by-game endpoint. *@
-            @if (!Catalog)
-            {
-                <DxGridDataColumn FieldName="RecipeSummary" Caption="Cena výstavby" Width="280px">
-                    <CellDisplayTemplate>
-                        @{ var b = (BuildingListDto)context.DataItem; }
-                        @if (string.IsNullOrWhiteSpace(b.RecipeSummary))
-                        {
-                            <span class="text-muted">—</span>
-                        }
-                        else
-                        {
-                            <span class="text-secondary"><i class="bi bi-hammer me-1"></i>@b.RecipeSummary</span>
-                        }
-                    </CellDisplayTemplate>
-                </DxGridDataColumn>
-            }
-            <DxGridDataColumn FieldName="Description" Caption="Popis" Width="260px" Visible="false" />
-            <DxGridDataColumn FieldName="Notes" Caption="Poznámky" Width="260px" Visible="false" />
-@if (Catalog)
-            {
-                <DxGridDataColumn Caption="" Width="120px" TextAlignment="GridTextAlignment.Center">
-                    <CellDisplayTemplate>
-                        @{
-                            var b = (BuildingListDto)context.DataItem;
-                            var isAssigned = assignedBuildingIds.Contains(b.Id);
-                        }
-                        @if (isAssigned)
-                        {
-                            <button class="btn btn-sm btn-outline-danger" @onclick="() => UnassignBuildingAsync(b.Id)" @onclick:stopPropagation="true">Odebrat</button>
-                        }
-                        else
-                        {
-                            <button class="btn btn-sm btn-outline-success" @onclick="() => AssignBuildingAsync(b.Id)" @onclick:stopPropagation="true">Přiřadit</button>
-                        }
-                    </CellDisplayTemplate>
-                </DxGridDataColumn>
-            }
+            <DxGridDataColumn FieldName="Description" Caption="Popis" MinWidth="240" Visible="false" />
+            <DxGridDataColumn FieldName="Notes" Caption="Poznámky" MinWidth="240" Visible="false" />
         </Columns>
     </OvcinaGrid>
 }
 
-<DxPopup AllowResize="true" @bind-Visible="@isModalVisible" HeaderText="@modalTitle" Width="900px">
-    <BodyContentTemplate Context="popupContext">
-        <div class="row g-3">
-            @if (editingId.HasValue)
-            {
-                <div class="col-md-5">
-                    <ImagePicker EntityType="buildings" EntityId="editingId.Value" Alt="Obrázek budovy" AspectRatio="3:2" />
-                </div>
-            }
-            <div class="@(editingId.HasValue ? "col-md-7" : "col-md-12")">
-                <DxFormLayout>
-                    <DxFormLayoutItem Caption="Název" ColSpanMd="12">
-                        <DxTextBox @bind-Text="@name" />
-                    </DxFormLayoutItem>
-                    <DxFormLayoutItem Caption="Popis" ColSpanMd="12">
-                        <DxMemo @bind-Text="@description" Rows="3" />
-                    </DxFormLayoutItem>
-                    <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
-                        <DxMemo @bind-Text="@notes" Rows="3" />
-                    </DxFormLayoutItem>
-                    <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
-                        <DxComboBox Data="@gameLocations" @bind-Value="@locationId"
-                                    TextFieldName="Name" ValueFieldName="Id"
-                                    NullText="Bez lokace" ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
-                    </DxFormLayoutItem>
-                    <DxFormLayoutItem Caption="" ColSpanMd="12">
-                        <DxCheckBox @bind-Checked="@isPrebuilt">Představěná organizátory</DxCheckBox>
-                    </DxFormLayoutItem>
-                </DxFormLayout>
-            </div>
-        </div>
-
-        @* Issue #142 — Building crafting cost (per-game). Hidden in catalog
-           mode (recipes are per-game) and in the new-building branch (need
-           the building Id first). Mirrors the Item-side editor in
-           ItemList.razor; the duplication is tracked as a follow-up issue
-           for extracting a shared CraftingRecipeEditor. *@
-        @if (editingId.HasValue && !Catalog && GameContext.SelectedGameId.HasValue)
+@* "+ Nová stavba" minimal create modal. After create, nav to /buildings/{id}
+   for full editing on the Upravit tab. *@
+<DxPopup AllowResize="true" @bind-Visible="@isCreateVisible" HeaderText="Nová stavba" Width="560px">
+    <BodyContentTemplate Context="cCtx">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název" ColSpanMd="12">
+                <DxTextBox @bind-Text="@createName" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        @if (createError is not null)
         {
-            <div class="mt-3 p-3 border rounded" style="background: var(--oh-surface);">
-                <h6 class="mb-2"><i class="bi bi-hammer me-1"></i> Cena výstavby (aktuální hra)</h6>
-                @if (recipe is not null)
-                {
-                    <div class="mb-2">
-                        <strong class="small">Cena v zlaťácích:</strong>
-                        <div class="d-flex gap-2 align-items-end mt-1">
-                            <div style="width:140px">
-                                <DxSpinEdit @bind-Value="@recipeMoneyCost" MinValue="0" NullText="(žádná)" />
-                            </div>
-                            <button class="btn btn-sm btn-outline-primary"
-                                    disabled="@(recipeMoneyCost == recipe.MoneyCost)"
-                                    @onclick="SaveRecipeMoneyAsync">
-                                Uložit cenu
-                            </button>
-                        </div>
-                    </div>
-                    <RecipeIngredientPicker
-                        Ingredients="@_ingredientRows"
-                        AvailableItems="@allItems"
-                        OnAdd="@AddIngredientAsync"
-                        OnRemove="@RemoveIngredientAsync" />
-
-                    <RecipeNotesEditor
-                        PersistedValue="@recipe.IngredientNotes"
-                        OnSave="@SaveRecipeNotesAsync" />
-
-                    <RecipeBuildingPicker
-                        Caption="Předpoklady (jiné budovy)"
-                        AddPlaceholder="(přidat předpoklad)"
-                        Buildings="@_prerequisiteRows"
-                        AvailableBuildings="@AvailablePrereqBuildings"
-                        OnAdd="@AddPrereqAsync"
-                        OnRemove="@RemovePrereqAsync" />
-
-                    <RecipeSkillPicker
-                        SelectedSkillIds="@recipe.RequiredSkillIds"
-                        AllGameSkills="@gameSkills"
-                        AvailableSkills="@AvailableGameSkills"
-                        OnAdd="@AddSkillAsync"
-                        OnRemove="@RemoveSkillAsync" />
-
-                    <button class="btn btn-sm btn-outline-danger" @onclick="() => isDeleteRecipeVisible = true">Smazat recept</button>
-                }
-                else
-                {
-                    <p class="text-muted small mb-2">Tato budova nemá nastavenou cenu výstavby pro tuto hru.</p>
-                    <button class="btn btn-sm btn-outline-primary" @onclick="CreateRecipeAsync"><i class="bi bi-plus-circle me-1"></i>Vytvořit cenu</button>
-                }
-            </div>
+            <div class="alert alert-danger mt-2">@createError</div>
         }
-
-        @if (error is not null) { <div class="alert alert-danger mt-2">@error</div> }
-        <div class="d-flex gap-2 mt-3">
-            @if (editingId.HasValue) { <button class="btn btn-outline-danger" @onclick="() => isDeleteVisible = true">Smazat</button> }
-            <div style="flex: 1"></div>
-            <button class="btn btn-secondary" @onclick="() => isModalVisible = false">Zrušit</button>
-            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@isSaving">Uložit</button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
-
-<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Potvrdit smazání" Width="400px">
-    <BodyContentTemplate Context="popupContext">
-        <p>Smazat budovu <strong>@name</strong>?</p>
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="() => isDeleteVisible = false">Zrušit</button>
-            <button class="btn btn-danger" @onclick="ConfirmDeleteAsync">Smazat</button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
-
-@* Issue #142 — destructive recipe-delete confirmation, per the
-   destructive-action-confirm memory rule. *@
-<DxPopup @bind-Visible="@isDeleteRecipeVisible" HeaderText="Smazat recept?" Width="420px">
-    <BodyContentTemplate Context="popupContext">
-        <p>Opravdu chcete smazat cenu výstavby pro budovu <strong>@name</strong>? Ingredience, předpoklady a požadované dovednosti se odeberou společně s receptem.</p>
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="() => isDeleteRecipeVisible = false">Zrušit</button>
-            <button class="btn btn-danger" @onclick="ConfirmDeleteRecipeAsync">Smazat recept</button>
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" type="button" @onclick="() => isCreateVisible = false" disabled="@isCreating">Zrušit</button>
+            <button class="btn btn-primary" type="button" @onclick="CreateAsync"
+                    disabled="@(isCreating || string.IsNullOrWhiteSpace(createName))">
+                @if (isCreating) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit a otevřít
+            </button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
 
 @code {
-    [SupplyParameterFromQuery] public bool Catalog { get; set; }
+    private List<BuildingListDto> buildings = [];
+    private bool loading = true;
 
-    private List<BuildingListDto> buildings = []; private bool loading = true, isModalVisible, isDeleteVisible, isSaving, isPrebuilt;
-    private string modalTitle = "", name = ""; private string? error, description, notes; private int? editingId;
-    private int? locationId;
-    private List<LocationListDto> gameLocations = [];
-    private HashSet<int> assignedBuildingIds = [];
-    private int gameId => GameContext.SelectedGameId ?? 1;
+    private string view = "galerie"; // galerie | karty | seznam — persisted
+    private string searchText = "";
+    private bool onlyWithImage;
+    private bool onlyWithRecipes;
+    private bool onlyWithEffect;
 
-    // ----- Building crafting recipe state (issue #142) -----
-    // Mirrors the Item recipe pattern in ItemList.razor's edit popup. The
-    // Issue #163 — leaf components (RecipeIngredientPicker /
-    // RecipeBuildingPicker / RecipeSkillPicker / RecipeNotesEditor) own
-    // their own input state, so the parallel `newIngItemId`/`newSkillId`/
-    // etc fields that lived here are gone. The Building-only Cena
-    // (`recipeMoneyCost`) stays page-level — Item recipes don't have it.
-    private BuildingRecipeDetailDto? recipe;
-    private List<ItemListDto> allItems = [];
-    private List<BuildingListDto> allCatalogBuildings = [];
-    private List<GameSkillDto> gameSkills = [];
-    private int? recipeMoneyCost;
-    private bool isDeleteRecipeVisible;
-    // Pre-projected leaf-row caches, refreshed once per recipe load so
-    // popup re-renders don't allocate fresh lists every frame
-    // (Copilot review on PR #173).
-    private IReadOnlyList<RecipeIngredientPicker.IngredientRow> _ingredientRows = [];
-    private IReadOnlyList<RecipeBuildingPicker.BuildingRow> _prerequisiteRows = [];
+    private bool isCreateVisible;
+    private bool isCreating;
+    private string? createError;
+    private string createName = "";
 
-    // Skills already required by the recipe shouldn't appear in the picker.
-    private List<GameSkillDto> AvailableGameSkills =>
-        recipe is null
-            ? []
-            : gameSkills.Where(gs => !recipe.RequiredSkillIds.Contains(gs.Id)).ToList();
-
-    // Prerequisite candidates exclude the building being edited (a recipe
-    // can't depend on its own output) and any building already added.
-    private List<BuildingListDto> AvailablePrereqBuildings =>
-        recipe is null
-            ? []
-            : allCatalogBuildings
-                .Where(b => b.Id != editingId
-                    && !recipe.PrerequisiteBuildings.Any(pb => pb.BuildingId == b.Id))
-                .ToList();
-
-    private bool _previousCatalog;
+    private List<BuildingListDto> filtered =>
+        buildings.Where(b =>
+            (string.IsNullOrWhiteSpace(searchText)
+                || b.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                || (b.Description?.Contains(searchText, StringComparison.OrdinalIgnoreCase) ?? false)
+                || (b.Effect?.Contains(searchText, StringComparison.OrdinalIgnoreCase) ?? false))
+            && (!onlyWithImage || !string.IsNullOrEmpty(b.ImageUrl))
+            && (!onlyWithRecipes || b.CraftingRecipesCount > 0)
+            && (!onlyWithEffect || !string.IsNullOrWhiteSpace(b.Effect)))
+            .ToList();
 
     protected override async Task OnInitializedAsync()
     {
-        await GameContext.InitializeAsync();
-        GameContext.OnGameChanged += OnGameChanged;
-        _previousCatalog = Catalog;
+        try
+        {
+            view = await JS.InvokeAsync<string>("localStorage.getItem", "oh-building-view") ?? "galerie";
+            if (view != "galerie" && view != "karty" && view != "seznam") view = "galerie";
+        }
+        catch { view = "galerie"; }
         await LoadAsync();
     }
 
-    protected override async Task OnParametersSetAsync()
-    {
-        if (Catalog != _previousCatalog)
-        {
-            _previousCatalog = Catalog;
-            await LoadAsync();
-        }
-    }
     private async Task LoadAsync()
     {
         loading = true;
-        if (Catalog)
+        try
         {
             buildings = await Api.GetListAsync<BuildingListDto>("/api/buildings");
-            var assigned = await Api.GetListAsync<BuildingListDto>($"/api/buildings/by-game/{gameId}");
-            assignedBuildingIds = assigned.Select(b => b.Id).ToHashSet();
         }
-        else
-        {
-            buildings = await Api.GetListAsync<BuildingListDto>($"/api/buildings/by-game/{gameId}");
-        }
-        loading = false;
-    }
-    private async void OnGameChanged() { await LoadAsync(); StateHasChanged(); }
-    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
-
-    private async void OpenModal(BuildingListDto? b)
-    {
-        error = null;
-        gameLocations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gameId}");
-        if (b is null) { editingId = null; name = ""; description = null; notes = null; locationId = null; isPrebuilt = false; modalTitle = "Nová budova"; }
-        else { editingId = b.Id; name = b.Name; description = b.Description; notes = b.Notes; locationId = b.LocationId; isPrebuilt = b.IsPrebuilt; modalTitle = $"Upravit: {b.Name}"; }
-
-        // Issue #142 — load recipe state for the building-cost editor. Only
-        // meaningful in game mode for an existing building; the editor markup
-        // already gates rendering on those conditions.
-        recipe = null;
-        recipeMoneyCost = null;
-        if (editingId.HasValue && !Catalog && GameContext.SelectedGameId is int gid)
-        {
-            // Items eligible as ingredients are catalog-wide (the recipe
-            // structure references catalog Items, not GameItems).
-            allItems = await Api.GetListAsync<ItemListDto>("/api/items");
-            // Prerequisite buildings come from the catalog so an organizer
-            // can require a building that's also assigned to other games.
-            allCatalogBuildings = await Api.GetListAsync<BuildingListDto>("/api/buildings");
-            gameSkills = (await SkillSvc.GetGameSkillsAsync(gid)).ToList();
-            await LoadRecipeAsync(editingId.Value);
-        }
-
-        isModalVisible = true;
-        StateHasChanged();
+        finally { loading = false; }
     }
 
-    // ---- Recipe load + CRUD handlers (issue #142) ----
-
-    private async Task LoadRecipeAsync(int buildingId)
+    private async Task SetViewAsync(string newView)
     {
-        recipe = null;
-        recipeMoneyCost = null;
-        _ingredientRows = [];
-        _prerequisiteRows = [];
-        if (GameContext.SelectedGameId is not int gid) return;
+        if (view == newView) return;
+        view = newView;
+        try { await JS.InvokeVoidAsync("localStorage.setItem", "oh-building-view", view); }
+        catch { /* localStorage unavailable — ignore */ }
+    }
 
-        // /api/building-recipes/by-game/{gid} returns one entry per recipe,
-        // plus the OutputBuildingId so we can pick the one for THIS building.
-        var recipes = await Api.GetListAsync<BuildingRecipeListDto>($"/api/building-recipes/by-game/{gid}");
-        var match = recipes.FirstOrDefault(r => r.OutputBuildingId == buildingId);
-        if (match is not null)
+    private void OpenCreateModal()
+    {
+        createName = "";
+        createError = null;
+        isCreateVisible = true;
+    }
+
+    private async Task CreateAsync()
+    {
+        if (string.IsNullOrWhiteSpace(createName)) return;
+        createError = null;
+        isCreating = true;
+        try
         {
-            recipe = await Api.GetAsync<BuildingRecipeDetailDto>($"/api/building-recipes/{match.Id}");
-            recipeMoneyCost = recipe?.MoneyCost;
-            // Project DTO collections once per recipe load (Copilot on PR #173).
-            if (recipe is not null)
+            var (ok, created, problem) = await Api.PostWithProblemAsync<CreateBuildingDto, BuildingDetailDto>(
+                "/api/buildings",
+                new CreateBuildingDto(createName.Trim()));
+            if (!ok)
             {
-                _ingredientRows = recipe.Ingredients
-                    .Select(i => new RecipeIngredientPicker.IngredientRow(i.ItemId, i.ItemName, i.Quantity))
-                    .ToList();
-                _prerequisiteRows = recipe.PrerequisiteBuildings
-                    .Select(pb => new RecipeBuildingPicker.BuildingRow(pb.BuildingId, pb.BuildingName))
-                    .ToList();
+                createError = problem ?? "Vytvoření stavby se nepodařilo.";
+                return;
             }
+            isCreateVisible = false;
+            if (created is not null)
+                Nav.NavigateTo($"/buildings/{created.Id}");
+            else
+                await LoadAsync();
         }
+        catch (Exception ex) { createError = ex.Message; }
+        finally { isCreating = false; }
     }
 
-    private async Task CreateRecipeAsync()
+    private void ClearFilters()
     {
-        if (editingId is null || GameContext.SelectedGameId is not int gid) return;
-        try
-        {
-            await Api.PostAsync<CreateBuildingRecipeDto, BuildingRecipeDetailDto>("/api/building-recipes",
-                new CreateBuildingRecipeDto(gid, editingId.Value));
-            await LoadRecipeAsync(editingId.Value);
-            StateHasChanged();
-        }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task ConfirmDeleteRecipeAsync()
-    {
-        if (recipe is null) return;
-        try
-        {
-            await Api.DeleteAsync($"/api/building-recipes/{recipe.Id}");
-            recipe = null;
-            recipeMoneyCost = null;
-            isDeleteRecipeVisible = false;
-            StateHasChanged();
-        }
-        catch (Exception ex) { error = ex.Message; isDeleteRecipeVisible = false; }
-    }
-
-    private async Task AddIngredientAsync((int ItemId, int Quantity) ev)
-    {
-        if (recipe is null) return;
-        try
-        {
-            await Api.PostAsync<AddBuildingRecipeIngredientDto, object>($"/api/building-recipes/{recipe.Id}/ingredients",
-                new AddBuildingRecipeIngredientDto(ev.ItemId, ev.Quantity));
-            await LoadRecipeAsync(editingId!.Value);
-            StateHasChanged();
-        }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task RemoveIngredientAsync(int itemId)
-    {
-        if (recipe is null) return;
-        try
-        {
-            await Api.DeleteAsync($"/api/building-recipes/{recipe.Id}/ingredients/{itemId}");
-            await LoadRecipeAsync(editingId!.Value);
-            StateHasChanged();
-        }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task AddPrereqAsync(int buildingId)
-    {
-        if (recipe is null) return;
-        try
-        {
-            await Api.PostAsync<AddBuildingRecipePrerequisiteDto, object>($"/api/building-recipes/{recipe.Id}/prerequisites",
-                new AddBuildingRecipePrerequisiteDto(buildingId));
-            await LoadRecipeAsync(editingId!.Value);
-            StateHasChanged();
-        }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task RemovePrereqAsync(int buildingId)
-    {
-        if (recipe is null) return;
-        try
-        {
-            await Api.DeleteAsync($"/api/building-recipes/{recipe.Id}/prerequisites/{buildingId}");
-            await LoadRecipeAsync(editingId!.Value);
-            StateHasChanged();
-        }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task AddSkillAsync(int skillId)
-    {
-        if (recipe is null) return;
-        var next = recipe.RequiredSkillIds.ToList();
-        if (next.Contains(skillId)) return;
-        next.Add(skillId);
-        await PutRecipeAsync(
-            moneyCost: recipe.MoneyCost,
-            skillIds: next,
-            ingredientNotes: recipe.IngredientNotes);
-    }
-
-    private async Task RemoveSkillAsync(int skillId)
-    {
-        if (recipe is null) return;
-        var next = recipe.RequiredSkillIds.Where(s => s != skillId).ToList();
-        await PutRecipeAsync(
-            moneyCost: recipe.MoneyCost,
-            skillIds: next,
-            ingredientNotes: recipe.IngredientNotes);
-    }
-
-    private async Task SaveRecipeMoneyAsync()
-    {
-        if (recipe is null) return;
-        // Use the editor's current value verbatim — null means "clear it",
-        // not "leave unchanged" (Copilot review on PR #164: ?? fallback
-        // prevented users from clearing MoneyCost back to null).
-        await PutRecipeAsync(
-            moneyCost: recipeMoneyCost,
-            skillIds: recipe.RequiredSkillIds.ToList(),
-            ingredientNotes: recipe.IngredientNotes);
-    }
-
-    private async Task SaveRecipeNotesAsync(string? newValue)
-    {
-        if (recipe is null || editingId is null) return;
-        var normalized = string.IsNullOrWhiteSpace(newValue) ? null : newValue.Trim();
-        // Same shape as money — pass `normalized` (which may be null) verbatim
-        // so clearing the memo actually persists as null.
-        await PutRecipeAsync(
-            moneyCost: recipe.MoneyCost,
-            skillIds: recipe.RequiredSkillIds.ToList(),
-            ingredientNotes: normalized);
-    }
-
-    /// <summary>
-    /// Single PUT helper that requires explicit values for every mutable
-    /// field. Callers are responsible for sending the recipe's current
-    /// server-side values for fields they don't want to change — without
-    /// that contract, a null param meant "preserve" and clearing a field
-    /// silently no-op'd (Copilot review on PR #164).
-    /// </summary>
-    private async Task PutRecipeAsync(
-        int? moneyCost, IReadOnlyList<int> skillIds, string? ingredientNotes)
-    {
-        if (recipe is null) return;
-        try
-        {
-            var dto = new UpdateBuildingRecipeDto(
-                recipe.OutputBuildingId,
-                MoneyCost: moneyCost,
-                RequiredSkillIds: skillIds,
-                IngredientNotes: ingredientNotes);
-            await Api.PutAsync($"/api/building-recipes/{recipe.Id}", dto);
-            await LoadRecipeAsync(editingId!.Value);
-            StateHasChanged();
-        }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task SaveAsync()
-    {
-        error = null; isSaving = true;
-        try
-        {
-            if (editingId.HasValue) await Api.PutAsync($"/api/buildings/{editingId}", new UpdateBuildingDto(name, description, notes, locationId, isPrebuilt));
-            else await Api.PostAsync<CreateBuildingDto, BuildingDetailDto>($"/api/buildings?gameId={gameId}", new CreateBuildingDto(name, description, notes, locationId, isPrebuilt));
-            isModalVisible = false; await LoadAsync();
-        }
-        catch (Exception ex) { error = ex.Message; } finally { isSaving = false; }
-    }
-
-    private async Task ConfirmDeleteAsync()
-    {
-        try { await Api.DeleteAsync($"/api/buildings/{editingId}"); isDeleteVisible = false; isModalVisible = false; await LoadAsync(); }
-        catch (Exception ex) { error = ex.Message; }
-    }
-
-    private async Task AssignBuildingAsync(int buildingId)
-    {
-        await Api.PostAsync<GameBuildingDto, object>("/api/buildings/by-game", new GameBuildingDto(gameId, buildingId));
-        assignedBuildingIds.Add(buildingId);
-        StateHasChanged();
-    }
-
-    private async Task UnassignBuildingAsync(int buildingId)
-    {
-        await Api.DeleteAsync($"/api/buildings/by-game/{gameId}/{buildingId}");
-        assignedBuildingIds.Remove(buildingId);
-        StateHasChanged();
+        searchText = "";
+        onlyWithImage = false;
+        onlyWithRecipes = false;
+        onlyWithEffect = false;
     }
 }

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3693,3 +3693,128 @@
         box-shadow:0 1px 4px rgba(0,0,0,.18)}
 }
 }
+
+/* ===========================================================================
+ * Shared coin/groše pill — extracted from buildings port (#208). Reuse on
+ * Items + Recipes catalogs in follow-ups.
+ * =========================================================================== */
+.oh-coin-pill{display:inline-flex;align-items:center;gap:5px;padding:3px 10px;
+    border-radius:999px;background:rgba(45,80,22,.08);color:#2D5016;
+    border:1px solid rgba(45,80,22,.4);font:600 .8rem/1.3 var(--oh-font-mono,ui-monospace,monospace);
+    white-space:nowrap}
+.oh-coin-pill i{font-size:.95rem;color:#7a5b00}
+.oh-coin-pill--free{background:#f5f0e1;color:#7a6f50;border-color:#d8d2be}
+.oh-coin-pill--free i{color:#a89e7a}
+.oh-coin-input{max-width:160px}
+
+/* ===========================================================================
+ * Buildings — /buildings catalog (3-mode toggle Galerie/Karty/Seznam) +
+ * /buildings/{id} 2-tab detail (Karta · Upravit). Recipe pair (CostMoney →
+ * Effect) is the building's identity surface (issue #208).
+ * Class prefix .oh-bld-* — reserved per design canon.
+ * =========================================================================== */
+
+/* — Filters — */
+.oh-bld-filters{display:flex;gap:12px;align-items:center;flex-wrap:wrap;
+    padding:10px 12px;background:#FFF8F0;border:1px solid #ead9b8;border-radius:8px}
+.oh-bld-filter-search{min-width:240px;flex:1 1 240px}
+.oh-bld-filter-toggle{display:inline-flex;align-items:center;gap:6px;font:500 .875rem/1 var(--oh-font-body,inherit);color:#5a5642;cursor:pointer;user-select:none}
+.oh-bld-filter-toggle input{cursor:pointer}
+
+/* — Galerie tile (5:7 portrait) — */
+.oh-bld-gallery{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:18px}
+.oh-bld-tile{position:relative;display:flex;flex-direction:column;
+    background:#FFF8F0;border:1px solid #d8d2be;border-radius:10px;overflow:hidden;
+    cursor:pointer;text-align:left;padding:0;transition:.18s ease;font-family:inherit}
+.oh-bld-tile:hover{border-color:#2D5016;box-shadow:0 6px 14px rgba(45,80,22,.18);transform:translateY(-2px)}
+.oh-bld-tile:focus-visible{outline:3px solid #2D5016;outline-offset:2px}
+.oh-bld-tile-art{position:relative;aspect-ratio:5/7;background:#f5f0e1;overflow:hidden}
+.oh-bld-tile-art img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-bld-tile-fade{position:absolute;left:0;right:0;bottom:0;height:50%;
+    background:linear-gradient(180deg,rgba(0,0,0,0) 0%,rgba(20,12,4,.8) 100%);
+    pointer-events:none}
+.oh-bld-tile-name-on-img{position:absolute;left:12px;right:12px;bottom:10px;
+    color:#FFF8F0;font:700 1rem/1.2 var(--oh-font-headline,Merriweather,Georgia,serif);
+    text-shadow:0 1px 2px rgba(0,0,0,.6);
+    display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+.oh-bld-tile-parchment{position:absolute;inset:0;display:flex;flex-direction:column;
+    align-items:center;justify-content:center;gap:8px;padding:14px;text-align:center;
+    background:repeating-linear-gradient(45deg,#FFF8F0 0 8px,#f4ead2 8px 9px);color:#7a5520}
+.oh-bld-tile-parchment > i{font-size:2.2rem;opacity:.6}
+.oh-bld-tile-parchment-name{font:700 1rem/1.2 var(--oh-font-headline,Merriweather,Georgia,serif);color:#3a2e1a}
+.oh-bld-tile-prebuilt{position:absolute;top:8px;right:8px;display:inline-flex;align-items:center;justify-content:center;
+    width:26px;height:26px;border-radius:50%;background:rgba(178,98,35,.85);color:#FFF8F0;font-size:.85rem}
+.oh-bld-tile-body{padding:10px 12px 12px;display:flex;flex-direction:column;gap:8px}
+.oh-bld-tile-foot{display:flex;align-items:center;gap:6px;flex-wrap:wrap;font-size:.72rem;color:#5a5642}
+.oh-bld-tile-foot-loc{display:inline-flex;align-items:center;gap:3px;font-style:italic;color:#7a6f50}
+
+/* — Mini-tile inside Seznam grid first column — */
+.oh-bld-mini-tile{width:40px;height:56px;border-radius:4px;background:#f5f0e1;
+    border:1px solid #d8d2be;overflow:hidden;display:flex;align-items:center;justify-content:center;color:#7a6f50}
+.oh-bld-mini-tile img{width:100%;height:100%;object-fit:cover;display:block}
+
+/* — Karty mode (horizontal card-rows) — */
+.oh-bld-cardrow-wrap{display:flex;flex-direction:column;gap:10px}
+.oh-bld-cardrow{display:grid;grid-template-columns:86px 1fr auto;gap:14px;align-items:center;
+    background:#FFF8F0;border:1px solid #ead9b8;border-radius:10px;overflow:hidden;
+    cursor:pointer;text-align:left;padding:10px;transition:.15s ease;font-family:inherit;
+    min-height:120px}
+.oh-bld-cardrow:hover{border-color:#2D5016;box-shadow:0 4px 10px rgba(45,80,22,.14)}
+.oh-bld-cardrow:focus-visible{outline:3px solid #2D5016;outline-offset:2px}
+.oh-bld-cardrow-thumb{width:86px;height:120px;border-radius:6px;overflow:hidden;background:#f5f0e1;
+    display:flex;align-items:center;justify-content:center;color:#7a6f50;font-size:1.6rem}
+.oh-bld-cardrow-thumb img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-bld-cardrow-thumb--placeholder{background:repeating-linear-gradient(45deg,#FFF8F0 0 6px,#f4ead2 6px 7px)}
+.oh-bld-cardrow-body{display:flex;flex-direction:column;gap:6px;min-width:0}
+.oh-bld-cardrow-name{font:700 1.2rem/1.2 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2a2218;margin:0;display:flex;align-items:center;gap:8px}
+.oh-bld-cardrow-prebuilt{display:inline-flex;align-items:center;color:#B26223;font-size:.95rem}
+.oh-bld-cardrow-desc{font:italic 400 .9rem/1.4 Georgia,serif;color:#5a5642;margin:0;
+    display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+.oh-bld-cardrow-stats{display:flex;flex-direction:column;align-items:flex-end;gap:5px;flex-shrink:0}
+
+/* — Recipe block (cost → effect formula) — */
+.oh-bld-rec{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:.8rem;color:#3a2e1a;line-height:1.4}
+.oh-bld-rec--compact{font-size:.75rem}
+.oh-bld-rec-arrow{display:inline-flex;align-items:center;color:#7a5520;font-size:.95rem;flex-shrink:0}
+.oh-bld-rec-effect{font:400 .85rem/1.4 Georgia,serif;color:#2a2218;flex:1;min-width:0;
+    display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+.oh-bld-rec--compact .oh-bld-rec-effect{font-size:.78rem}
+.oh-bld-rec-effect--empty{font-style:italic;color:#a89e7a}
+
+/* — Effect cell in Seznam — */
+.oh-bld-effect-cell{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;
+    overflow:hidden;font:400 .85rem/1.4 Georgia,serif;color:#2a2218}
+
+/* — Karta tab — */
+.oh-bld-karta{background:#FFF8F0;border:1px solid #ead9b8;border-radius:10px;padding:24px}
+.oh-bld-karta-hero{display:grid;grid-template-columns:60fr 40fr;gap:24px;align-items:start;margin-bottom:18px}
+@media (max-width:880px){.oh-bld-karta-hero{grid-template-columns:1fr}}
+.oh-bld-karta-img-wrap{display:flex;justify-content:center}
+.oh-bld-karta-img{width:100%;max-width:380px;aspect-ratio:5/7;object-fit:cover;
+    border-radius:6px;border:1px solid #d8d2be;background:#f5f0e1;display:block}
+.oh-bld-karta-img--placeholder{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px;
+    background:repeating-linear-gradient(45deg,#FFF8F0 0 8px,#f4ead2 8px 9px);color:#7a5520}
+.oh-bld-karta-img--placeholder i{font-size:3rem;opacity:.55}
+.oh-bld-karta-img-name{font:700 1.1rem/1.2 var(--oh-font-headline,Merriweather,Georgia,serif);color:#3a2e1a;text-align:center;padding:0 14px}
+.oh-bld-karta-side{display:flex;flex-direction:column;gap:14px;position:sticky;top:14px}
+.oh-bld-karta-name{font:900 2.2rem/1.15 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2a2218;margin:0}
+.oh-bld-karta-stats{background:#fff;border:1px solid #ead9b8;border-radius:8px;padding:10px 14px;display:flex;flex-direction:column;gap:6px}
+.oh-bld-karta-stat-row{display:flex;justify-content:space-between;align-items:center;font-size:.875rem;color:#3a2e1a}
+.oh-bld-karta-stat-row strong{font:600 .9rem/1 var(--oh-font-mono,ui-monospace,monospace);color:#2D5016}
+.oh-bld-karta-cluster-title{font:700 .85rem/1 var(--oh-font-headline,Merriweather,Georgia,serif);
+    text-transform:uppercase;letter-spacing:.04em;color:#5a3a18;margin:0}
+.oh-bld-karta-cluster{display:flex;gap:6px;flex-wrap:wrap}
+.oh-bld-karta-desc{font:400 1.02rem/1.65 Georgia,serif;color:#2a2218;margin:0 0 8px;text-align:justify;white-space:pre-wrap}
+.oh-bld-karta-desc::first-letter{font:900 2.6rem/1 var(--oh-font-headline,Merriweather,Georgia,serif);
+    float:left;margin-right:8px;color:#2D5016;line-height:.9}
+.oh-bld-karta-notes{font:italic 400 .9rem/1.55 Georgia,serif;color:#5a5642;margin:0;white-space:pre-wrap}
+
+/* — Upravit tab — */
+.oh-bld-edit{background:#FFF8F0;border:1px solid #ead9b8;border-radius:10px;padding:18px}
+.oh-bld-edit-foot{display:flex;gap:8px;align-items:center;margin-top:18px;padding-top:14px;border-top:1px solid #ead9b8;
+    position:sticky;bottom:0;background:#FFF8F0;z-index:1;flex-wrap:wrap}
+.oh-bld-delete-blocked{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;
+    border-radius:6px;background:rgba(178,98,35,.08);color:#7a5520;
+    border:1px solid rgba(178,98,35,.3);font:500 .825rem/1.3 var(--oh-font-body,inherit)}
+.oh-bld-delete-blocked i{color:#B26223}
+.oh-bld-delete-blocked strong{color:#3a2e1a}

--- a/src/OvcinaHra.Shared/Domain/Entities/Building.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Building.cs
@@ -10,6 +10,13 @@ public class Building
     public int? LocationId { get; set; }
     public bool IsPrebuilt { get; set; }
 
+    // Issue #208 — every building carries a "build recipe" pair: cost in
+    // groše + sacred effect prose. CostMoney null/0 → "Zdarma" pill; Effect
+    // null → muted "Bez efektu" placeholder. NOT to be conflated with
+    // BuildingRecipe (construction-recipe entity from issue #142).
+    public int? CostMoney { get; set; }
+    public string? Effect { get; set; }
+
     public Location? Location { get; set; }
     public ICollection<GameBuilding> GameBuildings { get; set; } = [];
     public ICollection<CraftingBuildingRequirement> CraftingRequirements { get; set; } = [];

--- a/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
@@ -7,20 +7,38 @@ public record BuildingListDto(
     // Issue #142 — per-game construction recipe summary. Populated by the
     // by-game endpoint with a compact "3× ingrediencí · 50 zlaťáků · 1 dovednost"
     // string for display in the grid; catalog endpoint leaves null.
-    string? RecipeSummary = null);
+    string? RecipeSummary = null,
+    // Issue #208 — building's own "build recipe" pair (cost → effect). Null
+    // CostMoney renders as "Zdarma" pill; null Effect renders as muted
+    // "Bez efektu" placeholder.
+    int? CostMoney = null,
+    string? Effect = null,
+    // "Použito v" cluster counts surfaced on tile/card-row footers + Karta
+    // hero. CraftingRecipesCount = number of CraftingRecipes requiring this
+    // building. GamesCount = number of games using this building via
+    // GameBuilding link. Both projected server-side to avoid N+1 lookups.
+    int CraftingRecipesCount = 0,
+    int GamesCount = 0);
 
 public record BuildingDetailDto(
     int Id, string Name, string? Description, string? Notes, string? ImagePath,
-    int? LocationId, bool IsPrebuilt);
+    int? LocationId, string? LocationName, bool IsPrebuilt,
+    string? ImageUrl = null,
+    int? CostMoney = null,
+    string? Effect = null,
+    int CraftingRecipesCount = 0,
+    int GamesCount = 0);
 
 public record CreateBuildingDto(
     string Name,
     string? Description = null, string? Notes = null,
-    int? LocationId = null, bool IsPrebuilt = false);
+    int? LocationId = null, bool IsPrebuilt = false,
+    int? CostMoney = null, string? Effect = null);
 
 public record UpdateBuildingDto(
     string Name, string? Description, string? Notes,
-    int? LocationId, bool IsPrebuilt);
+    int? LocationId, bool IsPrebuilt,
+    int? CostMoney = null, string? Effect = null);
 
 // Game assignment
 public record GameBuildingDto(int GameId, int BuildingId);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/BuildingPhase1Tests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/BuildingPhase1Tests.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using System.Net.Http.Json;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+/// <summary>
+/// Phase 1 of the Buildings port (issue #208): adds Building.CostMoney +
+/// Building.Effect (the "build recipe" pair) plus list/detail count
+/// projections (CraftingRecipesCount, GamesCount, ImageUrl). These tests
+/// cover the new fields end-to-end and the projection contract that the
+/// 3-mode catalog and 2-tab detail rely on.
+/// </summary>
+public class BuildingPhase1Tests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    [Fact]
+    public async Task Create_DefaultsCostMoneyAndEffect_ToNull()
+    {
+        var response = await Client.PostAsJsonAsync("/api/buildings",
+            new CreateBuildingDto("Bylinkářství"));
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var created = await response.Content.ReadFromJsonAsync<BuildingDetailDto>();
+        Assert.NotNull(created);
+        Assert.Equal("Bylinkářství", created.Name);
+        // Phase 1 invariant: a fresh building has neither cost nor effect.
+        Assert.Null(created.CostMoney);
+        Assert.Null(created.Effect);
+        Assert.Equal(0, created.CraftingRecipesCount);
+    }
+
+    [Fact]
+    public async Task Create_WithCostAndEffect_PersistsBoth()
+    {
+        var response = await Client.PostAsJsonAsync("/api/buildings",
+            new CreateBuildingDto(
+                "Kovárna",
+                Description: "Kovárna pro výrobu zbraní",
+                CostMoney: 250,
+                Effect: "Umožňuje výrobu kovových zbraní a brnění."));
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var created = await response.Content.ReadFromJsonAsync<BuildingDetailDto>();
+        Assert.NotNull(created);
+        Assert.Equal(250, created.CostMoney);
+        Assert.Equal("Umožňuje výrobu kovových zbraní a brnění.", created.Effect);
+    }
+
+    [Fact]
+    public async Task Update_SetsCostMoneyAndEffect()
+    {
+        var createResponse = await Client.PostAsJsonAsync("/api/buildings",
+            new CreateBuildingDto("Pivovar"));
+        var created = (await createResponse.Content.ReadFromJsonAsync<BuildingDetailDto>())!;
+
+        // Round-trip: PUT with both fields populated, then re-read and verify.
+        var updateDto = new UpdateBuildingDto(
+            Name: "Pivovar",
+            Description: "Vaří pivo a kvas",
+            Notes: null,
+            LocationId: null,
+            IsPrebuilt: false,
+            CostMoney: 120,
+            Effect: "Hráči si mohou koupit pivo za 5 grošů.");
+        var putResponse = await Client.PutAsJsonAsync($"/api/buildings/{created.Id}", updateDto);
+        Assert.Equal(HttpStatusCode.NoContent, putResponse.StatusCode);
+
+        var fetched = await Client.GetFromJsonAsync<BuildingDetailDto>($"/api/buildings/{created.Id}");
+        Assert.NotNull(fetched);
+        Assert.Equal(120, fetched.CostMoney);
+        Assert.Equal("Hráči si mohou koupit pivo za 5 grošů.", fetched.Effect);
+    }
+
+    [Fact]
+    public async Task Update_ClearsCostMoneyAndEffect_BackToNull()
+    {
+        // Set first, then clear — confirms null is honoured (not silently
+        // preserved) when the client wants to revert to "Zdarma / Bez efektu".
+        var createResponse = await Client.PostAsJsonAsync("/api/buildings",
+            new CreateBuildingDto(
+                "Sklepení",
+                CostMoney: 50,
+                Effect: "Skladovací kapacita pro 10 zlaťáků."));
+        var created = (await createResponse.Content.ReadFromJsonAsync<BuildingDetailDto>())!;
+
+        var clearDto = new UpdateBuildingDto(
+            Name: "Sklepení",
+            Description: null, Notes: null,
+            LocationId: null, IsPrebuilt: false,
+            CostMoney: null, Effect: null);
+        var putResponse = await Client.PutAsJsonAsync($"/api/buildings/{created.Id}", clearDto);
+        Assert.Equal(HttpStatusCode.NoContent, putResponse.StatusCode);
+
+        var fetched = await Client.GetFromJsonAsync<BuildingDetailDto>($"/api/buildings/{created.Id}");
+        Assert.NotNull(fetched);
+        Assert.Null(fetched.CostMoney);
+        Assert.Null(fetched.Effect);
+    }
+
+    [Fact]
+    public async Task GetById_PopulatesCountsAndLocationName()
+    {
+        // Location FK so LocationName resolves on detail.
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Náměstí", LocationKind.Town, 49.0m, 17.0m));
+        var location = (await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>())!;
+
+        var createResponse = await Client.PostAsJsonAsync("/api/buildings",
+            new CreateBuildingDto(
+                "Hostinec",
+                LocationId: location.Id,
+                CostMoney: 80,
+                Effect: "Hráči si mohou objednat jídlo."));
+        var created = (await createResponse.Content.ReadFromJsonAsync<BuildingDetailDto>())!;
+
+        var detail = await Client.GetFromJsonAsync<BuildingDetailDto>($"/api/buildings/{created.Id}");
+        Assert.NotNull(detail);
+        Assert.Equal("Hostinec", detail.Name);
+        Assert.Equal(location.Id, detail.LocationId);
+        Assert.Equal("Náměstí", detail.LocationName);
+        // No CraftingBuildingRequirement or GameBuilding linked yet.
+        Assert.Equal(0, detail.CraftingRecipesCount);
+        Assert.Equal(0, detail.GamesCount);
+    }
+
+    [Fact]
+    public async Task GetAll_ProjectsCostMoneyAndEffectAndCounts()
+    {
+        await Client.PostAsJsonAsync("/api/buildings",
+            new CreateBuildingDto("S efektem", CostMoney: 100, Effect: "Něco dělá."));
+        await Client.PostAsJsonAsync("/api/buildings",
+            new CreateBuildingDto("Bez efektu"));
+
+        var list = await Client.GetFromJsonAsync<List<BuildingListDto>>("/api/buildings");
+        Assert.NotNull(list);
+
+        var withEffect = list.Single(b => b.Name == "S efektem");
+        Assert.Equal(100, withEffect.CostMoney);
+        Assert.Equal("Něco dělá.", withEffect.Effect);
+
+        var withoutEffect = list.Single(b => b.Name == "Bez efektu");
+        Assert.Null(withoutEffect.CostMoney);
+        Assert.Null(withoutEffect.Effect);
+
+        // List projection always carries the count fields, defaulting to 0
+        // when no joins reference the building yet — required for the
+        // BuildingTile / BuildingCardRow render paths.
+        Assert.Equal(0, withoutEffect.CraftingRecipesCount);
+        Assert.Equal(0, withoutEffect.GamesCount);
+    }
+
+    [Fact]
+    public async Task Create_WithGameIdQuery_IncrementsGamesCount()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = (await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>())!;
+
+        // Auto-assignment via ?gameId=N query param (existing endpoint contract).
+        var createResponse = await Client.PostAsJsonAsync(
+            $"/api/buildings?gameId={game.Id}",
+            new CreateBuildingDto("Mlýn", CostMoney: 60, Effect: "Mele obilí na mouku."));
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        var created = (await createResponse.Content.ReadFromJsonAsync<BuildingDetailDto>())!;
+        Assert.Equal(1, created.GamesCount);
+
+        // Verify the same count is reflected in the list/detail re-fetches.
+        var detail = await Client.GetFromJsonAsync<BuildingDetailDto>($"/api/buildings/{created.Id}");
+        Assert.NotNull(detail);
+        Assert.Equal(1, detail.GamesCount);
+    }
+}


### PR DESCRIPTION
Closes #208 (Phase 1).

## What ships

Port of the Buildings catalog into the cartographer's-workshop look established by the Quests/Items/Spells tinkerer ports. Adds the new **build recipe pair** (`CostMoney → Effect`) as the building's defining surface, three view modes on the catalog, and a focused 2-tab detail.

### Frontend
- **`/buildings`** — full rewrite of `BuildingList.razor`. Three view modes with toolbar segmented control:
  - **Galerie** (default) — 5:7 portrait tiles, full-bleed image with bottom-fade name overlay, recipe block + count pills below.
  - **Karty** — horizontal card-rows (~120px) with 86×120 thumb + name + 2-line description preview + recipe block + stats cluster.
  - **Seznam** — DxGrid with mini-tile, name, cost (CoinPill), effect (sacred prose, line-clamped via CSS), location, recipes count, prebuilt flag.
  - View persisted in `localStorage` under `oh-building-view`.
  - Filters: text search · jen s obrázkem · jen s recepty · jen s efektem.
  - "+ Nová stavba" minimal create modal → navigates to detail.
- **`/buildings/{id}`** — new `BuildingDetail.razor`. Two tabs (**Karta** · **Upravit**):
  - Karta hero: 60fr/40fr — 5:7 image (or parchment placeholder) on left; name + recipe block + "Použito v" cluster (recipes/her counts) on right. Description (Georgia drop-cap) and Notes paragraph below.
  - Upravit form groups: Identita (Název, Lokace, Představěná) · Obrázek (5:7 ImagePicker) · **Recept** with sacred-banner over the Effect memo · Obsah (Popis, Poznámky). Sticky footer with Smazat (blocked + muted pill when `CraftingRecipesCount > 0`) / Zrušit / Uložit; DxPopup confirm on delete.
- **New components:**
  - `CoinPill` — shared groše pill (forest-green for cost > 0, parchment "Zdarma" for null/0). Reuse on Items/Recipes follow-ups.
  - `BuildingRecipeBlock` — cost → effect formula, used on tile/card-row/Karta hero.
  - `BuildingTile` — Galerie 5:7 tile with image @onerror state-flag + URL-change reset.
  - `BuildingCardRow` — Karty horizontal row.

### Backend
- `Building.CostMoney` (int?, nullable) + `Building.Effect` (string?, sacred prose).
- Migration **`AddCostMoneyAndEffectToBuilding`** — both columns nullable; existing rows backfill `NULL` (renders "Zdarma" / "Bez efektu" placeholders).
- DTOs extended:
  - `BuildingListDto`, `BuildingDetailDto`: + `CostMoney`, `Effect`, `ImageUrl`, `LocationName`, `CraftingRecipesCount`, `GamesCount`.
  - `CreateBuildingDto`, `UpdateBuildingDto`: + optional `CostMoney`, `Effect` (defaults preserve existing test compat).
- `BuildingEndpoints` projects all new fields + counts on GetAll/GetByGame/GetById; Create resolves `LocationName` so the freshly-created shape matches GetById; Update writes `CostMoney`/`Effect` verbatim (null clears, no silent preserve).
- `ImageEndpoints.ValidEntityTypes` already had `"buildings"` — no change needed.

### Theme CSS
- New `.oh-bld-*` block (~120 lines) appended to `ovcinahra-theme.css`.
- New shared utility: `.oh-coin-pill` — extracted per the brief, reuse hook for Items/Recipes.
- **Reuses** existing `.oh-segmented`, `.oh-pill`, `.oh-pill-mono`, `.oh-sacred-banner` (declared in #206 quests port — not redefined per Override 3).
- LayoutKey bump on Seznam: `grid-layout-buildings-v2`.

## Phase 1 simplifications (Phase 2 follow-ups)

These are intentional scope cuts; flagging here for follow-up tracking:

1. **Per-game BuildingRecipe editor (#142) removed from `/buildings`** — the legacy "Cena výstavby" inline popup that lived in the old BuildingList is gone. The `BuildingRecipe` entity + `/api/building-recipes/*` endpoints are untouched, but the editor needs a proper home (a dedicated `/recipes` catalog page didn't exist at the time of this PR). Treating as a known regression — if the editor is needed before `/recipes` lands, the old popup can be cherry-picked into BuildingDetail Upravit as a 5th section.
2. **Catalog↔per-game toggle on `/buildings` dropped** — buildings are global per the design brief. Downstream code using `GameBuilding` still works.
3. **`Building.CostItems`** (cost in items, not just money) — deferred per brief.
4. **"Použito v" expansion to side panel** — deferred; current cluster shows counts only.
5. **Building images sliced from `domy_ovcina.jpg`** — content task, deferred.
6. **`SkillBuildingRequirement` count surfacing** — would need a new join projection; deferred until Phase 2 (currently no count surfaced for skills).
7. **Playwright E2E** — intentionally skipped per #92.

## Verification

- `dotnet build OvcinaHra.slnx`: **0 warnings, 0 errors** (`TreatWarningsAsErrors=true`).
- `dotnet test`: **400 / 400 passing** in ~35 s — including 7 new `BuildingPhase1Tests`. No regressions in the 8 existing `BuildingEndpointTests`.
- §20 self-check: diff vs merge-base shows 6 modified + 8 new files, all in expected zones. `BuildingList.razor` is the only file with substantial deletion (the explicit rewrite target). No `domy_ovcina.jpg` dropped, no #207/#208-collateral files touched.

## Manual test plan

- [ ] `/buildings` Galerie renders 5:7 tiles + parchment placeholder for image-less rows; recipe block (cost → effect) on each tile.
- [ ] Galerie → Karty → Seznam toggle persists across reload (`localStorage` `oh-building-view`).
- [ ] Filters narrow correctly (text · obrázek · recepty · efekt).
- [ ] Seznam row click → `/buildings/{id}` Karta tab.
- [ ] Karta hero: 60fr/40fr layout, drop-cap on description, "Použito v" cluster shows correct counts.
- [ ] Upravit form: Identita / Obrázek / Recept (sacred banner above Effect) / Obsah; ImagePicker uploads 5:7 jpeg; "Uložit" persists CostMoney + Effect; clearing CostMoney back to null persists "Zdarma".
- [ ] Smazat button hidden + muted pill shown when `CraftingRecipesCount > 0`; otherwise DxPopup confirm fires before delete.
- [ ] "Představěná" label intact on the IsPrebuilt toggle.
- [ ] Empty state when catalog is empty + filters cleared via "Zrušit filtry".

## Version

No csproj `<Version>` bump — auto-bump CI handles per Override 1 in the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)