### PR TITLE
fix(items): unified Save + double-click detail + DxTextBox crash + Recepty nav (closes #185, #229)

### DIFF
--- a/src/OvcinaHra.Client/Components/OvcinaGrid.razor
+++ b/src/OvcinaHra.Client/Components/OvcinaGrid.razor
@@ -26,6 +26,7 @@
         SelectedDataItems="@SelectedDataItems"
         SelectedDataItemsChanged="@SelectedDataItemsChanged"
         RowClick="@RowClick"
+        RowDoubleClick="@RowDoubleClick"
         ShowGroupPanel="@ShowGroupPanel"
         VirtualScrollingEnabled="true"
         ColumnResizeMode="GridColumnResizeMode.NextColumn"
@@ -63,6 +64,7 @@
     [Parameter] public IReadOnlyList<object>? SelectedDataItems { get; set; }
     [Parameter] public EventCallback<IReadOnlyList<object>> SelectedDataItemsChanged { get; set; }
     [Parameter] public EventCallback<GridRowClickEventArgs> RowClick { get; set; }
+    [Parameter] public EventCallback<GridRowClickEventArgs> RowDoubleClick { get; set; }
     [Parameter] public Action<GridCustomizeElementEventArgs>? CustomizeElement { get; set; }
     [Parameter] public bool ShowSearchBox { get; set; } = true;
     [Parameter] public string? SearchText { get; set; }

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -115,6 +115,10 @@
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-houses-fill ni"></i><span class="oh-nav-label">Budovy</span>
                     </NavLink>
+                    <NavLink class="oh-nav-item" href="recipes">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-journal-richtext ni"></i><span class="oh-nav-label">Recepty</span>
+                    </NavLink>
                     @if (GameContext.SelectedGameId is int hraSkillsGameId)
                     {
                         <NavLink class="oh-nav-item" href="@($"games/{hraSkillsGameId}/skills")">
@@ -167,6 +171,10 @@
                     <NavLink class="oh-nav-item" href="buildings?catalog=true">
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-houses ni"></i><span class="oh-nav-label">Budovy</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="recipes">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-journal-richtext ni"></i><span class="oh-nav-label">Recepty</span>
                     </NavLink>
                     <NavLink class="oh-nav-item" href="skills">
                         <span class="oh-nav-rail"></span>

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -113,7 +113,7 @@ else if (Catalog)
                 CustomizeEditModel="OnCatalogCustomizeEdit"
                 EditModelSaving="OnCatalogSaving"
                 EmptyDataAreaTemplate="ItemsConfusedEmpty"
-                RowClick="@(e => OpenQuickPeek((ItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+                RowDoubleClick="@(e => OpenQuickPeek((ItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             @* Akce — fixed left. Otevřít detail → /items/{id} mirrors the LocationList
                pattern (PR #106). Destructive delete stays on the edit popup; not
@@ -194,6 +194,7 @@ else if (Catalog)
             <DxGridDataColumn FieldName="Effect" Caption="Efekt" Width="320px">
                 <CellEditTemplate>
                     <DxTextBox Text="@(((ItemInlineEditBuffer)context.EditModel).Effect)"
+                               TextExpression="@(() => ((ItemInlineEditBuffer)context.EditModel).Effect)"
                                TextChanged="@(v => ((ItemInlineEditBuffer)context.EditModel).Effect = v)"
                                NullText="(žádný efekt)" />
                 </CellEditTemplate>
@@ -204,6 +205,7 @@ else if (Catalog)
             <DxGridDataColumn FieldName="Note" Caption="Poznámka" Width="240px">
                 <CellEditTemplate>
                     <DxTextBox Text="@(((ItemInlineEditBuffer)context.EditModel).Note)"
+                               TextExpression="@(() => ((ItemInlineEditBuffer)context.EditModel).Note)"
                                TextChanged="@(v => ((ItemInlineEditBuffer)context.EditModel).Note = v)"
                                NullText="(žádná poznámka)" />
                 </CellEditTemplate>
@@ -264,7 +266,7 @@ else
                 CustomizeEditModel="OnGameCustomizeEdit"
                 EditModelSaving="OnGameSaving"
                 EmptyDataAreaTemplate="ItemsConfusedEmpty"
-                RowClick="@(e => OpenQuickPeek((GameItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
+                RowDoubleClick="@(e => OpenQuickPeek((GameItemListDto)e.Grid.GetDataItem(e.VisibleIndex)))">
         <Columns>
             @* Akce — fixed left. Primary "Otevřít detail" button per issue #97.
                The 3-dot context menu column below still owns Upravit / Odebrat /
@@ -415,6 +417,7 @@ else
             <DxGridDataColumn FieldName="Note" Caption="Poznámka" Width="240px" Visible="false">
                 <CellEditTemplate>
                     <DxTextBox Text="@(((GameItemInlineEditBuffer)context.EditModel).Note)"
+                               TextExpression="@(() => ((GameItemInlineEditBuffer)context.EditModel).Note)"
                                TextChanged="@(v => ((GameItemInlineEditBuffer)context.EditModel).Note = v)"
                                NullText="(žádná poznámka)" />
                 </CellEditTemplate>
@@ -429,6 +432,7 @@ else
             <DxGridDataColumn FieldName="SaleCondition" Caption="Podmínka prodeje" Width="240px" Visible="false">
                 <CellEditTemplate>
                     <DxTextBox Text="@(((GameItemInlineEditBuffer)context.EditModel).SaleCondition)"
+                               TextExpression="@(() => ((GameItemInlineEditBuffer)context.EditModel).SaleCondition)"
                                TextChanged="@(v => ((GameItemInlineEditBuffer)context.EditModel).SaleCondition = v)"
                                NullText="(bez podmínky)" />
                 </CellEditTemplate>
@@ -660,8 +664,11 @@ else
                             <DxTextBox @bind-Text="@giSaleCondition" NullText="(bez podmínky)" />
                         </DxFormLayoutItem>
                     </DxFormLayout>
+                    @* Issue #185 — per-game settings persist via the main popup
+                       Save button below; no separate "Uložit nastavení" click needed.
+                       The destructive Odebrat z hry stays separate per the
+                       feedback_ovcinahra_destructive_confirm pattern. *@
                     <div class="d-flex gap-2 mt-2">
-                        <button class="btn btn-sm btn-primary" @onclick="SaveGameItemAsync" disabled="@isSaving">Uložit nastavení</button>
                         <button class="btn btn-sm btn-outline-danger" @onclick="RemoveGameItemAsync" disabled="@isSaving">Odebrat z hry</button>
                     </div>
                 }
@@ -1421,13 +1428,53 @@ else
 
     private async Task SaveAsync()
     {
-        error = null; isSaving = true;
+        error = null;
+
+        // Issue #185 — when the popup also surfaces per-game settings,
+        // mirror ItemDetail.razor's price guards so the unified Save can't
+        // ship an inconsistent state. Negative is blocked at the SpinEdit
+        // input layer too; this is a paranoia check + clear Czech message.
+        if (editingId.HasValue && gameItemExists && GameContext.SelectedGameId.HasValue)
+        {
+            if (giPrice.HasValue && giPrice.Value < 0)
+            {
+                error = "Cena nesmí být záporná.";
+                return;
+            }
+            if (giIsSold && (!giPrice.HasValue || giPrice.Value <= 0))
+            {
+                error = "Prodávaný předmět musí mít cenu vyšší než nula.";
+                return;
+            }
+        }
+
+        isSaving = true;
         try
         {
             if (editingId.HasValue)
+            {
+                // 1) Catalog item.
                 await Api.PutAsync($"/api/items/{editingId}",
                     new UpdateItemDto(name, itemType, effect, physicalForm, isCraftable, reqWarrior, reqArcher, reqMage, reqThief, isUnique, isLimited,
                         Note: note));
+
+                // 2) Per-game GameItem (#185) — only when the item is actually
+                // assigned to the active game. Same DTO + endpoint as the
+                // standalone /items/{id} detail page so the two surfaces stay
+                // coherent. Surfaces the server's Czech ProblemDetails verbatim
+                // (e.g. the #99 GameItem-in-use block).
+                if (gameItemExists && GameContext.SelectedGameId is int gid)
+                {
+                    var (ok, problem) = await Api.PutWithProblemAsync(
+                        $"/api/items/game-item/{gid}/{editingId}",
+                        new UpdateGameItemDto(giPrice, giStockCount, giIsSold, giSaleCondition, giIsFindable));
+                    if (!ok)
+                    {
+                        error = problem ?? "Uložení nastavení pro hru selhalo.";
+                        return;
+                    }
+                }
+            }
             else
             {
                 var created = await Api.PostAsync<CreateItemDto, ItemDetailDto>("/api/items",


### PR DESCRIPTION
## Bugs fixed

Four regressions hitting the **/items** page after the recent inline-edit + ports work landed:

### 1. #185 — popup still required two saves
PR #202 unified Save on the standalone `/items/{id}` detail page, but the per-row edit popup on `/items` (`ItemList.razor`) kept two separate buttons:
- `"Uložit nastavení"` (line 664) → `SaveGameItemAsync` (per-game GameItem)
- `"Uložit"` (line 680) → `SaveAsync` (catalog Item only)

User was clicking both, then reporting the click sequence as the bug. The issue's screenshot was actually the list popup, not the standalone detail page.

**Fix:** `ItemList.SaveAsync` now also PUTs `/api/items/game-item/{gid}/{itemId}` when `editingId.HasValue && gameItemExists`. Mirrors the price guards from `ItemDetail.SaveAsync` (#185 ask 4 — sold ⇒ price > 0; never negative). Standalone `"Uložit nastavení"` button removed; destructive `"Odebrat z hry"` stays separate per `feedback_ovcinahra_destructive_confirm`.

### 2. DxTextBox runtime crash on inline edit
DevExpress 25.2.5 raises:

> `DevExpress.Blazor.Internal.Editors.Models.TextBoxModel requires a value for the 'TextExpression' property. It is specified automatically when you use two-way binding('bind-Text').`

Four sites in `ItemList.razor` used one-way `Text="@..."` + `TextChanged="@..."` without `TextExpression` or `@bind-Text`:
- L196: Effect (catalog grid CellEditTemplate)
- L206: Note (catalog grid)
- L417: Note (per-game grid)
- L432: SaleCondition (per-game grid)

Click a cell → crash → grid blanks. Same shape as `DxSpinEdit` already getting `ValueExpression` correctly (L367, L390).

**Fix:** Add `TextExpression="@(() => ((Buffer)context.EditModel).Field)"` to each.

### 3. Single-click opens detail → blocks inline edit + double-click
Both grids wired `RowClick` to `OpenQuickPeek`. Clicking a Cena cell opened the peek before the editor could focus, and the user couldn't trigger a double-click at all (the first click already did something).

**Fix:** Added `RowDoubleClick` passthrough to `OvcinaGrid`. `ItemList` switches both grids' detail-open from `RowClick` → `RowDoubleClick`. Single-click now belongs to the cell (inline edit + select); double-click opens the peek.

### 4. #229 — Recepty nav link missing
PR #220 (just merged) added `/recipes` (RecipeList) and `/recipes/{id}` (RecipeDetail) but didn't update `NavMenu.razor`. The cookbook was unreachable from the sidebar.

**Fix:** Add `Recepty` entries (icon `bi-journal-richtext`) to both `hra` and `katalog` panes, slotted alongside `Budovy`.

## Verification

- `dotnet build OvcinaHra.slnx` clean (0 warnings, 0 errors)
- `git diff origin/main --stat`: 3 files, +61/-4, scoped exactly to Items + nav
- §20.2 self-check ✓ — no mass deletions on unrelated files

## Manual smoke (after merge)

- [ ] Open /items, click a Cena cell → no crash, inline editor focuses
- [ ] Single-click a row → no peek opens (was opening before)
- [ ] Double-click a row → peek opens
- [ ] Open per-row edit popup → edit per-game settings (Cena, Sklad, etc.) → click main `Uložit` → both catalog + per-game persist in one click
- [ ] `Odebrat z hry` button still present, still destructive
- [ ] Open sidebar in `hra` mode → Recepty link visible alongside Budovy
- [ ] Switch to `katalog` mode → Recepty link still visible

Closes #185, #229.