### PR TITLE
feat(map): zoom-conditional location labels (closes #258) [v0.15.83]

### DIFF
--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3675,6 +3675,18 @@
    move an existing one). Class toggled by map-interop.js keydown/keyup. */
 .oh-map-ctrl-held .maplibregl-canvas-container,
 .oh-map-ctrl-held .maplibregl-canvas{cursor:crosshair !important}
+
+/* Issue #258 — zoom-conditional location labels. Default hidden so
+   tightly-clustered pins (e.g. 22 in 280 m) don't render an unreadable
+   blob at low zoom. Towns (kingdom seats) override the default and are
+   always visible — they're the most important wayfinding anchors. */
+.oh-map-pin-label{display:none;position:absolute;top:100%;left:50%;
+    transform:translate(-50%,4px);white-space:nowrap;
+    font:600 .72rem var(--oh-font-body,sans-serif);color:#1a1a2e;
+    text-shadow:0 0 3px #fff,0 0 3px #fff,0 0 3px #fff,0 0 3px #fff;
+    pointer-events:none;user-select:none;z-index:1}
+.oh-map-pin-loc[data-kind="town"] .oh-map-pin-label{display:block}
+.oh-map-zoomed-in .oh-map-pin-label{display:block}
 .oh-map-peek-backdrop{position:fixed;inset:0;background:rgba(20,16,8,.32);z-index:1070}
 .oh-map-peek{position:fixed;top:64px;right:0;bottom:0;width:min(420px,90vw);
     background:var(--oh-surface,#FAF6EC);border-left:1px solid var(--oh-border,#d8d2be);

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -92,6 +92,23 @@ window.ovcinaMap = {
             }
         });
 
+        // Issue #258 — zoom-conditional labels. Toggle .oh-map-zoomed-in
+        // on the map container at zoom >= 15 so non-town labels become
+        // visible only when pins are spread out enough to avoid overlap.
+        // Town pins (kingdom seats) are always-visible via a separate
+        // CSS rule that doesn't depend on this class.
+        var LABEL_ZOOM_THRESHOLD = 15;
+        var mc = this._map.getContainer();
+        var applyZoomLabelClass = () => {
+            if (this._map.getZoom() >= LABEL_ZOOM_THRESHOLD) {
+                mc.classList.add('oh-map-zoomed-in');
+            } else {
+                mc.classList.remove('oh-map-zoomed-in');
+            }
+        };
+        applyZoomLabelClass(); // initial state
+        this._map.on('zoomend', applyZoomLabelClass);
+
         // Crosshair cursor while Ctrl/Meta is held — visual hint that
         // Ctrl+Click will place an ungeocoded location. Pure CSS via a
         // class toggle so MapLibre's own cursor logic still works the
@@ -896,10 +913,20 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     pin.className = 'oh-map-pin oh-map-pin-loc';
     pin.setAttribute('data-kind', (kind || 'wilderness').toLowerCase());
     wrapper.title = name || '';
-    // Labels deferred to issue #258 (conditional zoom-based visibility).
-    // Always-on labels visually overlapped neighbouring pins in clustered
-    // areas — the label's pointer-events:none made events fall through to
-    // the map canvas, blocking marker drag on what looked like a pin.
+    // Issue #258 — zoom-conditional labels. The label is always rendered,
+    // CSS controls visibility:
+    //   - Town pins (kingdom seats): always shown
+    //   - Other kinds: only shown when the map container has class
+    //     `oh-map-zoomed-in` (set by the zoom listener in init() once
+    //     map.getZoom() >= 15)
+    // pointer-events:none + position:absolute keep the wrapper at 18×18
+    // so MapLibre's drag hit-test stays accurate.
+    if (name) {
+        var label = document.createElement('div');
+        label.className = 'oh-map-pin-label';
+        label.textContent = name;
+        pin.appendChild(label);
+    }
     wrapper.appendChild(pin);
     var self = this;
     wrapper.addEventListener('click', function (e) {


### PR DESCRIPTION
## Why

Labels were dropped in #262 because the always-on variant overlapped pins in clustered areas — your Vsetín test cluster has 22 pins in 280×320 m, which renders as one unreadable blob at low zoom.

This PR brings them back with **zoom gating**.

## Spec

- **Town** (kingdom seats) — labels **always** visible
- All other kinds — labels visible only when `map.getZoom() >= 15`
- Hidden when 'Lokace' master toggle is off (existing behavior — pins removed entirely)
- Children locations never get labels (existing rule — they don't get pins either)

## Why threshold = 15?

| Zoom | Pin spread (Vsetín cluster) | Labels |
|---|---|---|
| 12-14 | overlap heavily | town only |
| **15** | starting to separate | **all kinds** |
| 16-18 | clearly separable | all kinds |

Easy to bump to 14 (more spread-out games) or 16 (tighter clusters) — it's a single `LABEL_ZOOM_THRESHOLD` constant in `map-interop.js`.

## Implementation

- `init()` listens to MapLibre's `zoomend`, toggles `.oh-map-zoomed-in` on the map container based on threshold. Initial state applied immediately so labels are correct on first paint.
- `addLocationPin` adds a `.oh-map-pin-label` child element with the name (when name is non-empty)
- CSS visibility:
  ```css
  .oh-map-pin-label { display: none; ... position: absolute }
  .oh-map-pin-loc[data-kind="town"] .oh-map-pin-label { display: block }
  .oh-map-zoomed-in .oh-map-pin-label { display: block }
  ```

## Drag safety (the #260 regression that bit us)

- `pointer-events: none` on the label — events pass through
- `position: absolute` keeps the wrapper at 18×18 — MapLibre's drag hit-test stays aligned with the actual pin pixels
- Plus: at `zoom >= 15`, pins are spread enough that label-on-pin overlap is minimal

## Verification

- `dotnet build` clean
- 2 files (js + css), +43/-4
- Manual smoke after deploy:
  - At zoom < 15: only town labels visible
  - At zoom >= 15: all kind labels visible
  - Drag still works
  - Toggling 'Lokace' off hides everything

Closes #258.