### PR TITLE
fix(characters): surface import-from-registrace failures with top-of-page banner (closes #209)

### DIFF
--- a/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
+++ b/src/OvcinaHra.Client/Pages/Characters/CharacterList.razor
@@ -31,6 +31,17 @@
     </div>
 }
 
+@* Issue #209 — import errors must render at top of page. The save/delete `error`
+   field renders inside the edit DxPopup, which is closed during the import flow,
+   so a separate banner is needed for the organizer to see why import failed. *@
+@if (importError is not null)
+{
+    <div class="alert alert-danger alert-dismissible mb-3">
+        <strong>Import z registrace selhal.</strong> @importError
+        <button type="button" class="btn-close" @onclick="() => importError = null"></button>
+    </div>
+}
+
 @if (loading)
 {
     <p>Načítám...</p>
@@ -314,6 +325,7 @@ else
     private bool isPlayedCharacter;
     private string searchText = "";
     private ImportResultDto? importResult;
+    private string? importError;
 
     private IEnumerable<CharacterListDto> ParentCandidates =>
         allCharacters.Where(c => editingId is null || c.Id != editingId);
@@ -464,25 +476,27 @@ else
     private async Task ImportAsync()
     {
         if (!GameContext.SelectedGameId.HasValue) return;
-        isImporting = true; importResult = null; error = null;
+        isImporting = true; importResult = null; importError = null;
         try
         {
             // Issue #191 — server may return 400 ProblemDetails when the
             // local game is not yet linked to registrace. PostWithProblemAsync
             // surfaces the Czech detail string verbatim ("…klikněte na
             // „Propojit s registrací"") so the organizer knows what to do.
+            // Issue #209 — surface as `importError` (top-of-page banner), not
+            // `error` (which only renders inside the edit popup).
             var (ok, value, problem) = await Api.PostWithProblemAsync<object, ImportResultDto>(
                 $"/api/characters/import/{GameContext.SelectedGameId}", new { });
             if (!ok)
             {
-                error = problem ?? "Server odmítl požadavek bez podrobností.";
+                importError = problem ?? "Server odmítl požadavek bez podrobností.";
                 return;
             }
             importResult = value;
             await LoadAsync();
             await LoadParentSourceAsync();
         }
-        catch (Exception ex) { error = ex.Message; }
+        catch (Exception ex) { importError = ex.Message; }
         finally { isImporting = false; }
     }
 }


### PR DESCRIPTION
## Bug

User clicks **Importovat z registrace**, server returns `400 Bad Request` with proper Czech ProblemDetails (`GameNotLinkedToRegistraceException` path), but **nothing renders on the page**. The screenshot in #209 shows three silent 400s — the user clicked the button three times because there was zero feedback.

## Root cause

The `ImportAsync` handler at `CharacterList.razor:467` correctly sets `error = problem ?? "Server odmítl..."` on failure. **But the rendering of `@error` lives at line 264 — inside the character-edit `DxPopup` (line 115–286).** The Import button is outside the popup; clicking it never opens the popup; therefore the error message has no visible surface.

`PostWithProblemAsync` + `ReadProblemDetailAsync` plumbing was already correct from #191. That fix landed in the helper layer but had no visible UI on this page.

## Fix

- Dedicated `importError` field (separate from popup-scoped `error`)
- `alert-danger` banner at top of page, alongside the existing `importResult` info banner
- `ImportAsync` sets/clears `importError`; `error` stays reserved for save/delete errors inside the popup

```razor
@if (importError is not null)
{
    <div class=""alert alert-danger alert-dismissible mb-3"">
        <strong>Import z registrace selhal.</strong> @importError
        <button type=""button"" class=""btn-close"" @onclick=""() => importError = null""></button>
    </div>
}
```

## Verification

- `dotnet build OvcinaHra.slnx` clean (0 warnings, 0 errors)
- `git diff origin/main --stat`: 1 file, +17/-3, scoped to `CharacterList.razor`

## Manual smoke

After merge: clicking **Importovat z registrace** on a game whose registrace link is missing now surfaces the Czech detail (`"Otevřete Správu her a u dané hry klikněte na "Propojit s registrací"..."`) in a red dismissible banner above the table.

Closes #209.