### PR TITLE
fix(quests): post-merge Copilot findings on QuestWaypoint (closes #224)

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/QuestConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/QuestConfiguration.cs
@@ -68,7 +68,7 @@ public class QuestRewardConfiguration : IEntityTypeConfiguration<QuestReward>
 /// <summary>
 /// Issue #214 — ordered location waypoints inside a quest. Surrogate
 /// PK so reordering doesn't cascade-delete waypoint rows the way a
-/// (QuestId, Order) composite PK would. Filtered unique guard on
+/// (QuestId, Order) composite PK would. Plain unique index on
 /// (QuestId, Order) keeps two waypoints from claiming the same step.
 /// </summary>
 public class QuestWaypointConfiguration : IEntityTypeConfiguration<QuestWaypoint>

--- a/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
@@ -382,7 +383,7 @@ public static class QuestEndpoints
         return TypedResults.Ok(rows);
     }
 
-    private static async Task<Results<Created<QuestWaypointDto>, NotFound, ProblemHttpResult>> AddWaypoint(
+    private static async Task<Results<Ok<QuestWaypointDto>, NotFound, ProblemHttpResult>> AddWaypoint(
         int id, AddQuestWaypointDto dto, WorldDbContext db)
     {
         if (!await db.Quests.AnyAsync(q => q.Id == id)) return TypedResults.NotFound();
@@ -392,9 +393,13 @@ public static class QuestEndpoints
                 detail: $"Lokace s ID {dto.LocationId} neexistuje.",
                 statusCode: StatusCodes.Status400BadRequest);
 
-        // Append at end — next free Order. Reorder/insert lives on the
-        // bulk reorder endpoint so the editor's drag-drop has a single
-        // path that's atomic.
+        // Issue #224 — wrap MAX(Order)+1 read-then-write in a SERIALIZABLE
+        // transaction so two concurrent POSTs can't pick the same next
+        // Order and trip the (QuestId, Order) unique-index violation.
+        // Postgres will retry-fail one of the txns; the editor surfaces
+        // the failure as a banner and the user clicks Add again.
+        await using var tx = await db.Database.BeginTransactionAsync(IsolationLevel.Serializable);
+
         var nextOrder = (await db.QuestWaypoints
             .Where(w => w.QuestId == id)
             .Select(w => (int?)w.Order)
@@ -415,8 +420,15 @@ public static class QuestEndpoints
             .Select(l => l.Name)
             .FirstAsync();
 
-        return TypedResults.Created(
-            $"/api/quests/{id}/waypoints/{wp.Id}",
+        await tx.CommitAsync();
+
+        // Issue #224 — return 200 OK with the DTO instead of 201 Created.
+        // The 201 contract previously emitted a Location header pointing
+        // at /api/quests/{id}/waypoints/{wpId} but no GET-by-id route
+        // existed there. The editor reloads the whole list after add, so
+        // GET-by-id was never load-bearing; dropping the header avoids
+        // shipping a stale link.
+        return TypedResults.Ok(
             new QuestWaypointDto(wp.Id, wp.QuestId, wp.LocationId, locationName, wp.Order, wp.Label));
     }
 
@@ -475,7 +487,7 @@ public static class QuestEndpoints
         {
             return TypedResults.Problem(
                 title: "Neplatné pořadí.",
-                detail: "Seznam ID musí přesně odpovídat existujícím waypointům této úkolu.",
+                detail: "Seznam ID musí přesně odpovídat existujícím waypointům tohoto úkolu.",
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
@@ -492,8 +504,10 @@ public static class QuestEndpoints
         for (var i = 0; i < requested.Count; i++)
         {
             var target = byId[requested[i]];
-            // Reload tracked entity, set the final order. ExecuteUpdate
-            // on a single row by Id keeps each step independent.
+            // ExecuteUpdate on a single row by Id keeps each step
+            // independent of the change tracker — no entity is reloaded
+            // here, the SQL writes directly. Stage 1 already flipped
+            // Order to negatives; this stage writes the final positive.
             await db.QuestWaypoints
                 .Where(w => w.Id == target.Id)
                 .ExecuteUpdateAsync(s => s.SetProperty(w => w.Order, _ => i + 1));

--- a/src/OvcinaHra.Client/Components/QuestWaypointEditor.razor
+++ b/src/OvcinaHra.Client/Components/QuestWaypointEditor.razor
@@ -38,19 +38,19 @@
                             <span class="text-muted small ms-1">· @wp.LocationName</span>
                         }
                     </span>
-                    <button class="btn btn-sm btn-outline-secondary oh-qwp-mv"
+                    <button type="button" class="btn btn-sm btn-outline-secondary oh-qwp-mv"
                             @onclick="() => MoveAsync(idx, idx - 1)"
                             disabled="@(idx == 0 || _busy)"
                             title="Posunout nahoru" aria-label="Posunout nahoru">
                         <i class="bi bi-arrow-up"></i>
                     </button>
-                    <button class="btn btn-sm btn-outline-secondary oh-qwp-mv"
+                    <button type="button" class="btn btn-sm btn-outline-secondary oh-qwp-mv"
                             @onclick="() => MoveAsync(idx, idx + 1)"
                             disabled="@(idx == _waypoints.Count - 1 || _busy)"
                             title="Posunout dolů" aria-label="Posunout dolů">
                         <i class="bi bi-arrow-down"></i>
                     </button>
-                    <button class="btn btn-sm btn-outline-danger oh-qwp-rm"
+                    <button type="button" class="btn btn-sm btn-outline-danger oh-qwp-rm"
                             @onclick="() => RemoveAsync(wp.Id)"
                             disabled="@_busy"
                             title="Odebrat" aria-label="Odebrat">
@@ -72,7 +72,7 @@
         </select>
         <input class="form-control form-control-sm" placeholder="Popisek (volitelný, např. Brod)"
                @bind="_addLabel" maxlength="120" disabled="@_busy" />
-        <button class="btn btn-sm btn-primary"
+        <button type="button" class="btn btn-sm btn-primary"
                 @onclick="AddAsync"
                 disabled="@(_busy || _addLocationId <= 0)">
             <i class="bi bi-plus-lg me-1"></i>Přidat


### PR DESCRIPTION
**Report @ 09:55 (UTC+2)** — small surgical bundle. Issue #224 collected 8 Copilot findings that landed after PR #221 merged.

## Real bugs (4)

- **AddWaypoint `MAX(Order)+1` race** — wrapped in `SERIALIZABLE` transaction so two concurrent POSTs can't pick the same next `Order` and trip the `(QuestId, Order)` unique-index violation.
- **AddWaypoint 201 with no GET-by-id** — switched to `Ok<QuestWaypointDto>` (200). The editor reloads the full list after add; the Location header that pointed at `/api/quests/{id}/waypoints/{wpId}` was a route that didn't exist. Dropping the stale link beats fabricating a route.
- **`QuestWaypointEditor` buttons missing `type="button"`** — all four action buttons (↑, ↓, remove, add) now explicit so a future `<form>` wrap can't fire unintended submit/navigation.
- **Czech grammar** — "této úkolu" → "tohoto úkolu" in the reorder `ProblemDetails`.

## Doc nits (2)

- EF config XML doc: "Filtered unique guard" → "Plain unique index" (the (QuestId, Order) index isn't filtered; Order is non-nullable).
- Reorder loop comment rewritten — the previous "Reload tracked entity" line was misleading because `ExecuteUpdate` writes SQL directly with no tracking involved.

## Deferred (queued in #224 follow-up notes if you want them split)

- **GameId scoping for editor combobox** — loads full `/api/locations` catalog today; should use `/api/locations/by-game/{gid}` when the quest is assigned to a game. UX improvement; not a bug.
- **Reorder N+1 `ExecuteUpdate` → single `CASE` UPDATE** — perf optimization. Current pattern is fine for ≤10 waypoints/quest expected scale.

## §20 self-check

```
src/OvcinaHra.Api/Data/Configurations/QuestConfiguration.cs |  4 ++--
src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs                | 24 +++++++++++++++++++-----
src/OvcinaHra.Client/Components/QuestWaypointEditor.razor    | 14 +++++++-------
3 files changed, 28 insertions(+), 14 deletions(-)
```

Three files, all Quest-scoped, surgical changes only. No surprise touches.

## Test plan

- [x] `dotnet build OvcinaHra.slnx` — 0W/0E
- [x] `dotnet test --filter QuestWaypointEndpointTests` — 8/8 green (response-shape change from Created→Ok works because tests `EnsureSuccessStatusCode()` then `ReadFromJsonAsync<QuestWaypointDto>`)
- [ ] Manual smoke: open `/quests/{id}` → "Trasa" tab → add three waypoints rapidly to confirm no unique violation; reorder + delete to verify the editor still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)