### PR TITLE
fix(map): size pin wrapper so drag hit-testing works [v0.15.80]

### DIFF
--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -858,7 +858,16 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     // origin while tiles slide underneath, looking like the pin "drifts"
     // on zoom. The clean wrapper has no positioning of its own so MapLibre
     // can apply transform: translate(...) freely.
+    // display:flex sizes the wrapper to the inner pin (18×18) instead of
+    // letting it stretch to the map container's full width. Without it,
+    // MapLibre's drag hit-testing happens on a giant invisible box and
+    // mousedown on the visible pin doesn't register as "on the marker"
+    // — drag never starts. Matches the still-working addMarker pattern
+    // for LocationDetail's mini-map.
     var wrapper = document.createElement('div');
+    wrapper.style.display = 'flex';
+    wrapper.style.alignItems = 'center';
+    wrapper.style.justifyContent = 'center';
     wrapper.style.cursor = 'pointer';
     var pin = document.createElement('div');
     pin.className = 'oh-map-pin oh-map-pin-loc';
@@ -905,7 +914,16 @@ window.ovcinaMap.addStashPin = function (id, locationId, lat, lon, name, count, 
     // apply its positioning transform cleanly. The pin keeps its own
     // `position: relative` for the count badge (`.oh-map-pin-count` is
     // absolutely positioned relative to the pin, not the wrapper).
+    // display:flex sizes the wrapper to the inner pin (18×18) instead of
+    // letting it stretch to the map container's full width. Without it,
+    // MapLibre's drag hit-testing happens on a giant invisible box and
+    // mousedown on the visible pin doesn't register as "on the marker"
+    // — drag never starts. Matches the still-working addMarker pattern
+    // for LocationDetail's mini-map.
     var wrapper = document.createElement('div');
+    wrapper.style.display = 'flex';
+    wrapper.style.alignItems = 'center';
+    wrapper.style.justifyContent = 'center';
     wrapper.style.cursor = 'pointer';
     var pin = document.createElement('div');
     pin.className = 'oh-map-pin oh-map-pin-stash';


### PR DESCRIPTION
## Why

PR #255 wrapped pin elements to fix the position-drift bug — that worked, **pins now stay at correct geographic positions**. But the wrapper had only `cursor: pointer`, no `display` / dimensions.

A default-block div inside MapLibre's map container expands to full container width. So MapLibre's drag listener hit-tested against a **giant invisible box**. Mousedown on the visible 18×18 pin pixel area landed at the 'edge' of that giant wrapper and never registered as 'on the marker' — drag never started, `dragend` never fired, the confirm popup from PR #254 never appeared.

## Fix

Match the still-working `addMarker` (LocationDetail mini-map) wrapper styling:

```js
wrapper.style.display = 'flex';
wrapper.style.alignItems = 'center';
wrapper.style.justifyContent = 'center';
wrapper.style.cursor = 'pointer';
```

`display: flex` makes the wrapper size to its only child (the 18×18 pin), so MapLibre's drag hit-test now matches the visible pin. Same fix for both `addLocationPin` and `addStashPin`.

## Verification

- `dotnet build` clean
- 1 file, +18/0
- Manual smoke after deploy:
  - /map pins stay at correct positions (no regression of #255)
  - Click + drag a pin → confirm popup *Přesunout {name}?* appears (PR #254 wakes back up)
  - Click (no drag) on a pin → peek panel opens (existing behavior preserved)