### PR TITLE
feat(map): Ctrl+Click to place ungeocoded location, labels, child locations in peek [v0.15.81]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/MapEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/MapEndpoints.cs
@@ -181,6 +181,15 @@ public static class MapEndpoints
 
         var lorePreview = MakeLorePreview(loc.Description);
 
+        // Children / variants — sub-locations of this parent. They never
+        // get pins on the map (parent-only rule) but the peek lists them
+        // so the organizer can navigate to a variant via /locations/{id}.
+        var children = await db.Locations
+            .Where(l => l.ParentLocationId == id)
+            .OrderBy(l => l.Name)
+            .Select(l => new LocationPeekChildDto(l.Id, l.Name, l.LocationKind))
+            .ToListAsync();
+
         return TypedResults.Ok(new LocationPeekDto(
             loc.Id, loc.Name,
             string.IsNullOrWhiteSpace(loc.ImagePath) ? null : blob.GetSasUrl(loc.ImagePath),
@@ -191,7 +200,8 @@ public static class MapEndpoints
             loc.LocationKind, loc.LocationKind.GetDisplayName(),
             stashDtos,
             stageRows,
-            lorePreview));
+            lorePreview,
+            children));
     }
 
     /// <summary>

--- a/src/OvcinaHra.Client/Components/MapClickEventArgs.cs
+++ b/src/OvcinaHra.Client/Components/MapClickEventArgs.cs
@@ -1,6 +1,6 @@
 namespace OvcinaHra.Client.Components;
 
-public record OvcinaMapClickEventArgs(double Latitude, double Longitude);
+public record OvcinaMapClickEventArgs(double Latitude, double Longitude, bool CtrlKey = false);
 
 public record OvcinaMarkerDragEventArgs(int Id, double Latitude, double Longitude, double OrigLatitude, double OrigLongitude);
 

--- a/src/OvcinaHra.Client/Components/MapLayerRail.razor
+++ b/src/OvcinaHra.Client/Components/MapLayerRail.razor
@@ -49,6 +49,10 @@
     <p class="oh-map-layer-hint text-muted small fst-italic">
         Setkání questů přibydou, jakmile budou mít body na mapě.
     </p>
+    <p class="oh-map-layer-hint text-muted small">
+        <i class="bi bi-cursor"></i>
+        <strong>Ctrl + klik</strong> na mapu umístí dosud neumístěnou lokaci.
+    </p>
 </aside>
 
 @code {

--- a/src/OvcinaHra.Client/Components/MapPinPeek.razor
+++ b/src/OvcinaHra.Client/Components/MapPinPeek.razor
@@ -74,6 +74,24 @@
                 </a>
             </section>
         }
+
+        @* Variants / sub-locations under this parent. They never appear
+           on the map (parent-only rule) but the peek lists them so the
+           organizer can navigate to a child via /locations/{id}. *@
+        @if (Peek.Children is { Count: > 0 } children)
+        {
+            <section class="oh-map-peek-sec">
+                <h3>Podlokace (@children.Count)</h3>
+                @foreach (var c in children)
+                {
+                    <a class="oh-map-peek-link" href="@($"/locations/{c.Id}")">
+                        <i class="bi bi-diagram-3"></i>
+                        <span>@c.Name</span>
+                        <span class="text-muted small ms-auto">@c.KindDisplay</span>
+                    </a>
+                }
+            </section>
+        }
     }
     else if (Loading)
     {

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -425,8 +425,8 @@
         => await JS.InvokeVoidAsync("ovcinaMap.setStageFilter", (object?)(stages?.ToArray()));
 
     [JSInvokable]
-    public async Task OnMapClicked(double lat, double lng)
-        => await OnMapClick.InvokeAsync(new OvcinaMapClickEventArgs(lat, lng));
+    public async Task OnMapClicked(double lat, double lng, bool ctrlKey = false)
+        => await OnMapClick.InvokeAsync(new OvcinaMapClickEventArgs(lat, lng, ctrlKey));
 
     [JSInvokable]
     public async Task OnPieMarkerClicked(int id)

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -60,7 +60,8 @@
                                  Height="calc(100vh - 200px)"
                                  OnStyleLoaded="OnMapReadyAsync"
                                  OnMapPagePinClick="OnPinClickedAsync"
-                                 OnMapPagePinDrag="OnPinDraggedAsync" />
+                                 OnMapPagePinDrag="OnPinDraggedAsync"
+                                 OnMapClick="OnMapClickAsync" />
                     </div>
 
                     <MapPinPeek Visible="@_peekVisible"
@@ -99,6 +100,74 @@
                     </div>
                 </BodyContentTemplate>
             </DxPopup>
+
+            @* Ctrl+Click placement picker — Ctrl+Clicking on the map
+               opens this popup; the user picks an ungeocoded parent
+               location from the active game and the clicked coords
+               become its new GPS. Coarse-pointer users (touch / tablet)
+               can't easily Ctrl+Click; that's by design — placing is a
+               PC-only workflow same as drag-relocate. *@
+            <DxPopup @bind-Visible="@_placeVisible"
+                     HeaderText="Vyber lokaci k umístění"
+                     Width="540px"
+                     CloseOnEscape="true">
+                <BodyContentTemplate>
+                    <p class="text-muted small mb-2">
+                        Souřadnice: <code>@_placeLat.ToString("F6"), @_placeLng.ToString("F6")</code>
+                    </p>
+                    <DxTextBox @bind-Text="@_placeSearch"
+                               NullText="Hledat podle názvu nebo oblasti…"
+                               CssClass="mb-2" />
+                    @if (_ungeocoded is null)
+                    {
+                        <p class="text-muted small">Načítám…</p>
+                    }
+                    else
+                    {
+                        var filtered = _ungeocoded
+                            .Where(l => string.IsNullOrWhiteSpace(_placeSearch)
+                                || l.Name.Contains(_placeSearch, StringComparison.OrdinalIgnoreCase)
+                                || (l.Region is not null && l.Region.Contains(_placeSearch, StringComparison.OrdinalIgnoreCase)))
+                            .ToList();
+                        if (filtered.Count == 0 && _ungeocoded.Count == 0)
+                        {
+                            <p class="text-muted small text-center py-3">Všechny lokace v této hře už mají GPS.</p>
+                        }
+                        else if (filtered.Count == 0)
+                        {
+                            <p class="text-muted small text-center py-3">Nic nenalezeno.</p>
+                        }
+                        else
+                        {
+                            <div class="list-group" style="max-height:420px;overflow-y:auto;">
+                                @foreach (var loc in filtered)
+                                {
+                                    <button type="button"
+                                            class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
+                                            disabled="@_placeSaving"
+                                            @onclick="@(() => ConfirmPlaceAsync(loc))">
+                                        <div>
+                                            <div><strong>@loc.Name</strong></div>
+                                            @if (!string.IsNullOrWhiteSpace(loc.Region))
+                                            {
+                                                <small class="text-muted">@loc.Region</small>
+                                            }
+                                        </div>
+                                        <span class="badge rounded-pill text-bg-secondary">@loc.LocationKindDisplay</span>
+                                    </button>
+                                }
+                            </div>
+                        }
+                    }
+                    @if (_placeError is not null)
+                    {
+                        <div class="alert alert-danger py-2 mt-2 mb-0">@_placeError</div>
+                    }
+                    <div class="d-flex justify-content-end mt-3">
+                        <button class="btn btn-secondary" @onclick="() => _placeVisible = false" disabled="@_placeSaving">Zavřít</button>
+                    </div>
+                </BodyContentTemplate>
+            </DxPopup>
         }
     </Authorized>
     <NotAuthorized>
@@ -134,6 +203,16 @@
     private double _pendingDragLng;
     private bool _pendingDragSaving;
     private string? _pendingDragError;
+
+    // Ctrl+Click placement state — picks an ungeocoded parent location
+    // from the active game and PUTs the clicked coords as its GPS.
+    private bool _placeVisible;
+    private double _placeLat;
+    private double _placeLng;
+    private List<LocationListDto>? _ungeocoded;
+    private string _placeSearch = "";
+    private bool _placeSaving;
+    private string? _placeError;
     // Issue #216 — phone-only layer rail toggle. CSS gates the visible
     // surface so on tablet/desktop this flag has no effect.
     private bool _railOpen;
@@ -392,6 +471,64 @@
         _pendingDragVisible = false;
         _pendingDragId = null;
         await PaintPinsAsync();
+    }
+
+    /// <summary>
+    /// Map click handler. Plain click does nothing (peek only opens via
+    /// pin clicks). Ctrl+Click opens the "place ungeocoded location"
+    /// picker — user picks one from the grid and the clicked coords
+    /// become its new GPS.
+    /// </summary>
+    private async Task OnMapClickAsync(OvcinaMapClickEventArgs e)
+    {
+        if (!e.CtrlKey) return;
+        if (GameContext.SelectedGameId is not int gid) return;
+        _placeLat = e.Latitude;
+        _placeLng = e.Longitude;
+        _placeError = null;
+        _placeSearch = "";
+        _placeSaving = false;
+        // Fetch the per-game location list and filter to ungeocoded
+        // parent rows (no GPS, no parent). Re-fetched on every open so
+        // the list reflects the current state without stale caching.
+        var all = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gid}");
+        _ungeocoded = all
+            .Where(l => l.ParentLocationId is null
+                && (l.Latitude is null || l.Longitude is null))
+            .OrderBy(l => l.Name)
+            .ToList();
+        _placeVisible = true;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task ConfirmPlaceAsync(LocationListDto loc)
+    {
+        _placeError = null;
+        _placeSaving = true;
+        try
+        {
+            // Round-trip GET → PUT so we don't wipe Description / Details /
+            // NpcInfo. Mirrors the OnPinDragged flow.
+            var detail = await Api.GetAsync<LocationDetailDto>($"/api/locations/{loc.Id}");
+            if (detail is null) { _placeError = "Lokace nenalezena."; return; }
+            await Api.PutAsync($"/api/locations/{loc.Id}",
+                new UpdateLocationDto(
+                    detail.Name, detail.LocationKind,
+                    Latitude: (decimal)_placeLat, Longitude: (decimal)_placeLng,
+                    Description: detail.Description,
+                    Details: detail.Details,
+                    GamePotential: detail.GamePotential,
+                    Prompt: detail.Prompt,
+                    Region: detail.Region,
+                    NpcInfo: detail.NpcInfo,
+                    SetupNotes: detail.SetupNotes,
+                    ParentLocationId: detail.ParentLocationId));
+            _placeVisible = false;
+            _ungeocoded = null;
+            await ReloadDataAndRenderAsync();
+        }
+        catch (Exception ex) { _placeError = ex.Message; }
+        finally { _placeSaving = false; }
     }
 
     private async Task OnKindToggle(LocationKind kind)

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3670,6 +3670,19 @@
 .oh-map-pin-count{position:absolute;top:-6px;right:-6px;background:#fff;color:#2a2a2a;
     border-radius:99px;padding:0 4px;font:700 .65rem var(--oh-font-body);
     border:1px solid var(--oh-border,#d8d2be);min-width:14px;text-align:center}
+/* Always-on location name label below the pin. Absolutely positioned
+   relative to the pin (position:relative) so the wrapper stays at 18×18
+   and MapLibre's drag hit-test stays on the pin alone. Issue #258 will
+   add zoom-conditional visibility. */
+.oh-map-pin-label{position:absolute;top:100%;left:50%;transform:translate(-50%,4px);
+    white-space:nowrap;font:600 .72rem var(--oh-font-body,sans-serif);color:#1a1a2e;
+    text-shadow:0 0 3px #fff,0 0 3px #fff,0 0 3px #fff,0 0 3px #fff;
+    pointer-events:none;user-select:none;z-index:1}
+/* Ctrl/Meta held over the map → crosshair cursor (visual hint that
+   Ctrl+Click will place an ungeocoded location). Class toggled by
+   map-interop.js keydown/keyup listeners. */
+.oh-map-ctrl-held .maplibregl-canvas-container,
+.oh-map-ctrl-held .maplibregl-canvas{cursor:crosshair !important}
 .oh-map-peek-backdrop{position:fixed;inset:0;background:rgba(20,16,8,.32);z-index:1070}
 .oh-map-peek{position:fixed;top:64px;right:0;bottom:0;width:min(420px,90vw);
     background:var(--oh-surface,#FAF6EC);border-left:1px solid var(--oh-border,#d8d2be);

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -82,9 +82,29 @@ window.ovcinaMap = {
 
         this._map.on('click', (e) => {
             if (this._dotnetRef) {
-                this._dotnetRef.invokeMethodAsync('OnMapClicked', e.lngLat.lat, e.lngLat.lng);
+                // Forward Ctrl/Meta state — /map uses Ctrl+Click to
+                // place an ungeocoded location at the clicked point.
+                var ctrl = !!(e.originalEvent && (e.originalEvent.ctrlKey || e.originalEvent.metaKey));
+                this._dotnetRef.invokeMethodAsync('OnMapClicked', e.lngLat.lat, e.lngLat.lng, ctrl);
             }
         });
+
+        // Crosshair cursor while Ctrl/Meta is held — visual hint that
+        // Ctrl+Click will place an ungeocoded location. Pure CSS via a
+        // class toggle so MapLibre's own cursor logic still works the
+        // rest of the time. Listeners cleared in dispose().
+        var mapContainer = this._map.getContainer();
+        var keyDown = function (e) {
+            if (e.key === 'Control' || e.key === 'Meta') mapContainer.classList.add('oh-map-ctrl-held');
+        };
+        var keyUp = function (e) {
+            if (e.key === 'Control' || e.key === 'Meta') mapContainer.classList.remove('oh-map-ctrl-held');
+        };
+        var blur = function () { mapContainer.classList.remove('oh-map-ctrl-held'); };
+        document.addEventListener('keydown', keyDown);
+        document.addEventListener('keyup', keyUp);
+        window.addEventListener('blur', blur);
+        this._ctrlListeners = { keyDown: keyDown, keyUp: keyUp, blur: blur };
 
         // Fire OnStyleLoadedCallback once the initial basemap style is fully
         // loaded so MapPage / TreasurePlanning can paint pins. Without this,
@@ -873,6 +893,16 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     pin.className = 'oh-map-pin oh-map-pin-loc';
     pin.setAttribute('data-kind', (kind || 'wilderness').toLowerCase());
     wrapper.title = name || '';
+    // Always-on label below the pin (issue #258 will add zoom-conditional
+    // visibility). The label is absolutely positioned relative to the
+    // pin (which has position:relative) so it doesn't expand the wrapper
+    // — that keeps MapLibre's drag hit-test on the pin alone.
+    if (name) {
+        var label = document.createElement('div');
+        label.className = 'oh-map-pin-label';
+        label.textContent = name;
+        pin.appendChild(label);
+    }
     wrapper.appendChild(pin);
     var self = this;
     wrapper.addEventListener('click', function (e) {

--- a/src/OvcinaHra.Shared/Dtos/MapDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MapDtos.cs
@@ -69,9 +69,21 @@ public record LocationPeekDto(
     string KindDisplay,
     IReadOnlyList<LocationPeekStashDto> Stashes,
     IReadOnlyList<TreasuresByStageRowDto> TreasuresByStage,
-    string? LorePreview);
+    string? LorePreview,
+    IReadOnlyList<LocationPeekChildDto>? Children = null);
 
 public record LocationPeekStashDto(int Id, string Name, int TreasureCount);
+
+/// <summary>
+/// A child / variant location nested under a parent (e.g. "Pod borovicí"
+/// inside parent "Lesní mýtina"). Children never get pins on the map,
+/// but the parent's peek lists them so the user can navigate to them.
+/// </summary>
+public record LocationPeekChildDto(int Id, string Name, LocationKind Kind)
+{
+    [JsonIgnore]
+    public string KindDisplay => Kind.GetDisplayName();
+}
 
 /// <summary>
 /// One row in the treasures-by-stage block. The cockpit renders all


### PR DESCRIPTION
## Three coordinated improvements

### 1. Ctrl+Click placement (urgent unblock)
The organizer needs to place the remaining ungeocoded locations on /map. Drag-drop only relocates already-placed pins. There was no way to put a fresh pin from a list onto the map.

- Map click handler forwards `e.originalEvent.ctrlKey/metaKey` to .NET
- On Ctrl+Click, `MapPage` opens a DxPopup picker showing all ungeocoded parent locations in the active game (`Latitude/Longitude is null` && `ParentLocationId is null`)
- User picks one → GET → PUT chain saves the clicked coords, popup closes, `_data` reloads, pin appears
- Layer rail shows the hint: *"Ctrl + klik na mapu umístí dosud neumístěnou lokaci."*
- **Crosshair cursor while Ctrl/Meta is held** — toggles `.oh-map-ctrl-held` class on map container via document keydown/keyup listeners

### 2. Always-on location-name labels (subset of #258)
- Each pin gets a child `.oh-map-pin-label` div with the location name; absolutely positioned below the pin so the wrapper stays 18×18 (drag hit-test still on the pin alone)
- White text-shadow ring keeps labels legible over any basemap
- Issue #258 will add zoom-conditional visibility (towns always, others only when `map.zoom >= 14`)

### 3. Child locations in MapPinPeek
- `LocationPeekDto` gains `Children: IReadOnlyList<LocationPeekChildDto>` (id, name, kind). Default `null` for backwards compat.
- `GetLocationPeek` endpoint queries `Locations.Where(ParentLocationId == id)`, orders by Name, projects to `LocationPeekChildDto`
- `MapPinPeek` renders a *Podlokace (N)* section with links to `/locations/{childId}` for each
- Children never appear on the map (parent-only rule preserved server-side via the `Coordinates != null` filter + `ParentLocationId == null` gate)

## Companion issues filed
- **#257** tear-drop pin design with per-kind icons (designer mockup)
- **#258** conditional label visibility by zoom (kingdoms always, others only zoomed-in)
- **#259** printable map views (blind + labeled)

## Verification
- `dotnet build OvcinaHra.slnx` clean (0 warnings, 0 errors)
- 9 files, +231/-7

## Manual smoke after deploy
- [ ] /map: pin labels visible below every pin
- [ ] /map: hold Ctrl over the map → crosshair cursor
- [ ] /map: Ctrl+Click on the map → picker shows ungeocoded parent locations only; click one → pin appears at clicked spot
- [ ] /map: click a pin → peek panel shows existing sections + new *Podlokace* section listing variants linking to /locations/{id}
- [ ] /map: drag a pin → confirm popup still works (no regression of #254)