### PR TITLE
feat(dashboard,terminology): trim dashboard panels + rename úkol→quest everywhere

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
@@ -59,19 +59,12 @@ public static class DashboardEndpoints
         var itemsNoPrice = await db.GameItems
             .Where(gi => gi.GameId == gameId && gi.IsSold && gi.Price == null)
             .CountAsync();
-        var questsNoEnc = await db.Quests
-            .Where(q => q.GameId == gameId && !q.QuestEncounters.Any())
-            .CountAsync();
         var treasuresUnplaced = await db.TreasureQuests
             .Where(t => t.GameId == gameId && t.LocationId == null && t.SecretStashId == null)
             .CountAsync();
         var emptyStashes = await db.GameSecretStashes
             .Where(gss => gss.GameId == gameId
                 && !db.TreasureQuests.Any(t => t.GameId == gameId && t.SecretStashId == gss.SecretStashId))
-            .CountAsync();
-        var monstersNoLoot = await db.GameMonsters
-            .Where(gm => gm.GameId == gameId
-                && !db.MonsterLoots.Any(ml => ml.GameId == gameId && ml.MonsterId == gm.MonsterId))
             .CountAsync();
         // Game-scoped — Copilot caught these counting catalog-wide and
         // misreporting issues from other games. The skill/spell text lives
@@ -89,14 +82,10 @@ public static class DashboardEndpoints
                 locationsNoGps, Severity(locationsNoGps), "/locations"),
             new("items-no-price", "Předměty bez ceny",
                 itemsNoPrice, Severity(itemsNoPrice), "/items"),
-            new("quests-no-encounters", "Úkoly bez setkání",
-                questsNoEnc, Severity(questsNoEnc), "/quests"),
             new("treasures-unplaced", "Poklady neumístěné",
                 treasuresUnplaced, Severity(treasuresUnplaced), "/treasures"),
             new("empty-stashes", "Skrýše bez pokladu",
                 emptyStashes, Severity(emptyStashes), "/secret-stashes"),
-            new("monsters-no-loot", "Příšery bez kořisti",
-                monstersNoLoot, Severity(monstersNoLoot), "/monsters"),
             new("skills-no-effect", "Dovednosti bez Efektu",
                 skillsNoEffect, Severity(skillsNoEffect), "/skills"),
             new("spells-no-effect", "Kouzla bez Efektu",

--- a/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
@@ -487,7 +487,7 @@ public static class QuestEndpoints
         {
             return TypedResults.Problem(
                 title: "Neplatné pořadí.",
-                detail: "Seznam ID musí přesně odpovídat existujícím waypointům tohoto úkolu.",
+                detail: "Seznam ID musí přesně odpovídat existujícím waypointům tohoto questu.",
                 statusCode: StatusCodes.Status400BadRequest);
         }
 

--- a/src/OvcinaHra.Client/Components/MapLayerRail.razor
+++ b/src/OvcinaHra.Client/Components/MapLayerRail.razor
@@ -47,7 +47,7 @@
         <span class="oh-map-layer-num text-muted">@StashesCount</span>
     </label>
     <p class="oh-map-layer-hint text-muted small fst-italic">
-        Setkání úkolů přibydou, jakmile budou mít body na mapě.
+        Setkání questů přibydou, jakmile budou mít body na mapě.
     </p>
 </aside>
 

--- a/src/OvcinaHra.Client/Components/QuestWaypointEditor.razor
+++ b/src/OvcinaHra.Client/Components/QuestWaypointEditor.razor
@@ -14,13 +14,13 @@
     else if (_waypoints.Count == 0)
     {
         <p class="text-muted small fst-italic mb-2">
-            Tento úkol zatím nemá žádné body trasy.
+            Tento quest zatím nemá žádné body trasy.
             Přidej první lokaci níže — Mapa pak nakreslí cestu mezi nimi.
         </p>
     }
     else
     {
-        <ol class="oh-qwp-list" aria-label="Trasa úkolu">
+        <ol class="oh-qwp-list" aria-label="Trasa questu">
             @for (var i = 0; i < _waypoints.Count; i++)
             {
                 var idx = i;

--- a/src/OvcinaHra.Client/Components/QuickLaunchTiles.razor
+++ b/src/OvcinaHra.Client/Components/QuickLaunchTiles.razor
@@ -25,7 +25,7 @@
         new("loc",   "Lokace",     "bi-geo-alt-fill",   "/locations"),
         new("itm",   "Předměty",   "bi-box-seam",       "/items"),
         new("mon",   "Příšery",    "bi-bug",            "/monsters"),
-        new("qst",   "Úkoly",      "bi-list-check",     "/quests"),
+        new("qst",   "Questy",      "bi-list-check",     "/quests"),
         new("skl",   "Dovednosti", "bi-mortarboard",    "/skills"),
         new("spl",   "Kouzla",     "bi-magic",          "/spells"),
         new("stash", "Skrýše",     "bi-archive",        "/secret-stashes"),

--- a/src/OvcinaHra.Client/Components/StavSvetaStrip.razor
+++ b/src/OvcinaHra.Client/Components/StavSvetaStrip.razor
@@ -25,6 +25,6 @@
         new Cell("Kouzla",      Stats?.SpellsCount     ?? 0, "/spells"),
         new Cell("Dovednosti",  Stats?.SkillsCount     ?? 0, "/skills"),
         new Cell("Poklady",     Stats?.TreasuresCount  ?? 0, "/treasures"),
-        new Cell("Úkoly",       Stats?.QuestsCount     ?? 0, "/quests"),
+        new Cell("Questy",       Stats?.QuestsCount     ?? 0, "/quests"),
     };
 }

--- a/src/OvcinaHra.Client/Pages/Games/GameQuests.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameQuests.razor
@@ -12,10 +12,10 @@
 
 <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
     <div>
-        <h1 class="mb-0">Úkoly hry @(game?.Name)</h1>
+        <h1 class="mb-0">Questy hry @(game?.Name)</h1>
         @if (game is not null)
         {
-            <p class="text-muted small mb-0">edice @game.Edition · @quests.Count úkolů</p>
+            <p class="text-muted small mb-0">edice @game.Edition · @quests.Count questů</p>
         }
     </div>
     <div class="d-flex gap-2">
@@ -52,7 +52,7 @@ else if (filtered.Count == 0)
 {
     <div class="text-center text-muted py-5">
         <i class="bi bi-journal-richtext fs-1 d-block mb-2"></i>
-        <p>Žádné úkoly v této hře odpovídají filtru.</p>
+        <p>Žádné questy v této hře odpovídají filtru.</p>
     </div>
 }
 else
@@ -117,7 +117,7 @@ else
 @* Add-from-template popup: pick a catalog quest, server CopyToGame creates
    the per-game fork with deep-copied tags/locations/encounters/rewards. *@
 <DxPopup AllowResize="true" @bind-Visible="@isFromTemplateVisible"
-         HeaderText="Přidat úkol ze šablony" Width="640px">
+         HeaderText="Přidat quest ze šablony" Width="640px">
     <BodyContentTemplate Context="ctx">
         @if (catalog is null)
         {
@@ -125,7 +125,7 @@ else
         }
         else if (catalog.Count == 0)
         {
-            <p class="text-muted">V katalogu nejsou žádné šablony úkolů.</p>
+            <p class="text-muted">V katalogu nejsou žádné šablony questů.</p>
         }
         else
         {
@@ -164,7 +164,7 @@ else
 </DxPopup>
 
 @* Blank create popup *@
-<DxPopup AllowResize="true" @bind-Visible="@isBlankVisible" HeaderText="Nový úkol (od nuly)" Width="560px">
+<DxPopup AllowResize="true" @bind-Visible="@isBlankVisible" HeaderText="Nový quest (od nuly)" Width="560px">
     <BodyContentTemplate Context="ctx">
         <DxFormLayout>
             <DxFormLayoutItem Caption="Název" ColSpanMd="12">
@@ -324,7 +324,7 @@ else
                 new CreateQuestDto(createName.Trim(), createType, GameId: GameId));
             if (!ok)
             {
-                createError = problem ?? "Vytvoření úkolu se nepodařilo.";
+                createError = problem ?? "Vytvoření questu se nepodařilo.";
                 return;
             }
             isBlankVisible = false;

--- a/src/OvcinaHra.Client/Pages/Home.razor
+++ b/src/OvcinaHra.Client/Pages/Home.razor
@@ -52,7 +52,8 @@
                 }
 
                 <div class="oh-home-bottom-row">
-                    <RecentActivityFeed Rows="_activity" />
+                    @* RecentActivityFeed removed pending real audit log — see issue #247.
+                       Stub feed (per-entity UpdatedAtUtc) was too noisy to keep on the dashboard. *@
                     <QuickLaunchTiles />
                 </div>
             </div>
@@ -72,7 +73,6 @@
 
     private DashboardStatsDto? _stats;
     private DashboardIssuesDto? _issues;
-    private List<DashboardActivityDto>? _activity;
     private List<TimelineRowDto>? _timeline;
 
     protected override async Task OnInitializedAsync()
@@ -89,7 +89,7 @@
         var gameId = GameContext.SelectedGameId;
         if (gameId is null)
         {
-            _stats = null; _issues = null; _activity = null; _timeline = null;
+            _stats = null; _issues = null; _timeline = null;
             await InvokeAsync(StateHasChanged);
             return;
         }
@@ -104,12 +104,10 @@
                 $"/api/dashboard/stats?gameId={gameId.Value}");
             var issuesTask = Api.GetAsync<DashboardIssuesDto>(
                 $"/api/dashboard/issues?gameId={gameId.Value}");
-            var activityTask = Api.GetListAsync<DashboardActivityDto>(
-                $"/api/dashboard/activity?gameId={gameId.Value}&limit=10");
             var timelineTask = Api.GetListAsync<TimelineRowDto>(
                 $"/api/dashboard/timeline?gameId={gameId.Value}&take=6");
 
-            await Task.WhenAll(gameTask, statsTask, issuesTask, activityTask, timelineTask);
+            await Task.WhenAll(gameTask, statsTask, issuesTask, timelineTask);
 
             var game = gameTask.Result;
             if (game is not null)
@@ -121,7 +119,6 @@
             }
             _stats = statsTask.Result;
             _issues = issuesTask.Result;
-            _activity = activityTask.Result;
             _timeline = timelineTask.Result;
             // Drive Hra běží mode from the explicit server bool, not the
             // localised label — Copilot caught the brittle string match.

--- a/src/OvcinaHra.Client/Pages/Quests/QuestDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestDetail.razor
@@ -12,7 +12,7 @@
             @onclick='() => Nav.NavigateTo("/quests")'>
         <i class="bi bi-arrow-left"></i> Zpět
     </button>
-    <h1 class="mb-0">@(quest?.Name ?? "Úkol")</h1>
+    <h1 class="mb-0">@(quest?.Name ?? "Quest")</h1>
     @if (quest is not null && quest.GameId is not null)
     {
         <QuestStateChip State="@quest.State" />
@@ -22,7 +22,7 @@
         {
             <button class="btn btn-sm btn-outline-secondary" type="button"
                     @onclick="@(() => Nav.NavigateTo($"/quests/{Id}/print"))"
-                    title="Otevřít A5 kartu úkolu k tisku">
+                    title="Otevřít A5 kartu questu k tisku">
                 <i class="bi bi-printer"></i> Tisk A5
             </button>
         }
@@ -37,7 +37,7 @@ else if (quest is null && error is not null)
 {
     <div class="alert alert-danger d-flex align-items-center gap-2">
         <i class="bi bi-wifi-off"></i>
-        <span>Nepodařilo se načíst úkol: @error</span>
+        <span>Nepodařilo se načíst quest: @error</span>
         <button type="button" class="btn btn-sm btn-outline-primary ms-auto" @onclick="LoadAsync">Zkusit znovu</button>
     </div>
 }
@@ -45,7 +45,7 @@ else if (quest is null)
 {
     <div class="text-center text-muted py-5">
         <i class="bi bi-emoji-frown fs-1 d-block mb-2"></i>
-        <p>Úkol nenalezen.</p>
+        <p>Quest nenalezen.</p>
     </div>
 }
 else
@@ -186,7 +186,7 @@ else
                                     NullText="(žádné)"
                                     ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
                     </DxFormLayoutItem>
-                    <DxFormLayoutItem Caption="Nadřazený úkol (ID)" ColSpanMd="4">
+                    <DxFormLayoutItem Caption="Nadřazený quest (ID)" ColSpanMd="4">
                         <DxSpinEdit @bind-Value="@editModel.ParentQuestId" MinValue="0"
                                     NullText="(žádný)"
                                     ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
@@ -366,7 +366,7 @@ else
     else if (activeTab == "lokace")
     {
         <div class="oh-qst-loc">
-            <h3 class="mb-3"><i class="bi bi-geo-alt"></i> Lokace tohoto úkolu</h3>
+            <h3 class="mb-3"><i class="bi bi-geo-alt"></i> Lokace tohoto questu</h3>
             @if (quest.Locations.Count == 0)
             {
                 <p class="text-muted">Žádné lokace zatím nejsou přiřazeny.</p>
@@ -430,7 +430,7 @@ else
                 <summary><i class="bi bi-mortarboard"></i> Dovednosti — odměny</summary>
                 <div class="oh-qst-rew-disabled">
                     <i class="bi bi-hourglass-split"></i>
-                    <p class="mb-1">Dovednosti jako odměna úkolu vyžadují novou tabulku QuestSkillReward — plánováno v migraci 0.16.x (#193 follow-up).</p>
+                    <p class="mb-1">Dovednosti jako odměna questu vyžadují novou tabulku QuestSkillReward — plánováno v migraci 0.16.x (#193 follow-up).</p>
                     <button type="button" class="btn btn-outline-secondary btn-sm" disabled>
                         <i class="bi bi-plus"></i> Přidat dovednost (Phase 2)
                     </button>
@@ -440,7 +440,7 @@ else
                 <summary><i class="bi bi-magic"></i> Kouzla — odměny</summary>
                 <div class="oh-qst-rew-disabled">
                     <i class="bi bi-hourglass-split"></i>
-                    <p class="mb-1">Kouzla jako odměna úkolu vyžadují novou tabulku QuestSpellReward — plánováno v migraci 0.16.x (#193 follow-up).</p>
+                    <p class="mb-1">Kouzla jako odměna questu vyžadují novou tabulku QuestSpellReward — plánováno v migraci 0.16.x (#193 follow-up).</p>
                     <button type="button" class="btn btn-outline-secondary btn-sm" disabled>
                         <i class="bi bi-plus"></i> Přidat kouzlo (Phase 2)
                     </button>
@@ -456,9 +456,9 @@ else
     }
 }
 
-<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Smazat úkol?" Width="400px">
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Smazat quest?" Width="400px">
     <BodyContentTemplate Context="ctx">
-        <p>Smazat úkol <strong>@(quest?.Name)</strong>? Setkání, lokace, odměny a tagy budou odpojeny.</p>
+        <p>Smazat quest <strong>@(quest?.Name)</strong>? Setkání, lokace, odměny a tagy budou odpojeny.</p>
         @if (deleteError is not null)
         {
             <div class="alert alert-danger">@deleteError</div>
@@ -554,7 +554,7 @@ else
             quest = await Api.GetAsync<QuestDetailDto>($"/api/quests/{Id}");
             if (quest is null)
             {
-                error = "Úkol nenalezen.";
+                error = "Quest nenalezen.";
                 return;
             }
             ResetEditModel();
@@ -633,7 +633,7 @@ else
             var ok = await Api.DeleteAsync($"/api/quests/{quest.Id}");
             if (!ok)
             {
-                deleteError = "Smazání se nezdařilo (úkol může mít odkazy).";
+                deleteError = "Smazání se nezdařilo (quest může mít odkazy).";
                 return;
             }
             isDeleteVisible = false;

--- a/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
@@ -9,7 +9,7 @@
 @using OvcinaHra.Shared.Extensions
 
 <div class="d-flex justify-content-between align-items-center mb-3">
-    <h1 class="mb-0">Katalog úkolů</h1>
+    <h1 class="mb-0">Katalog questů</h1>
     <div class="d-flex gap-2 align-items-center">
         @* Mode toggle: Catalog (templates) ↔ Per-game grid. Per-game lives at
            /games/{gid}/quests so this is just a navigation jump, not a query
@@ -38,7 +38,7 @@
         </div>
 
         <button class="btn btn-primary" type="button" @onclick="OpenCreateModal">
-            <i class="bi bi-plus-lg"></i> Nový úkol
+            <i class="bi bi-plus-lg"></i> Nový quest
         </button>
     </div>
 </div>
@@ -66,7 +66,7 @@ else if (filtered.Count == 0)
 {
     <div class="text-center text-muted py-5">
         <i class="bi bi-journal-richtext fs-1 d-block mb-2"></i>
-        <p>Žádné úkoly v katalogu odpovídají filtru.</p>
+        <p>Žádné questy v katalogu odpovídají filtru.</p>
         <button class="btn btn-outline-primary" type="button" @onclick="ClearFilters">Zrušit filtry</button>
     </div>
 }
@@ -128,7 +128,7 @@ else
 }
 
 @* Quick-peek popup — Seznam row click. Same shape as Spell peek. *@
-<DxPopup @bind-Visible="@isPeekVisible" HeaderText="@(peekItem?.Name ?? "Úkol")" Width="720px">
+<DxPopup @bind-Visible="@isPeekVisible" HeaderText="@(peekItem?.Name ?? "Quest")" Width="720px">
     <BodyContentTemplate Context="qpCtx">
         @if (peekItem is null)
         {
@@ -182,9 +182,9 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
-@* "+ Nový úkol" create modal — minimal (Name + QuestType). After create we
+@* "+ Nový quest" create modal — minimal (Name + QuestType). After create we
    navigate to /quests/{id} for full editing on the Upravit tab. *@
-<DxPopup AllowResize="true" @bind-Visible="@isCreateVisible" HeaderText="Nový úkol (šablona)" Width="560px">
+<DxPopup AllowResize="true" @bind-Visible="@isCreateVisible" HeaderText="Nový quest (šablona)" Width="560px">
     <BodyContentTemplate Context="cCtx">
         <DxFormLayout>
             <DxFormLayoutItem Caption="Název" ColSpanMd="12">
@@ -315,7 +315,7 @@ else
                 new CreateQuestDto(createName.Trim(), createType, GameId: null));
             if (!ok)
             {
-                createError = problem ?? "Vytvoření úkolu se nepodařilo.";
+                createError = problem ?? "Vytvoření questu se nepodařilo.";
                 return;
             }
             isCreateVisible = false;

--- a/src/OvcinaHra.Client/Pages/Quests/QuestPrint.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestPrint.razor
@@ -6,13 +6,13 @@
 @using OvcinaHra.Shared.Domain.Enums
 @using OvcinaHra.Shared.Extensions
 
-@* Karta úkolu — A5 portrait, ONE quest per sheet. Designer brief calls for
+@* Karta questu — A5 portrait, ONE quest per sheet. Designer brief calls for
    organizer hand-out, smaller scope than Spellbook (per-quest, not per-game).
    @media print rules in ovcinahra-theme.css strip the on-screen toolbar. *@
 
 <div class="oh-qst-print-toolbar">
     <div class="oh-qst-print-toolbar-info">
-        <i class="bi bi-printer"></i> Karta úkolu — A5 portrét
+        <i class="bi bi-printer"></i> Karta questu — A5 portrét
     </div>
     <div class="d-flex gap-2">
         <button class="btn btn-sm btn-outline-secondary" type="button"
@@ -33,7 +33,7 @@ else if (quest is null)
 {
     <div class="text-center text-muted py-5">
         <i class="bi bi-emoji-frown fs-1 d-block mb-2"></i>
-        <p>Úkol nenalezen.</p>
+        <p>Quest nenalezen.</p>
     </div>
 }
 else
@@ -41,7 +41,7 @@ else
     <div class="oh-qst-print-stage">
         <article class="oh-qst-print-card">
             <header class="oh-qst-print-banner">
-                <h1>Karta úkolu</h1>
+                <h1>Karta questu</h1>
                 @if (gameName is not null)
                 {
                     <p class="oh-qst-print-banner-sub">@gameName</p>

--- a/src/OvcinaHra.Shared/Domain/Enums/GameEventKind.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/GameEventKind.cs
@@ -6,7 +6,7 @@ namespace OvcinaHra.Shared.Domain.Enums;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum GameEventKind
 {
-    [Display(Name = "Úkol")]
+    [Display(Name = "Quest")]
     Quest,
 
     [Display(Name = "Setkání")]

--- a/src/OvcinaHra.Shared/Domain/Enums/TagKind.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/TagKind.cs
@@ -9,6 +9,6 @@ public enum TagKind
     [Display(Name = "Příšera")]
     Monster,
 
-    [Display(Name = "Úkol")]
+    [Display(Name = "Quest")]
     Quest
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
@@ -93,18 +93,21 @@ public class DashboardEndpointsTests(PostgresFixture postgres)
     }
 
     [Fact]
-    public async Task Issues_AllEight_AlwaysReturned()
+    public async Task Issues_AllSix_AlwaysReturned()
     {
         // Even when a fresh game has zero issues across the board, the
-        // endpoint returns all eight issue rows so the UI keeps a stable
-        // shape. Severity for all should be "low" (count == 0).
+        // endpoint returns all six issue rows so the UI keeps a stable
+        // shape. The 'quests-no-encounters' and 'monsters-no-loot' rows
+        // were dropped by design — quest encounters and monster loot are
+        // optional, so flagging "missing" was noise. Severity for all
+        // remaining rows should be "low" (count == 0).
         var game = await CreateGameAsync();
 
         var issues = await Client.GetFromJsonAsync<DashboardIssuesDto>(
             $"/api/dashboard/issues?gameId={game.Id}");
 
         Assert.NotNull(issues);
-        Assert.Equal(8, issues.Issues.Count);
+        Assert.Equal(6, issues.Issues.Count);
         Assert.All(issues.Issues, i => Assert.Equal("low", i.Severity));
     }
 


### PR DESCRIPTION
## Three coordinated changes

### 1. Recent Activity feed removed from /home
The pre-MVP stub feed (cherry-picked per-entity `UpdatedAtUtc`, verb hardcoded to 'upravil', no actor name, only Character/Event/NPC entities) was noise without value. Issue **#247** captures the follow-up to bring it back when a real `WorldChange` audit log lands.

- `<RecentActivityFeed>` dropped from `Home.razor` (component file kept for re-use)
- `_activity` field + `activityTask` fetch + reset path removed
- Server endpoint `GET /api/dashboard/activity` left in place as the future plug-in point

### 2. Two warnings dropped from /home
- 'Úkoly bez setkání' — quests don't all need encounters by design
- 'Příšery bez kořisti' — monsters don't all drop loot by design

Backing `CountAsync` queries also removed.

### 3. Czech terminology: úkol → quest everywhere
"Úkol" implies a to-do — this app is about narrative LARP quests. User-facing strings now say *Quest / Questy / questů / questu / questem / questech* across all Czech declensions.

Touched files (13):
- Dashboard: `DashboardEndpoints.cs`, `Home.razor`
- Pages: `Quests/QuestDetail.razor`, `Quests/QuestList.razor`, `Quests/QuestPrint.razor`, `Games/GameQuests.razor`
- Components: `MapLayerRail.razor`, `QuestWaypointEditor.razor`, `QuickLaunchTiles.razor`, `StavSvetaStrip.razor`
- API: `QuestEndpoints.cs` (ProblemDetails Czech text)
- Enums: `GameEventKind.cs`, `TagKind.cs` (`[Display(Name=...)]` attributes)

Domain/EF entities and JSON DTO field names already used `Quest` — this is a pure UI / display-string change. No schema migration.

## Verification
- `dotnet build OvcinaHra.slnx` clean (0 warnings, 0 errors)
- `git grep '[ÚúŮů]ko[lů]' src/` → empty
- 13 files, +42/-56 (more deletions than additions thanks to the dashboard trim)

## After deploy — manual smoke
- /home: smaller dashboard, no Recent Activity panel, no "Úkoly bez setkání" / "Příšery bez kořisti" cards
- /quests: header reads "Katalog questů"; create error reads "Vytvoření questu se nepodařilo."; sidebar tile reads "Questy"
- /quests/{id}: title fallback "Quest", "Lokace tohoto questu", "Karta questu k tisku"
- TagKind / GameEventKind dropdowns show "Quest" for the quest values