### PR TITLE
fix(map): wrap location & stash pins so MapLibre can apply its transform (no more drift on zoom)

### DIFF
--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -850,21 +850,28 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
         console.log('[pin-diag] addLocationPin id=' + id + ' lat=' + lat + ' lon=' + lon + ' kind=' + kind + ' name=' + (name || '?'));
     }
     this.removeLocationPin(id);
+    // Wrapper / inner pin pattern (matches the still-working addMarker for
+    // LocationDetail). Passing the .oh-map-pin element directly to MapLibre
+    // — which has `position: relative` for the stash badge — interacts
+    // badly with MapLibre's transform-based positioning: `wrapper.style
+    // .transform` ends up empty and the marker stays at the map container
+    // origin while tiles slide underneath, looking like the pin "drifts"
+    // on zoom. The clean wrapper has no positioning of its own so MapLibre
+    // can apply transform: translate(...) freely.
+    var wrapper = document.createElement('div');
+    wrapper.style.cursor = 'pointer';
     var pin = document.createElement('div');
     pin.className = 'oh-map-pin oh-map-pin-loc';
     pin.setAttribute('data-kind', (kind || 'wilderness').toLowerCase());
-    pin.title = name || '';
+    wrapper.title = name || '';
+    wrapper.appendChild(pin);
     var self = this;
-    pin.addEventListener('click', function (e) {
+    wrapper.addEventListener('click', function (e) {
         e.stopPropagation();
         if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapPinClicked', 'location', id);
     });
-    // Drag-to-relocate. Disabled on coarse pointers (touch / tablet) so
-    // a stray finger drag doesn't accidentally move a placed pin. On PC
-    // the organizer can drag a pin to refine its GPS — `dragend` posts
-    // the new coordinates back to MapPage which PUTs the location.
-    // Default-coarse when detection is unavailable (embedded webviews,
-    // older browsers) — safer to lock drag than to enable it by accident.
+    // Drag-to-relocate on PC; disabled for coarse pointers. Default-coarse
+    // when detection unavailable (embedded webviews) — safer to lock.
     var isCoarsePointer = true;
     if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
         isCoarsePointer = window.matchMedia('(pointer: coarse)').matches;
@@ -872,14 +879,13 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
         isCoarsePointer = navigator.maxTouchPoints > 0;
     }
     var draggable = !isCoarsePointer;
-    var marker = new maplibregl.Marker({ element: pin, anchor: 'center', draggable: draggable })
+    var marker = new maplibregl.Marker({ element: wrapper, anchor: 'center', draggable: draggable })
         .setLngLat([lon, lat])
         .addTo(this._map);
     if (draggable) {
         marker.on('dragend', function () {
             var newPos = marker.getLngLat();
             if (self._dotnetRef) {
-                // Use `lng` consistently with MapLibre's own LngLat naming.
                 self._dotnetRef.invokeMethodAsync('OnLocationPinDragged', id, newPos.lat, newPos.lng);
             }
         });
@@ -895,24 +901,31 @@ window.ovcinaMap.removeLocationPin = function (id) {
 window.ovcinaMap.addStashPin = function (id, locationId, lat, lon, name, count, stage) {
     if (!this._map) return;
     this.removeStashPin(id);
+    // Same wrapper/inner-pin pattern as addLocationPin so MapLibre can
+    // apply its positioning transform cleanly. The pin keeps its own
+    // `position: relative` for the count badge (`.oh-map-pin-count` is
+    // absolutely positioned relative to the pin, not the wrapper).
+    var wrapper = document.createElement('div');
+    wrapper.style.cursor = 'pointer';
     var pin = document.createElement('div');
     pin.className = 'oh-map-pin oh-map-pin-stash';
     if (stage) pin.setAttribute('data-stage', stage);
-    pin.title = (name || '') + (count ? ' · ' + count + ' pokladů' : '');
+    wrapper.title = (name || '') + (count ? ' · ' + count + ' pokladů' : '');
     if (count > 0) {
         var badge = document.createElement('span');
         badge.className = 'oh-map-pin-count';
         badge.textContent = String(count);
         pin.appendChild(badge);
     }
+    wrapper.appendChild(pin);
     var self = this;
-    pin.addEventListener('click', function (e) {
+    wrapper.addEventListener('click', function (e) {
         e.stopPropagation();
         // Stash pins open the host location's peek per the brief —
         // "stash IS at the location" — keeps one peek surface.
         if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapPinClicked', 'location', locationId);
     });
-    var marker = new maplibregl.Marker({ element: pin, anchor: 'center' })
+    var marker = new maplibregl.Marker({ element: wrapper, anchor: 'center' })
         .setLngLat([lon, lat])
         .addTo(this._map);
     this._mapPagePins.stash[id] = marker;


### PR DESCRIPTION
## Root cause — confirmed by user's diagnostic dump

```
marker.getLngLat()      → correct lat/lon
wrapper.style.transform → '' (EMPTY)
pin_rect                → fixed pixel position
```

Pins were attached to the right **geographic** position internally, but MapLibre never applied the position-translating CSS transform to their wrappers. The pin DOM elements stayed at the map container origin and only **appeared** to drift on zoom because the tiles slid underneath.

## Why

`.oh-map-pin` has `position: relative` (needed for the absolutely-positioned count badge on stash pins). When that element is passed **directly** to `maplibregl.Marker` as the marker element, MapLibre's transform-based positioning interacts badly with the relative-positioned child — the wrapper transform comes out empty.

The still-working `addMarker` on LocationDetail's mini-map wraps its pin in a clean div and attaches the marker to the wrapper. That's why it works there but not on /map.

## Fix

Copy the wrapper pattern. Both `addLocationPin` and `addStashPin` now build:

```
wrapper (clean div: cursor:pointer + title + click)
  └── pin (.oh-map-pin .oh-map-pin-loc/-stash with position:relative)
```

Click handler attached to the wrapper. The count badge still anchors to the inner pin (its own `position: relative` parent unchanged) so stash counters render correctly.

## Long-standing bug

Introduced in #212 cartographer's-workshop rewrite. PR #237 made the pins paint at all; **this PR makes them paint at the RIGHT pixel positions**.

## Verification

- `dotnet build` clean
- 1 file, +26/-13
- Manual smoke after deploy: zoom in/out — pin cluster around Vsetín should stay a cluster at every zoom level (was spreading vertically across the whole Czech-Slovak border region before)