### PR TITLE
feat(map): URL query state — share map view via ?layers=...&mode=...&style=...&selected=... (closes #215)

### DIFF
--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -3,7 +3,9 @@
 @inject ApiClient Api
 @inject GameContextService GameContext
 @inject IJSRuntime JS
+@inject NavigationManager Nav
 @implements IDisposable
+@using System.Web
 @using OvcinaHra.Shared.Dtos
 
 <AuthorizeView>
@@ -70,6 +72,14 @@
     // a newer one if the user clicks pins faster than the network responds.
     private int _peekRequestId;
 
+    // Issue #215 — URL state. _urlHydratedFromQuery tells the first-load
+    // path to skip localStorage (URL > localStorage > defaults). _urlPushReady
+    // gates PushUrl() until first-load completes so we don't write a fresh
+    // URL on every hydrate-driven state change during boot.
+    private bool _urlHydratedFromQuery;
+    private bool _urlPushReady;
+    private int? _urlPendingSelectedLocationId;
+
     private MapDataDto? _data;
     private bool _peekVisible;
     private bool _peekLoading;
@@ -79,6 +89,9 @@
     {
         await GameContext.InitializeAsync();
         GameContext.OnGameChanged += HandleGameChanged;
+        // Issue #215 — read URL state BEFORE the basemap loads so the
+        // first paint uses the right layers / style / selected pin.
+        HydrateFromUrl();
     }
 
     private void HandleGameChanged()
@@ -98,15 +111,36 @@
         // OnStyleLoaded fires both on first basemap load AND after every
         // SwitchStyle. The data fetch + localStorage hydrate only need to
         // run once; subsequent style swaps just need to repaint the pins
-        // since the new style wipes the old layer (Copilot C3).
+        // since the new style wipes the old layer.
         if (_firstStyleLoadDone)
         {
             await PaintPinsAsync();
             return;
         }
         _firstStyleLoadDone = true;
-        await HydrateLayerStateAsync();
+        // Issue #215 — URL > localStorage > defaults. Only hydrate from
+        // localStorage when the URL didn't already set layer state.
+        if (!_urlHydratedFromQuery)
+        {
+            await HydrateLayerStateAsync();
+        }
+        // Apply URL-derived style now that the basemap is ready (default
+        // is "tourist", so we only need to switch when URL asked for
+        // something else). The pin paint happens inside SetStyleAsync.
+        if (_activeStyle != "tourist")
+        {
+            await JS.InvokeVoidAsync("ovcinaMap.switchStyle", _activeStyle);
+        }
         await ReloadDataAndRenderAsync();
+        // Auto-open the URL-pinned peek after data lands, if one was
+        // requested via ?selected=loc:N.
+        if (_urlPendingSelectedLocationId is int pinned)
+        {
+            _urlPendingSelectedLocationId = null;
+            await OpenPeekAsync(pinned);
+        }
+        // First load complete — future state changes are safe to push.
+        _urlPushReady = true;
     }
 
     private async Task HydrateLayerStateAsync()
@@ -183,6 +217,7 @@
         await JS.InvokeVoidAsync("ovcinaMap.setMapPageLayerVisibility",
             change.Layer, change.Visible);
         await PersistLayerStateAsync();
+        PushUrl();
     }
 
     private Task OnModeChange(string mode)
@@ -191,6 +226,7 @@
         // Katalog mode is wired up the same way as Pro hru today —
         // a follow-up issue will add cross-game data + clustering.
         // Switching modes simply re-fires the data load (no-op in MVP).
+        PushUrl();
         return Task.CompletedTask;
     }
 
@@ -200,6 +236,7 @@
         await JS.InvokeVoidAsync("ovcinaMap.switchStyle", style);
         // Style change disposes/re-creates the basemap; pins must repaint.
         await PaintPinsAsync();
+        PushUrl();
     }
 
     private async Task OnPinClickedAsync((string Kind, int Id) click)
@@ -234,12 +271,102 @@
         _peek = loaded;
         _peekLoading = false;
         await InvokeAsync(StateHasChanged);
+        PushUrl(selectedLocationId: locationId);
     }
 
     private void ClosePeek()
     {
         _peekVisible = false;
         _peek = null;
+        PushUrl(selectedLocationId: null);
+    }
+
+    /// <summary>
+    /// Issue #215 — read state from the current URL's query string. Called
+    /// once during OnInitializedAsync, before the first basemap load, so
+    /// the page paints with URL-derived layers / mode / style on first
+    /// render. Sets <see cref="_urlHydratedFromQuery"/> when any param is
+    /// present so the localStorage fallback is skipped (URL wins).
+    /// </summary>
+    private void HydrateFromUrl()
+    {
+        var uri = new Uri(Nav.Uri);
+        if (string.IsNullOrEmpty(uri.Query)) return;
+        var qs = HttpUtility.ParseQueryString(uri.Query);
+        var any = false;
+
+        var layers = qs["layers"];
+        if (layers is not null)
+        {
+            any = true;
+            // Empty string is meaningful — both layers off.
+            var set = layers.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => s.Trim().ToLowerInvariant())
+                .ToHashSet();
+            _locationsVisible = set.Contains("loc");
+            _stashesVisible = set.Contains("stash");
+        }
+
+        var mode = qs["mode"];
+        if (mode is "pro-hru" or "katalog") { _mode = mode; any = true; }
+
+        var style = qs["style"];
+        if (style is "tourist" or "aerial" or "basic" or "osm")
+        {
+            _activeStyle = style; any = true;
+        }
+
+        var selected = qs["selected"];
+        if (!string.IsNullOrEmpty(selected) && selected.StartsWith("loc:")
+            && int.TryParse(selected[4..], out var id))
+        {
+            _urlPendingSelectedLocationId = id;
+            any = true;
+        }
+
+        _urlHydratedFromQuery = any;
+    }
+
+    /// <summary>
+    /// Issue #215 — emit the current state into the URL via
+    /// NavigationManager.NavigateTo with replace:true so back/forward
+    /// don't accumulate one history entry per click. Default values are
+    /// omitted from the query string so a fresh load reads cleanly.
+    /// </summary>
+    /// <param name="selectedLocationId">
+    /// <c>null</c> means "no peek open" (drops the param). When the
+    /// caller is itself the open/close peek path, pass the new value
+    /// explicitly so we don't read stale fields here.
+    /// </param>
+    private void PushUrl(int? selectedLocationId = -1)
+    {
+        if (!_urlPushReady) return;
+
+        var pairs = new List<string>();
+
+        // Layers — emit only when not the default (both visible).
+        if (!(_locationsVisible && _stashesVisible))
+        {
+            var parts = new List<string>(2);
+            if (_locationsVisible) parts.Add("loc");
+            if (_stashesVisible) parts.Add("stash");
+            // Empty string is meaningful (both off); always emit the key.
+            pairs.Add($"layers={Uri.EscapeDataString(string.Join(',', parts))}");
+        }
+
+        if (_mode != "pro-hru") pairs.Add($"mode={Uri.EscapeDataString(_mode)}");
+        if (_activeStyle != "tourist") pairs.Add($"style={Uri.EscapeDataString(_activeStyle)}");
+
+        // Sentinel -1 means "use current peek state"; null means "drop";
+        // any other int means that's the new selection.
+        int? selectionToEmit = selectedLocationId == -1
+            ? (_peekVisible ? _peek?.Id : null)
+            : selectedLocationId;
+        if (selectionToEmit is int sel)
+            pairs.Add($"selected={Uri.EscapeDataString($"loc:{sel}")}");
+
+        var query = pairs.Count == 0 ? "" : "?" + string.Join('&', pairs);
+        Nav.NavigateTo($"/map{query}", forceLoad: false, replace: true);
     }
 
     private record LayerState(bool Locations, bool Stashes);

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -72,13 +72,17 @@
     // a newer one if the user clicks pins faster than the network responds.
     private int _peekRequestId;
 
-    // Issue #215 — URL state. _urlHydratedFromQuery tells the first-load
-    // path to skip localStorage (URL > localStorage > defaults). _urlPushReady
-    // gates PushUrl() until first-load completes so we don't write a fresh
-    // URL on every hydrate-driven state change during boot.
-    private bool _urlHydratedFromQuery;
+    // Issue #215 — URL state. Per-field hydration flags (Copilot caught
+    // the broad _urlHydratedFromQuery suppressing layer localStorage when
+    // only ?mode=... was present). _urlPushReady gates PushUrl() until
+    // first-load completes so we don't write a fresh URL on every
+    // hydrate-driven state change during boot. _selectedLocationId tracks
+    // the active peek separately from _peek so PushUrl() emits a stable
+    // value even while a slow peek fetch is still in flight.
+    private bool _urlLayersHydratedFromQuery;
     private bool _urlPushReady;
     private int? _urlPendingSelectedLocationId;
+    private int? _selectedLocationId;
 
     private MapDataDto? _data;
     private bool _peekVisible;
@@ -118,15 +122,19 @@
             return;
         }
         _firstStyleLoadDone = true;
-        // Issue #215 — URL > localStorage > defaults. Only hydrate from
-        // localStorage when the URL didn't already set layer state.
-        if (!_urlHydratedFromQuery)
+        // Issue #215 — URL > localStorage > defaults, applied per-field.
+        // Only the layer-visibility hydration consults localStorage, so
+        // we only skip it when the URL actually provided ?layers=...
+        // (Copilot caught the broad flag suppressing layer prefs when
+        // unrelated params like ?mode=... were present).
+        if (!_urlLayersHydratedFromQuery)
         {
             await HydrateLayerStateAsync();
         }
         // Apply URL-derived style now that the basemap is ready (default
         // is "tourist", so we only need to switch when URL asked for
-        // something else). The pin paint happens inside SetStyleAsync.
+        // something else). Calling switchStyle directly here — going
+        // through SetStyleAsync would push a fresh URL during hydrate.
         if (_activeStyle != "tourist")
         {
             await JS.InvokeVoidAsync("ovcinaMap.switchStyle", _activeStyle);
@@ -249,8 +257,12 @@
     {
         // Token guard against fast successive pin clicks — the older
         // request must not be allowed to overwrite the newer peek state
-        // when its response lands late (Copilot C7).
+        // when its response lands late.
         var requestId = ++_peekRequestId;
+        // Issue #215 — track the selected id separately from _peek so an
+        // unrelated PushUrl() (style/layers/mode change) during the peek
+        // fetch still emits ?selected=loc:N (Copilot caught this drop).
+        _selectedLocationId = locationId;
         _peekVisible = true;
         _peekLoading = true;
         _peek = null;
@@ -271,14 +283,16 @@
         _peek = loaded;
         _peekLoading = false;
         await InvokeAsync(StateHasChanged);
-        PushUrl(selectedLocationId: locationId);
+        // _selectedLocationId already set at the top of this method.
+        PushUrl();
     }
 
     private void ClosePeek()
     {
         _peekVisible = false;
         _peek = null;
-        PushUrl(selectedLocationId: null);
+        _selectedLocationId = null;
+        PushUrl();
     }
 
     /// <summary>
@@ -293,38 +307,33 @@
         var uri = new Uri(Nav.Uri);
         if (string.IsNullOrEmpty(uri.Query)) return;
         var qs = HttpUtility.ParseQueryString(uri.Query);
-        var any = false;
 
         var layers = qs["layers"];
         if (layers is not null)
         {
-            any = true;
             // Empty string is meaningful — both layers off.
             var set = layers.Split(',', StringSplitOptions.RemoveEmptyEntries)
                 .Select(s => s.Trim().ToLowerInvariant())
                 .ToHashSet();
             _locationsVisible = set.Contains("loc");
             _stashesVisible = set.Contains("stash");
+            _urlLayersHydratedFromQuery = true;
         }
 
         var mode = qs["mode"];
-        if (mode is "pro-hru" or "katalog") { _mode = mode; any = true; }
+        if (mode is "pro-hru" or "katalog") _mode = mode;
 
         var style = qs["style"];
         if (style is "tourist" or "aerial" or "basic" or "osm")
-        {
-            _activeStyle = style; any = true;
-        }
+            _activeStyle = style;
 
         var selected = qs["selected"];
-        if (!string.IsNullOrEmpty(selected) && selected.StartsWith("loc:")
+        if (!string.IsNullOrEmpty(selected)
+            && selected.StartsWith("loc:", StringComparison.Ordinal)
             && int.TryParse(selected[4..], out var id))
         {
             _urlPendingSelectedLocationId = id;
-            any = true;
         }
-
-        _urlHydratedFromQuery = any;
     }
 
     /// <summary>
@@ -332,13 +341,11 @@
     /// NavigationManager.NavigateTo with replace:true so back/forward
     /// don't accumulate one history entry per click. Default values are
     /// omitted from the query string so a fresh load reads cleanly.
+    /// Selection is sourced from <c>_selectedLocationId</c> (set
+    /// immediately on pin click) rather than the loaded peek payload
+    /// so a slow peek fetch can't drop ?selected= mid-load.
     /// </summary>
-    /// <param name="selectedLocationId">
-    /// <c>null</c> means "no peek open" (drops the param). When the
-    /// caller is itself the open/close peek path, pass the new value
-    /// explicitly so we don't read stale fields here.
-    /// </param>
-    private void PushUrl(int? selectedLocationId = -1)
+    private void PushUrl()
     {
         if (!_urlPushReady) return;
 
@@ -357,12 +364,7 @@
         if (_mode != "pro-hru") pairs.Add($"mode={Uri.EscapeDataString(_mode)}");
         if (_activeStyle != "tourist") pairs.Add($"style={Uri.EscapeDataString(_activeStyle)}");
 
-        // Sentinel -1 means "use current peek state"; null means "drop";
-        // any other int means that's the new selection.
-        int? selectionToEmit = selectedLocationId == -1
-            ? (_peekVisible ? _peek?.Id : null)
-            : selectedLocationId;
-        if (selectionToEmit is int sel)
+        if (_selectedLocationId is int sel)
             pairs.Add($"selected={Uri.EscapeDataString($"loc:{sel}")}");
 
         var query = pairs.Count == 0 ? "" : "?" + string.Join('&', pairs);


### PR DESCRIPTION
**Report @ 09:24 (UTC+2)** — small surgical PR. Single-file change.

## What's wired

`?layers=loc,stash` · `?mode=pro-hru|katalog` · `?style=tourist|aerial|basic|osm` · `?selected=loc:N`

**Hydration priority** is URL > localStorage > defaults:
- `HydrateFromUrl()` runs in `OnInitializedAsync` (before the basemap), parses query params, sets fields, flips `_urlHydratedFromQuery` if anything was found.
- `OnMapReadyAsync` skips the existing localStorage hydrate when the URL already set state. URL-pinned `?selected=loc:N` is queued via `_urlPendingSelectedLocationId` and opened after data lands.

**Push** via `NavigationManager.NavigateTo(..., replace: true)` so back/forward don't accumulate one entry per click. Default values (`pro-hru`, `tourist`, both layers visible, no peek) are omitted so a fresh load reads cleanly. Wired into all four mutation paths:
- `OnLayerVisibilityChange` (every checkbox toggle)
- `OnModeChange` (Pro hru / Katalog)
- `SetStyleAsync` (turistická / letecká / základní / OSM)
- `OpenPeekAsync` (sets `?selected=loc:N`) / `ClosePeek` (drops it)

**`_urlPushReady` gate** — pushes are suppressed until `OnMapReadyAsync` completes, so we don't write a fresh URL on every hydrate-driven state change during boot.

## §20 self-check

```
src/OvcinaHra.Client/Pages/Map/MapPage.razor | 131 ++++++++++++++++++++++++++-
1 file changed, 129 insertions(+), 2 deletions(-)
```

One file. No new components, no JS interop changes, no schema, no API.

## Test plan

- [x] `dotnet build src/OvcinaHra.Client/OvcinaHra.Client.csproj` — 0W/0E
- [ ] Manual: open `/map?layers=loc&mode=katalog&style=aerial&selected=loc:14` — only locations layer visible, Katalog mode active, aerial basemap, peek for location #14 slides in. Toggle a layer → URL updates without history entry. Click a different pin → `?selected=` updates. Hit ESC / backdrop → `?selected=` drops.
- [ ] Manual: open `/map` cold → existing localStorage state restores (pre-existing `oh-map-layers` key still loads).

## Follow-ups (out of scope)

- Add `?center=lat,lng&zoom=N` for sharing the exact viewport (basemap pan/zoom isn't tracked yet).
- Persist `mode` to localStorage too (currently only on URL — defaults to Pro hru on cold reload without query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)