### PR TITLE
fix(map): restore overlay editor entry point on /map [v0.15.87]

### DIFF
--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.85</Version>
+    <Version>0.15.87</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -58,6 +58,7 @@
                         </div>
                         <MapView @ref="_mapView"
                                  Height="calc(100vh - 200px)"
+                                 GameId="@GameContext.SelectedGameId"
                                  OnStyleLoaded="OnMapReadyAsync"
                                  OnMapPagePinClick="OnPinClickedAsync"
                                  OnMapPagePinDrag="OnPinDraggedAsync"


### PR DESCRIPTION
## Bug

The vector-overlay editor (issue #96, PRs #138 / #161 / #165 / #196 — \"big feature\") has been silently hidden on \`/map\` since PR #212 was merged.

PR #212 (\"cartographer's workshop\") rewrote \`MapPage.razor\` from scratch and dropped one parameter on the new \`<MapView>\` call site:

\`\`\`diff
 <MapView @ref=\"_mapView\"
          Height=\"calc(100vh - 200px)\"
+         GameId=\"@GameContext.SelectedGameId\"
          OnStyleLoaded=\"OnMapReadyAsync\"
          ...
\`\`\`

\`MapView.razor\` gates the overlay-edit button on:

\`\`\`razor
@if (GameId.HasValue && !_editMode)
{
    <button ...>Upravit překryv</button>
}
\`\`\`

With \`GameId\` unbound it's always \`null\` → \`HasValue\` always \`false\` → button never paints → the whole editor (toolbar + property panel + save/load) is unreachable from the UI.

## Fix

One line: pass \`GameContext.SelectedGameId\` through to \`<MapView>\`.

The component already subscribes to \`GameContext.OnGameChanged\`, so the button appears the moment a game is selected and disappears when the user switches back to the no-game state. \`MapEmptyState\` still handles the no-game branch above this.

## What's intact (no other regression found)

- API endpoints: \`GET /api/games/{id}/overlay\` and \`PUT /api/games/{id}/overlay\` in \`GameEndpoints.cs\`
- DTO: \`MapOverlayDto\`
- DB column / migration: \`AddGameOverlayJson\`
- JS interop: \`overlay-interop.js\` (still loaded by \`index.html\`)
- Components: \`MapOverlayToolbar\`, \`OverlayPropertyPanel\`
- Hosted in \`MapView.razor\` with all event wiring

## Test plan

- [ ] CI green
- [ ] Open \`/map\` with a game selected → \"Upravit překryv\" button visible top-right
- [ ] Click it → toolbar + property panel show, edit/save/cancel works against an existing overlay
- [ ] Switch \`Žádná hra\` → button disappears (returns to MapEmptyState)