### PR TITLE
feat(map): per-LocationKind legend with toggle chips + new palette

### DIFF
--- a/src/OvcinaHra.Client/Components/MapLayerRail.razor
+++ b/src/OvcinaHra.Client/Components/MapLayerRail.razor
@@ -1,7 +1,9 @@
-@* Issue #207 — left rail with the two active map layers (Lokace +
-   Skrýše & Poklady). Encounters layer dropped from this PR — see
-   MapDtos.cs scope note. Layer state hydrates from / saves to
-   localStorage via MapPage. *@
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Extensions
+
+@* Issue #207 — left rail with map layers. Lokace expands to per-kind
+   sub-chips so the user can hide individual LocationKinds. Layer +
+   per-kind state hydrates from / saves to localStorage via MapPage. *@
 
 <aside class="oh-map-layer-rail" aria-label="Vrstvy mapy">
     <h2 class="oh-map-layer-title">Vrstvy</h2>
@@ -12,6 +14,31 @@
         <span class="oh-map-layer-lbl">Lokace</span>
         <span class="oh-map-layer-num text-muted">@LocationsCount</span>
     </label>
+
+    @* Per-kind sub-chips — only when the master Lokace layer is on. *@
+    @if (LocationsVisible)
+    {
+        <ul class="oh-map-kind-list">
+            @foreach (var kind in KindOrder)
+            {
+                var isHidden = HiddenKinds.Contains(kind);
+                var count = LocationsByKind?.GetValueOrDefault(kind) ?? 0;
+                var dataKind = kind.ToString().ToLowerInvariant();
+                <li>
+                    <button type="button"
+                            class="oh-map-kind-row @(isHidden ? "is-hidden" : "")"
+                            aria-pressed="@(isHidden ? "false" : "true")"
+                            title="@(isHidden ? "Zobrazit" : "Skrýt") — @kind.GetDisplayName()"
+                            @onclick="@(() => OnKindToggle.InvokeAsync(kind))">
+                        <span class="oh-map-kind-dot" data-kind="@dataKind"></span>
+                        <span class="oh-map-kind-lbl">@kind.GetDisplayName()</span>
+                        <span class="oh-map-kind-num">@count</span>
+                    </button>
+                </li>
+            }
+        </ul>
+    }
+
     <label class="oh-map-layer-row">
         <input type="checkbox" checked="@StashesVisible"
                @onchange="@(e => OnVisibilityChange.InvokeAsync(("stash", (bool)e.Value!)))" />
@@ -30,4 +57,19 @@
     [Parameter] public int LocationsCount { get; set; }
     [Parameter] public int StashesCount { get; set; }
     [Parameter] public EventCallback<(string Layer, bool Visible)> OnVisibilityChange { get; set; }
+    [Parameter] public IReadOnlyDictionary<LocationKind, int>? LocationsByKind { get; set; }
+    [Parameter] public HashSet<LocationKind> HiddenKinds { get; set; } = new();
+    [Parameter] public EventCallback<LocationKind> OnKindToggle { get; set; }
+
+    // Display order — common kinds on top, rare ones at the bottom.
+    private static readonly LocationKind[] KindOrder =
+    [
+        LocationKind.Village,
+        LocationKind.Town,
+        LocationKind.Magical,
+        LocationKind.Hobbit,
+        LocationKind.Wilderness,
+        LocationKind.Dungeon,
+        LocationKind.PointOfInterest,
+    ];
 }

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -7,6 +7,7 @@
 @implements IDisposable
 @using System.Web
 @using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Domain.Enums
 
 <AuthorizeView>
     <Authorized Context="auth">
@@ -39,7 +40,10 @@
                                   StashesVisible="@_stashesVisible"
                                   LocationsCount="@(_data?.Locations.Count ?? 0)"
                                   StashesCount="@(_data?.Stashes.Count ?? 0)"
-                                  OnVisibilityChange="OnLayerVisibilityChange" />
+                                  LocationsByKind="@_locationsByKind"
+                                  HiddenKinds="@_hiddenKinds"
+                                  OnVisibilityChange="OnLayerVisibilityChange"
+                                  OnKindToggle="OnKindToggle" />
 
                     <div class="oh-map-canvas">
                         <div class="oh-map-style-toolbar">
@@ -72,13 +76,22 @@
 </AuthorizeView>
 
 @code {
-    private const string LayerStateKey = "oh-map-layers";
+    // Bumped to v2 when the per-kind chip filter was added (schema now
+    // also persists HiddenKinds). Old v1 entries without HiddenKinds
+    // continue to deserialize via the record's default value.
+    private const string LayerStateKey = "oh-map-layers-v2";
 
     private MapView? _mapView;
     private string _mode = "pro-hru";
     private string _activeStyle = "tourist";
     private bool _locationsVisible = true;
     private bool _stashesVisible = true;
+    // Per-LocationKind hide set. Empty (default) = all kinds visible.
+    // Persists alongside the layer-visibility flags.
+    private HashSet<LocationKind> _hiddenKinds = new();
+    // Built from _data on every reload so the legend chip counters stay
+    // in sync with the active game's data.
+    private IReadOnlyDictionary<LocationKind, int>? _locationsByKind;
     // Issue #216 — phone-only layer rail toggle. CSS gates the visible
     // surface so on tablet/desktop this flag has no effect.
     private bool _railOpen;
@@ -181,6 +194,10 @@
             if (saved is null) return;
             _locationsVisible = saved.Locations;
             _stashesVisible = saved.Stashes;
+            if (saved.HiddenKinds is { Count: > 0 })
+            {
+                _hiddenKinds = saved.HiddenKinds.ToHashSet();
+            }
         }
         catch { /* localStorage unavailable / malformed — keep defaults */ }
     }
@@ -190,7 +207,7 @@
         try
         {
             var json = System.Text.Json.JsonSerializer.Serialize(
-                new LayerState(_locationsVisible, _stashesVisible));
+                new LayerState(_locationsVisible, _stashesVisible, _hiddenKinds.ToList()));
             await JS.InvokeVoidAsync("localStorage.setItem", LayerStateKey, json);
         }
         catch { /* same fallback */ }
@@ -215,6 +232,13 @@
             Console.Error.WriteLine($"[map-diag] /api/map/data FAILED: {ex.GetType().Name}: {ex.Message}");
         }
 
+        // Refresh per-kind counts for the legend chips. Group on the same
+        // payload that PaintPinsAsync iterates, so chip totals always match
+        // what the user sees on the map.
+        _locationsByKind = _data?.Locations
+            .GroupBy(l => l.Kind)
+            .ToDictionary(g => g.Key, g => g.Count());
+
         await PaintPinsAsync();
         await InvokeAsync(StateHasChanged);
     }
@@ -233,6 +257,10 @@
         {
             foreach (var l in _data.Locations)
             {
+                // Skip kinds the user has hidden via the legend chips. The
+                // counts in the rail still show the underlying total, but
+                // the pins drop out of the painted set.
+                if (_hiddenKinds.Contains(l.Kind)) continue;
                 await JS.InvokeVoidAsync("ovcinaMap.addLocationPin",
                     l.Id, l.Lat, l.Lon, l.Name, l.Kind.ToString());
             }
@@ -254,6 +282,16 @@
         else if (change.Layer == "stash") _stashesVisible = change.Visible;
         await JS.InvokeVoidAsync("ovcinaMap.setMapPageLayerVisibility",
             change.Layer, change.Visible);
+        await PersistLayerStateAsync();
+        PushUrl();
+    }
+
+    private async Task OnKindToggle(LocationKind kind)
+    {
+        if (!_hiddenKinds.Add(kind)) _hiddenKinds.Remove(kind);
+        // Repaint instead of toggling the loc layer wholesale — the master
+        // Lokace toggle stays on; only the filtered set changes.
+        await PaintPinsAsync();
         await PersistLayerStateAsync();
         PushUrl();
     }
@@ -364,6 +402,20 @@
         {
             _urlPendingSelectedLocationId = id;
         }
+
+        // Per-kind hide list. URL form: ?hiddenKinds=village,wilderness.
+        // Empty / missing = no kinds hidden (default). Unknown values are
+        // dropped silently so a stale shared link can't break the parser.
+        var hiddenKinds = qs["hiddenKinds"];
+        if (hiddenKinds is not null)
+        {
+            _hiddenKinds = hiddenKinds.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => Enum.TryParse<LocationKind>(s.Trim(), ignoreCase: true, out var k) ? k : (LocationKind?)null)
+                .Where(k => k.HasValue)
+                .Select(k => k!.Value)
+                .ToHashSet();
+            _urlLayersHydratedFromQuery = true;
+        }
     }
 
     /// <summary>
@@ -397,11 +449,20 @@
         if (_selectedLocationId is int sel)
             pairs.Add($"selected={Uri.EscapeDataString($"loc:{sel}")}");
 
+        if (_hiddenKinds.Count > 0)
+        {
+            var kinds = string.Join(',', _hiddenKinds.Select(k => k.ToString().ToLowerInvariant()));
+            pairs.Add($"hiddenKinds={Uri.EscapeDataString(kinds)}");
+        }
+
         var query = pairs.Count == 0 ? "" : "?" + string.Join('&', pairs);
         Nav.NavigateTo($"/map{query}", forceLoad: false, replace: true);
     }
 
-    private record LayerState(bool Locations, bool Stashes);
+    // Persistence schema. HiddenKinds defaults to an empty list so a v1
+    // entry without the field deserializes cleanly (System.Text.Json
+    // tolerates missing properties on records with default values).
+    private record LayerState(bool Locations, bool Stashes, List<LocationKind>? HiddenKinds = null);
 
     public void Dispose() => GameContext.OnGameChanged -= HandleGameChanged;
 }

--- a/src/OvcinaHra.Client/wwwroot/css/app.css
+++ b/src/OvcinaHra.Client/wwwroot/css/app.css
@@ -48,12 +48,16 @@
     --oh-stage-lategame-soft: rgba(140,  36,  35, 0.12);
     --oh-stage-endgame-soft:  rgba( 74,  29,  36, 0.12);
 
-    /* === Location kind (map marker dots — canon) === */
-    --oh-kind-town:       #2c3e50;
-    --oh-kind-village:    #27ae60;
-    --oh-kind-magical:    #8e44ad;
-    --oh-kind-hobbit:     #f39c12;
-    --oh-kind-wilderness: #16a085;
+    /* === Location kind (map marker dots — canon) ===
+       User-confirmed palette 2026-04-26. White wilderness needs a dark
+       border on map pins (see .oh-map-pin-loc[data-kind="wilderness"]). */
+    --oh-kind-town:            #B26BA8;
+    --oh-kind-village:         #FF0000;
+    --oh-kind-magical:         #EAF626;
+    --oh-kind-hobbit:          #9400D4;
+    --oh-kind-wilderness:      #FFFFFF;
+    --oh-kind-dungeon:         #000000;
+    --oh-kind-pointofinterest: #FF6600;
 
     /* === Status === */
     --oh-status-draft: #8B4513;

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2449,8 +2449,8 @@
 .oh-tp-pin-zero[data-kind="magical"]{--c:var(--oh-kind-magical)}
 .oh-tp-pin-zero[data-kind="hobbit"]{--c:var(--oh-kind-hobbit)}
 .oh-tp-pin-zero[data-kind="wilderness"]{--c:var(--oh-kind-wilderness)}
-.oh-tp-pin-zero[data-kind="pointofinterest"]{--c:var(--oh-kind-town)}
-.oh-tp-pin-zero[data-kind="dungeon"]{--c:var(--oh-kind-magical)}
+.oh-tp-pin-zero[data-kind="pointofinterest"]{--c:var(--oh-kind-pointofinterest)}
+.oh-tp-pin-zero[data-kind="dungeon"]{--c:var(--oh-kind-dungeon)}
 .oh-tp-pin-dragtarget{transform:scale(1.18);filter:drop-shadow(0 0 0 4px rgba(212,166,60,.55)) drop-shadow(0 4px 8px rgba(40,25,5,.5));z-index:9;position:relative}
 .oh-tp-pin-dragtarget::after{content:"+";position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);font:700 1.6rem var(--oh-font-mono);color:var(--oh-stage-early);text-shadow:0 1px 2px rgba(0,0,0,.5);pointer-events:none}
 
@@ -3625,6 +3625,24 @@
 .oh-map-layer-lbl{flex:1}
 .oh-map-layer-num{font-variant-numeric:tabular-nums}
 .oh-map-layer-hint{margin-top:8px;line-height:1.3}
+/* Per-LocationKind sub-chips inside the Lokace section. Indented under the
+   master Lokace toggle. Click toggles hidden state — faded to 35% opacity
+   when hidden so the user can see what's filtered out. */
+.oh-map-kind-list{margin:4px 0 6px 18px;padding:0;list-style:none;display:flex;flex-direction:column;gap:2px}
+.oh-map-kind-row{display:flex;align-items:center;gap:8px;padding:4px 6px;cursor:pointer;border-radius:5px;
+    background:transparent;border:0;width:100%;text-align:left;color:inherit;font:inherit}
+.oh-map-kind-row:hover{background:var(--oh-surface-alt,#F2EBD8)}
+.oh-map-kind-row.is-hidden{opacity:.35}
+.oh-map-kind-dot{width:10px;height:10px;border-radius:50%;flex-shrink:0;border:1px solid rgba(0,0,0,.18)}
+.oh-map-kind-dot[data-kind="town"]            {background:var(--oh-kind-town)}
+.oh-map-kind-dot[data-kind="village"]         {background:var(--oh-kind-village)}
+.oh-map-kind-dot[data-kind="magical"]         {background:var(--oh-kind-magical)}
+.oh-map-kind-dot[data-kind="hobbit"]          {background:var(--oh-kind-hobbit)}
+.oh-map-kind-dot[data-kind="wilderness"]      {background:var(--oh-kind-wilderness);border-color:#2a2a2a}
+.oh-map-kind-dot[data-kind="dungeon"]         {background:var(--oh-kind-dungeon)}
+.oh-map-kind-dot[data-kind="pointofinterest"] {background:var(--oh-kind-pointofinterest)}
+.oh-map-kind-lbl{flex:1;font-size:.875rem}
+.oh-map-kind-num{font-variant-numeric:tabular-nums;font-size:.8rem;color:var(--oh-text-muted,#6b6453)}
 .oh-map-canvas{position:relative;border:1px solid var(--oh-border,#d8d2be);border-radius:8px;overflow:hidden}
 .oh-map-style-toolbar{position:absolute;top:8px;right:8px;z-index:10;display:flex;gap:4px;
     background:rgba(250,246,236,.92);padding:3px;border-radius:99px;
@@ -3634,7 +3652,16 @@
 .oh-map-style-btn.is-active{background:#2D5016;color:#fff}
 .oh-map-pin{position:relative;width:18px;height:18px;border-radius:50%;
     border:2px solid #fff;cursor:pointer;box-shadow:0 1px 3px rgba(0,0,0,.45)}
-.oh-map-pin-loc{background:#2D5016}
+.oh-map-pin-loc{background:var(--oh-kind-village,#2D5016)}
+/* Per-LocationKind pin colors — palette tokens in app.css.
+   Wilderness is white so it gets a dark border to stay visible. */
+.oh-map-pin-loc[data-kind="town"]            {background:var(--oh-kind-town)}
+.oh-map-pin-loc[data-kind="village"]         {background:var(--oh-kind-village)}
+.oh-map-pin-loc[data-kind="magical"]         {background:var(--oh-kind-magical)}
+.oh-map-pin-loc[data-kind="hobbit"]          {background:var(--oh-kind-hobbit)}
+.oh-map-pin-loc[data-kind="wilderness"]      {background:var(--oh-kind-wilderness);border-color:#2a2a2a}
+.oh-map-pin-loc[data-kind="dungeon"]         {background:var(--oh-kind-dungeon)}
+.oh-map-pin-loc[data-kind="pointofinterest"] {background:var(--oh-kind-pointofinterest)}
 .oh-map-pin-stash{background:#C19A3A;width:20px;height:20px}
 .oh-map-pin-stash[data-stage="Start"]   {background:#7FA657}
 .oh-map-pin-stash[data-stage="Early"]   {background:#D4A63C}


### PR DESCRIPTION
## Why

Restores the per-kind filter that lived on the pre-#212 map page. The cartographer's-workshop rewrite simplified the legend to just \"Lokace / Skrýše\" — the user wants the per-kind toggle back so they can hide individual LocationKinds (e.g., \"only show Magical lokace and Hobbit\").

## Palette (user-confirmed 2026-04-26)

| Kind | Hex |
|---|---|
| Town | \`#B26BA8\` mauve |
| Village | \`#FF0000\` red |
| Magical | \`#EAF626\` yellow |
| Hobbit | \`#9400D4\` deep purple |
| Wilderness | \`#FFFFFF\` white — pin gets dark border so it stays visible |
| Dungeon | \`#000000\` black, new token |
| PointOfInterest | \`#FF6600\` orange, new token |

Tokens are **global** (in \`app.css\`) so the Treasures pie-pin map also picks up the new colors automatically. Treasures' previous aliasing of dungeon→magical and pointofinterest→town is removed; both now point at their own canonical tokens.

## What

### Pins
- \`.oh-map-pin-loc[data-kind=...]\` rules per kind reading \`var(--oh-kind-...)\`
- Wilderness pins get \`border-color: #2a2a2a\` so the white background doesn't disappear on light terrain

### Layer rail UI (\`MapLayerRail.razor\`)
- Master Lokace + Skrýše toggles unchanged at top of rail
- When Lokace is on, the rail expands into seven sub-chips: dot (kind color) + Czech display name + count
- Click a chip → toggle \`_hiddenKinds\` membership → hidden chips fade to 35% opacity
- Order: Village / Town / Magical / Hobbit / Wilderness / Dungeon / PointOfInterest (common-first)

### State plumbing (\`MapPage.razor\`)
- \`_hiddenKinds: HashSet<LocationKind>\` field, default empty
- \`_locationsByKind\` rebuilt on every reload from \`_data.Locations.GroupBy(l => l.Kind)\`
- \`PaintPinsAsync\` skips pins where \`_hiddenKinds.Contains(l.Kind)\`
- New \`OnKindToggle\` handler: toggle membership, repaint, persist, push URL

### Persistence
- localStorage key bumped: \`oh-map-layers\` → \`oh-map-layers-v2\` (schema added \`HiddenKinds\`). \`LayerState\` record's \`HiddenKinds\` defaults to \`null\` so older entries deserialize cleanly.
- URL query: \`?hiddenKinds=village,wilderness\` — empty/missing = none hidden. Mirrors the #215 pattern (replace history entry, hydrate on first load, unknown values dropped).

## Verification

- \`dotnet build\` clean (0 warnings, 0 errors)
- 4 files, +151/-17, scoped to map + legend + palette
- LayoutKey bump per memory rule \`feedback_ovcinagrid_layoutkey_bump\`

## Manual smoke (after deploy)

- [ ] /map: pins now per-kind colored (village=red, magical=yellow, wilderness=white-with-dark-border, etc.)
- [ ] Layer rail shows seven kind chips under Lokace, each with the matching color dot + count
- [ ] Click \"Vesnice\" chip → village pins disappear from map; chip fades; counter still shows total
- [ ] Refresh page — hidden kinds persist
- [ ] Share URL \`/map?hiddenKinds=village,wilderness\` — opening it hides those kinds from the start
- [ ] /treasures pie-pin map: dungeon and pointofinterest locations now show in their own colors (black / orange) instead of being aliased