### PR TITLE
feat(quests): catalogue/game routing + bulk add

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -39,8 +39,61 @@ public static class GameEndpoints
         group.MapPost("/{gameId:int}/skills", CreateGameSkill);
         group.MapPut("/{gameId:int}/skills/{gameSkillId:int}", UpdateGameSkill);
         group.MapDelete("/{gameId:int}/skills/{gameSkillId:int}", DeleteGameSkill);
+        group.MapPost("/{gameId:int}/quests/bulk", BulkAddQuests);
 
         return group;
+    }
+
+    private static async Task<Results<Ok<BulkAddQuestsResponse>, NotFound>> BulkAddQuests(
+        int gameId, BulkAddQuestsRequest request, WorldDbContext db, HttpContext http)
+    {
+        if (!await db.Games.AnyAsync(g => g.Id == gameId))
+            return TypedResults.NotFound();
+
+        var requestedIds = request.QuestCatalogueIds
+            .Where(id => id > 0)
+            .Distinct()
+            .ToList();
+
+        if (requestedIds.Count == 0)
+            return TypedResults.Ok(new BulkAddQuestsResponse([], []));
+
+        var catalogueNames = await db.Quests
+            .AsNoTracking()
+            .Where(q => q.GameId == null && requestedIds.Contains(q.Id))
+            .Select(q => new { q.Id, q.Name })
+            .ToDictionaryAsync(q => q.Id, q => q.Name);
+
+        var existingNames = (await db.Quests
+            .AsNoTracking()
+            .Where(q => q.GameId == gameId)
+            .Select(q => q.Name)
+            .ToListAsync())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var added = new List<int>();
+        var skipped = new List<int>();
+
+        foreach (var catalogueId in requestedIds)
+        {
+            if (!catalogueNames.TryGetValue(catalogueId, out var name) || existingNames.Contains(name))
+            {
+                skipped.Add(catalogueId);
+                continue;
+            }
+
+            var result = await QuestEndpoints.CopyQuestToGameAsync(catalogueId, gameId, db, http);
+            if (result is null)
+            {
+                skipped.Add(catalogueId);
+                continue;
+            }
+
+            added.Add(catalogueId);
+            existingNames.Add(name);
+        }
+
+        return TypedResults.Ok(new BulkAddQuestsResponse(added, skipped));
     }
 
     private static async Task<Ok<List<GameListDto>>> GetAll(WorldDbContext db)

--- a/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
@@ -111,13 +111,21 @@ public static class QuestEndpoints
 
     private static async Task<Results<Created<QuestCopyResultDto>, NotFound>> CopyToGame(int id, int gameId, WorldDbContext db, HttpContext http)
     {
+        var result = await CopyQuestToGameAsync(id, gameId, db, http);
+        return result is null
+            ? TypedResults.NotFound()
+            : TypedResults.Created($"/api/quests/{result.Quest.Id}", result);
+    }
+
+    internal static async Task<QuestCopyResultDto?> CopyQuestToGameAsync(int id, int gameId, WorldDbContext db, HttpContext http)
+    {
         var source = await db.Quests
             .Include(q => q.QuestTags).ThenInclude(qt => qt.Tag)
             .Include(q => q.QuestLocations)
             .Include(q => q.QuestEncounters)
             .Include(q => q.QuestRewards).ThenInclude(qr => qr.Item)
             .FirstOrDefaultAsync(q => q.Id == id);
-        if (source is null) return TypedResults.NotFound();
+        if (source is null) return null;
 
         var warnings = new List<string>();
 
@@ -159,15 +167,14 @@ public static class QuestEndpoints
         await db.SaveChangesAsync();
 
         var thumb = string.IsNullOrWhiteSpace(copy.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "quests", copy.Id, "small");
-        return TypedResults.Created($"/api/quests/{copy.Id}",
-            new QuestCopyResultDto(
-                new QuestListDto(copy.Id, copy.Name, copy.QuestType, copy.ChainOrder, copy.ParentQuestId, copy.GameId,
-                    copy.State, copy.ImagePath, thumb,
-                    EncountersCount: source.QuestEncounters.Count,
-                    RewardsCount: source.QuestRewards.Count(r => targetItemIds.Contains(r.ItemId)),
-                    LocationsCount: source.QuestLocations.Count(l => targetLocationIds.Contains(l.LocationId)),
-                    TagsCount: source.QuestTags.Count),
-                warnings));
+        return new QuestCopyResultDto(
+            new QuestListDto(copy.Id, copy.Name, copy.QuestType, copy.ChainOrder, copy.ParentQuestId, copy.GameId,
+                copy.State, copy.ImagePath, thumb,
+                EncountersCount: source.QuestEncounters.Count,
+                RewardsCount: source.QuestRewards.Count(r => targetItemIds.Contains(r.ItemId)),
+                LocationsCount: source.QuestLocations.Count(l => targetLocationIds.Contains(l.LocationId)),
+                TagsCount: source.QuestTags.Count),
+            warnings);
     }
 
     private static async Task<Ok<List<QuestListDto>>> GetByGame(int gameId, WorldDbContext db, HttpContext http)

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -103,7 +103,7 @@
                         <span class="oh-nav-rail"></span>
                         <img src="img/troll.svg" class="ni oh-nav-icon-svg" alt="" /><span class="oh-nav-label">Příšery</span>
                     </NavLink>
-                    <NavLink class="oh-nav-item" href="quests">
+                    <NavLink class="oh-nav-item" href="@QuestGameHref">
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-journal-text ni"></i><span class="oh-nav-label">Questy</span>
                     </NavLink>
@@ -160,7 +160,7 @@
                         <span class="oh-nav-rail"></span>
                         <img src="img/troll.svg" class="ni oh-nav-icon-svg" alt="" /><span class="oh-nav-label">Příšery</span>
                     </NavLink>
-                    <NavLink class="oh-nav-item" href="quests?catalog=true">
+                    <NavLink class="oh-nav-item" href="quests?mode=catalogue">
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-journal-text ni"></i><span class="oh-nav-label">Questy</span>
                     </NavLink>
@@ -263,6 +263,10 @@
             return name.Length > 20 ? name[..19] + "…" : name;
         }
     }
+
+    private string QuestGameHref => GameContext.SelectedGameId is int gameId
+        ? $"games/{gameId}/quests"
+        : "quests?mode=game";
 
     protected override void OnInitialized()
     {

--- a/src/OvcinaHra.Client/Pages/Games/GameQuests.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameQuests.razor
@@ -20,11 +20,14 @@
     </div>
     <div class="d-flex gap-2">
         <button class="btn btn-outline-secondary" type="button"
-                @onclick='() => Nav.NavigateTo("/quests")'>
+                @onclick='() => Nav.NavigateTo("/quests?mode=catalogue")'>
             <i class="bi bi-journal-richtext"></i> Katalog
         </button>
-        <button class="btn btn-outline-primary" type="button" @onclick="() => isFromTemplateVisible = true">
-            <i class="bi bi-files"></i> Přidat ze šablony
+        <button class="btn btn-outline-primary" type="button" @onclick="OpenFromCatalogAsync">
+            <i class="bi bi-files"></i> Přidat z katalogu
+        </button>
+        <button class="btn btn-outline-primary" type="button" @onclick="OpenBulkFromCatalogAsync">
+            <i class="bi bi-ui-checks-grid"></i> Přidat hromadně z katalogu
         </button>
         <button class="btn btn-primary" type="button" @onclick="OpenBlankCreateModal">
             <i class="bi bi-plus-lg"></i> Od nuly
@@ -32,16 +35,23 @@
     </div>
 </div>
 
-@* State filter pill row *@
-<div class="oh-qst-state-pillrow mb-3">
-    @foreach (var (key, label) in stateFilterOptions)
-    {
-        <button type="button"
-                class="oh-qst-state-pill @(stateFilter == key ? "oh-qst-state-pill--on" : "")"
-                @onclick="() => stateFilter = key">
-            @label
-        </button>
-    }
+<div class="d-flex align-items-center gap-2 flex-wrap mb-3">
+    <DxTagBox Data="@questTypeValues" Values="@selectedQuestTypes"
+              ValuesChanged="@((IEnumerable<QuestType> values) => OnQuestTypesChanged(values))"
+              TextFieldName="Display" ValueFieldName="Value"
+              NullText="Všechny typy"
+              SearchMode="ListSearchMode.AutoSearch"
+              style="min-width:220px" />
+    <div class="oh-qst-state-pillrow mb-0">
+        @foreach (var (key, label) in stateFilterOptions)
+        {
+            <button type="button"
+                    class="oh-qst-state-pill @(stateFilter == key ? "oh-qst-state-pill--on" : "")"
+                    @onclick="() => stateFilter = key">
+                @label
+            </button>
+        }
+    </div>
 </div>
 
 @if (loading)
@@ -117,23 +127,23 @@ else
 @* Add-from-template popup: pick a catalog quest, server CopyToGame creates
    the per-game fork with deep-copied tags/locations/encounters/rewards. *@
 <DxPopup AllowResize="true" @bind-Visible="@isFromTemplateVisible"
-         HeaderText="Přidat quest ze šablony" Width="640px">
+         HeaderText="Přidat quest z katalogu" Width="640px">
     <BodyContentTemplate Context="ctx">
         @if (catalog is null)
         {
             <p class="text-muted">Načítám katalog…</p>
         }
-        else if (catalog.Count == 0)
+        else if (AvailableCatalogQuests.Count == 0)
         {
-            <p class="text-muted">V katalogu nejsou žádné šablony questů.</p>
+            <p class="text-muted">V katalogu nejsou žádné další questy pro tuto hru.</p>
         }
         else
         {
             <DxFormLayout>
-                <DxFormLayoutItem Caption="Šablona" ColSpanMd="12">
-                    <DxComboBox Data="@catalog" @bind-Value="@templateId"
+                <DxFormLayoutItem Caption="Quest z katalogu" ColSpanMd="12">
+                    <DxComboBox Data="@AvailableCatalogQuests" @bind-Value="@templateId"
                                 TextFieldName="Name" ValueFieldName="Id"
-                                NullText="(vyberte šablonu)"
+                                NullText="(vyberte quest)"
                                 SearchMode="ListSearchMode.AutoSearch" />
                 </DxFormLayoutItem>
             </DxFormLayout>
@@ -158,6 +168,66 @@ else
                     disabled="@(isCopying || templateId is null)">
                 @if (isCopying) { <span class="spinner-border spinner-border-sm me-1"></span> }
                 Vytvořit kopii
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<DxPopup AllowResize="true" @bind-Visible="@isBulkFromCatalogVisible"
+         HeaderText="Přidat hromadně z katalogu" Width="1000px">
+    <BodyContentTemplate Context="bulkCtx">
+        @if (catalog is null)
+        {
+            <p class="text-muted">Načítám katalog…</p>
+        }
+        else if (AvailableCatalogQuests.Count == 0)
+        {
+            <p class="text-muted">V katalogu nejsou žádné další questy pro tuto hru.</p>
+        }
+        else
+        {
+            <OvcinaGrid Data="@AvailableCatalogQuests" KeyFieldName="Id" LayoutKey="grid-layout-quests-bulk-add-v1"
+                        SelectionMode="GridSelectionMode.Multiple"
+                        SelectedDataItems="@selectedBulkQuestItems"
+                        SelectedDataItemsChanged="@OnBulkQuestSelectionChanged">
+                <Columns>
+                    <DxGridDataColumn Caption="" Width="48px" AllowSort="false" AllowGroup="false">
+                        <CellDisplayTemplate>
+                            @{ var q = (QuestCatalogDto)context.DataItem; }
+                            <input type="checkbox"
+                                   checked="@IsBulkQuestSelected(q.Id)"
+                                   @onchange="@((ChangeEventArgs e) => ToggleBulkQuest(q, e))"
+                                   @onclick:stopPropagation="true" />
+                        </CellDisplayTemplate>
+                    </DxGridDataColumn>
+                    <DxGridDataColumn FieldName="Name" Caption="Název" MinWidth="220" />
+                    <DxGridDataColumn FieldName="QuestTypeDisplay" Caption="Typ" Width="140px" />
+                    <DxGridDataColumn FieldName="EncountersCount" Caption="Setkání" Width="100px" />
+                    <DxGridDataColumn FieldName="RewardsCount" Caption="Odměny" Width="100px" />
+                    <DxGridDataColumn FieldName="RewardSummary" Caption="Souhrn odměn" MinWidth="240" />
+                    <DxGridDataColumn FieldName="Description" Caption="Popis" MinWidth="240" Visible="false" />
+                </Columns>
+            </OvcinaGrid>
+        }
+
+        @if (bulkError is not null)
+        {
+            <div class="alert alert-danger mt-2">@bulkError</div>
+        }
+        @if (bulkResult?.Skipped.Count > 0)
+        {
+            <div class="alert alert-warning mt-2">
+                Přidáno: @bulkResult.Added.Count, přeskočeno: @bulkResult.Skipped.Count.
+            </div>
+        }
+
+        <div class="d-flex gap-2 justify-content-end mt-3">
+            <button class="btn btn-secondary" type="button" @onclick="() => isBulkFromCatalogVisible = false" disabled="@isBulkAdding">Zavřít</button>
+            <button class="btn btn-primary" type="button"
+                    @onclick="BulkAddFromCatalogAsync"
+                    disabled="@(isBulkAdding || selectedBulkQuestItems.Count == 0)">
+                @if (isBulkAdding) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Přidat vybrané
             </button>
         </div>
     </BodyContentTemplate>
@@ -196,6 +266,7 @@ else
     private bool loading = true;
 
     private string stateFilter = "all"; // all | inactive | active | done
+    private List<QuestType> selectedQuestTypes = [];
 
     private static readonly (string Key, string Label)[] stateFilterOptions =
     [
@@ -206,13 +277,15 @@ else
     ];
 
     private List<QuestListDto> filtered =>
-        quests.Where(q => stateFilter switch
-        {
-            "inactive" => q.State == QuestState.Inactive,
-            "active"   => q.State == QuestState.Active,
-            "done"     => q.State == QuestState.Completed,
-            _          => true
-        }).ToList();
+        quests.Where(q =>
+            (selectedQuestTypes.Count == 0 || selectedQuestTypes.Contains(q.QuestType))
+            && (stateFilter switch
+            {
+                "inactive" => q.State == QuestState.Inactive,
+                "active"   => q.State == QuestState.Active,
+                "done"     => q.State == QuestState.Completed,
+                _          => true
+            })).ToList();
 
     // Add-from-template state
     private bool isFromTemplateVisible;
@@ -220,6 +293,13 @@ else
     private bool isCopying;
     private string? copyError;
     private List<string> copyWarnings = [];
+
+    // Bulk add state
+    private bool isBulkFromCatalogVisible;
+    private IReadOnlyList<object> selectedBulkQuestItems = [];
+    private bool isBulkAdding;
+    private string? bulkError;
+    private BulkAddQuestsResponse? bulkResult;
 
     // Blank create state
     private bool isBlankVisible;
@@ -232,6 +312,11 @@ else
         .Select(v => new EnumItem<QuestType>(v, v.GetDisplayName())).ToList();
 
     private record EnumItem<T>(T Value, string Display);
+
+    private List<QuestCatalogDto> AvailableCatalogQuests =>
+        catalog?
+            .Where(c => !quests.Any(q => string.Equals(q.Name, c.Name, StringComparison.OrdinalIgnoreCase)))
+            .ToList() ?? [];
 
     protected override async Task OnInitializedAsync() => await LoadAsync();
 
@@ -271,7 +356,25 @@ else
     {
         if (catalog is not null) return;
         try { catalog = await Api.GetListAsync<QuestCatalogDto>("/api/quests/all"); }
-        catch (Exception ex) { copyError = ex.Message; catalog = []; }
+        catch (Exception ex) { copyError = ex.Message; bulkError = ex.Message; catalog = []; }
+    }
+
+    private async Task OpenFromCatalogAsync()
+    {
+        copyError = null;
+        copyWarnings = [];
+        templateId = null;
+        isFromTemplateVisible = true;
+        await LoadCatalogIfNeededAsync();
+    }
+
+    private async Task OpenBulkFromCatalogAsync()
+    {
+        bulkError = null;
+        bulkResult = null;
+        selectedBulkQuestItems = [];
+        isBulkFromCatalogVisible = true;
+        await LoadCatalogIfNeededAsync();
     }
 
     private async Task CopyFromTemplateAsync()
@@ -301,6 +404,60 @@ else
         }
         catch (Exception ex) { copyError = ex.Message; }
         finally { isCopying = false; }
+    }
+
+    private void OnQuestTypesChanged(IEnumerable<QuestType> values) =>
+        selectedQuestTypes = values.ToList();
+
+    private void OnBulkQuestSelectionChanged(IReadOnlyList<object> items) =>
+        selectedBulkQuestItems = items;
+
+    private bool IsBulkQuestSelected(int questId) =>
+        selectedBulkQuestItems.OfType<QuestCatalogDto>().Any(q => q.Id == questId);
+
+    private void ToggleBulkQuest(QuestCatalogDto quest, ChangeEventArgs e)
+    {
+        var items = selectedBulkQuestItems
+            .OfType<QuestCatalogDto>()
+            .Where(q => q.Id != quest.Id)
+            .Cast<object>()
+            .ToList();
+        if (e.Value is true)
+            items.Add(quest);
+        selectedBulkQuestItems = items;
+    }
+
+    private async Task BulkAddFromCatalogAsync()
+    {
+        var selectedIds = selectedBulkQuestItems
+            .OfType<QuestCatalogDto>()
+            .Select(q => q.Id)
+            .Distinct()
+            .ToArray();
+        if (selectedIds.Length == 0) return;
+
+        bulkError = null;
+        bulkResult = null;
+        isBulkAdding = true;
+        try
+        {
+            var (ok, result, problem) = await Api.PostWithProblemAsync<BulkAddQuestsRequest, BulkAddQuestsResponse>(
+                $"/api/games/{GameId}/quests/bulk",
+                new BulkAddQuestsRequest(selectedIds));
+            if (!ok || result is null)
+            {
+                bulkError = problem ?? "Hromadné přidání questů se nepodařilo.";
+                return;
+            }
+
+            bulkResult = result;
+            selectedBulkQuestItems = [];
+            await LoadAsync();
+            if (result.Skipped.Count == 0)
+                isBulkFromCatalogVisible = false;
+        }
+        catch (Exception ex) { bulkError = ex.Message; }
+        finally { isBulkAdding = false; }
     }
 
     private async Task OpenBlankCreateModal()

--- a/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
@@ -16,7 +16,7 @@
            flag. *@
         <div class="oh-segmented" role="tablist" aria-label="Režim">
             <button type="button" class="oh-segmented-btn oh-segmented-btn--on"
-                    aria-selected="true">Šablony katalogu</button>
+                    aria-selected="true">Katalog</button>
             <button type="button" class="oh-segmented-btn"
                     @onclick="NavigateToGameGrid"
                     aria-selected="false">Pro tuto hru</button>
@@ -48,6 +48,12 @@
 <div class="oh-qst-filters mb-3">
     <DxTextBox Text="@searchText" TextChanged="@((string v) => searchText = v)"
                NullText="Hledat (název, popis)…" CssClass="oh-qst-filter-search" />
+    <DxTagBox Data="@questTypeValues" Values="@selectedQuestTypes"
+              ValuesChanged="@((IEnumerable<QuestType> values) => OnQuestTypesChanged(values))"
+              TextFieldName="Display" ValueFieldName="Value"
+              NullText="Všechny typy"
+              SearchMode="ListSearchMode.AutoSearch"
+              style="min-width:220px" />
     <label class="oh-qst-filter-toggle">
         <input type="checkbox" @bind="onlyWithImage" />
         <span>jen s obrázkem</span>
@@ -218,6 +224,7 @@ else
 
     private string view = "galerie"; // galerie | seznam — persisted in localStorage
     private string searchText = "";
+    private List<QuestType> selectedQuestTypes = [];
     private bool onlyWithImage;
     private bool onlyWithRewards;
 
@@ -241,6 +248,7 @@ else
                 || q.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase)
                 || (q.Description?.Contains(searchText, StringComparison.OrdinalIgnoreCase) ?? false)
                 || (q.FullText?.Contains(searchText, StringComparison.OrdinalIgnoreCase) ?? false))
+            && (selectedQuestTypes.Count == 0 || selectedQuestTypes.Contains(q.QuestType))
             && (!onlyWithImage || !string.IsNullOrEmpty(q.ImageUrl))
             // "jen s odměnami" must accept scalar-only rewards (XP/groše/notes)
             // even when there are no item rewards — RewardSummary is non-null
@@ -289,6 +297,9 @@ else
         Nav.NavigateTo($"/games/{gameId.Value}/quests");
     }
 
+    private void OnQuestTypesChanged(IEnumerable<QuestType> values) =>
+        selectedQuestTypes = values.ToList();
+
     private void OpenPeek(QuestCatalogDto q)
     {
         peekItem = q;
@@ -331,6 +342,7 @@ else
     private void ClearFilters()
     {
         searchText = "";
+        selectedQuestTypes = [];
         onlyWithImage = false;
         onlyWithRewards = false;
     }

--- a/src/OvcinaHra.Shared/Dtos/QuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/QuestDtos.cs
@@ -106,4 +106,6 @@ public record QuestCatalogDto(
     public string QuestTypeDisplay => QuestType.GetDisplayName();
 }
 public record QuestCopyResultDto(QuestListDto Quest, List<string> Warnings);
+public record BulkAddQuestsRequest(IReadOnlyList<int> QuestCatalogueIds);
+public record BulkAddQuestsResponse(IReadOnlyList<int> Added, IReadOnlyList<int> Skipped);
 public record MoveQuestToGameDto(int GameId);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/QuestCopyTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/QuestCopyTests.cs
@@ -59,6 +59,13 @@ public class QuestCopyTests(PostgresFixture postgres) : IntegrationTestBase(post
         return (await response.Content.ReadFromJsonAsync<QuestDetailDto>())!;
     }
 
+    private async Task<QuestListDto> CreateCatalogQuestAsync(string name, QuestType type = QuestType.General)
+    {
+        var response = await Client.PostAsJsonAsync("/api/quests",
+            new CreateQuestDto(name, type, GameId: null));
+        return (await response.Content.ReadFromJsonAsync<QuestListDto>())!;
+    }
+
     [Fact]
     public async Task CopyQuest_CopiesBasicFields()
     {
@@ -238,5 +245,30 @@ public class QuestCopyTests(PostgresFixture postgres) : IntegrationTestBase(post
         Assert.NotNull(copy);
         Assert.Null(copy.ChainOrder);
         Assert.Null(copy.ParentQuestId);
+    }
+
+    [Fact]
+    public async Task BulkAddQuests_CopiesCatalogQuestsAndSkipsExistingNames()
+    {
+        var game = await CreateGameAsync("Bulk game");
+        var first = await CreateCatalogQuestAsync("Katalogový quest", QuestType.General);
+        var second = await CreateCatalogQuestAsync("Druhý katalogový quest", QuestType.Timed);
+
+        await Client.PostAsJsonAsync("/api/quests",
+            new CreateQuestDto("Katalogový quest", QuestType.General, game.Id));
+
+        var response = await Client.PostAsJsonAsync($"/api/games/{game.Id}/quests/bulk",
+            new BulkAddQuestsRequest([first.Id, second.Id]));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<BulkAddQuestsResponse>();
+        Assert.NotNull(result);
+        Assert.Contains(second.Id, result.Added);
+        Assert.Contains(first.Id, result.Skipped);
+
+        var gameQuests = await Client.GetFromJsonAsync<List<QuestListDto>>($"/api/quests/by-game/{game.Id}");
+        Assert.NotNull(gameQuests);
+        Assert.Contains(gameQuests, q => q.Name == "Druhý katalogový quest");
+        Assert.Single(gameQuests, q => q.Name == "Katalogový quest");
     }
 }


### PR DESCRIPTION
## Summary
- Routes `Tato hra` -> Questy to `/games/{gameId}/quests` while catalogue Questy stays on `/quests?mode=catalogue`.
- Renames quest catalogue/template copy to `Katalog` / `Přidat z katalogu`.
- Adds multi-select quest type filters on catalogue and game quest views.
- Adds bulk catalogue add modal plus `POST /api/games/{gameId}/quests/bulk`.

## Issue checklist
- ✅ #228 column-aware Questy routing and catalogue wording
- ✅ #230 quest type multi-select filter, button rename, bulk-add modal
- ✅ #278 game Questy opens actual game quests; catalogue Questy opens catalogue

## Design choices
- Game mode keeps the existing `/games/{gameId}/quests` route instead of duplicating the page behind `/quests?mode=game`.
- Bulk response returns catalogue IDs in `added` / `skipped`; the UI refreshes the game quest grid after confirm.
- Duplicate skipping uses case-insensitive quest name matching because the quest schema has no source catalogue/template id.

## Verification
- `dotnet build --nologo`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter QuestCopyTests --logger "console;verbosity=minimal"` (9 passed)
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --logger "console;verbosity=minimal"` (424 passed)