### PR TITLE
fix(map): fire OnStyleLoadedCallback on initial map load — restores location pins on /map and /treasures

### DIFF
--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -75,6 +75,17 @@ window.ovcinaMap = {
             }
         });
 
+        // Fire OnStyleLoadedCallback once the initial basemap style is fully
+        // loaded so MapPage / TreasurePlanning can paint pins. Without this,
+        // the callback only fires after a style switch — Map page never gets
+        // its first paint trigger and ends up with 0 lokací (regression from
+        // #212 which only wired the switchStyle path).
+        this._map.once('load', () => {
+            if (this._dotnetRef) {
+                this._dotnetRef.invokeMethodAsync('OnStyleLoadedCallback');
+            }
+        });
+
         this._map.addControl(new maplibregl.NavigationControl(), 'top-right');
         this._map.addControl(new maplibregl.ScaleControl(), 'bottom-left');
     },


### PR DESCRIPTION
## Root cause (pinned via [map-diag] logging from PR #235)

\`ovcinaMap.init()\` creates the MapLibre map and wires error/click handlers but **never subscribes to the initial \`load\` event**. Only \`switchStyle()\` invokes \`OnStyleLoadedCallback\`. Result on first nav to /map (and any TreasurePlanning view that mounts MapView):

1. Map renders, basemap tiles load, user sees the basemap ✓
2. But Blazor never gets the ready signal
3. \`MapPage.OnMapReadyAsync\` never fires
4. \`ReloadDataAndRenderAsync\` never fires
5. \`/api/map/data\` never called
6. Pins never painted → **0 lokací** everywhere

Diagnostic output that pinned it:

\`\`\`
[map-diag] OnInitializedAsync entry
[map-diag] After InitializeAsync — SelectedGameId=30
[map-diag] After HydrateFromUrl — _locationsVisible=True, _stashesVisible=True, ...
(END — OnMapReadyAsync entry never logged)
\`\`\`

## Fix

Add \`this._map.once('load', ...)\` in \`init()\` that calls \`invokeMethodAsync('OnStyleLoadedCallback')\`, mirroring the existing \`switchStyle\` path. Affects both /map and TreasurePlanning since both go through MapView.

## Regression source

Introduced in #212 (cartographer's workshop) which added the \`OnStyleLoadedCallback\` infrastructure but only wired it on the \`switchStyle\` path, not on initial init.

Issue #211 was previously closed by PR #219 which only added a partial-GPS coverage banner — didn't actually fix the no-pins-on-load bug. This properly fixes both surfaces.

## Verification

- \`dotnet build\` clean (0 warnings, 0 errors)
- 1 file, +12/-1, JS-only change
- Manual smoke pending after deploy: /map should paint pins immediately on first load (no need to switch style); /treasures pie-pin map likewise

Closes #211 properly.