### PR TITLE
fix(map): Ctrl+Shift+Click MOVE fallback + fix drag on touchscreen laptops [v0.15.82]

### DIFF
--- a/src/OvcinaHra.Client/Components/MapClickEventArgs.cs
+++ b/src/OvcinaHra.Client/Components/MapClickEventArgs.cs
@@ -1,6 +1,6 @@
 namespace OvcinaHra.Client.Components;
 
-public record OvcinaMapClickEventArgs(double Latitude, double Longitude, bool CtrlKey = false);
+public record OvcinaMapClickEventArgs(double Latitude, double Longitude, bool CtrlKey = false, bool ShiftKey = false);
 
 public record OvcinaMarkerDragEventArgs(int Id, double Latitude, double Longitude, double OrigLatitude, double OrigLongitude);
 

--- a/src/OvcinaHra.Client/Components/MapLayerRail.razor
+++ b/src/OvcinaHra.Client/Components/MapLayerRail.razor
@@ -53,6 +53,10 @@
         <i class="bi bi-cursor"></i>
         <strong>Ctrl + klik</strong> na mapu umístí dosud neumístěnou lokaci.
     </p>
+    <p class="oh-map-layer-hint text-muted small">
+        <i class="bi bi-arrows-move"></i>
+        <strong>Ctrl + Shift + klik</strong> přesune libovolnou lokaci sem.
+    </p>
 </aside>
 
 @code {

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -425,8 +425,8 @@
         => await JS.InvokeVoidAsync("ovcinaMap.setStageFilter", (object?)(stages?.ToArray()));
 
     [JSInvokable]
-    public async Task OnMapClicked(double lat, double lng, bool ctrlKey = false)
-        => await OnMapClick.InvokeAsync(new OvcinaMapClickEventArgs(lat, lng, ctrlKey));
+    public async Task OnMapClicked(double lat, double lng, bool ctrlKey = false, bool shiftKey = false)
+        => await OnMapClick.InvokeAsync(new OvcinaMapClickEventArgs(lat, lng, ctrlKey, shiftKey));
 
     [JSInvokable]
     public async Task OnPieMarkerClicked(int id)

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -108,30 +108,38 @@
                can't easily Ctrl+Click; that's by design — placing is a
                PC-only workflow same as drag-relocate. *@
             <DxPopup @bind-Visible="@_placeVisible"
-                     HeaderText="Vyber lokaci k umístění"
+                     HeaderText="@(_placeMode == "move" ? "Přesunout lokaci sem" : "Vyber lokaci k umístění")"
                      Width="540px"
                      CloseOnEscape="true">
                 <BodyContentTemplate>
                     <p class="text-muted small mb-2">
-                        Souřadnice: <code>@_placeLat.ToString("F6"), @_placeLng.ToString("F6")</code>
+                        Nové souřadnice: <code>@_placeLat.ToString("F6"), @_placeLng.ToString("F6")</code>
+                        @if (_placeMode == "move")
+                        {
+                            <span class="ms-2 badge text-bg-warning">Přepíše stávající GPS</span>
+                        }
                     </p>
                     <DxTextBox @bind-Text="@_placeSearch"
                                NullText="Hledat podle názvu nebo oblasti…"
                                CssClass="mb-2" />
-                    @if (_ungeocoded is null)
+                    @if (_placeCandidates is null)
                     {
                         <p class="text-muted small">Načítám…</p>
                     }
                     else
                     {
-                        var filtered = _ungeocoded
+                        var filtered = _placeCandidates
                             .Where(l => string.IsNullOrWhiteSpace(_placeSearch)
                                 || l.Name.Contains(_placeSearch, StringComparison.OrdinalIgnoreCase)
                                 || (l.Region is not null && l.Region.Contains(_placeSearch, StringComparison.OrdinalIgnoreCase)))
                             .ToList();
-                        if (filtered.Count == 0 && _ungeocoded.Count == 0)
+                        if (filtered.Count == 0 && _placeCandidates.Count == 0)
                         {
-                            <p class="text-muted small text-center py-3">Všechny lokace v této hře už mají GPS.</p>
+                            <p class="text-muted small text-center py-3">
+                                @(_placeMode == "move"
+                                    ? "Žádné lokace v této hře."
+                                    : "Všechny lokace v této hře už mají GPS.")
+                            </p>
                         }
                         else if (filtered.Count == 0)
                         {
@@ -142,6 +150,7 @@
                             <div class="list-group" style="max-height:420px;overflow-y:auto;">
                                 @foreach (var loc in filtered)
                                 {
+                                    var hasGps = loc.Latitude.HasValue && loc.Longitude.HasValue;
                                     <button type="button"
                                             class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
                                             disabled="@_placeSaving"
@@ -151,6 +160,16 @@
                                             @if (!string.IsNullOrWhiteSpace(loc.Region))
                                             {
                                                 <small class="text-muted">@loc.Region</small>
+                                            }
+                                            @if (_placeMode == "move" && hasGps)
+                                            {
+                                                <small class="text-muted d-block">
+                                                    Aktuálně: <code>@loc.Latitude!.Value.ToString("F4"), @loc.Longitude!.Value.ToString("F4")</code>
+                                                </small>
+                                            }
+                                            else if (_placeMode == "move" && !hasGps)
+                                            {
+                                                <small class="text-muted d-block fst-italic">Bez GPS</small>
                                             }
                                         </div>
                                         <span class="badge rounded-pill text-bg-secondary">@loc.LocationKindDisplay</span>
@@ -204,12 +223,15 @@
     private bool _pendingDragSaving;
     private string? _pendingDragError;
 
-    // Ctrl+Click placement state — picks an ungeocoded parent location
-    // from the active game and PUTs the clicked coords as its GPS.
+    // Ctrl+Click placement / Ctrl+Shift+Click move state.
+    //   "place" → picker shows only ungeocoded parent locations
+    //   "move"  → picker shows all parent locations (current GPS overwritten)
+    // Same DxPopup, header + list filter swap based on mode.
     private bool _placeVisible;
+    private string _placeMode = "place";
     private double _placeLat;
     private double _placeLng;
-    private List<LocationListDto>? _ungeocoded;
+    private List<LocationListDto>? _placeCandidates;
     private string _placeSearch = "";
     private bool _placeSaving;
     private string? _placeError;
@@ -475,26 +497,26 @@
 
     /// <summary>
     /// Map click handler. Plain click does nothing (peek only opens via
-    /// pin clicks). Ctrl+Click opens the "place ungeocoded location"
-    /// picker — user picks one from the grid and the clicked coords
-    /// become its new GPS.
+    /// pin clicks). Modifier-clicks open the placement picker:
+    ///   Ctrl+Click       → place an ungeocoded parent location
+    ///   Ctrl+Shift+Click → move any parent location (current GPS overwritten)
     /// </summary>
     private async Task OnMapClickAsync(OvcinaMapClickEventArgs e)
     {
         if (!e.CtrlKey) return;
         if (GameContext.SelectedGameId is not int gid) return;
+        _placeMode = e.ShiftKey ? "move" : "place";
         _placeLat = e.Latitude;
         _placeLng = e.Longitude;
         _placeError = null;
         _placeSearch = "";
         _placeSaving = false;
-        // Fetch the per-game location list and filter to ungeocoded
-        // parent rows (no GPS, no parent). Re-fetched on every open so
-        // the list reflects the current state without stale caching.
+        // Fetch the per-game location list. Filter depends on mode:
+        // place mode = only ungeocoded parents; move mode = all parents.
         var all = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gid}");
-        _ungeocoded = all
+        _placeCandidates = all
             .Where(l => l.ParentLocationId is null
-                && (l.Latitude is null || l.Longitude is null))
+                && (_placeMode == "move" || l.Latitude is null || l.Longitude is null))
             .OrderBy(l => l.Name)
             .ToList();
         _placeVisible = true;
@@ -524,7 +546,7 @@
                     SetupNotes: detail.SetupNotes,
                     ParentLocationId: detail.ParentLocationId));
             _placeVisible = false;
-            _ungeocoded = null;
+            _placeCandidates = null;
             await ReloadDataAndRenderAsync();
         }
         catch (Exception ex) { _placeError = ex.Message; }

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3670,17 +3670,9 @@
 .oh-map-pin-count{position:absolute;top:-6px;right:-6px;background:#fff;color:#2a2a2a;
     border-radius:99px;padding:0 4px;font:700 .65rem var(--oh-font-body);
     border:1px solid var(--oh-border,#d8d2be);min-width:14px;text-align:center}
-/* Always-on location name label below the pin. Absolutely positioned
-   relative to the pin (position:relative) so the wrapper stays at 18×18
-   and MapLibre's drag hit-test stays on the pin alone. Issue #258 will
-   add zoom-conditional visibility. */
-.oh-map-pin-label{position:absolute;top:100%;left:50%;transform:translate(-50%,4px);
-    white-space:nowrap;font:600 .72rem var(--oh-font-body,sans-serif);color:#1a1a2e;
-    text-shadow:0 0 3px #fff,0 0 3px #fff,0 0 3px #fff,0 0 3px #fff;
-    pointer-events:none;user-select:none;z-index:1}
 /* Ctrl/Meta held over the map → crosshair cursor (visual hint that
-   Ctrl+Click will place an ungeocoded location). Class toggled by
-   map-interop.js keydown/keyup listeners. */
+   Ctrl+Click will place an ungeocoded location, Ctrl+Shift+Click will
+   move an existing one). Class toggled by map-interop.js keydown/keyup. */
 .oh-map-ctrl-held .maplibregl-canvas-container,
 .oh-map-ctrl-held .maplibregl-canvas{cursor:crosshair !important}
 .oh-map-peek-backdrop{position:fixed;inset:0;background:rgba(20,16,8,.32);z-index:1070}

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -82,10 +82,13 @@ window.ovcinaMap = {
 
         this._map.on('click', (e) => {
             if (this._dotnetRef) {
-                // Forward Ctrl/Meta state — /map uses Ctrl+Click to
-                // place an ungeocoded location at the clicked point.
-                var ctrl = !!(e.originalEvent && (e.originalEvent.ctrlKey || e.originalEvent.metaKey));
-                this._dotnetRef.invokeMethodAsync('OnMapClicked', e.lngLat.lat, e.lngLat.lng, ctrl);
+                // Forward Ctrl/Meta + Shift state — /map uses
+                //   Ctrl+Click       → place ungeocoded location
+                //   Ctrl+Shift+Click → move existing location (any)
+                var orig = e.originalEvent;
+                var ctrl = !!(orig && (orig.ctrlKey || orig.metaKey));
+                var shift = !!(orig && orig.shiftKey);
+                this._dotnetRef.invokeMethodAsync('OnMapClicked', e.lngLat.lat, e.lngLat.lng, ctrl, shift);
             }
         });
 
@@ -893,31 +896,29 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     pin.className = 'oh-map-pin oh-map-pin-loc';
     pin.setAttribute('data-kind', (kind || 'wilderness').toLowerCase());
     wrapper.title = name || '';
-    // Always-on label below the pin (issue #258 will add zoom-conditional
-    // visibility). The label is absolutely positioned relative to the
-    // pin (which has position:relative) so it doesn't expand the wrapper
-    // — that keeps MapLibre's drag hit-test on the pin alone.
-    if (name) {
-        var label = document.createElement('div');
-        label.className = 'oh-map-pin-label';
-        label.textContent = name;
-        pin.appendChild(label);
-    }
+    // Labels deferred to issue #258 (conditional zoom-based visibility).
+    // Always-on labels visually overlapped neighbouring pins in clustered
+    // areas — the label's pointer-events:none made events fall through to
+    // the map canvas, blocking marker drag on what looked like a pin.
     wrapper.appendChild(pin);
     var self = this;
     wrapper.addEventListener('click', function (e) {
         e.stopPropagation();
         if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapPinClicked', 'location', id);
     });
-    // Drag-to-relocate on PC; disabled for coarse pointers. Default-coarse
-    // when detection unavailable (embedded webviews) — safer to lock.
-    var isCoarsePointer = true;
+    // Drag-to-relocate. Enabled when ANY fine pointer is available
+    // (mouse, trackpad). The earlier `(pointer: coarse)` gate broke on
+    // Windows touchscreen laptops where the primary pointer reports as
+    // coarse even with a mouse plugged in. `(any-pointer: fine)` matches
+    // if a fine input exists at all, which is the right gate. Pure-touch
+    // tablets with no mouse fall back to Ctrl+Shift+Click via the click
+    // picker.
+    var draggable = true;
     if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
-        isCoarsePointer = window.matchMedia('(pointer: coarse)').matches;
+        draggable = window.matchMedia('(any-pointer: fine)').matches;
     } else if (typeof navigator !== 'undefined' && typeof navigator.maxTouchPoints === 'number') {
-        isCoarsePointer = navigator.maxTouchPoints > 0;
+        draggable = navigator.maxTouchPoints === 0;
     }
-    var draggable = !isCoarsePointer;
     var marker = new maplibregl.Marker({ element: wrapper, anchor: 'center', draggable: draggable })
         .setLngLat([lon, lat])
         .addTo(this._map);


### PR DESCRIPTION
## Three coordinated fixes for the recurring drag-drop drama

### 1. Drag works on hybrid touchscreen laptops
User's diagnostic confirmed `matchMedia('(pointer: coarse)') = true` even with a mouse plugged in — Windows reports the touchscreen as the primary pointer on hybrid laptops. The old gate `!coarse` locked drag entirely on those devices.

**Fix:** switch to `(any-pointer: fine)` — drag enabled whenever ANY fine pointer (mouse / trackpad) is available. Pure-touch tablets with no mouse stay locked.

### 2. Reliable click-based fallback: Ctrl+Shift+Click → MOVE
User-proposed safety net for when drag flakes again. Same DxPopup as the existing Ctrl+Click flow, two modes:

| Modifier | Mode | Picker shows |
|---|---|---|
| Ctrl+Click | place | only ungeocoded parent locations |
| Ctrl+Shift+Click | **move** (new) | all parent locations |

Header swaps (*"Vyber lokaci k umístění"* vs *"Přesunout lokaci sem"*). Move mode shows current GPS per row + a *"Přepíše stávající GPS"* warning chip. Layer rail gets a second hint for the new shortcut.

Plumbing: JS forwards `e.originalEvent.shiftKey` alongside ctrlKey; `OvcinaMapClickEventArgs` gains `ShiftKey`; `MapView.OnMapClicked` passes through; `MapPage` routes Ctrl±Shift to the right `_placeMode`.

### 3. Always-on labels reverted (back to issue #258)
The labels visually overlapped pins in clustered areas. Even with `pointer-events: none`, hovering 'on' a label-overlapped pin showed the canvas's grab cursor and clicks panned the map instead of dragging. Labels return when issue #258 implements zoom-conditional visibility (towns always, others only when zoomed in).

## Verification

- `dotnet build` clean (0 warnings, 0 errors)
- 6 files, +70/-51

## Manual smoke after deploy

- [ ] Hybrid laptop (touch + mouse): drag works again
- [ ] Ctrl+Click on map → place picker (ungeocoded only)
- [ ] Ctrl+Shift+Click on map → move picker (all parents, GPS chip on each row, warning badge in header area)
- [ ] Crosshair cursor while Ctrl is held (existing — should still work for both shortcuts)