### PR TITLE
fix(treasures): partial-GPS banner + Karty shortcut

### DIFF
--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -89,26 +89,48 @@ else
                                 @onclick="() => ToggleStage(s.Key)">@s.Label</button>
                     }
                 </div>
-                @* Issue #160 sub-task B: surface an explicit hint when the
-                   game has assigned locations but none have GPS coordinates
-                   yet — without this the map looks empty and the user can't
-                   tell whether it's a bug or a data state. *@
-                @if (locations.Count > 0 && locations.All(l => !l.Latitude.HasValue || !l.Longitude.HasValue))
-                {
-                    <div class="alert alert-info small mb-2 d-flex align-items-center gap-2">
-                        <i class="bi bi-geo-alt"></i>
-                        <span>
-                            Žádná z @locations.Count přiřazených lokací nemá nastavené GPS souřadnice.
-                            Otevři detail lokace a nastav je, aby se zobrazila na mapě.
-                        </span>
-                    </div>
+                @* Issue #160 sub-task B + #211: surface an explicit hint when
+                   locations are missing GPS coordinates. Three states:
+                   • 0 locations → warn (assign in Lokace section)
+                   • all locations missing GPS → info banner with "switch to Karty"
+                   • partial GPS coverage → info banner with M / N count + Karty link.
+                   Without this the map looks empty and the user can't tell
+                   whether it's a bug or a data state (#211 reproduction). *@
+                @{
+                    var withGps = locations.Count(l => l.Latitude.HasValue && l.Longitude.HasValue);
+                    var missingGps = locations.Count - withGps;
                 }
-                else if (locations.Count == 0)
+                @if (locations.Count == 0)
                 {
                     <div class="alert alert-warning small mb-2 d-flex align-items-center gap-2">
                         <i class="bi bi-exclamation-triangle"></i>
                         <span>
                             Tato hra nemá přiřazené žádné lokace. Přidej je v sekci „Lokace" a vrať se sem.
+                        </span>
+                    </div>
+                }
+                else if (withGps == 0)
+                {
+                    <div class="alert alert-info small mb-2 d-flex align-items-center gap-2">
+                        <i class="bi bi-geo-alt"></i>
+                        <span>
+                            Žádná z @locations.Count přiřazených lokací nemá nastavené GPS souřadnice.
+                            Otevři detail lokace a nastav je, aby se zobrazila na mapě —
+                            nebo přepni na <button type="button" class="btn btn-link btn-sm p-0 align-baseline"
+                                @onclick='() => SetTreasuresViewAsync("cards")'>karty</button>.
+                        </span>
+                    </div>
+                }
+                else if (missingGps > 0 && treasuresView == "map")
+                {
+                    <div class="alert alert-info small mb-2 d-flex align-items-center gap-2">
+                        <i class="bi bi-geo-alt"></i>
+                        <span>
+                            Mapa zobrazuje @withGps z @locations.Count lokací.
+                            @missingGps @(missingGps == 1 ? "lokace nemá" : missingGps < 5 ? "lokace nemají" : "lokací nemá") nastavené GPS —
+                            otevři jejich detail a nastav souřadnice, nebo přepni na
+                            <button type="button" class="btn btn-link btn-sm p-0 align-baseline"
+                                @onclick='() => SetTreasuresViewAsync("cards")'>karty</button>.
                         </span>
                     </div>
                 }


### PR DESCRIPTION
Closes #211.

## What

The Treasures map's pre-existing GPS-warning banner only fired when **ALL** locations were missing GPS. Partial coverage (e.g. 22 of 86 — actual user data) silently produced "no markers visible" without explanation.

This PR adds a third state — **partial GPS coverage** — with a clear count banner and an inline "karty" shortcut.

## Three states now

| State | Banner |
|---|---|
| 0 locations assigned | Warn → add in Lokace section |
| All locations missing GPS | Info → add GPS or switch to **karty** |
| Partial (M < N have GPS) | Info → "Mapa zobrazuje M z N lokací. K lokací nemá GPS — nastav, nebo přepni na **karty**." |

Plurals are Czech-grammar correct (1 → lokace, 2-4 → lokace, 5+ → lokací).

## Risk

Pure UI / messaging. No backend, no DTO, no marker rendering changes — markers still render exactly as before, this is just better signaling.

## Verification

- `dotnet build OvcinaHra.slnx` clean (0/0)
- `dotnet test tests/OvcinaHra.Api.Tests` — **406 / 406** passed in 39 s
- `git diff origin/main --stat`: 1 file, +32 / −10

## Manual smoke test post-merge

1. `/treasures` on game with 22/86 GPS locations → partial banner shows "22 z 86" + clickable karty link
2. Click karty link → view switches to cards immediately
3. `/treasures` on game with 0/86 GPS → all-missing banner with karty link
4. `/treasures` on game with 86/86 GPS → no banner (current behavior)
5. `/treasures` on game with 0 locations → existing warning unchanged