### PR TITLE
feat(items): include IngredientNotes + section labels in Recept column

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -227,20 +227,27 @@ public static class ItemEndpoints
 
     private static string? BuildRecipeSummary(CraftingRecipe r)
     {
+        // Each section is labelled (Suroviny / Pozn. / Budovy / Dovednosti)
+        // so the Recept grid column reads cleanly even when fields are
+        // missing or vary across rows.
         var parts = new List<string>();
         if (r.Ingredients.Count > 0)
         {
-            parts.Add(string.Join(", ",
+            parts.Add("Suroviny: " + string.Join(", ",
                 r.Ingredients.OrderBy(i => i.Item.Name).Select(i => $"{i.Quantity}× {i.Item.Name}")));
+        }
+        if (!string.IsNullOrWhiteSpace(r.IngredientNotes))
+        {
+            parts.Add("Pozn.: " + r.IngredientNotes.Trim());
         }
         if (r.BuildingRequirements.Count > 0)
         {
-            parts.Add(string.Join(", ",
+            parts.Add("Budovy: " + string.Join(", ",
                 r.BuildingRequirements.OrderBy(b => b.Building.Name).Select(b => b.Building.Name)));
         }
         if (r.SkillRequirements.Count > 0)
         {
-            parts.Add(string.Join(", ",
+            parts.Add("Dovednosti: " + string.Join(", ",
                 r.SkillRequirements.OrderBy(s => s.GameSkill.Name).Select(s => s.GameSkill.Name)));
         }
         return parts.Count > 0 ? string.Join(" │ ", parts) : null;


### PR DESCRIPTION
## Why

The /items per-game grid Recept column already concatenated ingredients, buildings, and skills, but unlabelled — separated only by `│`. Easy to miss what each section was. And the recipe-level **IngredientNotes** field (e.g. "Byliny — 3× stejný druh") was not included at all.

User asked: *"add the Poznámka k surovinám into the Recept field in the grid. You're already concatenating all the ingredients; just add the notes to it as well. And required buildings and required skills."* — buildings + skills were already in there, but the absence of labels made them invisible.

## What changed

`ItemEndpoints.BuildRecipeSummary` now outputs four labelled sections, each dropped when its underlying field is empty:

```
Suroviny: 3× šalvěj, 2× rmuťavka │ Pozn.: Byliny — 3× stejný druh │
  Budovy: Lékárna │ Dovednosti: Bylinkářství
```

## Notes

- IngredientNotes is a scalar on `CraftingRecipe` already loaded by the existing query — no extra `Include` needed
- Search index unchanged — `gi.RecipeSummary?.Contains(...)` (ItemList:847) still finds matches in any section

## Verification

- `dotnet build` clean (0 warnings, 0 errors)
- 1 file, +10/-3, scoped to `BuildRecipeSummary` helper
- Manual smoke after deploy: reveal Recept column on /items per-game grid → labelled multi-section text visible