### PR TITLE
fix(home): remove hero overview image + audit recent-activity panel (closes #210)

### DIFF
--- a/src/OvcinaHra.Client/Components/HomeHero.razor
+++ b/src/OvcinaHra.Client/Components/HomeHero.razor
@@ -1,23 +1,11 @@
-@* Issue #158 — Home cockpit hero. 16:9 game cover (reuses Game.ImagePath
-   per memory rule "secondary-image entity-type alias"), title + edition
-   date strip, prep-or-stage chip, and a Změnit hru control that flips a
-   GameSelector inline picker. *@
+@* Issue #158 — Home cockpit hero. Title + edition date strip, prep-or-stage
+   chip, and a Změnit hru control that flips a GameSelector inline picker.
+   Issue #210: the 16:9 game cover image was removed (`Game.ImagePath` was
+   never populated and the user wanted a cleaner hero); body now stands on
+   its own, the .oh-home-hero-art / -scrim CSS rules are orphaned but
+   harmless and will be reaped in a follow-up cleanup. *@
 
 <div class="oh-home-hero">
-    <div class="oh-home-hero-art">
-        @if (!string.IsNullOrEmpty(GameImageUrl) && !_imgFailed)
-        {
-            <img src="@GameImageUrl" alt="@GameName"
-                 @onerror="() => _imgFailed = true" />
-        }
-        else
-        {
-            <div class="oh-home-hero-art-fallback">
-                <i class="bi bi-shield-fill"></i>
-            </div>
-        }
-        <div class="oh-home-hero-scrim"></div>
-    </div>
     <div class="oh-home-hero-body">
         <div class="oh-home-hero-meta">
             @if (IsGameRunning)
@@ -53,24 +41,9 @@
     [Parameter] public int Edition { get; set; }
     [Parameter] public DateOnly? StartDate { get; set; }
     [Parameter] public DateOnly? EndDate { get; set; }
-    [Parameter] public string? GameImageUrl { get; set; }
     [Parameter] public bool IsGameRunning { get; set; }
     [Parameter] public string? StageLabel { get; set; }
     [Parameter] public EventCallback OnChangeGame { get; set; }
-
-    private bool _imgFailed;
-    private string? _lastImageUrl;
-
-    protected override void OnParametersSet()
-    {
-        // State-flag onerror reset on URL change per
-        // feedback_blazor_img_onerror_state_and_key.
-        if (_lastImageUrl != GameImageUrl)
-        {
-            _lastImageUrl = GameImageUrl;
-            _imgFailed = false;
-        }
-    }
 
     private async Task OnChangeGameClick() => await OnChangeGame.InvokeAsync();
 }

--- a/src/OvcinaHra.Client/Pages/Home.razor
+++ b/src/OvcinaHra.Client/Pages/Home.razor
@@ -34,7 +34,6 @@
                           Edition="_edition"
                           StartDate="_startDate"
                           EndDate="_endDate"
-                          GameImageUrl="@_gameImageUrl"
                           IsGameRunning="_isGameRunning"
                           OnChangeGame="OnChangeGameClick" />
 
@@ -69,7 +68,6 @@
     private int _edition;
     private DateOnly? _startDate;
     private DateOnly? _endDate;
-    private string? _gameImageUrl;
     private bool _isGameRunning;
 
     private DashboardStatsDto? _stats;
@@ -120,10 +118,6 @@
                 _edition = game.Edition;
                 _startDate = game.StartDate;
                 _endDate = game.EndDate;
-                // Hero image follow-up: ImageEndpoints' ValidEntityTypes
-                // doesn't include "games" yet, so the hero falls back to
-                // its parchment + shield art. Flagged in PR.
-                _gameImageUrl = null;
             }
             _stats = statsTask.Result;
             _issues = issuesTask.Result;


### PR DESCRIPTION
Closes #210.

Two-part dashboard tweak — small follow-up to PR #205 (Home cockpit, issue #158).

## What ships

### 1. Remove the hero overview image

`HomeHero.razor` used to render a 16:9 game cover via `Game.ImagePath`. In practice the URL was always `null` because `ImageEndpoints.ValidEntityTypes` never gained a `"games"` key — the hero always rendered the parchment + shield fallback art. The user wanted that gone for a cleaner hero.

- Removed the entire `.oh-home-hero-art` block (img + fallback + scrim).
- Removed the `GameImageUrl` parameter + `_imgFailed` / `_lastImageUrl` / `OnParametersSet` plumbing.
- Updated `Pages/Home.razor` — dropped `GameImageUrl="..."`, the `_gameImageUrl` field, and the hard-coded `null` assignment.

Layout: hero collapses to a single `.oh-home-hero-body` row (title + edition/dates + prep/stage chip + Změnit hru). Self-contained padding + parchment surface, no breakage at desktop / tablet / mobile widths.

Orphaned `.oh-home-hero-art*` / `.oh-home-hero-scrim` rules in `ovcinahra-theme.css` are intentionally left in place — harmless, will be reaped in a follow-up cleanup.

### 2. "Co se nedávno dělo" audit — left as-is

`RecentActivityFeed.razor` already does the right thing:
- Calls `/api/dashboard/activity?gameId={id}&limit=10`.
- Renders 1:1 thumbnail rows.
- Routes each row to `/characters/{id}`, `/timeline`, or `/npcs/{id}` via `RouteFor()`.

Cross-checked against the server: `DashboardEndpoints.GetActivity` returns exactly those three entity types (`"character"` / `"event"` / `"npc"`). The route table fully covers the API output — no broken links, no missing icons, no empty rows beyond the legitimate empty-state fallback ("Zatím žádné úpravy.").

**No code changes** to the panel. User just wanted to confirm backend support exists; it does. Per the brief's default ("keep the panel as-is unless something obvious is broken"), I left it alone.

## Verification

- `dotnet build OvcinaHra.slnx`: **0 warnings, 0 errors** (`TreatWarningsAsErrors=true`).
- `dotnet test`: **406 / 406 passing** in ~37 s — no regressions in `DashboardEndpoints` tests.
- `git diff origin/main --stat`: 2 files changed, +6 / -39 lines — only HomeHero.razor and Home.razor.

## Manual test plan

- [ ] `/` active-game state shows hero **without** the 16:9 image; title + edition/dates + chips render cleanly.
- [ ] `/` no-game / Žádná hra state still works (title fallback "Vyber hru").
- [ ] "Co se nedávno dělo" panel still renders with skeleton → real data → empty-state fallback as appropriate.
- [ ] Activity rows click through to the correct entity detail pages.
- [ ] No layout breakage at desktop / tablet / mobile widths.

## Version

No csproj `<Version>` bump — auto-bump CI handles per the brief's overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)