### PR TITLE
ci(deploy): double Container Apps health-poll budget to 600s [v0.15.86]

### DIFF
--- a/.github/scripts/wait-for-containerapp-revision.sh
+++ b/.github/scripts/wait-for-containerapp-revision.sh
@@ -15,7 +15,7 @@ set -e
 APP=${1:?usage: $0 <container-app-name> <resource-group>}
 RG=${2:?usage: $0 <container-app-name> <resource-group>}
 
-ATTEMPTS=30
+ATTEMPTS=60
 SLEEP_SECONDS=10
 
 echo "Polling latest revision of $APP (up to $((ATTEMPTS * SLEEP_SECONDS))s)..."

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.88</Version>
+    <Version>0.15.89</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What

Bumps `ATTEMPTS` in `.github/scripts/wait-for-containerapp-revision.sh` from `30` to `60`. With `SLEEP_SECONDS=10` unchanged, the wait budget grows from **300s → 600s** (10 min).

## Why

PR #263 deploy ([run 24966174376](https://github.com/timurlain/ovcinahra/actions/runs/24966174376)) hit a false failure tonight:

- 20:26:18 — revision \`ovcinahra-api--0000190\` created
- 20:26:33 → 20:33:40 — wait-script polled 28× while revision stayed at \`state=Activating health=None\`
- 20:33:40 — workflow exits 1 (timeout at 300s)
- 20:37:12 — container actually finished cold-start; \`/api/version\` returns \`commit:928587c\` (the very commit we were deploying)

Verified just now via \`az containerapp revision show\`:
\`\`\`
Name                    State              Health    Replicas    Traffic
ovcinahra-api--0000190  RunningAtMaxScale  Healthy   1           100
\`\`\`

So prod IS on the latest commit — the deploy effectively succeeded, the workflow just gave up too early during an unusually slow Azure cold-start.

## Risk

- Real boot failures still exit immediately via the \`STATE=ActivationFailed\` early-return — that branch fires before the timeout, so signal quality is unchanged.
- Downside is at most 5 extra wait minutes on a genuinely-stuck deploy. Acceptable trade for not crying wolf on a healthy revision.

## Test plan

- [ ] Both CI workflows (Client CI, API CI) pass
- [ ] Next deploy after merge runs the patched wait-script and either succeeds within 600s or surfaces a real failure