### PR TITLE
feat(recipes): cookbook + 1-page detail + per-game grid + 4-category enum + template fork (Phase 1)

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/CraftingConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/CraftingConfiguration.cs
@@ -9,10 +9,29 @@ public class CraftingRecipeConfiguration : IEntityTypeConfiguration<CraftingReci
     public void Configure(EntityTypeBuilder<CraftingRecipe> builder)
     {
         builder.HasKey(e => e.Id);
-        builder.HasOne(e => e.Game).WithMany(g => g.CraftingRecipes).HasForeignKey(e => e.GameId);
+        // Issue #218 — GameId nullable (catalog templates have GameId == null).
+        builder.HasOne(e => e.Game).WithMany(g => g.CraftingRecipes).HasForeignKey(e => e.GameId).IsRequired(false);
         builder.HasOne(e => e.OutputItem).WithMany().HasForeignKey(e => e.OutputItemId);
         builder.HasOne(e => e.Location).WithMany().HasForeignKey(e => e.LocationId);
         builder.Property(e => e.IngredientNotes).HasMaxLength(2000);
+
+        // Issue #218 — recipe.Name (optional). 300-char ceiling matches Quest
+        // / Building / Item naming columns elsewhere.
+        builder.Property(e => e.Name).HasMaxLength(300);
+
+        // Issue #218 — Category enum stored as string (HasConversion). Same
+        // pattern as Quest.State + Building.State elsewhere in the schema.
+        builder.Property(e => e.Category).HasConversion<string>().HasMaxLength(20);
+
+        // Issue #218 — self-FK for template fork. ON DELETE SET NULL would be
+        // safer than the EF default, but cascading is fine for Phase 1: per-
+        // game forks are independent rows that survive their template's
+        // deletion — DeleteBehavior.SetNull keeps them as orphans the user
+        // can re-link or delete manually.
+        builder.HasOne(e => e.TemplateRecipe)
+            .WithMany()
+            .HasForeignKey(e => e.TemplateRecipeId)
+            .OnDelete(DeleteBehavior.SetNull);
     }
 }
 

--- a/src/OvcinaHra.Api/Endpoints/CraftingEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/CraftingEndpoints.cs
@@ -65,8 +65,13 @@ public static class CraftingEndpoints
         CreateCraftingRecipeDto dto, WorldDbContext db, CancellationToken ct)
     {
         var skillIds = dto.RequiredSkillIds?.Distinct().ToList() ?? [];
-        var problem = await ValidateRequiredSkillsAsync(db, dto.GameId, skillIds, ct);
-        if (problem is not null) return TypedResults.BadRequest(problem);
+        // Issue #218 — catalog templates (GameId is null) skip the per-game
+        // GameSkill validation; the fork endpoint re-validates per target.
+        if (dto.GameId is int createGid)
+        {
+            var problem = await ValidateRequiredSkillsAsync(db, createGid, skillIds, ct);
+            if (problem is not null) return TypedResults.BadRequest(problem);
+        }
 
         var ingredientNotes = dto.IngredientNotes?.Trim();
         if (!string.IsNullOrEmpty(ingredientNotes) && ingredientNotes.Length > IngredientNotesMaxLength)
@@ -138,8 +143,15 @@ public static class CraftingEndpoints
         }
 
         var skillIds = dto.RequiredSkillIds?.Distinct().ToList() ?? [];
-        var problem = await ValidateRequiredSkillsAsync(db, recipe.GameId, skillIds, ct);
-        if (problem is not null) return TypedResults.BadRequest(problem);
+        // Issue #218 — catalog templates (GameId is null) can carry GameSkill
+        // IDs only when forked into a game. Skip the per-game validation for
+        // catalog rows; the from-template fork endpoint re-validates against
+        // the target game's GameSkill set when it deep-copies.
+        if (recipe.GameId is int gid)
+        {
+            var problem = await ValidateRequiredSkillsAsync(db, gid, skillIds, ct);
+            if (problem is not null) return TypedResults.BadRequest(problem);
+        }
 
         var ingredientNotes = dto.IngredientNotes?.Trim();
         if (!string.IsNullOrEmpty(ingredientNotes) && ingredientNotes.Length > IngredientNotesMaxLength)

--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -460,7 +460,10 @@ public static class ItemEndpoints
             .Where(r => r.OutputItemId == id)
             .Select(r => new ItemUsageRecipeDto(
                 r.Id,
-                new ItemUsageGameRefDto(r.GameId, r.Game.Name, r.Game.Edition),
+                // Issue #218 — Recipe.GameId is nullable; catalog templates
+                // emit a null Game ref. Tvorba tab groups them under
+                // a "Šablona katalogu" header.
+                r.Game == null ? null : new ItemUsageGameRefDto(r.Game.Id, r.Game.Name, r.Game.Edition),
                 r.OutputItemId, r.OutputItem.Name,
                 r.LocationId, r.Location != null ? r.Location.Name : null,
                 r.Ingredients.Select(i => new CraftingIngredientDto(i.ItemId, i.Item.Name, i.Quantity)).ToList(),
@@ -472,7 +475,10 @@ public static class ItemEndpoints
             .Where(r => r.Ingredients.Any(i => i.ItemId == id))
             .Select(r => new ItemUsageRecipeDto(
                 r.Id,
-                new ItemUsageGameRefDto(r.GameId, r.Game.Name, r.Game.Edition),
+                // Issue #218 — Recipe.GameId is nullable; catalog templates
+                // emit a null Game ref. Tvorba tab groups them under
+                // a "Šablona katalogu" header.
+                r.Game == null ? null : new ItemUsageGameRefDto(r.Game.Id, r.Game.Name, r.Game.Edition),
                 r.OutputItemId, r.OutputItem.Name,
                 r.LocationId, r.Location != null ? r.Location.Name : null,
                 r.Ingredients.Select(i => new CraftingIngredientDto(i.ItemId, i.Item.Name, i.Quantity)).ToList(),

--- a/src/OvcinaHra.Api/Endpoints/RecipeEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/RecipeEndpoints.cs
@@ -1,0 +1,417 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Endpoints;
+
+/// <summary>
+/// Issue #218 — Recipes cookbook surface. Companion to the legacy
+/// <see cref="CraftingEndpoints"/> /api/crafting routes (kept for backward
+/// compatibility with existing Item Tvorba consumption). The /api/recipes
+/// surface speaks the richer <see cref="RecipeListDto"/> + template-fork
+/// vocabulary used by the new cookbook UI, /games/{gid}/recipes per-game
+/// grid, and the eventual Tvorba-tab refresh.
+/// </summary>
+public static class RecipeEndpoints
+{
+    public static RouteGroupBuilder MapRecipeEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/recipes").WithTags("Recipes");
+
+        // Catalog (templates: GameId == null)
+        group.MapGet("/", GetCatalog);
+        group.MapGet("/{id:int}", GetById);
+        group.MapPost("/", Create);
+        group.MapPut("/{id:int}", Update);
+        group.MapDelete("/{id:int}", Delete);
+
+        // Per-game scope
+        var gameGroup = routes.MapGroup("/api/games/{gameId:int}/recipes").WithTags("Recipes");
+        gameGroup.MapGet("/", GetByGame);
+        gameGroup.MapPost("/from-template/{templateId:int}", CopyFromTemplate);
+
+        return group;
+    }
+
+    private static async Task<Ok<List<RecipeListDto>>> GetCatalog(WorldDbContext db, HttpContext http)
+    {
+        var rows = await db.CraftingRecipes
+            .AsNoTracking()
+            .Where(r => r.GameId == null)
+            .OrderBy(r => r.Name ?? r.OutputItem.Name)
+            .Select(r => new
+            {
+                r.Id,
+                r.Name,
+                r.Category,
+                r.GameId,
+                r.TemplateRecipeId,
+                r.OutputItemId,
+                OutputItemName = r.OutputItem.Name,
+                OutputItemImagePath = r.OutputItem.ImagePath,
+                r.LocationId,
+                LocationName = r.Location != null ? r.Location.Name : null,
+                Ingredients = r.Ingredients
+                    .OrderBy(i => i.Item.Name)
+                    .Select(i => new { i.ItemId, ItemName = i.Item.Name, ItemImagePath = i.Item.ImagePath, i.Quantity })
+                    .ToList(),
+                Buildings = r.BuildingRequirements
+                    .OrderBy(br => br.Building.Name)
+                    .Select(br => new { br.BuildingId, BuildingName = br.Building.Name })
+                    .ToList(),
+                Skills = r.SkillRequirements
+                    .OrderBy(sr => sr.GameSkill.Name)
+                    .Select(sr => new { sr.GameSkillId, SkillName = sr.GameSkill.Name })
+                    .ToList(),
+                r.IngredientNotes,
+                ForksCount = db.CraftingRecipes.Count(f => f.TemplateRecipeId == r.Id)
+            })
+            .ToListAsync();
+
+        return TypedResults.Ok(rows.Select(r => MapToListDto(http, r)).ToList());
+    }
+
+    private static async Task<Ok<List<RecipeListDto>>> GetByGame(int gameId, WorldDbContext db, HttpContext http)
+    {
+        var rows = await db.CraftingRecipes
+            .AsNoTracking()
+            .Where(r => r.GameId == gameId)
+            .OrderBy(r => r.Name ?? r.OutputItem.Name)
+            .Select(r => new
+            {
+                r.Id,
+                r.Name,
+                r.Category,
+                r.GameId,
+                r.TemplateRecipeId,
+                r.OutputItemId,
+                OutputItemName = r.OutputItem.Name,
+                OutputItemImagePath = r.OutputItem.ImagePath,
+                r.LocationId,
+                LocationName = r.Location != null ? r.Location.Name : null,
+                Ingredients = r.Ingredients
+                    .OrderBy(i => i.Item.Name)
+                    .Select(i => new { i.ItemId, ItemName = i.Item.Name, ItemImagePath = i.Item.ImagePath, i.Quantity })
+                    .ToList(),
+                Buildings = r.BuildingRequirements
+                    .OrderBy(br => br.Building.Name)
+                    .Select(br => new { br.BuildingId, BuildingName = br.Building.Name })
+                    .ToList(),
+                Skills = r.SkillRequirements
+                    .OrderBy(sr => sr.GameSkill.Name)
+                    .Select(sr => new { sr.GameSkillId, SkillName = sr.GameSkill.Name })
+                    .ToList(),
+                r.IngredientNotes,
+                ForksCount = 0  // Per-game rows are forks themselves; ForksCount is only meaningful on catalog templates.
+            })
+            .ToListAsync();
+
+        return TypedResults.Ok(rows.Select(r => MapToListDto(http, r)).ToList());
+    }
+
+    private static async Task<Results<Ok<RecipeDetailDto>, NotFound>> GetById(int id, WorldDbContext db, HttpContext http)
+    {
+        var r = await db.CraftingRecipes
+            .Include(r => r.OutputItem)
+            .Include(r => r.Location)
+            .Include(r => r.Ingredients).ThenInclude(i => i.Item)
+            .Include(r => r.BuildingRequirements).ThenInclude(br => br.Building)
+            .Include(r => r.SkillRequirements).ThenInclude(sr => sr.GameSkill)
+            .FirstOrDefaultAsync(r => r.Id == id);
+        if (r is null) return TypedResults.NotFound();
+
+        // For catalog templates, count their per-game forks (drives Smazat-
+        // blocked check + UI badge). For per-game rows, ForksCount stays 0.
+        int forksCount = 0;
+        if (r.GameId is null)
+            forksCount = await db.CraftingRecipes.CountAsync(f => f.TemplateRecipeId == r.Id);
+
+        return TypedResults.Ok(new RecipeDetailDto(
+            r.Id, r.Name,
+            Title: r.Name ?? r.OutputItem.Name,
+            r.Category, r.GameId, r.TemplateRecipeId,
+            r.OutputItemId, r.OutputItem.Name,
+            OutputItemThumbnailUrl: ThumbForItem(http, r.OutputItem),
+            OutputQuantity: 1,
+            r.LocationId, r.Location?.Name,
+            r.Ingredients.OrderBy(i => i.Item.Name).Select(i =>
+                new RecipeIngredientChipDto(i.ItemId, i.Item.Name, ThumbForItem(http, i.Item), i.Quantity)).ToList(),
+            r.BuildingRequirements.OrderBy(br => br.Building.Name).Select(br =>
+                new RecipeBuildingChipDto(br.BuildingId, br.Building.Name)).ToList(),
+            r.SkillRequirements.OrderBy(sr => sr.GameSkill.Name).Select(sr =>
+                new RecipeSkillChipDto(sr.GameSkillId, sr.GameSkill.Name)).ToList(),
+            r.IngredientNotes,
+            forksCount));
+    }
+
+    private static async Task<Results<Created<RecipeDetailDto>, BadRequest<ProblemDetails>, NotFound>> Create(
+        CreateRecipeDto dto, WorldDbContext db, HttpContext http, CancellationToken ct)
+    {
+        if (!Enum.IsDefined(dto.Category))
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Neznámá kategorie",
+                Detail = $"Hodnota '{dto.Category}' není povolena.",
+                Status = StatusCodes.Status400BadRequest
+            });
+
+        var itemExists = await db.Items.AnyAsync(i => i.Id == dto.OutputItemId, ct);
+        if (!itemExists)
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Vybraný výstupní předmět neexistuje.",
+                Detail = $"Předmět s ID {dto.OutputItemId} nebyl nalezen.",
+                Status = StatusCodes.Status400BadRequest
+            });
+
+        var recipe = new CraftingRecipe
+        {
+            Name = string.IsNullOrWhiteSpace(dto.Name) ? null : dto.Name.Trim(),
+            OutputItemId = dto.OutputItemId,
+            Category = dto.Category,
+            GameId = dto.GameId,
+            LocationId = dto.LocationId,
+            TemplateRecipeId = dto.TemplateRecipeId,
+            IngredientNotes = string.IsNullOrWhiteSpace(dto.IngredientNotes) ? null : dto.IngredientNotes.Trim()
+        };
+        db.CraftingRecipes.Add(recipe);
+        await db.SaveChangesAsync(ct);
+
+        var detail = await GetById(recipe.Id, db, http);
+        return detail.Result switch
+        {
+            Ok<RecipeDetailDto> ok when ok.Value is not null => TypedResults.Created($"/api/recipes/{recipe.Id}", ok.Value),
+            _ => TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Internal projection failed",
+                Status = StatusCodes.Status500InternalServerError
+            })
+        };
+    }
+
+    private static async Task<Results<NoContent, NotFound, BadRequest<ProblemDetails>>> Update(
+        int id, UpdateRecipeDto dto, WorldDbContext db, CancellationToken ct)
+    {
+        // Include SkillRequirements because we replace the set — same
+        // pattern as CraftingEndpoints.Update.
+        var recipe = await db.CraftingRecipes
+            .Include(r => r.SkillRequirements)
+            .SingleOrDefaultAsync(r => r.Id == id, ct);
+        if (recipe is null) return TypedResults.NotFound();
+
+        if (!Enum.IsDefined(dto.Category))
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Neznámá kategorie",
+                Detail = $"Hodnota '{dto.Category}' není povolena.",
+                Status = StatusCodes.Status400BadRequest
+            });
+
+        var itemExists = await db.Items.AnyAsync(i => i.Id == dto.OutputItemId, ct);
+        if (!itemExists)
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Vybraný výstupní předmět neexistuje.",
+                Detail = $"Předmět s ID {dto.OutputItemId} nebyl nalezen.",
+                Status = StatusCodes.Status400BadRequest
+            });
+
+        var skillIds = dto.RequiredSkillIds?.Distinct().ToList() ?? [];
+        // Skills only validated against the per-game GameSkill set when the
+        // recipe IS per-game. Catalog templates (GameId == null) skip this
+        // check; the from-template fork endpoint re-validates when copying.
+        if (recipe.GameId is int gid && skillIds.Count > 0)
+        {
+            var existingSkills = await db.GameSkills
+                .Where(gs => gs.GameId == gid && skillIds.Contains(gs.Id))
+                .Select(gs => gs.Id)
+                .ToArrayAsync(ct);
+            var missing = skillIds.Except(existingSkills).ToArray();
+            if (missing.Length > 0)
+                return TypedResults.BadRequest(new ProblemDetails
+                {
+                    Title = "Dovednosti nejsou ve hře dostupné.",
+                    Detail = $"Dovednosti s ID [{string.Join(", ", missing)}] nejsou v této hře.",
+                    Status = StatusCodes.Status400BadRequest
+                });
+        }
+
+        recipe.Name = string.IsNullOrWhiteSpace(dto.Name) ? null : dto.Name.Trim();
+        recipe.OutputItemId = dto.OutputItemId;
+        recipe.Category = dto.Category;
+        recipe.LocationId = dto.LocationId;
+        recipe.IngredientNotes = string.IsNullOrWhiteSpace(dto.IngredientNotes) ? null : dto.IngredientNotes.Trim();
+
+        // Replace SkillRequirements as a set.
+        var currentIds = recipe.SkillRequirements.Select(r => r.GameSkillId).ToHashSet();
+        var desiredIds = skillIds.ToHashSet();
+        foreach (var req in recipe.SkillRequirements.Where(r => !desiredIds.Contains(r.GameSkillId)).ToList())
+            recipe.SkillRequirements.Remove(req);
+        foreach (var sid in desiredIds.Where(s => !currentIds.Contains(s)))
+            recipe.SkillRequirements.Add(new CraftingSkillRequirement { CraftingRecipeId = id, GameSkillId = sid });
+
+        await db.SaveChangesAsync(ct);
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound, Conflict<ProblemDetails>>> Delete(int id, WorldDbContext db, CancellationToken ct)
+    {
+        var recipe = await db.CraftingRecipes.FindAsync([id], ct);
+        if (recipe is null) return TypedResults.NotFound();
+
+        // Block deletion of catalog templates that have per-game forks. Same
+        // pattern as Skills + Quests catalog deletes.
+        if (recipe.GameId is null)
+        {
+            var forksCount = await db.CraftingRecipes.CountAsync(f => f.TemplateRecipeId == id, ct);
+            if (forksCount > 0)
+                return TypedResults.Conflict(new ProblemDetails
+                {
+                    Title = "Šablonu nelze smazat — používá se v hrách.",
+                    Detail = $"Tato šablona je zkopírována do {forksCount} her. Smažte kopie nejdříve.",
+                    Status = StatusCodes.Status409Conflict
+                });
+        }
+
+        db.CraftingRecipes.Remove(recipe);
+        await db.SaveChangesAsync(ct);
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<Created<RecipeDetailDto>, NotFound, BadRequest<ProblemDetails>>> CopyFromTemplate(
+        int gameId, int templateId, WorldDbContext db, HttpContext http, CancellationToken ct)
+    {
+        var template = await db.CraftingRecipes
+            .Include(r => r.Ingredients)
+            .Include(r => r.BuildingRequirements)
+            .Include(r => r.SkillRequirements)
+            .FirstOrDefaultAsync(r => r.Id == templateId, ct);
+        if (template is null) return TypedResults.NotFound();
+
+        if (template.GameId is not null)
+            return TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Zdrojový recept není šablona",
+                Detail = "Forkovat lze pouze recepty z katalogu (GameId == null).",
+                Status = StatusCodes.Status400BadRequest
+            });
+
+        var gameExists = await db.Games.AnyAsync(g => g.Id == gameId, ct);
+        if (!gameExists) return TypedResults.NotFound();
+
+        var fork = new CraftingRecipe
+        {
+            Name = template.Name,
+            OutputItemId = template.OutputItemId,
+            Category = template.Category,
+            GameId = gameId,
+            LocationId = template.LocationId,  // organizer can re-pin per game on edit
+            TemplateRecipeId = template.Id,
+            IngredientNotes = template.IngredientNotes
+        };
+        db.CraftingRecipes.Add(fork);
+        await db.SaveChangesAsync(ct);
+
+        // Deep-copy children. Skills are filtered to ones available in the
+        // target game's GameSkill set — a template skill that doesn't exist
+        // in this game gets dropped silently (organizer can re-add per game).
+        foreach (var ing in template.Ingredients)
+            db.CraftingIngredients.Add(new CraftingIngredient
+            {
+                CraftingRecipeId = fork.Id,
+                ItemId = ing.ItemId,
+                Quantity = ing.Quantity
+            });
+
+        foreach (var br in template.BuildingRequirements)
+            db.CraftingBuildingRequirements.Add(new CraftingBuildingRequirement
+            {
+                CraftingRecipeId = fork.Id,
+                BuildingId = br.BuildingId
+            });
+
+        var validSkillIds = await db.GameSkills
+            .Where(gs => gs.GameId == gameId
+                && template.SkillRequirements.Select(sr => sr.GameSkillId).Contains(gs.Id))
+            .Select(gs => gs.Id)
+            .ToListAsync(ct);
+        foreach (var sid in validSkillIds)
+            db.CraftingSkillRequirements.Add(new CraftingSkillRequirement
+            {
+                CraftingRecipeId = fork.Id,
+                GameSkillId = sid
+            });
+
+        await db.SaveChangesAsync(ct);
+
+        var detail = await GetById(fork.Id, db, http);
+        return detail.Result switch
+        {
+            Ok<RecipeDetailDto> ok when ok.Value is not null => TypedResults.Created($"/api/recipes/{fork.Id}", ok.Value),
+            _ => TypedResults.BadRequest(new ProblemDetails
+            {
+                Title = "Internal projection failed",
+                Status = StatusCodes.Status500InternalServerError
+            })
+        };
+    }
+
+    private static string? ThumbForItem(HttpContext http, Item item)
+        => string.IsNullOrWhiteSpace(item.ImagePath)
+            ? null
+            : ImageEndpoints.ThumbUrl(http, "items", item.Id, "small");
+
+    // Static helper because anonymous-type projections from EF land here as
+    // an `object` in the C# compiler's view; dynamic dispatch on properties
+    // would erase IntelliSense support. The shape is small enough to keep
+    // the local-record verbosity in line.
+    private static RecipeListDto MapToListDto(HttpContext http, dynamic r)
+    {
+        string outputItemName = (string)r.OutputItemName;
+        string? outputItemImagePath = (string?)r.OutputItemImagePath;
+        int outputItemId = (int)r.OutputItemId;
+        string? thumb = string.IsNullOrWhiteSpace(outputItemImagePath)
+            ? null
+            : ImageEndpoints.ThumbUrl(http, "items", outputItemId, "small");
+
+        var ingredients = new List<RecipeIngredientChipDto>();
+        foreach (var i in r.Ingredients)
+        {
+            string? ingThumb = string.IsNullOrWhiteSpace((string?)i.ItemImagePath)
+                ? null
+                : ImageEndpoints.ThumbUrl(http, "items", (int)i.ItemId, "small");
+            ingredients.Add(new RecipeIngredientChipDto((int)i.ItemId, (string)i.ItemName, ingThumb, (int)i.Quantity));
+        }
+
+        var buildings = new List<RecipeBuildingChipDto>();
+        foreach (var b in r.Buildings)
+            buildings.Add(new RecipeBuildingChipDto((int)b.BuildingId, (string)b.BuildingName));
+
+        var skills = new List<RecipeSkillChipDto>();
+        foreach (var s in r.Skills)
+            skills.Add(new RecipeSkillChipDto((int)s.GameSkillId, (string)s.SkillName));
+
+        return new RecipeListDto(
+            (int)r.Id,
+            (string?)r.Name,
+            Title: (string?)r.Name ?? outputItemName,
+            (RecipeCategory)r.Category,
+            (int?)r.GameId,
+            (int?)r.TemplateRecipeId,
+            outputItemId,
+            outputItemName,
+            thumb,
+            OutputQuantity: 1,
+            (int?)r.LocationId,
+            (string?)r.LocationName,
+            ingredients,
+            buildings,
+            skills,
+            (string?)r.IngredientNotes,
+            (int)r.ForksCount);
+    }
+}

--- a/src/OvcinaHra.Api/Migrations/20260426093833_AddRecipeTemplateForkNameAndCategory.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260426093833_AddRecipeTemplateForkNameAndCategory.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260426093833_AddRecipeTemplateForkNameAndCategory")]
+    partial class AddRecipeTemplateForkNameAndCategory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1537,37 +1540,6 @@ namespace OvcinaHra.Api.Migrations
                     b.ToTable("QuestTagLinks");
                 });
 
-            modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.QuestWaypoint", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("Label")
-                        .HasMaxLength(120)
-                        .HasColumnType("character varying(120)");
-
-                    b.Property<int>("LocationId")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("Order")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("QuestId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("LocationId");
-
-                    b.HasIndex("QuestId", "Order")
-                        .IsUnique();
-
-                    b.ToTable("QuestWaypoints");
-                });
-
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.SecretStash", b =>
                 {
                     b.Property<int>("Id")
@@ -2663,25 +2635,6 @@ namespace OvcinaHra.Api.Migrations
                     b.Navigation("Tag");
                 });
 
-            modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.QuestWaypoint", b =>
-                {
-                    b.HasOne("OvcinaHra.Shared.Domain.Entities.Location", "Location")
-                        .WithMany()
-                        .HasForeignKey("LocationId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.HasOne("OvcinaHra.Shared.Domain.Entities.Quest", "Quest")
-                        .WithMany("QuestWaypoints")
-                        .HasForeignKey("QuestId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Location");
-
-                    b.Navigation("Quest");
-                });
-
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.SkillBuildingRequirement", b =>
                 {
                     b.HasOne("OvcinaHra.Shared.Domain.Entities.Building", "Building")
@@ -2938,8 +2891,6 @@ namespace OvcinaHra.Api.Migrations
                     b.Navigation("QuestRewards");
 
                     b.Navigation("QuestTags");
-
-                    b.Navigation("QuestWaypoints");
                 });
 
             modelBuilder.Entity("OvcinaHra.Shared.Domain.Entities.SecretStash", b =>

--- a/src/OvcinaHra.Api/Migrations/20260426093833_AddRecipeTemplateForkNameAndCategory.cs
+++ b/src/OvcinaHra.Api/Migrations/20260426093833_AddRecipeTemplateForkNameAndCategory.cs
@@ -1,0 +1,113 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRecipeTemplateForkNameAndCategory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CraftingRecipes_Games_GameId",
+                table: "CraftingRecipes");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "GameId",
+                table: "CraftingRecipes",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Category",
+                table: "CraftingRecipes",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "Ostatni");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Name",
+                table: "CraftingRecipes",
+                type: "character varying(300)",
+                maxLength: 300,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TemplateRecipeId",
+                table: "CraftingRecipes",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CraftingRecipes_TemplateRecipeId",
+                table: "CraftingRecipes",
+                column: "TemplateRecipeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CraftingRecipes_CraftingRecipes_TemplateRecipeId",
+                table: "CraftingRecipes",
+                column: "TemplateRecipeId",
+                principalTable: "CraftingRecipes",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CraftingRecipes_Games_GameId",
+                table: "CraftingRecipes",
+                column: "GameId",
+                principalTable: "Games",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CraftingRecipes_CraftingRecipes_TemplateRecipeId",
+                table: "CraftingRecipes");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CraftingRecipes_Games_GameId",
+                table: "CraftingRecipes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CraftingRecipes_TemplateRecipeId",
+                table: "CraftingRecipes");
+
+            migrationBuilder.DropColumn(
+                name: "Category",
+                table: "CraftingRecipes");
+
+            migrationBuilder.DropColumn(
+                name: "Name",
+                table: "CraftingRecipes");
+
+            migrationBuilder.DropColumn(
+                name: "TemplateRecipeId",
+                table: "CraftingRecipes");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "GameId",
+                table: "CraftingRecipes",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CraftingRecipes_Games_GameId",
+                table: "CraftingRecipes",
+                column: "GameId",
+                principalTable: "Games",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -213,6 +213,7 @@ try
     app.MapSkillEndpoints().RequireAuthorization();
     app.MapSpellEndpoints().RequireAuthorization();
     app.MapCraftingEndpoints().RequireAuthorization();
+    app.MapRecipeEndpoints().RequireAuthorization();
     app.MapBuildingRecipeEndpoints().RequireAuthorization();
     app.MapTreasureQuestEndpoints().RequireAuthorization();
     app.MapPersonalQuestEndpoints().RequireAuthorization();

--- a/src/OvcinaHra.Client/Components/RecipeCategoryChip.razor
+++ b/src/OvcinaHra.Client/Components/RecipeCategoryChip.razor
@@ -1,0 +1,32 @@
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+@* Small coloured chip for the 4-value RecipeCategory enum. Colours come
+   from the --oh-rec-cat-* CSS custom properties on :root (declared in
+   the .oh-rec-* theme block). Each chip applies a `.oh-rec-cat-{name}`
+   modifier so the CSS picks the right token. *@
+
+<span class="oh-rec-cat oh-rec-cat-@CssKey" title="@Category.GetDisplayName()">
+    <i class="bi @Icon"></i>
+    <span>@Category.GetDisplayName()</span>
+</span>
+
+@code {
+    [Parameter, EditorRequired] public RecipeCategory Category { get; set; }
+
+    private string CssKey => Category switch
+    {
+        RecipeCategory.Budova    => "budova",
+        RecipeCategory.Lektvar   => "lektvar",
+        RecipeCategory.Artefakt  => "artefakt",
+        _                        => "ostatni"
+    };
+
+    private string Icon => Category switch
+    {
+        RecipeCategory.Budova    => "bi-house-fill",
+        RecipeCategory.Lektvar   => "bi-droplet-half",
+        RecipeCategory.Artefakt  => "bi-gem",
+        _                        => "bi-three-dots"
+    };
+}

--- a/src/OvcinaHra.Client/Components/RecipeEditPopup.razor
+++ b/src/OvcinaHra.Client/Components/RecipeEditPopup.razor
@@ -1,0 +1,359 @@
+@using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+@inject ApiClient Api
+
+@* Issue #218 — shared edit popup for /recipes catalog, /games/{gid}/recipes
+   per-game grid, and (eventually) the Item Tvorba tab. Three sections:
+   Identita (Name + Output item + Category) · Suroviny (ingredient picker
+   + sacred banner over the notes memo) · Vyžaduje (building + skill
+   pickers). Reuses the existing leaf pickers from #142 (RecipeIngredient
+   Picker / RecipeBuildingPicker / RecipeSkillPicker / RecipeNotesEditor)
+   so this PR doesn't reinvent that surface. *@
+
+<DxPopup AllowResize="true" @bind-Visible="@Visible"
+         HeaderText="@(detail is null ? "Recept" : (detail.Title ?? "Recept"))"
+         Width="780px">
+    <BodyContentTemplate Context="ctx">
+        @if (loading || detail is null)
+        {
+            <p class="text-muted">Načítám…</p>
+        }
+        else
+        {
+            <DxFormLayout>
+                <DxFormLayoutGroup Caption="Identita" ColSpanMd="12">
+                    <DxFormLayoutItem Caption="Název" ColSpanMd="8">
+                        <DxTextBox @bind-Text="@editName" NullText="(volitelné — výchozí podle výstupu)" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Kategorie" ColSpanMd="4">
+                        <DxComboBox Data="@categoryValues" @bind-Value="@editCategory"
+                                    TextFieldName="Display" ValueFieldName="Value" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Výstupní předmět" ColSpanMd="8">
+                        <DxComboBox Data="@allItems" @bind-Value="@editOutputItemId"
+                                    TextFieldName="Name" ValueFieldName="Id"
+                                    NullText="(vyberte předmět)"
+                                    SearchMode="ListSearchMode.AutoSearch" />
+                    </DxFormLayoutItem>
+                    <DxFormLayoutItem Caption="Lokace" ColSpanMd="4">
+                        <DxComboBox Data="@allLocations" @bind-Value="@editLocationId"
+                                    TextFieldName="Name" ValueFieldName="Id"
+                                    NullText="Bez lokace"
+                                    SearchMode="ListSearchMode.AutoSearch"
+                                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+                    </DxFormLayoutItem>
+                </DxFormLayoutGroup>
+            </DxFormLayout>
+
+            <div class="oh-rec-popup-section mt-3">
+                <h6><i class="bi bi-basket"></i> Suroviny</h6>
+                <div class="oh-sacred-banner">
+                    <i class="bi bi-shield-fill-exclamation"></i>
+                    <span>Názvy a počty surovin jsou <strong>posvátné</strong> — pište přesně, jak je hráč uvidí na herní kartě. Nezkracujte, neparafrázujte.</span>
+                </div>
+                <RecipeIngredientPicker
+                    Ingredients="@_ingredientRows"
+                    AvailableItems="@allItems"
+                    OnAdd="@AddIngredientAsync"
+                    OnRemove="@RemoveIngredientAsync" />
+                <RecipeNotesEditor
+                    PersistedValue="@detail.IngredientNotes"
+                    OnSave="@SaveNotesAsync" />
+            </div>
+
+            <div class="oh-rec-popup-section mt-3">
+                <h6><i class="bi bi-tools"></i> Vyžaduje</h6>
+                <RecipeBuildingPicker
+                    Caption="Stavby"
+                    AddPlaceholder="(přidat stavbu)"
+                    Buildings="@_buildingRows"
+                    AvailableBuildings="@AvailableBuildings"
+                    OnAdd="@AddBuildingAsync"
+                    OnRemove="@RemoveBuildingAsync" />
+                @if (detail.GameId is not null)
+                {
+                    <RecipeSkillPicker
+                        SelectedSkillIds="@_skillIds"
+                        AllGameSkills="@gameSkills"
+                        AvailableSkills="@AvailableGameSkills"
+                        OnAdd="@AddSkillAsync"
+                        OnRemove="@RemoveSkillAsync" />
+                }
+                else
+                {
+                    <p class="text-muted small mt-2">
+                        <i class="bi bi-info-circle"></i>
+                        Dovednosti se přiřadí až po vytvoření kopie pro hru — šablona v katalogu je nezná.
+                    </p>
+                }
+            </div>
+
+            @if (error is not null)
+            {
+                <div class="alert alert-danger mt-2">@error</div>
+            }
+        }
+
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button type="button" class="btn btn-secondary" @onclick="Cancel" disabled="@isSaving">Zrušit</button>
+            <button type="button" class="btn btn-primary" @onclick="SaveAsync"
+                    disabled="@(isSaving || detail is null || editOutputItemId is null)">
+                @if (isSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Uložit
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter] public int? RecipeId { get; set; }
+    [Parameter] public EventCallback OnSaved { get; set; }
+
+    private RecipeDetailDto? detail;
+    private bool loading = true;
+    private bool isSaving;
+    private string? error;
+
+    private string? editName;
+    private RecipeCategory editCategory = RecipeCategory.Ostatni;
+    private int? editOutputItemId;
+    private int? editLocationId;
+
+    private List<ItemListDto> allItems = [];
+    private List<LocationListDto> allLocations = [];
+    private List<BuildingListDto> allBuildings = [];
+    private List<GameSkillDto> gameSkills = [];
+
+    private IReadOnlyList<RecipeIngredientPicker.IngredientRow> _ingredientRows = [];
+    private IReadOnlyList<RecipeBuildingPicker.BuildingRow> _buildingRows = [];
+    private List<int> _skillIds = [];
+
+    private static readonly List<EnumItem<RecipeCategory>> categoryValues = Enum.GetValues<RecipeCategory>()
+        .Select(v => new EnumItem<RecipeCategory>(v, v.GetDisplayName())).ToList();
+
+    private record EnumItem<T>(T Value, string Display);
+
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        var prevVisible = Visible;
+        var prevId = RecipeId;
+        await base.SetParametersAsync(parameters);
+        if (Visible && (!prevVisible || prevId != RecipeId))
+        {
+            await LoadAsync();
+        }
+    }
+
+    private List<BuildingListDto> AvailableBuildings =>
+        detail is null ? [] :
+        allBuildings.Where(b => !_buildingRows.Any(br => br.BuildingId == b.Id)).ToList();
+
+    private List<GameSkillDto> AvailableGameSkills =>
+        gameSkills.Where(gs => !_skillIds.Contains(gs.Id)).ToList();
+
+    private async Task LoadAsync()
+    {
+        if (RecipeId is null) return;
+        loading = true;
+        error = null;
+        try
+        {
+            detail = await Api.GetAsync<RecipeDetailDto>($"/api/recipes/{RecipeId.Value}");
+            if (detail is null)
+            {
+                error = "Recept nenalezen.";
+                return;
+            }
+            editName = detail.Name;
+            editCategory = detail.Category;
+            editOutputItemId = detail.OutputItemId;
+            editLocationId = detail.LocationId;
+            _ingredientRows = detail.Ingredients
+                .Select(i => new RecipeIngredientPicker.IngredientRow(i.ItemId, i.Name, i.Quantity))
+                .ToList();
+            _buildingRows = detail.Buildings
+                .Select(b => new RecipeBuildingPicker.BuildingRow(b.BuildingId, b.Name))
+                .ToList();
+            _skillIds = detail.Skills.Select(s => s.SkillId).ToList();
+
+            // Picker source data — fetch in parallel to avoid serial waterfall.
+            var itemsTask = Api.GetListAsync<ItemListDto>("/api/items");
+            var locationsTask = Api.GetListAsync<LocationListDto>("/api/locations");
+            var buildingsTask = Api.GetListAsync<BuildingListDto>("/api/buildings");
+            await Task.WhenAll(itemsTask, locationsTask, buildingsTask);
+            allItems = await itemsTask;
+            allLocations = await locationsTask;
+            allBuildings = await buildingsTask;
+
+            if (detail.GameId is int gid)
+            {
+                gameSkills = await Api.GetListAsync<GameSkillDto>($"/api/games/{gid}/skills");
+            }
+            else
+            {
+                gameSkills = [];
+            }
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { loading = false; }
+    }
+
+    private async Task SaveAsync()
+    {
+        if (detail is null || editOutputItemId is null) return;
+        error = null;
+        isSaving = true;
+        try
+        {
+            var dto = new UpdateRecipeDto(
+                Name: string.IsNullOrWhiteSpace(editName) ? null : editName.Trim(),
+                OutputItemId: editOutputItemId.Value,
+                Category: editCategory,
+                LocationId: editLocationId,
+                RequiredSkillIds: _skillIds,
+                IngredientNotes: detail.IngredientNotes);
+            var (ok, problem) = await Api.PutWithProblemAsync($"/api/recipes/{detail.Id}", dto);
+            if (!ok)
+            {
+                error = problem ?? "Uložení se nezdařilo.";
+                return;
+            }
+            await OnSaved.InvokeAsync();
+            await VisibleChanged.InvokeAsync(false);
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
+    }
+
+    private async Task Cancel() => await VisibleChanged.InvokeAsync(false);
+
+    // ── Ingredient row CRUD ──────────────────────────────────────────────
+    private async Task AddIngredientAsync((int ItemId, int Quantity) ev)
+    {
+        if (detail is null) return;
+        try
+        {
+            var (ok, _, problem) = await Api.PostWithProblemAsync<AddCraftingIngredientDto, object>(
+                $"/api/crafting/{detail.Id}/ingredients",
+                new AddCraftingIngredientDto(ev.ItemId, ev.Quantity));
+            if (!ok) { error = problem ?? "Přidání suroviny selhalo."; return; }
+            await ReloadDetailAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task RemoveIngredientAsync(int itemId)
+    {
+        if (detail is null) return;
+        try
+        {
+            var ok = await Api.DeleteAsync($"/api/crafting/{detail.Id}/ingredients/{itemId}");
+            if (!ok) { error = "Odebrání suroviny selhalo."; return; }
+            await ReloadDetailAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    // ── Building requirement CRUD ────────────────────────────────────────
+    private async Task AddBuildingAsync(int buildingId)
+    {
+        if (detail is null) return;
+        try
+        {
+            var (ok, _, problem) = await Api.PostWithProblemAsync<AddCraftingBuildingReqDto, object>(
+                $"/api/crafting/{detail.Id}/buildings",
+                new AddCraftingBuildingReqDto(buildingId));
+            if (!ok) { error = problem ?? "Přidání stavby selhalo."; return; }
+            await ReloadDetailAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task RemoveBuildingAsync(int buildingId)
+    {
+        if (detail is null) return;
+        try
+        {
+            var ok = await Api.DeleteAsync($"/api/crafting/{detail.Id}/buildings/{buildingId}");
+            if (!ok) { error = "Odebrání stavby selhalo."; return; }
+            await ReloadDetailAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    // ── Skill set CRUD (PUT replaces the set) ────────────────────────────
+    private async Task AddSkillAsync(int skillId)
+    {
+        if (detail is null || _skillIds.Contains(skillId)) return;
+        var next = _skillIds.ToList();
+        next.Add(skillId);
+        await PersistSkillsAsync(next);
+    }
+
+    private async Task RemoveSkillAsync(int skillId)
+    {
+        if (detail is null) return;
+        var next = _skillIds.Where(s => s != skillId).ToList();
+        await PersistSkillsAsync(next);
+    }
+
+    private async Task PersistSkillsAsync(List<int> nextIds)
+    {
+        if (detail is null || editOutputItemId is null) return;
+        try
+        {
+            var dto = new UpdateRecipeDto(
+                Name: editName,
+                OutputItemId: editOutputItemId.Value,
+                Category: editCategory,
+                LocationId: editLocationId,
+                RequiredSkillIds: nextIds,
+                IngredientNotes: detail.IngredientNotes);
+            var (ok, problem) = await Api.PutWithProblemAsync($"/api/recipes/{detail.Id}", dto);
+            if (!ok) { error = problem ?? "Aktualizace dovedností selhala."; return; }
+            _skillIds = nextIds;
+            await ReloadDetailAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task SaveNotesAsync(string? newValue)
+    {
+        if (detail is null || editOutputItemId is null) return;
+        try
+        {
+            var normalized = string.IsNullOrWhiteSpace(newValue) ? null : newValue.Trim();
+            var dto = new UpdateRecipeDto(
+                Name: editName,
+                OutputItemId: editOutputItemId.Value,
+                Category: editCategory,
+                LocationId: editLocationId,
+                RequiredSkillIds: _skillIds,
+                IngredientNotes: normalized);
+            var (ok, problem) = await Api.PutWithProblemAsync($"/api/recipes/{detail.Id}", dto);
+            if (!ok) { error = problem ?? "Uložení poznámky selhalo."; return; }
+            await ReloadDetailAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+    }
+
+    private async Task ReloadDetailAsync()
+    {
+        if (RecipeId is null) return;
+        detail = await Api.GetAsync<RecipeDetailDto>($"/api/recipes/{RecipeId.Value}");
+        if (detail is not null)
+        {
+            _ingredientRows = detail.Ingredients
+                .Select(i => new RecipeIngredientPicker.IngredientRow(i.ItemId, i.Name, i.Quantity))
+                .ToList();
+            _buildingRows = detail.Buildings
+                .Select(b => new RecipeBuildingPicker.BuildingRow(b.BuildingId, b.Name))
+                .ToList();
+            _skillIds = detail.Skills.Select(s => s.SkillId).ToList();
+        }
+        StateHasChanged();
+    }
+}

--- a/src/OvcinaHra.Client/Components/RecipeFormulaCard.razor
+++ b/src/OvcinaHra.Client/Components/RecipeFormulaCard.razor
@@ -1,0 +1,159 @@
+@using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Domain.Enums
+
+@* Issue #218 — formula card. Three layout variants share the same
+   ingredient-chips → arrow → output-chip skeleton. List variant is the
+   catalog cookbook row; Hero is the larger detail-page hero; Compact is
+   the Tvorba-tab-style row. Sacred prose rule: ingredient names + qty
+   are NEVER abbreviated server-side, CSS handles wrapping. *@
+
+<div class="oh-rec-fc oh-rec-fc--@VariantClass oh-rec-cat-@CategoryKey @(Clickable ? "oh-rec-fc--clickable" : "")"
+     @key="Recipe.Id"
+     @onclick="HandleClick"
+     role="@(Clickable ? "button" : null)"
+     tabindex="@(Clickable ? "0" : null)">
+    <div class="oh-rec-fc-top">
+        <span class="oh-rec-fc-num">#@Recipe.Id</span>
+        <h3 class="oh-rec-fc-name">@Recipe.Title</h3>
+        <RecipeCategoryChip Category="@Recipe.Category" />
+        @if (Recipe.GameId is null)
+        {
+            <span class="oh-rec-src-badge oh-rec-src-badge--template" title="Šablona katalogu">
+                <i class="bi bi-bookmark-fill"></i>
+            </span>
+        }
+        else if (Recipe.TemplateRecipeId is int tplId)
+        {
+            <span class="oh-rec-src-badge oh-rec-src-badge--fork" title="@($"Šablona #{tplId}")">
+                <i class="bi bi-files"></i> Šablona #@tplId
+            </span>
+        }
+        else
+        {
+            <span class="oh-rec-src-badge oh-rec-src-badge--scratch" title="Od nuly">
+                <i class="bi bi-stars"></i> Od nuly
+            </span>
+        }
+    </div>
+
+    <div class="oh-rec-fc-body">
+        <div class="oh-rec-fc-inputs">
+            @if (Recipe.Ingredients.Count == 0)
+            {
+                <span class="oh-rec-fc-empty">Bez surovin</span>
+            }
+            else
+            {
+                @foreach (var ing in Recipe.Ingredients)
+                {
+                    <span class="oh-rec-fc-ing-chip" @key="ing.ItemId" title="@ing.Name">
+                        @if (!string.IsNullOrEmpty(ing.ThumbnailUrl))
+                        {
+                            <img src="@ing.ThumbnailUrl" alt="@ing.Name" class="oh-rec-fc-ing-thumb" />
+                        }
+                        else
+                        {
+                            <span class="oh-rec-fc-ing-thumb oh-rec-fc-ing-thumb--placeholder">
+                                <i class="bi bi-box"></i>
+                            </span>
+                        }
+                        <span class="oh-rec-fc-ing-name">@ing.Name</span>
+                        <span class="oh-rec-qty">×@ing.Quantity</span>
+                    </span>
+                }
+            }
+        </div>
+
+        <div class="oh-rec-fc-arrow" aria-hidden="true">
+            <i class="bi bi-arrow-right"></i>
+        </div>
+
+        <div class="oh-rec-fc-output">
+            <span class="oh-rec-fc-out-chip" title="@Recipe.OutputItemName">
+                @if (!string.IsNullOrEmpty(Recipe.OutputItemThumbnailUrl))
+                {
+                    <img src="@Recipe.OutputItemThumbnailUrl" alt="@Recipe.OutputItemName" class="oh-rec-fc-out-thumb" />
+                }
+                else
+                {
+                    <span class="oh-rec-fc-out-thumb oh-rec-fc-out-thumb--placeholder">
+                        <i class="bi bi-bag"></i>
+                    </span>
+                }
+                <span class="oh-rec-fc-out-name">@Recipe.OutputItemName</span>
+                @if (Recipe.OutputQuantity > 1)
+                {
+                    <span class="oh-rec-qty oh-rec-qty--out">×@Recipe.OutputQuantity</span>
+                }
+            </span>
+        </div>
+    </div>
+
+    @if (Recipe.Buildings.Count > 0 || Recipe.Skills.Count > 0 || !string.IsNullOrWhiteSpace(Recipe.LocationName))
+    {
+        <div class="oh-rec-fc-req">
+            @foreach (var b in Recipe.Buildings)
+            {
+                <span class="oh-rec-fc-req-chip oh-rec-fc-req-chip--building" @key="b.BuildingId" title="Vyžaduje stavbu">
+                    <i class="bi bi-house"></i>@b.Name
+                </span>
+            }
+            @foreach (var s in Recipe.Skills)
+            {
+                <span class="oh-rec-fc-req-chip oh-rec-fc-req-chip--skill" @key="s.SkillId" title="Vyžaduje dovednost">
+                    <i class="bi bi-mortarboard"></i>@s.Name
+                </span>
+            }
+            @if (!string.IsNullOrWhiteSpace(Recipe.LocationName))
+            {
+                <span class="oh-rec-fc-req-chip oh-rec-fc-req-chip--location" title="Lokace">
+                    <i class="bi bi-geo-alt"></i>@Recipe.LocationName
+                </span>
+            }
+        </div>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(Recipe.IngredientNotes) && Variant != FormulaVariant.Compact)
+    {
+        <div class="oh-rec-fc-notes">
+            <i class="bi bi-info-circle"></i>
+            <span>@Recipe.IngredientNotes</span>
+        </div>
+    }
+
+    @if (ChildContent is not null)
+    {
+        <div class="oh-rec-fc-actions">@ChildContent</div>
+    }
+</div>
+
+@code {
+    public enum FormulaVariant { List, Hero, Compact }
+
+    [Parameter, EditorRequired] public RecipeListDto Recipe { get; set; } = null!;
+    [Parameter] public FormulaVariant Variant { get; set; } = FormulaVariant.List;
+    [Parameter] public bool Clickable { get; set; }
+    [Parameter] public EventCallback<RecipeListDto> OnClick { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    private string VariantClass => Variant switch
+    {
+        FormulaVariant.Hero    => "hero",
+        FormulaVariant.Compact => "compact",
+        _                       => "list"
+    };
+
+    private string CategoryKey => Recipe.Category switch
+    {
+        RecipeCategory.Budova    => "budova",
+        RecipeCategory.Lektvar   => "lektvar",
+        RecipeCategory.Artefakt  => "artefakt",
+        _                        => "ostatni"
+    };
+
+    private async Task HandleClick()
+    {
+        if (Clickable)
+            await OnClick.InvokeAsync(Recipe);
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Games/GameRecipes.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameRecipes.razor
@@ -1,0 +1,318 @@
+@page "/games/{GameId:int}/recipes"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject NavigationManager Nav
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+@* Issue #218 — per-game recipe DxGrid. Source badges (Šablona #N / Od
+   nuly) + drift `≠` icon when fork fields diverge from template.
+   LayoutKey grid-layout-game-recipes-v2. *@
+
+<div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+    <div>
+        <h1 class="mb-0">Recepty hry @(game?.Name)</h1>
+        @if (game is not null)
+        {
+            <p class="text-muted small mb-0">edice @game.Edition · @recipes.Count receptů</p>
+        }
+    </div>
+    <div class="d-flex gap-2">
+        <button class="btn btn-outline-secondary" type="button"
+                @onclick='() => Nav.NavigateTo("/recipes")'>
+            <i class="bi bi-journal-text"></i> Kniha receptů
+        </button>
+        <button class="btn btn-outline-primary" type="button" @onclick="() => isFromTemplateVisible = true">
+            <i class="bi bi-files"></i> Přidat ze šablony
+        </button>
+    </div>
+</div>
+
+@if (loading)
+{
+    <p class="text-muted">Načítám…</p>
+}
+else if (recipes.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-journal-text fs-1 d-block mb-2"></i>
+        <p>V této hře nejsou žádné recepty.</p>
+        <button class="btn btn-outline-primary" type="button" @onclick="() => isFromTemplateVisible = true">
+            <i class="bi bi-files"></i> Přidat ze šablony
+        </button>
+    </div>
+}
+else
+{
+    <OvcinaGrid Data="@recipes" KeyFieldName="Id" LayoutKey="grid-layout-game-recipes-v2"
+                RowClick="@(e => OpenEditPopup((RecipeListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+        <Columns>
+            <DxGridDataColumn Caption="Šablona" Width="140px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var r = (RecipeListDto)context.DataItem; }
+                    @if (r.TemplateRecipeId is int tplId)
+                    {
+                        <span class="oh-rec-src-badge oh-rec-src-badge--fork">
+                            <i class="bi bi-files"></i> Šablona #@tplId
+                        </span>
+                    }
+                    else
+                    {
+                        <span class="oh-rec-src-badge oh-rec-src-badge--scratch">
+                            <i class="bi bi-stars"></i> Od nuly
+                        </span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn Caption="" Width="60px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var r = (RecipeListDto)context.DataItem; }
+                    <div class="oh-rec-mini-thumb @(string.IsNullOrEmpty(r.OutputItemThumbnailUrl) ? "oh-rec-mini-thumb--placeholder" : "")">
+                        @if (!string.IsNullOrEmpty(r.OutputItemThumbnailUrl))
+                        {
+                            <img src="@r.OutputItemThumbnailUrl" alt="@r.OutputItemName" />
+                        }
+                        else
+                        {
+                            <i class="bi bi-bag"></i>
+                        }
+                    </div>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="Title" Caption="Název" MinWidth="200" />
+            <DxGridDataColumn FieldName="CategoryDisplay" Caption="Kategorie" Width="130px">
+                <CellDisplayTemplate>
+                    @{ var r = (RecipeListDto)context.DataItem; }
+                    <RecipeCategoryChip Category="@r.Category" />
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn Caption="Vstupy" MinWidth="180" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var r = (RecipeListDto)context.DataItem; }
+                    @if (r.Ingredients.Count == 0)
+                    {
+                        <span class="text-muted fst-italic">—</span>
+                    }
+                    else
+                    {
+                        <span class="oh-rec-grid-chips">
+                            @foreach (var i in r.Ingredients.Take(3))
+                            {
+                                <span class="oh-pill" title="@i.Name">@i.Name ×@i.Quantity</span>
+                            }
+                            @if (r.Ingredients.Count > 3)
+                            {
+                                <span class="oh-pill-mono">+@(r.Ingredients.Count - 3)</span>
+                            }
+                        </span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="OutputItemName" Caption="Výstup" MinWidth="160" />
+
+            <DxGridDataColumn Caption="Stavby" Width="160" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var r = (RecipeListDto)context.DataItem; }
+                    @if (r.Buildings.Count == 0)
+                    {
+                        <span class="text-muted fst-italic">—</span>
+                    }
+                    else
+                    {
+                        <span class="oh-rec-grid-chips">
+                            @foreach (var b in r.Buildings)
+                            {
+                                <span class="oh-pill" title="@b.Name">@b.Name</span>
+                            }
+                        </span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn Caption="≠" Width="60px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var r = (RecipeListDto)context.DataItem; }
+                    @if (r.TemplateRecipeId is int tid && DriftFor(r, tid))
+                    {
+                        <span class="oh-rec-drift-ic" title="Pole se liší od šablony">
+                            <i class="bi bi-exclamation-diamond-fill"></i>
+                        </span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+        </Columns>
+    </OvcinaGrid>
+}
+
+<DxPopup AllowResize="true" @bind-Visible="@isFromTemplateVisible"
+         HeaderText="Přidat recept ze šablony" Width="640px">
+    <BodyContentTemplate Context="ctx">
+        @if (templateCatalog is null)
+        {
+            <p class="text-muted">Načítám katalog…</p>
+        }
+        else if (templateCatalog.Count == 0)
+        {
+            <p class="text-muted">V katalogu nejsou žádné šablony receptů.</p>
+        }
+        else
+        {
+            <DxFormLayout>
+                <DxFormLayoutItem Caption="Šablona" ColSpanMd="12">
+                    <DxComboBox Data="@templateCatalog" @bind-Value="@templateId"
+                                TextFieldName="Title" ValueFieldName="Id"
+                                NullText="(vyberte šablonu)"
+                                SearchMode="ListSearchMode.AutoSearch" />
+                </DxFormLayoutItem>
+            </DxFormLayout>
+        }
+        @if (copyError is not null)
+        {
+            <div class="alert alert-danger mt-2">@copyError</div>
+        }
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" type="button" @onclick="() => isFromTemplateVisible = false">Zavřít</button>
+            <button class="btn btn-primary" type="button"
+                    @onclick="CopyFromTemplateAsync"
+                    disabled="@(isCopying || templateId is null)">
+                @if (isCopying) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit kopii
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<RecipeEditPopup @bind-Visible="isEditVisible" RecipeId="@editingRecipeId" OnSaved="@LoadAsync" />
+
+@code {
+    [Parameter] public int GameId { get; set; }
+
+    private GameDetailDto? game;
+    private List<RecipeListDto> recipes = [];
+    private List<RecipeListDto>? templateCatalog;
+    private bool loading = true;
+
+    // Cached template lookup for drift detection — avoids O(N) scan per row.
+    private Dictionary<int, RecipeListDto> templateById = new();
+
+    private bool isFromTemplateVisible;
+    private int? templateId;
+    private bool isCopying;
+    private string? copyError;
+
+    private bool isEditVisible;
+    private int? editingRecipeId;
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (game is not null && game.Id != GameId) await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        try
+        {
+            var gameTask = Api.GetAsync<GameDetailDto>($"/api/games/{GameId}");
+            var recipesTask = Api.GetListAsync<RecipeListDto>($"/api/games/{GameId}/recipes");
+            await Task.WhenAll(gameTask, recipesTask);
+            game = await gameTask;
+            recipes = await recipesTask;
+
+            // Load templates referenced by any per-game fork — only those
+            // we need for drift detection. Cached as a dict so the per-row
+            // drift compare is O(1).
+            var refIds = recipes.Where(r => r.TemplateRecipeId.HasValue)
+                .Select(r => r.TemplateRecipeId!.Value)
+                .Distinct().ToList();
+            if (refIds.Count > 0)
+            {
+                var catalog = await Api.GetListAsync<RecipeListDto>("/api/recipes");
+                templateById = catalog.Where(t => refIds.Contains(t.Id)).ToDictionary(t => t.Id);
+            }
+            else
+            {
+                templateById = new();
+            }
+        }
+        finally { loading = false; }
+    }
+
+    private bool DriftFor(RecipeListDto fork, int templateId)
+    {
+        if (!templateById.TryGetValue(templateId, out var tpl)) return false;
+        // Compare scalar fields + child collections by content.
+        if (fork.Title != tpl.Title) return true;
+        if (fork.Category != tpl.Category) return true;
+        if (fork.OutputItemId != tpl.OutputItemId) return true;
+        if ((fork.IngredientNotes ?? "") != (tpl.IngredientNotes ?? "")) return true;
+        if (!IngredientsMatch(fork.Ingredients, tpl.Ingredients)) return true;
+        if (!BuildingsMatch(fork.Buildings, tpl.Buildings)) return true;
+        // Skills not compared — template has none (catalog can't reference
+        // GameSkills); fork has them legitimately, so a non-empty skills
+        // list is NOT drift.
+        return false;
+    }
+
+    private static bool IngredientsMatch(IReadOnlyList<RecipeIngredientChipDto> a, IReadOnlyList<RecipeIngredientChipDto> b)
+    {
+        if (a.Count != b.Count) return false;
+        var aMap = a.ToDictionary(x => x.ItemId, x => x.Quantity);
+        return b.All(x => aMap.TryGetValue(x.ItemId, out var q) && q == x.Quantity);
+    }
+
+    private static bool BuildingsMatch(IReadOnlyList<RecipeBuildingChipDto> a, IReadOnlyList<RecipeBuildingChipDto> b)
+    {
+        if (a.Count != b.Count) return false;
+        var aSet = a.Select(x => x.BuildingId).ToHashSet();
+        return b.All(x => aSet.Contains(x.BuildingId));
+    }
+
+    private void OpenEditPopup(RecipeListDto r)
+    {
+        editingRecipeId = r.Id;
+        isEditVisible = true;
+    }
+
+    private async Task CopyFromTemplateAsync()
+    {
+        if (templateId is null) return;
+        copyError = null;
+        isCopying = true;
+        try
+        {
+            var (ok, created, problem) = await Api.PostWithProblemAsync<object, RecipeDetailDto>(
+                $"/api/games/{GameId}/recipes/from-template/{templateId.Value}", new { });
+            if (!ok)
+            {
+                copyError = problem ?? "Vytvoření kopie se nezdařilo.";
+                return;
+            }
+            isFromTemplateVisible = false;
+            templateId = null;
+            await LoadAsync();
+            if (created is not null)
+            {
+                editingRecipeId = created.Id;
+                isEditVisible = true;
+            }
+        }
+        catch (Exception ex) { copyError = ex.Message; }
+        finally { isCopying = false; }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            try { templateCatalog = await Api.GetListAsync<RecipeListDto>("/api/recipes"); }
+            catch (Exception ex) { copyError = ex.Message; templateCatalog = []; }
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Items/ItemDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemDetail.razor
@@ -927,7 +927,15 @@ else
         <div class="oh-it-d-recipe" @key="@($"r-{r.RecipeId}")">
             <div class="oh-it-d-recipe-head">
                 <h5>@r.OutputItemName</h5>
-                <span class="oh-it-d-recipe-game">@r.Game.GameName · ED. @r.Game.Edition</span>
+                @* Issue #218 — Recipe.Game is nullable now (catalog templates have no game). *@
+                @if (r.Game is not null)
+                {
+                    <span class="oh-it-d-recipe-game">@r.Game.GameName · ED. @r.Game.Edition</span>
+                }
+                else
+                {
+                    <span class="oh-it-d-recipe-game oh-it-d-recipe-game--template">Šablona katalogu</span>
+                }
                 @if (!string.IsNullOrWhiteSpace(r.LocationName))
                 {
                     <span class="oh-it-d-recipe-loc"><i class="bi bi-geo-alt me-1"></i>@r.LocationName</span>

--- a/src/OvcinaHra.Client/Pages/Recipes/RecipeDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Recipes/RecipeDetail.razor
@@ -1,0 +1,234 @@
+@page "/recipes/{Id:int}"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject NavigationManager Nav
+@inject GameContextService GameContext
+@implements IDisposable
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+@* Issue #218 — single Karta page with Upravit popup. No Karta/Upravit tab
+   split — edit is gated behind the [Upravit] button which opens
+   RecipeEditPopup (shared with /recipes catalog + per-game grid). *@
+
+<div class="d-flex align-items-center gap-3 mb-3 flex-wrap">
+    <button class="btn btn-sm btn-outline-secondary" type="button"
+            @onclick='() => Nav.NavigateTo("/recipes")'>
+        <i class="bi bi-arrow-left"></i> Zpět na knihu receptů
+    </button>
+    <h1 class="mb-0">@(detail?.Title ?? "Recept")</h1>
+    @if (detail is not null)
+    {
+        <RecipeCategoryChip Category="@detail.Category" />
+    }
+    <div class="ms-auto d-flex gap-2">
+        @if (detail is not null)
+        {
+            <button class="btn btn-sm btn-outline-primary" type="button" @onclick="() => isEditVisible = true">
+                <i class="bi bi-pencil"></i> Upravit
+            </button>
+            @if (CanDelete)
+            {
+                <button class="btn btn-sm btn-outline-danger" type="button" @onclick="() => isDeleteVisible = true">
+                    <i class="bi bi-trash"></i> Smazat
+                </button>
+            }
+        }
+    </div>
+</div>
+
+@if (loading)
+{
+    <p class="text-muted">Načítám…</p>
+}
+else if (detail is null)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-emoji-frown fs-1 d-block mb-2"></i>
+        <p>Recept nenalezen.</p>
+    </div>
+}
+else
+{
+    @* Hero block — formula card in Hero variant *@
+    <RecipeFormulaCard Recipe="@AsListDto(detail)" Variant="RecipeFormulaCard.FormulaVariant.Hero" />
+
+    @* Below the hero: 4 mini-sections matching the issue spec *@
+    <div class="oh-rec-rel-grid mt-3">
+        <section class="oh-rec-rel-section">
+            <h6><i class="bi bi-basket"></i> Vstupní suroviny</h6>
+            @if (detail.Ingredients.Count == 0)
+            {
+                <p class="text-muted small mb-0">Žádné suroviny.</p>
+            }
+            else
+            {
+                <ul class="oh-rec-rel-list">
+                    @foreach (var ing in detail.Ingredients)
+                    {
+                        <li>
+                            <strong>@ing.Name</strong>
+                            <span class="oh-rec-qty">×@ing.Quantity</span>
+                        </li>
+                    }
+                </ul>
+            }
+        </section>
+
+        <section class="oh-rec-rel-section">
+            <h6><i class="bi bi-bag"></i> Výstupní artefakt</h6>
+            <ul class="oh-rec-rel-list">
+                <li>
+                    <strong>@detail.OutputItemName</strong>
+                    @if (detail.OutputQuantity > 1)
+                    {
+                        <span class="oh-rec-qty">×@detail.OutputQuantity</span>
+                    }
+                </li>
+            </ul>
+        </section>
+
+        <section class="oh-rec-rel-section">
+            <h6><i class="bi bi-house"></i> Vyžadováno na stavbě</h6>
+            @if (detail.Buildings.Count == 0)
+            {
+                <p class="text-muted small mb-0">Žádné požadavky na stavbu.</p>
+            }
+            else
+            {
+                <ul class="oh-rec-rel-list">
+                    @foreach (var b in detail.Buildings)
+                    {
+                        <li>
+                            <button type="button" class="oh-rec-rel-link"
+                                    @onclick="@(() => Nav.NavigateTo($"/buildings/{b.BuildingId}"))">
+                                @b.Name <i class="bi bi-arrow-right"></i>
+                            </button>
+                        </li>
+                    }
+                </ul>
+            }
+        </section>
+
+        <section class="oh-rec-rel-section">
+            <h6><i class="bi bi-mortarboard"></i> Vyžaduje dovednost(i)</h6>
+            @if (detail.Skills.Count == 0)
+            {
+                <p class="text-muted small mb-0">Žádné požadavky na dovednost.</p>
+            }
+            else
+            {
+                <ul class="oh-rec-rel-list">
+                    @foreach (var s in detail.Skills)
+                    {
+                        <li><strong>@s.Name</strong></li>
+                    }
+                </ul>
+            }
+        </section>
+    </div>
+
+    @if (!string.IsNullOrWhiteSpace(detail.IngredientNotes))
+    {
+        <div class="oh-rec-notes mt-3">
+            <h6><i class="bi bi-info-circle"></i> Poznámka k surovinám</h6>
+            <p>@detail.IngredientNotes</p>
+        </div>
+    }
+
+    @if (detail.GameId is null && detail.ForksCount > 0)
+    {
+        <div class="alert alert-secondary mt-3 d-flex align-items-center gap-2">
+            <i class="bi bi-files"></i>
+            <span>Šablona je rozkopírovaná do <strong>@detail.ForksCount</strong> her — Smazat je zablokované, dokud kopie existují.</span>
+        </div>
+    }
+}
+
+@* Shared edit popup *@
+<RecipeEditPopup @bind-Visible="isEditVisible" RecipeId="@Id" OnSaved="@LoadAsync" />
+
+@* Delete confirmation *@
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Smazat recept?" Width="420px">
+    <BodyContentTemplate Context="ctx">
+        <p>Smazat recept <strong>@(detail?.Title)</strong>? Akce je nevratná.</p>
+        @if (deleteError is not null)
+        {
+            <div class="alert alert-danger">@deleteError</div>
+        }
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" type="button" @onclick="() => isDeleteVisible = false">Zrušit</button>
+            <button class="btn btn-danger" type="button" @onclick="ConfirmDeleteAsync">Smazat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public int Id { get; set; }
+
+    private RecipeDetailDto? detail;
+    private bool loading = true;
+    private string? error;
+
+    private bool isEditVisible;
+    private bool isDeleteVisible;
+    private string? deleteError;
+
+    private bool CanDelete =>
+        detail is not null && (detail.GameId is not null || detail.ForksCount == 0);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        GameContext.OnGameChanged += OnGameChanged;
+        await LoadAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (detail is not null && detail.Id != Id)
+            await LoadAsync();
+    }
+
+    private async void OnGameChanged() => await LoadAsync();
+
+    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        error = null;
+        try
+        {
+            detail = await Api.GetAsync<RecipeDetailDto>($"/api/recipes/{Id}");
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { loading = false; StateHasChanged(); }
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        if (detail is null) return;
+        deleteError = null;
+        try
+        {
+            var (ok, problem) = await Api.DeleteWithProblemAsync($"/api/recipes/{detail.Id}");
+            if (!ok)
+            {
+                deleteError = problem ?? "Smazání se nezdařilo.";
+                return;
+            }
+            isDeleteVisible = false;
+            Nav.NavigateTo("/recipes");
+        }
+        catch (Exception ex) { deleteError = ex.Message; }
+    }
+
+    // Adapter — RecipeFormulaCard accepts the list DTO; cast detail to it.
+    private static RecipeListDto AsListDto(RecipeDetailDto d) =>
+        new(d.Id, d.Name, d.Title, d.Category, d.GameId, d.TemplateRecipeId,
+            d.OutputItemId, d.OutputItemName, d.OutputItemThumbnailUrl, d.OutputQuantity,
+            d.LocationId, d.LocationName,
+            d.Ingredients, d.Buildings, d.Skills,
+            d.IngredientNotes, d.ForksCount);
+}

--- a/src/OvcinaHra.Client/Pages/Recipes/RecipeList.razor
+++ b/src/OvcinaHra.Client/Pages/Recipes/RecipeList.razor
@@ -1,0 +1,199 @@
+@page "/recipes"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject NavigationManager Nav
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+@* Issue #218 — /recipes cookbook. Vertical list of formula cards filtered
+   to catalog templates (GameId is null). Filter chips for the 4 categories
+   + text search. Click a card → /recipes/{id}. "+ Nový recept" opens a
+   minimal create modal that forwards to detail for full editing. *@
+
+<div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+    <h1 class="mb-0">Kniha receptů</h1>
+    <button class="btn btn-primary" type="button" @onclick="OpenCreateModal">
+        <i class="bi bi-plus-lg"></i> Nový recept
+    </button>
+</div>
+
+<div class="oh-rec-filters mb-3">
+    <DxTextBox Text="@searchText" TextChanged="@((string v) => searchText = v)"
+               NullText="Hledat (název, výstup, surovina)…" CssClass="oh-rec-filter-search" />
+    <div class="oh-rec-cat-pillrow" role="group" aria-label="Filtr podle kategorie">
+        @foreach (var (cat, label) in categoryPills)
+        {
+            <button type="button"
+                    class="oh-rec-cat oh-rec-cat-@CssKey(cat) @(selectedCategories.Contains(cat) ? "oh-rec-cat--on" : "")"
+                    @onclick="() => ToggleCategory(cat)">
+                @label
+            </button>
+        }
+    </div>
+</div>
+
+@if (loading)
+{
+    <p class="text-muted">Načítám…</p>
+}
+else if (filtered.Count == 0)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-journal-text fs-1 d-block mb-2"></i>
+        <p>Zatím tu žádné recepty nejsou…</p>
+        <button class="btn btn-outline-primary" type="button" @onclick="OpenCreateModal">
+            <i class="bi bi-plus-lg"></i> Nový recept
+        </button>
+    </div>
+}
+else
+{
+    <div class="oh-rec-formula-list">
+        @foreach (var r in filtered)
+        {
+            <RecipeFormulaCard Recipe="@r" Variant="RecipeFormulaCard.FormulaVariant.List"
+                               Clickable="true"
+                               OnClick="@(_ => Nav.NavigateTo($"/recipes/{r.Id}"))" />
+        }
+    </div>
+}
+
+@* Minimal create modal — Name + Output + Category. Save → POST /api/recipes
+   with GameId=null then navigate to /recipes/{id} for full editing. *@
+<DxPopup AllowResize="true" @bind-Visible="@isCreateVisible" HeaderText="Nový recept (šablona)" Width="560px">
+    <BodyContentTemplate Context="cCtx">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Název (volitelně)" ColSpanMd="12">
+                <DxTextBox @bind-Text="@createName"
+                           NullText="(výchozí podle výstupu)" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Výstupní předmět" ColSpanMd="8">
+                <DxComboBox Data="@allItems" @bind-Value="@createOutputItemId"
+                            TextFieldName="Name" ValueFieldName="Id"
+                            NullText="(vyberte předmět)"
+                            SearchMode="ListSearchMode.AutoSearch" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Kategorie" ColSpanMd="4">
+                <DxComboBox Data="@categoryValues" @bind-Value="@createCategory"
+                            TextFieldName="Display" ValueFieldName="Value" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        @if (createError is not null)
+        {
+            <div class="alert alert-danger mt-2">@createError</div>
+        }
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" type="button" @onclick="() => isCreateVisible = false" disabled="@isCreating">Zrušit</button>
+            <button class="btn btn-primary" type="button" @onclick="CreateAsync"
+                    disabled="@(isCreating || createOutputItemId is null)">
+                @if (isCreating) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit a otevřít
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    private List<RecipeListDto> recipes = [];
+    private List<ItemListDto> allItems = [];
+    private bool loading = true;
+    private string searchText = "";
+    private HashSet<RecipeCategory> selectedCategories = [];
+
+    private bool isCreateVisible;
+    private bool isCreating;
+    private string? createError;
+    private string? createName;
+    private int? createOutputItemId;
+    private RecipeCategory createCategory = RecipeCategory.Ostatni;
+
+    private static readonly (RecipeCategory Cat, string Label)[] categoryPills =
+    [
+        (RecipeCategory.Budova,   "Budova"),
+        (RecipeCategory.Lektvar,  "Lektvar"),
+        (RecipeCategory.Artefakt, "Artefakt"),
+        (RecipeCategory.Ostatni,  "Ostatní")
+    ];
+
+    private static readonly List<EnumItem<RecipeCategory>> categoryValues = Enum.GetValues<RecipeCategory>()
+        .Select(v => new EnumItem<RecipeCategory>(v, v.GetDisplayName())).ToList();
+
+    private record EnumItem<T>(T Value, string Display);
+
+    private List<RecipeListDto> filtered =>
+        recipes.Where(r =>
+            (selectedCategories.Count == 0 || selectedCategories.Contains(r.Category))
+            && (string.IsNullOrWhiteSpace(searchText)
+                || r.Title.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                || r.OutputItemName.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                || r.Ingredients.Any(i => i.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase))))
+            .ToList();
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        try
+        {
+            var recipesTask = Api.GetListAsync<RecipeListDto>("/api/recipes");
+            var itemsTask = Api.GetListAsync<ItemListDto>("/api/items");
+            await Task.WhenAll(recipesTask, itemsTask);
+            recipes = await recipesTask;
+            allItems = await itemsTask;
+        }
+        finally { loading = false; }
+    }
+
+    private void ToggleCategory(RecipeCategory c)
+    {
+        if (!selectedCategories.Add(c))
+            selectedCategories.Remove(c);
+    }
+
+    private static string CssKey(RecipeCategory c) => c switch
+    {
+        RecipeCategory.Budova    => "budova",
+        RecipeCategory.Lektvar   => "lektvar",
+        RecipeCategory.Artefakt  => "artefakt",
+        _                        => "ostatni"
+    };
+
+    private void OpenCreateModal()
+    {
+        createName = null;
+        createOutputItemId = null;
+        createCategory = RecipeCategory.Ostatni;
+        createError = null;
+        isCreateVisible = true;
+    }
+
+    private async Task CreateAsync()
+    {
+        if (createOutputItemId is null) return;
+        createError = null;
+        isCreating = true;
+        try
+        {
+            var dto = new CreateRecipeDto(
+                Name: string.IsNullOrWhiteSpace(createName) ? null : createName.Trim(),
+                OutputItemId: createOutputItemId.Value,
+                Category: createCategory,
+                GameId: null);
+            var (ok, created, problem) = await Api.PostWithProblemAsync<CreateRecipeDto, RecipeDetailDto>(
+                "/api/recipes", dto);
+            if (!ok)
+            {
+                createError = problem ?? "Vytvoření receptu se nezdařilo.";
+                return;
+            }
+            isCreateVisible = false;
+            if (created is not null)
+                Nav.NavigateTo($"/recipes/{created.Id}");
+            else
+                await LoadAsync();
+        }
+        catch (Exception ex) { createError = ex.Message; }
+        finally { isCreating = false; }
+    }
+}

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3888,3 +3888,150 @@
     .oh-map-tb{flex-wrap:wrap;gap:8px}
     .oh-map-tb-counts{margin-left:0;flex-basis:100%}
 }
+/* ===========================================================================
+ * Recipe category palette — 4 tokens for the cookbook category chips
+ * (issue #218). Hex values match the mockup. Reuse anywhere a recipe-like
+ * category needs a colour cue.
+ * =========================================================================== */
+:root{
+    --oh-rec-cat-budova:    #6E5A3A;
+    --oh-rec-cat-lektvar:   #5A8B3A;
+    --oh-rec-cat-artefakt:  #8C2423;
+    --oh-rec-cat-ostatni:   #6E6E6E;
+}
+
+/* ===========================================================================
+ * Recipes — /recipes cookbook · /recipes/{id} Karta · /games/{gid}/recipes
+ * per-game grid · RecipeEditPopup · RecipeCategoryChip (issue #218).
+ * Class prefix .oh-rec-* — reserved per design canon.
+ * =========================================================================== */
+
+/* Filters above the cookbook */
+.oh-rec-filters{display:flex;gap:14px;align-items:center;flex-wrap:wrap;
+    padding:10px 12px;background:#FFF8F0;border:1px solid #ead9b8;border-radius:8px}
+.oh-rec-filter-search{min-width:240px;flex:1 1 240px}
+
+/* Category chip (also doubles as filter pill on /recipes toolbar) */
+.oh-rec-cat{display:inline-flex;align-items:center;gap:5px;padding:3px 10px;
+    border-radius:999px;border:1px solid currentColor;background:transparent;
+    font:600 .75rem/1.3 var(--oh-font-body,inherit);cursor:pointer;
+    color:var(--oh-rec-cat-color,#3a2e1a);transition:.15s ease}
+.oh-rec-cat:hover{background:rgba(0,0,0,.04)}
+.oh-rec-cat--on{background:var(--oh-rec-cat-color,#3a2e1a);color:#FFF8F0}
+.oh-rec-cat-budova{--oh-rec-cat-color:var(--oh-rec-cat-budova)}
+.oh-rec-cat-lektvar{--oh-rec-cat-color:var(--oh-rec-cat-lektvar)}
+.oh-rec-cat-artefakt{--oh-rec-cat-color:var(--oh-rec-cat-artefakt)}
+.oh-rec-cat-ostatni{--oh-rec-cat-color:var(--oh-rec-cat-ostatni)}
+.oh-rec-cat-pillrow{display:inline-flex;gap:6px;flex-wrap:wrap}
+
+/* Source + drift badges */
+.oh-rec-src-badge{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;
+    border-radius:4px;font:600 .7rem/1.4 var(--oh-font-mono,ui-monospace,monospace)}
+.oh-rec-src-badge--template{background:rgba(45,80,22,.1);color:#2D5016;border:1px solid rgba(45,80,22,.4)}
+.oh-rec-src-badge--fork{background:rgba(178,98,35,.1);color:#6c4720;border:1px solid rgba(178,98,35,.4)}
+.oh-rec-src-badge--scratch{background:rgba(60,60,60,.1);color:#3a2e1a;border:1px solid rgba(60,60,60,.3)}
+.oh-rec-drift-ic{color:#8C2423;font-size:1.1rem;display:inline-flex;align-items:center}
+
+/* Cookbook list — vertical stack of formula cards */
+.oh-rec-formula-list{display:flex;flex-direction:column;gap:14px}
+
+/* Formula card — base styling shared across variants */
+.oh-rec-fc{position:relative;background:#FFF8F0;border:1px solid #ead9b8;
+    border-left:4px solid var(--oh-rec-cat-color,#6E6E6E);
+    border-radius:8px;padding:12px 16px;display:flex;flex-direction:column;gap:10px;
+    transition:.15s ease;text-align:left}
+.oh-rec-fc.oh-rec-cat-budova{--oh-rec-cat-color:var(--oh-rec-cat-budova)}
+.oh-rec-fc.oh-rec-cat-lektvar{--oh-rec-cat-color:var(--oh-rec-cat-lektvar)}
+.oh-rec-fc.oh-rec-cat-artefakt{--oh-rec-cat-color:var(--oh-rec-cat-artefakt)}
+.oh-rec-fc.oh-rec-cat-ostatni{--oh-rec-cat-color:var(--oh-rec-cat-ostatni)}
+.oh-rec-fc--clickable{cursor:pointer}
+.oh-rec-fc--clickable:hover{box-shadow:0 4px 12px rgba(45,80,22,.16);border-color:#2D5016}
+.oh-rec-fc--clickable:focus-visible{outline:3px solid #2D5016;outline-offset:2px}
+
+.oh-rec-fc-top{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+.oh-rec-fc-num{font:600 .75rem/1 var(--oh-font-mono,ui-monospace,monospace);
+    color:#7a6f50;background:#f5f0e1;padding:2px 8px;border-radius:4px;border:1px solid #d8d2be}
+.oh-rec-fc-name{font:700 1.05rem/1.25 var(--oh-font-headline,Merriweather,Georgia,serif);
+    color:#2a2218;margin:0;flex:1;min-width:0}
+
+.oh-rec-fc-body{display:grid;grid-template-columns:1fr auto auto;align-items:center;gap:14px}
+.oh-rec-fc-inputs{display:flex;flex-wrap:wrap;gap:6px}
+.oh-rec-fc-empty{font:italic 400 .85rem/1.4 Georgia,serif;color:#a89e7a}
+.oh-rec-fc-ing-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;
+    background:#fff;border:1px solid #ead9b8;border-radius:6px;
+    font:500 .8rem/1.3 var(--oh-font-body,inherit);color:#3a2e1a}
+.oh-rec-fc-ing-thumb{width:20px;height:20px;border-radius:3px;overflow:hidden;
+    background:#f5f0e1;display:inline-flex;align-items:center;justify-content:center;
+    color:#7a6f50;font-size:.85rem}
+.oh-rec-fc-ing-thumb img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-rec-fc-ing-name{flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:140px}
+.oh-rec-qty{font:600 .75rem/1.2 var(--oh-font-mono,ui-monospace,monospace);
+    color:#6c4720;background:rgba(178,98,35,.1);padding:1px 6px;border-radius:3px}
+.oh-rec-qty--out{background:rgba(45,80,22,.1);color:#2D5016}
+
+.oh-rec-fc-arrow{color:var(--oh-rec-cat-color,#6E6E6E);font-size:1.4rem;display:flex;align-items:center}
+
+.oh-rec-fc-output{display:flex;align-items:center;justify-content:flex-end}
+.oh-rec-fc-out-chip{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;
+    background:#fff;border:1px solid var(--oh-rec-cat-color,#6E6E6E);border-radius:6px;
+    font:600 .9rem/1.3 var(--oh-font-headline,Merriweather,Georgia,serif);color:#2a2218}
+.oh-rec-fc-out-thumb{width:36px;height:36px;border-radius:4px;overflow:hidden;
+    background:#f5f0e1;display:inline-flex;align-items:center;justify-content:center;
+    color:#7a6f50;font-size:1.1rem}
+.oh-rec-fc-out-thumb img{width:100%;height:100%;object-fit:cover;display:block}
+
+.oh-rec-fc-req{display:flex;flex-wrap:wrap;gap:6px;padding-top:8px;border-top:1px dashed #ead9b8}
+.oh-rec-fc-req-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;
+    border-radius:999px;font:500 .75rem/1.4 var(--oh-font-body,inherit)}
+.oh-rec-fc-req-chip--building{background:rgba(110,90,58,.1);color:#5a4520;border:1px solid rgba(110,90,58,.4)}
+.oh-rec-fc-req-chip--skill{background:rgba(45,80,22,.1);color:#2D5016;border:1px solid rgba(45,80,22,.4)}
+.oh-rec-fc-req-chip--location{background:rgba(60,60,60,.08);color:#3a2e1a;border:1px solid rgba(60,60,60,.3)}
+
+.oh-rec-fc-notes{display:flex;align-items:flex-start;gap:6px;padding:8px 10px;
+    background:rgba(178,98,35,.06);border-left:3px solid #B26223;border-radius:3px;
+    font:italic 400 .8rem/1.4 Georgia,serif;color:#5a3a18}
+
+.oh-rec-fc-actions{display:flex;gap:6px;justify-content:flex-end}
+
+/* Hero variant for the detail page */
+.oh-rec-fc--hero{padding:20px 24px}
+.oh-rec-fc--hero .oh-rec-fc-name{font-size:1.4rem}
+.oh-rec-fc--hero .oh-rec-fc-body{gap:20px}
+.oh-rec-fc--hero .oh-rec-fc-out-chip{padding:8px 14px;font-size:1.05rem}
+.oh-rec-fc--hero .oh-rec-fc-out-thumb{width:54px;height:54px;font-size:1.4rem}
+
+/* Compact variant — for the Tvorba tab refresh */
+.oh-rec-fc--compact{padding:8px 12px}
+.oh-rec-fc--compact .oh-rec-fc-name{font-size:.95rem}
+.oh-rec-fc--compact .oh-rec-fc-num{font-size:.7rem}
+.oh-rec-fc--compact .oh-rec-fc-body{gap:8px}
+.oh-rec-fc--compact .oh-rec-fc-out-thumb{width:28px;height:28px}
+.oh-rec-fc--compact .oh-rec-fc-out-chip{padding:2px 8px;font-size:.85rem}
+.oh-rec-fc--compact .oh-rec-fc-req{padding-top:4px}
+
+/* Detail Karta related sections */
+.oh-rec-rel-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px}
+.oh-rec-rel-section{background:#FFF8F0;border:1px solid #ead9b8;border-radius:8px;padding:14px}
+.oh-rec-rel-section h6{font:700 .85rem/1 var(--oh-font-headline,Merriweather,Georgia,serif);
+    text-transform:uppercase;letter-spacing:.04em;color:#5a3a18;margin:0 0 10px;display:flex;align-items:center;gap:6px}
+.oh-rec-rel-list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.oh-rec-rel-list li{display:flex;align-items:center;gap:6px;font-size:.9rem;color:#2a2218}
+.oh-rec-rel-link{display:inline-flex;align-items:center;gap:4px;background:none;border:0;padding:0;
+    color:#2D5016;font:inherit;cursor:pointer;text-decoration:underline}
+.oh-rec-rel-link:hover{color:#1a3008}
+
+.oh-rec-notes{background:rgba(178,98,35,.06);border-left:3px solid #B26223;border-radius:3px;padding:10px 14px}
+.oh-rec-notes h6{font:700 .85rem/1 var(--oh-font-headline,Merriweather,Georgia,serif);
+    text-transform:uppercase;letter-spacing:.04em;color:#5a3a18;margin:0 0 6px;display:flex;align-items:center;gap:6px}
+.oh-rec-notes p{font:italic 400 .9rem/1.5 Georgia,serif;color:#3a2e1a;margin:0;white-space:pre-wrap}
+
+/* Mini-thumb in per-game DxGrid */
+.oh-rec-mini-thumb{width:40px;height:40px;border-radius:4px;background:#f5f0e1;
+    border:1px solid #d8d2be;overflow:hidden;display:flex;align-items:center;justify-content:center;color:#7a6f50}
+.oh-rec-mini-thumb img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-rec-grid-chips{display:inline-flex;gap:4px;flex-wrap:wrap}
+
+/* Edit popup section header */
+.oh-rec-popup-section{padding:14px;background:#FFF8F0;border:1px solid #ead9b8;border-radius:8px}
+.oh-rec-popup-section h6{font:700 .9rem/1 var(--oh-font-headline,Merriweather,Georgia,serif);
+    color:#5a3a18;margin:0 0 10px;display:flex;align-items:center;gap:6px}

--- a/src/OvcinaHra.Shared/Domain/Entities/CraftingRecipe.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/CraftingRecipe.cs
@@ -1,9 +1,32 @@
+using OvcinaHra.Shared.Domain.Enums;
+
 namespace OvcinaHra.Shared.Domain.Entities;
 
 public class CraftingRecipe
 {
     public int Id { get; set; }
-    public int GameId { get; set; }
+
+    // Issue #218 — Recipes catalog port. GameId is now nullable: null = catalog
+    // template, set = per-game record (forked from a template OR od-nuly).
+    public int? GameId { get; set; }
+
+    // Issue #218 — recipes carry a name distinct from the output item's name
+    // ("Hojivý lektvar — varianta s šalvějí" producing the catalog "Hojivý
+    // lektvar"). Optional so legacy data without a name still loads — reads
+    // fall back to OutputItem.Name in projections.
+    public string? Name { get; set; }
+
+    // Issue #218 — when this is a per-game fork of a catalog template, points
+    // back to the source template (also a CraftingRecipe row, with GameId
+    // null). Null on catalog templates and on od-nuly per-game records.
+    public int? TemplateRecipeId { get; set; }
+    public CraftingRecipe? TemplateRecipe { get; set; }
+
+    // Issue #218 — 4-value taxonomy (Budova / Lektvar / Artefakt / Ostatní).
+    // Stored as string in PostgreSQL so EnumIsDefined validation works at
+    // the API layer and DB rows stay grep-friendly during data audits.
+    public RecipeCategory Category { get; set; } = RecipeCategory.Ostatni;
+
     public int OutputItemId { get; set; }
     public int? LocationId { get; set; }
 
@@ -13,7 +36,7 @@ public class CraftingRecipe
     // Not tied to any one ingredient; belongs at the recipe level.
     public string? IngredientNotes { get; set; }
 
-    public Game Game { get; set; } = null!;
+    public Game? Game { get; set; }
     public Item OutputItem { get; set; } = null!;
     public Location? Location { get; set; }
     public ICollection<CraftingIngredient> Ingredients { get; set; } = [];

--- a/src/OvcinaHra.Shared/Domain/Enums/RecipeCategory.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/RecipeCategory.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Domain.Enums;
+
+/// <summary>
+/// Recipe taxonomy from the cookbook design (issue #218). Drives the
+/// catalog filter chips and the category-coloured ribbon on each formula
+/// card. Existing rows backfill to <see cref="Ostatni"/> via Migration B
+/// so organizers can re-categorise after the migration.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum RecipeCategory
+{
+    [Display(Name = "Budova")]   Budova,
+    [Display(Name = "Lektvar")]  Lektvar,
+    [Display(Name = "Artefakt")] Artefakt,
+    [Display(Name = "Ostatní")]  Ostatni
+}

--- a/src/OvcinaHra.Shared/Dtos/CraftingDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/CraftingDtos.cs
@@ -1,10 +1,18 @@
+using System.Text.Json.Serialization;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
+
 namespace OvcinaHra.Shared.Dtos;
 
-public record CraftingRecipeListDto(int Id, int OutputItemId, string OutputItemName, int? LocationId, string? LocationName, int GameId);
+// Issue #218 — GameId is now nullable on CraftingRecipe (catalog templates
+// have no game). Existing /api/crafting consumers see null on catalog rows
+// and treat them as "Šablona katalogu". The new /api/recipes surface uses
+// the richer RecipeListDto / RecipeDetailDto records below.
+public record CraftingRecipeListDto(int Id, int OutputItemId, string OutputItemName, int? LocationId, string? LocationName, int? GameId);
 
 public record CraftingRecipeDetailDto(
     int Id, int OutputItemId, string OutputItemName,
-    int? LocationId, string? LocationName, int GameId,
+    int? LocationId, string? LocationName, int? GameId,
     List<CraftingIngredientDto> Ingredients,
     List<CraftingBuildingReqDto> BuildingRequirements)
 {
@@ -18,7 +26,9 @@ public record CraftingRecipeDetailDto(
 }
 
 public record CreateCraftingRecipeDto(
-    int GameId,
+    // Issue #218 — Catalog templates use GameId = null. Existing per-game
+    // /api/crafting POST callers continue to set a value as before.
+    int? GameId,
     int OutputItemId,
     int? LocationId = null,
     IReadOnlyList<int>? RequiredSkillIds = null,
@@ -35,3 +45,84 @@ public record AddCraftingIngredientDto(int ItemId, int Quantity = 1);
 
 public record CraftingBuildingReqDto(int BuildingId, string BuildingName);
 public record AddCraftingBuildingReqDto(int BuildingId);
+
+// ────────────────────────────────────────────────────────────────────────
+// Issue #218 — Recipes catalog (cookbook) — richer DTOs for the new
+// /api/recipes surface. Tile/card/hero rendering powered by these.
+// ────────────────────────────────────────────────────────────────────────
+
+public record RecipeIngredientChipDto(int ItemId, string Name, string? ThumbnailUrl, int Quantity);
+public record RecipeBuildingChipDto(int BuildingId, string Name);
+public record RecipeSkillChipDto(int SkillId, string Name);
+
+public record RecipeListDto(
+    int Id,
+    string? Name,
+    // Title = Name when set, else OutputItem.Name. Convenience field for
+    // formula-card headings that always need something to print.
+    string Title,
+    RecipeCategory Category,
+    int? GameId,
+    int? TemplateRecipeId,
+    int OutputItemId,
+    string OutputItemName,
+    string? OutputItemThumbnailUrl,
+    int OutputQuantity,
+    int? LocationId,
+    string? LocationName,
+    IReadOnlyList<RecipeIngredientChipDto> Ingredients,
+    IReadOnlyList<RecipeBuildingChipDto> Buildings,
+    IReadOnlyList<RecipeSkillChipDto> Skills,
+    string? IngredientNotes,
+    // ForksCount: how many per-game forks point at this template. Drives
+    // the Smazat-blocked muted pill on catalog templates. Always 0 on
+    // per-game rows.
+    int ForksCount = 0)
+{
+    [JsonIgnore] public string CategoryDisplay => Category.GetDisplayName();
+}
+
+public record RecipeDetailDto(
+    int Id,
+    string? Name,
+    string Title,
+    RecipeCategory Category,
+    int? GameId,
+    int? TemplateRecipeId,
+    int OutputItemId,
+    string OutputItemName,
+    string? OutputItemThumbnailUrl,
+    int OutputQuantity,
+    int? LocationId,
+    string? LocationName,
+    IReadOnlyList<RecipeIngredientChipDto> Ingredients,
+    IReadOnlyList<RecipeBuildingChipDto> Buildings,
+    IReadOnlyList<RecipeSkillChipDto> Skills,
+    string? IngredientNotes,
+    int ForksCount = 0)
+{
+    [JsonIgnore] public string CategoryDisplay => Category.GetDisplayName();
+}
+
+public record CreateRecipeDto(
+    string? Name,
+    int OutputItemId,
+    RecipeCategory Category = RecipeCategory.Ostatni,
+    int? GameId = null,
+    int? LocationId = null,
+    int? TemplateRecipeId = null,
+    string? IngredientNotes = null);
+
+public record UpdateRecipeDto(
+    string? Name,
+    int OutputItemId,
+    RecipeCategory Category,
+    int? LocationId = null,
+    // Skills are replaced as a set on update — pass current state to keep
+    // unchanged. Null is treated as empty.
+    IReadOnlyList<int>? RequiredSkillIds = null,
+    string? IngredientNotes = null);
+
+public record AddRecipeIngredientDto(int ItemId, int Quantity = 1);
+public record AddRecipeBuildingDto(int BuildingId);
+public record AddRecipeSkillDto(int GameSkillId);

--- a/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
@@ -162,7 +162,10 @@ public record ItemUsageGameRefDto(int GameId, string GameName, int Edition);
 
 public record ItemUsageRecipeDto(
     int RecipeId,
-    ItemUsageGameRefDto Game,
+    // Issue #218 — Recipe.GameId became nullable (catalog templates have no
+    // game). Game is null on rows where GameId is null. Item Tvorba tab
+    // groups by Game and renders a "Šablona katalogu" header for nulls.
+    ItemUsageGameRefDto? Game,
     int OutputItemId,
     string OutputItemName,
     int? LocationId,

--- a/tests/OvcinaHra.Api.Tests/Endpoints/RecipePhase1Tests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/RecipePhase1Tests.cs
@@ -1,0 +1,218 @@
+using System.Net;
+using System.Net.Http.Json;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+/// <summary>
+/// Phase 1 of the Recipes port (issue #218): adds Recipe.Category enum +
+/// nullable GameId + TemplateRecipeId self-FK + Name. Tests cover the new
+/// /api/recipes endpoints: catalog list/detail, create/update/delete with
+/// the 4-category enum, template fork via /from-template/{id}, and
+/// Smazat-blocking when forks exist.
+/// </summary>
+public class RecipePhase1Tests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    private async Task<ItemDetailDto> CreateItemAsync(string name = "Lektvar")
+    {
+        var r = await Client.PostAsJsonAsync("/api/items", new CreateItemDto(name, ItemType.Potion));
+        return (await r.Content.ReadFromJsonAsync<ItemDetailDto>())!;
+    }
+
+    private async Task<GameDetailDto> CreateGameAsync()
+    {
+        var r = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        return (await r.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    [Fact]
+    public async Task Create_CatalogTemplate_DefaultsCategory_AndKeepsGameIdNull()
+    {
+        var item = await CreateItemAsync();
+        var dto = new CreateRecipeDto(
+            Name: "Hojivý lektvar",
+            OutputItemId: item.Id,
+            Category: RecipeCategory.Lektvar,
+            GameId: null);
+
+        var response = await Client.PostAsJsonAsync("/api/recipes", dto);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var created = await response.Content.ReadFromJsonAsync<RecipeDetailDto>();
+        Assert.NotNull(created);
+        Assert.Equal("Hojivý lektvar", created.Name);
+        Assert.Equal("Hojivý lektvar", created.Title);
+        Assert.Equal(RecipeCategory.Lektvar, created.Category);
+        Assert.Null(created.GameId);
+        Assert.Null(created.TemplateRecipeId);
+        Assert.Empty(created.Ingredients);
+        Assert.Empty(created.Buildings);
+        Assert.Empty(created.Skills);
+        Assert.Equal(0, created.ForksCount);
+    }
+
+    [Fact]
+    public async Task Create_NullName_FallsBackToOutputItemName_OnTitle()
+    {
+        // Title is convenience for the formula card heading; computed when
+        // Name is unset. This guards against a regression where Title is
+        // string.Empty after a "" Name.
+        var item = await CreateItemAsync("Klíč");
+        var response = await Client.PostAsJsonAsync("/api/recipes",
+            new CreateRecipeDto(Name: null, OutputItemId: item.Id));
+        var created = (await response.Content.ReadFromJsonAsync<RecipeDetailDto>())!;
+        Assert.Null(created.Name);
+        Assert.Equal("Klíč", created.Title);
+    }
+
+    [Fact]
+    public async Task GetCatalog_ReturnsOnlyTemplates()
+    {
+        var item = await CreateItemAsync("Šíp");
+        var game = await CreateGameAsync();
+
+        // Catalog template
+        await Client.PostAsJsonAsync("/api/recipes",
+            new CreateRecipeDto("Lovecký šíp", item.Id, RecipeCategory.Artefakt));
+
+        // Per-game record (NOT a fork — od nuly with explicit GameId)
+        await Client.PostAsJsonAsync("/api/recipes",
+            new CreateRecipeDto("Šíp pro hru", item.Id, RecipeCategory.Artefakt, GameId: game.Id));
+
+        var catalog = await Client.GetFromJsonAsync<List<RecipeListDto>>("/api/recipes");
+        Assert.NotNull(catalog);
+        Assert.All(catalog, r => Assert.Null(r.GameId));
+        Assert.Contains(catalog, r => r.Name == "Lovecký šíp");
+        Assert.DoesNotContain(catalog, r => r.Name == "Šíp pro hru");
+    }
+
+    [Fact]
+    public async Task GetByGame_ReturnsOnlyForks_AndOdNuly()
+    {
+        var item = await CreateItemAsync("Šíp");
+        var game = await CreateGameAsync();
+
+        await Client.PostAsJsonAsync("/api/recipes",
+            new CreateRecipeDto("Lovecký šíp", item.Id, RecipeCategory.Artefakt));  // catalog
+        await Client.PostAsJsonAsync("/api/recipes",
+            new CreateRecipeDto("Šíp od nuly", item.Id, RecipeCategory.Artefakt, GameId: game.Id));  // od nuly
+
+        var perGame = await Client.GetFromJsonAsync<List<RecipeListDto>>($"/api/games/{game.Id}/recipes");
+        Assert.NotNull(perGame);
+        Assert.Single(perGame);
+        Assert.Equal("Šíp od nuly", perGame[0].Name);
+        Assert.Equal(game.Id, perGame[0].GameId);
+        Assert.Null(perGame[0].TemplateRecipeId);
+    }
+
+    [Fact]
+    public async Task Update_ChangesCategoryAndName()
+    {
+        var item = await CreateItemAsync();
+        var create = await Client.PostAsJsonAsync("/api/recipes",
+            new CreateRecipeDto("Old Name", item.Id, RecipeCategory.Ostatni));
+        var created = (await create.Content.ReadFromJsonAsync<RecipeDetailDto>())!;
+
+        var updateDto = new UpdateRecipeDto(
+            Name: "New Name",
+            OutputItemId: item.Id,
+            Category: RecipeCategory.Lektvar);
+        var response = await Client.PutAsJsonAsync($"/api/recipes/{created.Id}", updateDto);
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var fetched = await Client.GetFromJsonAsync<RecipeDetailDto>($"/api/recipes/{created.Id}");
+        Assert.NotNull(fetched);
+        Assert.Equal("New Name", fetched.Name);
+        Assert.Equal(RecipeCategory.Lektvar, fetched.Category);
+    }
+
+    [Fact]
+    public async Task CopyFromTemplate_DeepCopiesIngredientsAndBuildings()
+    {
+        var item = await CreateItemAsync();
+        var bricks = await Client.PostAsJsonAsync("/api/items",
+            new CreateItemDto("Cihly", ItemType.Miscellaneous));
+        var brickItem = (await bricks.Content.ReadFromJsonAsync<ItemDetailDto>())!;
+        var building = await Client.PostAsJsonAsync("/api/buildings", new CreateBuildingDto("Kovárna"));
+        var bId = (await building.Content.ReadFromJsonAsync<BuildingDetailDto>())!.Id;
+
+        var template = await Client.PostAsJsonAsync("/api/recipes",
+            new CreateRecipeDto("Šablona", item.Id, RecipeCategory.Artefakt));
+        var templateRecipe = (await template.Content.ReadFromJsonAsync<RecipeDetailDto>())!;
+
+        // Wire ingredients + a building requirement onto the template via the
+        // legacy /api/crafting child routes (the new /api/recipes surface
+        // doesn't duplicate those — issue body says reuse).
+        await Client.PostAsJsonAsync($"/api/crafting/{templateRecipe.Id}/ingredients",
+            new AddCraftingIngredientDto(brickItem.Id, 5));
+        await Client.PostAsJsonAsync($"/api/crafting/{templateRecipe.Id}/buildings",
+            new AddCraftingBuildingReqDto(bId));
+
+        var game = await CreateGameAsync();
+        var copyResponse = await Client.PostAsync(
+            $"/api/games/{game.Id}/recipes/from-template/{templateRecipe.Id}", content: null);
+        Assert.Equal(HttpStatusCode.Created, copyResponse.StatusCode);
+
+        var fork = (await copyResponse.Content.ReadFromJsonAsync<RecipeDetailDto>())!;
+        Assert.Equal(game.Id, fork.GameId);
+        Assert.Equal(templateRecipe.Id, fork.TemplateRecipeId);
+        Assert.Equal(RecipeCategory.Artefakt, fork.Category);
+        // Children deep-copied:
+        Assert.Single(fork.Ingredients);
+        Assert.Equal(brickItem.Id, fork.Ingredients[0].ItemId);
+        Assert.Equal(5, fork.Ingredients[0].Quantity);
+        Assert.Single(fork.Buildings);
+        Assert.Equal(bId, fork.Buildings[0].BuildingId);
+    }
+
+    [Fact]
+    public async Task Delete_CatalogWithForks_ReturnsConflict()
+    {
+        var item = await CreateItemAsync();
+        var template = await Client.PostAsJsonAsync("/api/recipes",
+            new CreateRecipeDto("Šablona", item.Id));
+        var templateRecipe = (await template.Content.ReadFromJsonAsync<RecipeDetailDto>())!;
+
+        var game = await CreateGameAsync();
+        await Client.PostAsync($"/api/games/{game.Id}/recipes/from-template/{templateRecipe.Id}", content: null);
+
+        // Catalog-with-forks DELETE blocked with 409 + ProblemDetails.
+        var deleteResponse = await Client.DeleteAsync($"/api/recipes/{templateRecipe.Id}");
+        Assert.Equal(HttpStatusCode.Conflict, deleteResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_CatalogWithoutForks_Succeeds()
+    {
+        var item = await CreateItemAsync();
+        var create = await Client.PostAsJsonAsync("/api/recipes",
+            new CreateRecipeDto("Lone", item.Id));
+        var created = (await create.Content.ReadFromJsonAsync<RecipeDetailDto>())!;
+
+        var deleteResponse = await Client.DeleteAsync($"/api/recipes/{created.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var getResponse = await Client.GetAsync($"/api/recipes/{created.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_InvalidCategoryEnum_ReturnsBadRequest()
+    {
+        var item = await CreateItemAsync();
+        var create = await Client.PostAsJsonAsync("/api/recipes",
+            new CreateRecipeDto("R", item.Id));
+        var created = (await create.Content.ReadFromJsonAsync<RecipeDetailDto>())!;
+
+        // Cast a stray int to RecipeCategory to bypass JSON's enum-string check.
+        var updateDto = new UpdateRecipeDto(
+            Name: "R",
+            OutputItemId: item.Id,
+            Category: (RecipeCategory)9999);
+        var response = await Client.PutAsJsonAsync($"/api/recipes/{created.Id}", updateDto);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}


### PR DESCRIPTION
Closes #218 (Phase 1).

## What ships

Recipes catalog port — adds the cookbook UX (formula cards), single-page Karta detail with shared edit popup, per-game DxGrid with source badges + drift `≠`, the 4-value `RecipeCategory` taxonomy, and the template-copy fork pattern Skills/Quests use.

### Backend
- `CraftingRecipe.GameId` is now nullable. Catalog templates: `GameId == null`. Per-game forks (or od-nuly): `GameId == gameId`.
- New `CraftingRecipe.TemplateRecipeId` (int?, FK self) — points back to the source template on per-game forks. `ON DELETE SET NULL`.
- New `CraftingRecipe.Name` (string?) — recipes carry a name distinct from their output item ("Hojivý lektvar — varianta s šalvějí" producing the catalog "Hojivý lektvar"). Read paths fall back to `OutputItem.Name` on `Title`.
- New `RecipeCategory` enum (Budova / Lektvar / Artefakt / Ostatní) with Czech `[Display]` labels. Stored as string. Existing rows backfill `defaultValue="Ostatni"` so the migration doesn't fail.
- One combined migration `AddRecipeTemplateForkNameAndCategory` bundles all four schema changes — same DB state as the issue body's two-migration plan, less PR-tree churn.
- New `/api/recipes` endpoint surface alongside the legacy `/api/crafting` routes (kept untouched for current Item Tvorba consumption):
  - `GET /api/recipes` — catalog (`GameId is null`)
  - `GET /api/recipes/{id}` — detail
  - `POST /api/recipes` — create catalog template
  - `PUT /api/recipes/{id}` — update scalars + replace skill set
  - `DELETE /api/recipes/{id}` — block with 409 + ProblemDetails when forks exist
  - `GET /api/games/{gameId}/recipes` — per-game
  - `POST /api/games/{gameId}/recipes/from-template/{templateId}` — deep-copy fork (skills filtered to target game's GameSkill set)
- `ItemUsageRecipeDto.Game` becomes nullable so catalog templates surface on the Item Tvorba tab as "Šablona katalogu".

### Frontend
- **`/recipes`** — `RecipeList.razor` cookbook. Vertical stack of formula cards (List variant), 4-category filter pill row, text search across name + output + ingredients, "+ Nový recept" minimal create modal that navigates to detail.
- **`/recipes/{id}`** — `RecipeDetail.razor` single-page Karta with hero formula card, 4 mini-sections (Vstupní suroviny / Výstupní artefakt / Vyžadováno na stavbě / Vyžaduje dovednost(i)), Upravit button opens shared `RecipeEditPopup`, Smazat blocked with muted notice when ForksCount > 0.
- **`/games/{gid}/recipes`** — `GameRecipes.razor` per-game DxGrid with source badge column (Šablona #N / Od nuly), drift `≠` icon column comparing fork fields against the cached template, "+ Přidat ze šablony" picker calling `/from-template/{tid}`.
- **New components:**
  - `RecipeFormulaCard` — single component with `Variant=List/Hero/Compact`. Sacred-prose rule respected: ingredient names + qty never abbreviated server-side.
  - `RecipeCategoryChip` — small coloured chip driven by `--oh-rec-cat-*` palette tokens.
  - `RecipeEditPopup` — DxPopup edit form with Identita / Suroviny (sacred banner over notes) / Vyžaduje sections. Reuses existing `RecipeIngredientPicker / RecipeBuildingPicker / RecipeSkillPicker / RecipeNotesEditor` leaf components from #142 — same surface, just new parent.
- LayoutKey bumped on per-game grid: `grid-layout-game-recipes-v2`.

### Theme CSS
- New `.oh-rec-*` block (~150 lines) with the 4 RecipeCategory palette tokens on `:root`.
- Reuses existing `.oh-segmented`, `.oh-pill`, `.oh-pill-mono`, `.oh-sacred-banner` shared utilities (Override 3).

## Phase 1 simplifications (Phase 2 follow-ups)

1. **Item Tvorba tab visual refresh deferred.** The compact `RecipeFormulaCard` variant is wired and works on `/recipes`. Swapping `ItemDetail.razor` Tvorba rendering to use it is mechanical — kept out of this PR to limit risk surface. ItemDetail handles the new nullable `Game` gracefully (Šablona katalogu label).
2. **Building-output recipes** (Category=Budova producing a Building) — Phase 1 keeps `OutputItemId` only and uses Category as a tag. Phase 2 will add `OutputBuildingId` polymorphism.
3. **`/api/recipes` doesn't duplicate `/api/crafting/{id}/ingredients` child routes.** Edit popup mixes calls between `/api/recipes` (scalars + skills) and `/api/crafting` (ingredients + buildings). Phase 2 can unify if it's worth the migration cost.
4. **Multi-output recipes, yield variance, time/duration, station capacity, graph view, A6 print** — all flagged in the issue body. Deferred.
5. **Playwright E2E** — intentionally skipped per #92.

## Verification

- `dotnet build OvcinaHra.slnx`: **0 warnings, 0 errors** (`TreatWarningsAsErrors=true`).
- `dotnet test`: **415 / 415 passing** in ~41 s — including 9 new `RecipePhase1Tests`. No regressions in existing Crafting / Item / Skills tests.
- §20 self-check vs merge-base: 10 modified files (all in Recipe/Crafting/Item zones — `ItemDetail.razor`, `ItemDtos.cs`, `ItemEndpoints.cs` updated only for the nullable Game change; everything else is Recipe-zone). New files added: 1 enum + 1 endpoint + 1 migration (+designer) + 4 components + 3 pages + 1 test file.

## Manual test plan

- [ ] `/recipes` cookbook renders formula cards, category-coloured left ribbon visible.
- [ ] Filter pills toggle Budova / Lektvar / Artefakt / Ostatní; multi-select narrows.
- [ ] Text search matches recipe name, output item name, ingredient name.
- [ ] "+ Nový recept" create modal saves a catalog template and navigates to `/recipes/{id}`.
- [ ] `/recipes/{id}` Karta hero renders, 4 related sections show counts, Upravit popup opens populated.
- [ ] Edit popup adds/removes ingredients, buildings; Save replaces skill set on per-game forks.
- [ ] `/games/{gid}/recipes` shows source badges; "Šablona #N" + "Od nuly" both render correctly; `≠` drift icon appears when a fork's category/output/ingredients diverge from its template.
- [ ] "+ Přidat ze šablony" picker forks a template into the current game; deep-copies ingredients + buildings.
- [ ] Smazat on a catalog with forks → blocked notice + 409. Smazat on catalog without forks → succeeds, navigates back.
- [ ] Item Tvorba tab on `ItemDetail` shows "Šablona katalogu" header for catalog recipes (no game).

## Version

No csproj `<Version>` bump — auto-bump CI handles per Override 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)