### PR TITLE
feat(map): drag-drop location pins on /map (PC only)

### DIFF
--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -86,6 +86,13 @@
     /// Tuple is (kind, id) where kind is currently always "location".</summary>
     [Parameter] public EventCallback<(string Kind, int Id)> OnMapPagePinClick { get; set; }
 
+    /// <summary>Fires when the user drag-drops a Map-page location pin.
+    /// PC only — touch/tablet users have drag disabled to prevent stray
+    /// finger movement from relocating pins. Tuple = (id, newLat, newLng)
+    /// using MapLibre's LngLat naming for consistency across the JS / C#
+    /// boundary.</summary>
+    [Parameter] public EventCallback<(int Id, double Lat, double Lng)> OnMapPagePinDrag { get; set; }
+
     /// <summary>
     /// When set, the map loads the game's vector overlay (issue #96) and
     /// surfaces the "Upravit překryv" editor button.
@@ -436,6 +443,10 @@
     [JSInvokable]
     public async Task OnMarkerDragged(int id, double lat, double lng, double origLat, double origLng)
         => await OnMarkerDrag.InvokeAsync(new OvcinaMarkerDragEventArgs(id, lat, lng, origLat, origLng));
+
+    [JSInvokable]
+    public async Task OnLocationPinDragged(int id, double lat, double lng)
+        => await OnMapPagePinDrag.InvokeAsync((id, lat, lng));
 
     [JSInvokable]
     public async Task OnStyleLoadedCallback()

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -59,7 +59,8 @@
                         <MapView @ref="_mapView"
                                  Height="calc(100vh - 200px)"
                                  OnStyleLoaded="OnMapReadyAsync"
-                                 OnMapPagePinClick="OnPinClickedAsync" />
+                                 OnMapPagePinClick="OnPinClickedAsync"
+                                 OnMapPagePinDrag="OnPinDraggedAsync" />
                     </div>
 
                     <MapPinPeek Visible="@_peekVisible"
@@ -284,6 +285,43 @@
             change.Layer, change.Visible);
         await PersistLayerStateAsync();
         PushUrl();
+    }
+
+    /// <summary>
+    /// PC drag-drop relocate. Fired by MapView when a /map location pin
+    /// is dragged. Coarse pointers (touch / tablet) never get the dragend
+    /// event because the marker is created without `draggable: true` on
+    /// those devices — see addLocationPin in map-interop.js.
+    /// </summary>
+    private async Task OnPinDraggedAsync((int Id, double Lat, double Lng) e)
+    {
+        try
+        {
+            // Round-trip GET → PUT so we don't accidentally wipe Description /
+            // Details / NpcInfo when only GPS is changing. UpdateLocationDto's
+            // string fields all default to null and would clear the row otherwise.
+            var detail = await Api.GetAsync<LocationDetailDto>($"/api/locations/{e.Id}");
+            if (detail is null) return;
+            await Api.PutAsync($"/api/locations/{e.Id}",
+                new UpdateLocationDto(
+                    detail.Name, detail.LocationKind,
+                    Latitude: (decimal)e.Lat, Longitude: (decimal)e.Lng,
+                    Description: detail.Description,
+                    Details: detail.Details,
+                    GamePotential: detail.GamePotential,
+                    Prompt: detail.Prompt,
+                    Region: detail.Region,
+                    NpcInfo: detail.NpcInfo,
+                    SetupNotes: detail.SetupNotes,
+                    ParentLocationId: detail.ParentLocationId));
+            // Reload so the next layer-toggle / style-switch repaint picks
+            // up the new GPS in _data, and so the peek shows fresh values.
+            await ReloadDataAndRenderAsync();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[map] OnPinDragged failed: {ex.GetType().Name}: {ex.Message}");
+        }
     }
 
     private async Task OnKindToggle(LocationKind kind)

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -824,9 +824,31 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
         e.stopPropagation();
         if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapPinClicked', 'location', id);
     });
-    var marker = new maplibregl.Marker({ element: pin, anchor: 'center' })
+    // Drag-to-relocate. Disabled on coarse pointers (touch / tablet) so
+    // a stray finger drag doesn't accidentally move a placed pin. On PC
+    // the organizer can drag a pin to refine its GPS — `dragend` posts
+    // the new coordinates back to MapPage which PUTs the location.
+    // Default-coarse when detection is unavailable (embedded webviews,
+    // older browsers) — safer to lock drag than to enable it by accident.
+    var isCoarsePointer = true;
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+        isCoarsePointer = window.matchMedia('(pointer: coarse)').matches;
+    } else if (typeof navigator !== 'undefined' && typeof navigator.maxTouchPoints === 'number') {
+        isCoarsePointer = navigator.maxTouchPoints > 0;
+    }
+    var draggable = !isCoarsePointer;
+    var marker = new maplibregl.Marker({ element: pin, anchor: 'center', draggable: draggable })
         .setLngLat([lon, lat])
         .addTo(this._map);
+    if (draggable) {
+        marker.on('dragend', function () {
+            var newPos = marker.getLngLat();
+            if (self._dotnetRef) {
+                // Use `lng` consistently with MapLibre's own LngLat naming.
+                self._dotnetRef.invokeMethodAsync('OnLocationPinDragged', id, newPos.lat, newPos.lng);
+            }
+        });
+    }
     this._mapPagePins.loc[id] = marker;
 };
 


### PR DESCRIPTION
## Why — urgent unblock

User needs to place the remaining locations on the /map page, but pins aren't draggable there. The #212 cartographer's-workshop rewrite added a new `addLocationPin` path that never wired drag — only the older `addMarker` (used by LocationDetail mini-map) supported it.

## What

Restores drag-to-relocate on `/map`:

- **`map-interop.js` `addLocationPin`**: detect `(pointer: coarse)` — when **false** (PC), create the marker with `draggable: true` + a `dragend` handler that posts new `(id, lat, lng)` to MapView. Touch/tablet skips the wiring entirely so a stray finger drag can't relocate a pin.

- **`MapView.razor`**: new `OnMapPagePinDrag` EventCallback + `[JSInvokable] OnLocationPinDragged` that forwards to it. Mirrors the existing `OnMarkerDrag` path.

- **`MapPage.razor`**: `OnPinDraggedAsync` handler does **GET → PUT** so we don't wipe Description/Details/NpcInfo when only GPS changes (UpdateLocationDto's string fields would otherwise null them). Reloads `_data` after save so peek + pin position pick up fresh values.

## Notes on the still-open positioning bug

Diagnostic logging from PR #249 will show whether pins drift on zoom. **This** PR is independent — it only adds a new feature path. If the underlying drift bug exists, dragged pins will inherit it; the fix for that lands separately once we have the diag data.

## Verification

- `dotnet build` clean (0 warnings, 0 errors)
- 3 files, +64/-2

## Manual smoke (after deploy)

- [ ] PC: drag a location pin on /map → pin lands at new spot, /api/locations/{id} GET returns new GPS
- [ ] PC: refresh /map → pin still at new spot
- [ ] Mobile/tablet: press-and-drag on a pin → map pans normally, pin stays put