### PR TITLE
feat(dev): run Client locally against prod API + DB (with red banner)

### DIFF
--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -102,16 +102,32 @@ try
     builder.Services.AddSingleton(logBuffer);
     builder.Logging.AddProvider(new RingBufferLoggerProvider(logBuffer));
 
-    // CORS for Blazor WASM client
+    // CORS for Blazor WASM client. Configured origins (prod hostname) plus
+    // any localhost / 127.0.0.1 origin so a developer can run the Client
+    // locally with appsettings.LocalAgainstProd.json pointing here. Browsers
+    // can't fake the Origin header across machines, so the localhost branch
+    // is safe — it can only be exercised from the user's own machine.
     builder.Services.AddCors(options =>
     {
+        var configuredOrigins =
+            builder.Configuration.GetSection("Cors:Origins").Get<string[]>()
+            ?? ["https://localhost:5290", "http://localhost:5290"];
         options.AddPolicy("BlazorClient", policy => policy
-            .WithOrigins(
-                builder.Configuration.GetSection("Cors:Origins").Get<string[]>()
-                ?? ["https://localhost:5290", "http://localhost:5290"])
+            .SetIsOriginAllowed(origin =>
+                configuredOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase)
+                || IsLocalhostOrigin(origin))
             .AllowAnyHeader()
             .AllowAnyMethod());
     });
+
+    static bool IsLocalhostOrigin(string origin)
+    {
+        if (string.IsNullOrEmpty(origin)) return false;
+        return origin.StartsWith("https://localhost:", StringComparison.OrdinalIgnoreCase)
+            || origin.StartsWith("http://localhost:", StringComparison.OrdinalIgnoreCase)
+            || origin.StartsWith("https://127.0.0.1:", StringComparison.OrdinalIgnoreCase)
+            || origin.StartsWith("http://127.0.0.1:", StringComparison.OrdinalIgnoreCase);
+    }
 
     var app = builder.Build();
 

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -122,11 +122,13 @@ try
 
     static bool IsLocalhostOrigin(string origin)
     {
-        if (string.IsNullOrEmpty(origin)) return false;
-        return origin.StartsWith("https://localhost:", StringComparison.OrdinalIgnoreCase)
-            || origin.StartsWith("http://localhost:", StringComparison.OrdinalIgnoreCase)
-            || origin.StartsWith("https://127.0.0.1:", StringComparison.OrdinalIgnoreCase)
-            || origin.StartsWith("http://127.0.0.1:", StringComparison.OrdinalIgnoreCase);
+        // Use Uri.IsLoopback rather than StartsWith — covers IPv6 ([::1]),
+        // missing-port forms, and any future loopback aliases without
+        // brittle string prefix checks.
+        if (string.IsNullOrWhiteSpace(origin)) return false;
+        if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri)) return false;
+        return (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+            && uri.IsLoopback;
     }
 
     var app = builder.Build();

--- a/src/OvcinaHra.Client/Components/LocalAgainstProdBanner.razor
+++ b/src/OvcinaHra.Client/Components/LocalAgainstProdBanner.razor
@@ -7,7 +7,7 @@
 @if (string.Equals(Env.Environment, "LocalAgainstProd", System.StringComparison.OrdinalIgnoreCase))
 {
     <div class="oh-prod-warning-banner" role="alert" aria-live="polite">
-        <i class="bi bi-exclamation-triangle-fill"></i>
+        <i class="bi bi-exclamation-triangle-fill" aria-hidden="true"></i>
         <strong>DEV → PROD API</strong>
         <span>Tato instance míří na <code>api.hra.ovcina.cz</code> + skutečnou databázi. Každé Smazat = trvalé smazání. Ber to vážně.</span>
     </div>

--- a/src/OvcinaHra.Client/Components/LocalAgainstProdBanner.razor
+++ b/src/OvcinaHra.Client/Components/LocalAgainstProdBanner.razor
@@ -1,0 +1,14 @@
+@inject Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment Env
+
+@* Red sticky banner shown only when ASPNETCORE_ENVIRONMENT == "LocalAgainstProd"
+   (i.e. the user ran `dotnet run --launch-profile https-against-prod`). It's
+   intentionally not dismissable — every misclick on this build hits the real
+   production database. *@
+@if (string.Equals(Env.Environment, "LocalAgainstProd", System.StringComparison.OrdinalIgnoreCase))
+{
+    <div class="oh-prod-warning-banner" role="alert" aria-live="polite">
+        <i class="bi bi-exclamation-triangle-fill"></i>
+        <strong>DEV → PROD API</strong>
+        <span>Tato instance míří na <code>api.hra.ovcina.cz</code> + skutečnou databázi. Každé Smazat = trvalé smazání. Ber to vážně.</span>
+    </div>
+}

--- a/src/OvcinaHra.Client/Components/LocalAgainstProdBanner.razor.css
+++ b/src/OvcinaHra.Client/Components/LocalAgainstProdBanner.razor.css
@@ -1,7 +1,7 @@
 .oh-prod-warning-banner {
     position: sticky;
     top: 0;
-    z-index: 1100;
+    z-index: 1060;
     display: flex;
     align-items: center;
     gap: 10px;

--- a/src/OvcinaHra.Client/Components/LocalAgainstProdBanner.razor.css
+++ b/src/OvcinaHra.Client/Components/LocalAgainstProdBanner.razor.css
@@ -1,0 +1,36 @@
+.oh-prod-warning-banner {
+    position: sticky;
+    top: 0;
+    z-index: 1100;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 16px;
+    background: repeating-linear-gradient(
+        45deg,
+        #b8253a,
+        #b8253a 14px,
+        #9b1d30 14px,
+        #9b1d30 28px
+    );
+    color: #fff7ea;
+    font-size: 0.92rem;
+    border-bottom: 2px solid #6e1322;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+}
+
+.oh-prod-warning-banner i {
+    font-size: 1.15rem;
+}
+
+.oh-prod-warning-banner code {
+    background: rgba(255, 255, 255, 0.18);
+    color: inherit;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 0.88em;
+}
+
+.oh-prod-warning-banner strong {
+    letter-spacing: 0.04em;
+}

--- a/src/OvcinaHra.Client/Layout/MainLayout.razor
+++ b/src/OvcinaHra.Client/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 
+<LocalAgainstProdBanner />
 <VersionDriftBanner />
 
 <div class="page @(sidebarCollapsed ? "sidebar-collapsed" : "")">

--- a/src/OvcinaHra.Client/Properties/launchSettings.json
+++ b/src/OvcinaHra.Client/Properties/launchSettings.json
@@ -20,6 +20,16 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "https-against-prod": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "applicationUrl": "https://localhost:7153;http://localhost:5104",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "LocalAgainstProd"
+      }
     }
   }
 }

--- a/src/OvcinaHra.Client/wwwroot/appsettings.LocalAgainstProd.json
+++ b/src/OvcinaHra.Client/wwwroot/appsettings.LocalAgainstProd.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Used when running the Client locally against the production API + OIDC. Activate with: dotnet run --launch-profile https-against-prod. The MainLayout banner reminds you what mode you're in.",
+  "ApiBaseUrl": "https://api.hra.ovcina.cz",
+  "OidcAuthority": "https://registrace.ovcina.cz",
+  "OidcClientId": "ovcinahra",
+  "MapLibre": {
+    "GlyphsUrl": "https://ovcinahrastorage.blob.core.windows.net/ovcinahra-fonts/{fontstack}/{range}.pbf"
+  }
+}


### PR DESCRIPTION
## Why

Cut iteration time on UI fixes from **~8 min** (push, wait for CI, wait for Container App rollout, click) to **seconds** (Ctrl+S, refresh). Local build doesn't normally see prod data; this opens an opt-in path.

## Activate

```bash
dotnet run --project src/OvcinaHra.Client --launch-profile https-against-prod
```

The default `https` profile is unchanged — local-API-on-localhost workflow still works the same.

## Pieces

1. **API CORS** — `WithOrigins(...)` → `SetIsOriginAllowed(...)` predicate. Allows the configured prod origin **and** any `https?://localhost:*` / `https?://127.0.0.1:*`. Browsers can't fake the Origin header across machines, so the localhost branch is only ever hit by requests actually originating from a server on the user's own box.

2. **`appsettings.LocalAgainstProd.json`** — mirrors `Production.json` (prod API URL, prod OIDC authority + client id, blob-storage fonts). Loaded when `ASPNETCORE_ENVIRONMENT=LocalAgainstProd`.

3. **`https-against-prod` launch profile** — sets `ASPNETCORE_ENVIRONMENT=LocalAgainstProd`.

4. **`LocalAgainstProdBanner`** — sticky red barber-pole banner across the top of every page in this mode. Not dismissable on purpose; misclick on Smazat = real production delete.

## Side effect — registrace OIDC redirect URI

OIDC login redirects to `registrace.ovcina.cz` and expects to come back to `https://localhost:7153/authentication/login-callback`. The registrace OIDC client config must allow that redirect URI alongside the existing prod one. One-time config change on the registrace side; done outside this PR.

## Production behavior

Unchanged. `Cors:Origins` env var continues to pin `https://hra.ovcina.cz`. The localhost branch in the predicate is only matched when the request actually originates from localhost — every other origin still goes through the configured allowlist.

## Verification

- `dotnet build OvcinaHra.slnx`: 0 warnings, 0 errors
- `git diff origin/main --stat`: 6 files, +90/-4, all scoped to this feature