### PR TITLE
diag(map): [pin-diag] logging to pinpoint pin-positioning regression

### DIFF
--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -44,7 +44,18 @@ window.ovcinaMap = {
         return this._makeRasterStyle('outdoor', apiKey);
     },
 
+    // Diagnostic logging gate — opt in via the browser console with
+    // `localStorage.setItem('oh-map-pin-diag', '1');` then reload. Default
+    // OFF so production users don't see lat/lon flooding the console.
+    _pinDiag: function () {
+        try { return typeof localStorage !== 'undefined' && localStorage.getItem('oh-map-pin-diag') === '1'; }
+        catch (e) { return false; }
+    },
+
     init: function (elementId, dotnetRef, centerLat, centerLon, zoom, mapyCzApiKey, glyphsUrl) {
+        if (this._pinDiag()) {
+            console.log('[pin-diag] init() — elementId=' + elementId + ', existingMap=' + (this._map ? 'YES' : 'no') + ', center=[' + centerLon + ',' + centerLat + '], zoom=' + zoom);
+        }
         this._dotnetRef = dotnetRef;
         this._elementId = elementId;
         this._apiKey = (mapyCzApiKey && mapyCzApiKey.length > 5) ? mapyCzApiKey : null;
@@ -81,9 +92,27 @@ window.ovcinaMap = {
         // its first paint trigger and ends up with 0 lokací (regression from
         // #212 which only wired the switchStyle path).
         this._map.once('load', () => {
+            if (this._pinDiag()) {
+                console.log('[pin-diag] map load fired — bounds=' + JSON.stringify(this._map.getBounds()));
+            }
             if (this._dotnetRef) {
                 this._dotnetRef.invokeMethodAsync('OnStyleLoadedCallback');
             }
+        });
+
+        // Sample marker positions on every zoomend so we can correlate
+        // pin-screen-position with map-zoom-level. Gated to avoid console
+        // spam in normal use — flip the localStorage flag to enable.
+        this._map.on('zoomend', () => {
+            if (!this._pinDiag()) return;
+            var ids = Object.keys(this._mapPagePins.loc);
+            if (ids.length === 0) return;
+            var sample = ids.slice(0, 3).map((id) => {
+                var m = this._mapPagePins.loc[id];
+                var ll = m.getLngLat();
+                return id + '@[' + ll.lng.toFixed(6) + ',' + ll.lat.toFixed(6) + ']';
+            }).join(', ');
+            console.log('[pin-diag] zoomend zoom=' + this._map.getZoom().toFixed(2) + ' pinCount=' + ids.length + ' sample=' + sample);
         });
 
         this._map.addControl(new maplibregl.NavigationControl(), 'top-right');
@@ -813,7 +842,13 @@ window.ovcinaBboxMap = {
 window.ovcinaMap._mapPagePins = { loc: {}, stash: {} };
 
 window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
-    if (!this._map) return;
+    if (!this._map) {
+        if (this._pinDiag()) console.warn('[pin-diag] addLocationPin called but no map — id=' + id);
+        return;
+    }
+    if (this._pinDiag()) {
+        console.log('[pin-diag] addLocationPin id=' + id + ' lat=' + lat + ' lon=' + lon + ' kind=' + kind + ' name=' + (name || '?'));
+    }
     this.removeLocationPin(id);
     var pin = document.createElement('div');
     pin.className = 'oh-map-pin oh-map-pin-loc';


### PR DESCRIPTION
## Why

User reports pins on /map drift dramatically when zooming — they span ~200km north-south even though the API data is clustered in a ~280m radius. Possible root causes:

1. Multiple `init()` calls stacking maps + marker pools
2. `maplibregl.Marker` not tracking the map's projection (markers stuck at pixel positions)
3. CSS interference on the marker wrapper transform

The current path has **zero observability** at the JS boundary, so we can't tell which it is. This PR adds non-invasive diagnostic logging.

## Logs added

All prefixed `[pin-diag]` so they're easy to filter in DevTools console:

1. **`init()` entry** — logs `elementId`, `existingMap` (YES/no), center, zoom. If init fires twice we'll see `existingMap=YES` on the 2nd call.
2. **`addLocationPin` entry** — logs id, lat, lon, kind, name. If values are correct here but pins still wander, the bug is downstream of the interop boundary.
3. **map `zoomend` event** — logs current zoom + a 3-marker sample of `marker.getLngLat()`. Markers' lngLat should NOT change with zoom; if it does, smoking gun.

## Verification

- `dotnet build` clean (0 warnings, 0 errors)
- 1 file, +29/-1
- No production behavior change — purely observability

## Plan

1. Merge + deploy
2. User reproduces the bug, filters console for `[pin-diag]`, pastes output
3. Pinpoint root cause from the data
4. Real fix in a follow-up
5. Logging gets reverted (or kept lightweight)