### PR TITLE
feat(map): Town black, Dungeon gray — kind palette refresh [v0.15.83]

### DIFF
--- a/src/OvcinaHra.Client/wwwroot/css/app.css
+++ b/src/OvcinaHra.Client/wwwroot/css/app.css
@@ -49,14 +49,17 @@
     --oh-stage-endgame-soft:  rgba( 74,  29,  36, 0.12);
 
     /* === Location kind (map marker dots — canon) ===
-       User-confirmed palette 2026-04-26. White wilderness needs a dark
-       border on map pins (see .oh-map-pin-loc[data-kind="wilderness"]). */
-    --oh-kind-town:            #B26BA8;
+       User-confirmed palette refresh 2026-04-26. Town swapped from
+       mauve to black (kingdom seats stand out as anchors); Dungeon
+       lightened to gray so it's distinguishable from Town. White
+       wilderness still needs a dark border on map pins (see
+       .oh-map-pin-loc[data-kind="wilderness"]). */
+    --oh-kind-town:            #000000;
     --oh-kind-village:         #FF0000;
     --oh-kind-magical:         #EAF626;
     --oh-kind-hobbit:          #9400D4;
     --oh-kind-wilderness:      #FFFFFF;
-    --oh-kind-dungeon:         #000000;
+    --oh-kind-dungeon:         #6D6D6D;
     --oh-kind-pointofinterest: #FF6600;
 
     /* === Status === */


### PR DESCRIPTION
## Two color swaps

| Kind | Old | New |
|---|---|---|
| Town | `#B26BA8` mauve | **`#000000` black** |
| Dungeon | `#000000` black | **`#6D6D6D` gray** |

Other kinds unchanged: Village `#FF0000`, Magical `#EAF626`, Hobbit `#9400D4`, Wilderness `#FFFFFF`, PointOfInterest `#FF6600`.

## Rationale

Black towns stand out as kingdom-seat anchors. Gray dungeons stay distinct from the now-black towns while keeping a dim, ominous feel.

## Affects

All surfaces using `--oh-kind-*` tokens (single source of truth in `app.css`):
- `/map` location pins
- Treasures pie pins (`.oh-tp-pin-zero[data-kind=...]`)
- Legend chips in `MapLayerRail`
- Anywhere else that reads the tokens

Wilderness still has its dark-border override (`.oh-map-pin-loc[data-kind="wilderness"]`) for visibility on light terrain.

## Verification

- `dotnet build` clean
- 1 file (`app.css`), +7/-4 (mostly the comment update)