### PR TITLE
feat(items): page + recipe polish (closes #234 #236 #269 #270 #271)

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -75,7 +75,11 @@ public static class ItemEndpoints
             r.ReqWarrior, r.ReqArcher, r.ReqMage, r.ReqThief,
             r.IsUnique, r.IsLimited, r.ImagePath,
             Note: r.Note,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "items", r.Id, "small"),
+            // Issue #269 — was "small" (120×120 square crop) which stripped
+            // top + bottom of 5:7 portrait card photos. "medium" is 240×336
+            // (5:7) so the bytes match the .oh-it-tile container ratio and
+            // ImageSharp's Crop mode no longer eats the card art.
+            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "items", r.Id, "medium"),
             HasRecipe: craftedSet.Contains(r.Id))).ToList();
         return TypedResults.Ok(items);
     }
@@ -90,7 +94,7 @@ public static class ItemEndpoints
         // round-trip just to render the hero (per Copilot review on PR #90).
         var imageUrl = string.IsNullOrWhiteSpace(item.ImagePath)
             ? null
-            : ImageEndpoints.ThumbUrl(http, "items", item.Id, "small");
+            : ImageEndpoints.ThumbUrl(http, "items", item.Id, "medium");
 
         // Issue #154 — same flag as the catalog list, populated here so the
         // quick-peek popup can gate the IsCraftable badge consistently.
@@ -218,7 +222,7 @@ public static class ItemEndpoints
                 gi.GameId, gi.Price, gi.StockCount, gi.IsSold, gi.SaleCondition, gi.IsFindable,
                 summaryByItemId.GetValueOrDefault(gi.ItemId),
                 Note: gi.Item.Note,
-                ImageUrl: string.IsNullOrWhiteSpace(gi.Item.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "items", gi.Item.Id, "small"),
+                ImageUrl: string.IsNullOrWhiteSpace(gi.Item.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "items", gi.Item.Id, "medium"),
                 HasRecipe: hasRecipeByItemId.Contains(gi.ItemId)))
             .ToList();
 

--- a/src/OvcinaHra.Api/Endpoints/TagEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TagEndpoints.cs
@@ -9,6 +9,11 @@ namespace OvcinaHra.Api.Endpoints;
 
 public static class TagEndpoints
 {
+    // Matches Tag.Name HasMaxLength(100) in TagConfiguration. Centralised here
+    // so Create + Update validate the same ceiling and the Czech error message
+    // can quote the limit verbatim.
+    private const int NameMaxLength = 100;
+
     public static RouteGroupBuilder MapTagEndpoints(this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/tags").WithTags("Tags");
@@ -45,22 +50,79 @@ public static class TagEndpoints
         return TypedResults.Ok(new TagDto(tag.Id, tag.Name, tag.Kind));
     }
 
-    private static async Task<Created<TagDto>> Create(CreateTagDto dto, WorldDbContext db)
+    // Issue #234 — name now flows through Trim + non-empty + max-length +
+    // dup-check guards that surface Czech ProblemDetails verbatim instead of
+    // hiding behind EnsureSuccessStatusCode. The client passes the user's
+    // typed name through unchanged (PostAsJsonAsync, JSON body) so any char
+    // — `+`, `&`, `:`, `'`, space — round-trips end-to-end.
+    private static async Task<Results<Created<TagDto>, ProblemHttpResult>> Create(CreateTagDto dto, WorldDbContext db)
     {
-        var tag = new Tag { Name = dto.Name, Kind = dto.Kind };
+        var name = dto.Name?.Trim() ?? "";
+        if (string.IsNullOrEmpty(name))
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: "Název tagu nesmí být prázdný.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        if (name.Length > NameMaxLength)
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: $"Název tagu nesmí přesáhnout {NameMaxLength} znaků.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        if (!Enum.IsDefined(dto.Kind))
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: "Neplatný druh tagu.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        // EF translates Trim() to Postgres TRIM() so legacy rows that already
+        // have whitespace padding still collide on the dup-check.
+        var collision = await db.Tags
+            .AnyAsync(t => t.Kind == dto.Kind && t.Name.Trim() == name);
+        if (collision)
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: $"Tag s názvem „{name}“ už v této kategorii existuje.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        var tag = new Tag { Name = name, Kind = dto.Kind };
         db.Tags.Add(tag);
         await db.SaveChangesAsync();
 
         return TypedResults.Created($"/api/tags/{tag.Id}", new TagDto(tag.Id, tag.Name, tag.Kind));
     }
 
-    private static async Task<Results<NoContent, NotFound>> Update(int id, UpdateTagDto dto, WorldDbContext db)
+    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> Update(int id, UpdateTagDto dto, WorldDbContext db)
     {
+        // FindAsync first so a 404 on a missing id wins over the 400 input
+        // validation below — see _review-instincts §1.
         var tag = await db.Tags.FindAsync(id);
         if (tag is null)
             return TypedResults.NotFound();
 
-        tag.Name = dto.Name;
+        var name = dto.Name?.Trim() ?? "";
+        if (string.IsNullOrEmpty(name))
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: "Název tagu nesmí být prázdný.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        if (name.Length > NameMaxLength)
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: $"Název tagu nesmí přesáhnout {NameMaxLength} znaků.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        var collision = await db.Tags
+            .AnyAsync(t => t.Id != id && t.Kind == tag.Kind && t.Name.Trim() == name);
+        if (collision)
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: $"Tag s názvem „{name}“ už v této kategorii existuje.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        tag.Name = name;
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Endpoints/TagEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TagEndpoints.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
@@ -88,7 +89,22 @@ public static class TagEndpoints
 
         var tag = new Tag { Name = name, Kind = dto.Kind };
         db.Tags.Add(tag);
-        await db.SaveChangesAsync();
+        try
+        {
+            await db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // Concurrency race: AnyAsync above passed but a parallel request
+            // beat us to the (Kind, Name) UNIQUE index. Surface the same Czech
+            // ProblemDetails as the explicit dup-check so the client never
+            // sees a 500 for what is conceptually a duplicate-name conflict.
+            // Per Copilot review on PR #282 — same pattern as GameEndpoints.
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: $"Tag s názvem „{name}“ už v této kategorii existuje.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
 
         return TypedResults.Created($"/api/tags/{tag.Id}", new TagDto(tag.Id, tag.Name, tag.Kind));
     }
@@ -123,9 +139,28 @@ public static class TagEndpoints
                 statusCode: StatusCodes.Status400BadRequest);
 
         tag.Name = name;
-        await db.SaveChangesAsync();
+        try
+        {
+            await db.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // Same race as Create — a concurrent rename can still violate the
+            // (Kind, Name) UNIQUE index between AnyAsync and SaveChangesAsync.
+            // Per Copilot review on PR #282.
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: $"Tag s názvem „{name}“ už v této kategorii existuje.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
         return TypedResults.NoContent();
     }
+
+    // Npgsql surfaces unique-index violations as PostgresException with
+    // SqlState 23505. Mirrors the helper in GameEndpoints (PR #282 / Copilot).
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException pg
+        && pg.SqlState == PostgresErrorCodes.UniqueViolation;
 
     private static async Task<Results<NoContent, NotFound>> Delete(int id, WorldDbContext db)
     {

--- a/src/OvcinaHra.Client/Components/RecipeEditPopup.razor
+++ b/src/OvcinaHra.Client/Components/RecipeEditPopup.razor
@@ -15,6 +15,12 @@
          HeaderText="@(detail is null ? "Recept" : (detail.Title ?? "Recept"))"
          Width="780px">
     <BodyContentTemplate Context="ctx">
+        @* Issue #236 — wrap the body in a max-height scroll container so the
+           Suroviny + Vyžaduje sections (and inline editor states) don't push
+           the Save/Zrušit footer below the viewport on shorter laptop screens.
+           DxPopup doesn't constrain BodyContentTemplate height by default; the
+           popup grew with content and stranded the footer off-bottom. *@
+        <div style="max-height: 75vh; overflow-y: auto; overflow-x: hidden; padding-right: 6px;">
         @if (loading || detail is null)
         {
             <p class="text-muted">Načítám…</p>
@@ -95,7 +101,10 @@
             }
         }
 
-        <div class="d-flex gap-2 justify-content-end mt-3">
+        </div>
+        @* Footer sits OUTSIDE the scroll wrapper so Save/Zrušit are always
+           visible even when the body needs to scroll (#236). *@
+        <div class="d-flex gap-2 justify-content-end mt-3 pt-2 border-top">
             <button type="button" class="btn btn-secondary" @onclick="Cancel" disabled="@isSaving">Zrušit</button>
             <button type="button" class="btn btn-primary" @onclick="SaveAsync"
                     disabled="@(isSaving || detail is null || editOutputItemId is null)">

--- a/src/OvcinaHra.Client/Pages/Items/ItemDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemDetail.razor
@@ -748,16 +748,15 @@ else
         _lastId = Id;
         try
         {
-            // Buildings catalog feeds the Obchod quick-append picker (#270).
-            // Lazy-load the first time we need it; the list rarely changes
-            // during a session and is small enough to cache for the lifetime
-            // of the page instance. Best-effort — failure shouldn't block
-            // the item itself from rendering.
-            if (allBuildings.Count == 0)
-            {
-                try { allBuildings = await Api.GetListAsync<BuildingListDto>("/api/buildings"); }
-                catch { allBuildings = []; }
-            }
+            // Issue #270 — kick off the buildings catalog fetch in parallel
+            // with the item fetch instead of awaiting it first; a slow or
+            // hung /api/buildings must not block item render. Per Copilot
+            // review on PR #282. Best-effort: failure → empty list, item
+            // still loads. Skipped after the first successful load (catalog
+            // rarely changes during a session).
+            var buildingsTask = allBuildings.Count == 0
+                ? Api.GetListAsync<BuildingListDto>("/api/buildings")
+                : Task.FromResult(allBuildings);
 
             item = await Api.GetAsync<ItemDetailDto>($"/api/items/{Id}");
             if (item is not null)
@@ -782,10 +781,35 @@ else
                     usage = new ItemUsageDto(item.Id, item.Name, [], [], [], [], [], []);
                 }
                 ResetActiveShopFromUsage();
+                NormalizeActiveTabAgainstUsage();
             }
+
+            // Drain the parallel buildings fetch (#270 / Copilot PR #282).
+            // Item already rendered if it succeeded; this just populates the
+            // picker for the Obchod sale-condition quick-append. Best-effort.
+            try { allBuildings = await buildingsTask; }
+            catch { allBuildings = []; }
         }
         catch (Exception ex) { error = ex.Message; item = null; }
         finally { loading = false; }
+    }
+
+    // Issue #271 + Copilot review on PR #282 — when the data tabs are gated
+    // by usage counts, `activeTab` can survive a navigation from an item
+    // where (say) ObchodCount > 0 to one where it's 0. Without normalising
+    // here, no tab button would appear active but the body would still
+    // render the hidden tab's empty "Načítám…" / empty-state, leaving the
+    // user with no way to switch tabs except a full reload.
+    private void NormalizeActiveTabAgainstUsage()
+    {
+        switch (activeTab)
+        {
+            case "tvorba" when TvorbaCount == 0:
+            case "vyskyt" when VyskytCount == 0:
+            case "obchod" when ObchodCount == 0:
+                activeTab = "karta";
+                break;
+        }
     }
 
     private void ResetEditFromItem()

--- a/src/OvcinaHra.Client/Pages/Items/ItemDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemDetail.razor
@@ -62,6 +62,12 @@ else
         </div>
     </div>
 
+    @* Issue #271 — Karta + Upravit always render; the three data tabs only
+       appear when the item actually has data of that kind. The visibility
+       gates are derived from the same usage counts that feed the badges,
+       so a count of zero hides the tab entirely instead of leading the
+       user to a "Žádné..." dead-end. Tabs come back automatically once a
+       recipe / drop / shop assignment is added elsewhere. *@
     <div class="oh-it-d-tabs">
         <button class="oh-it-d-tab @(activeTab == "karta" ? "oh-it-d-active" : null)" @onclick='() => SetTab("karta")'>
             <i class="bi bi-bookmark-fill"></i> Karta
@@ -69,27 +75,27 @@ else
         <button class="oh-it-d-tab @(activeTab == "upravit" ? "oh-it-d-active" : null)" @onclick='() => SetTab("upravit")'>
             <i class="bi bi-pencil"></i> Upravit
         </button>
-        <button class="oh-it-d-tab @(activeTab == "tvorba" ? "oh-it-d-active" : null)" @onclick='() => SetTab("tvorba")'>
-            <i class="bi bi-tools"></i> Tvorba
-            @if (TvorbaCount > 0)
-            {
+        @if (TvorbaCount > 0)
+        {
+            <button class="oh-it-d-tab @(activeTab == "tvorba" ? "oh-it-d-active" : null)" @onclick='() => SetTab("tvorba")'>
+                <i class="bi bi-tools"></i> Tvorba
                 <span class="oh-it-d-tab-count">@TvorbaCount</span>
-            }
-        </button>
-        <button class="oh-it-d-tab @(activeTab == "vyskyt" ? "oh-it-d-active" : null)" @onclick='() => SetTab("vyskyt")'>
-            <i class="bi bi-geo-alt"></i> Výskyt
-            @if (VyskytCount > 0)
-            {
+            </button>
+        }
+        @if (VyskytCount > 0)
+        {
+            <button class="oh-it-d-tab @(activeTab == "vyskyt" ? "oh-it-d-active" : null)" @onclick='() => SetTab("vyskyt")'>
+                <i class="bi bi-geo-alt"></i> Výskyt
                 <span class="oh-it-d-tab-count">@VyskytCount</span>
-            }
-        </button>
-        <button class="oh-it-d-tab @(activeTab == "obchod" ? "oh-it-d-active" : null)" @onclick='() => SetTab("obchod")'>
-            <i class="bi bi-shop"></i> Obchod
-            @if (ObchodCount > 0)
-            {
+            </button>
+        }
+        @if (ObchodCount > 0)
+        {
+            <button class="oh-it-d-tab @(activeTab == "obchod" ? "oh-it-d-active" : null)" @onclick='() => SetTab("obchod")'>
+                <i class="bi bi-shop"></i> Obchod
                 <span class="oh-it-d-tab-count">@ObchodCount</span>
-            }
-        </button>
+            </button>
+        }
     </div>
 
     <div class="oh-it-d-body">
@@ -314,6 +320,22 @@ else
                             </DxFormLayoutItem>
                             <DxFormLayoutItem Caption="Podmínka prodeje" ColSpanMd="12">
                                 <DxTextBox @bind-Text="@pgSaleCondition" />
+                                @* Issue #270 — quick-append helper. Pick a building from the
+                                   catalog → click → "Vyžaduje budovu: {Name}" gets appended
+                                   to the free-text note. No per-game DB link, just a textual
+                                   memory aid for organizers. *@
+                                <div class="d-flex gap-2 mt-1">
+                                    <DxComboBox Data="@allBuildings" @bind-Value="@pgBuildingPickerId"
+                                                TextFieldName="Name" ValueFieldName="Id"
+                                                NullText="(vyber budovu)"
+                                                SearchMode="ListSearchMode.AutoSearch"
+                                                CssClass="flex-grow-1" />
+                                    <button class="btn btn-sm btn-outline-primary" type="button"
+                                            disabled="@(pgBuildingPickerId is null)"
+                                            @onclick="AppendBuildingToPgSaleCondition">
+                                        <i class="bi bi-plus-lg"></i> Vyžaduje budovu
+                                    </button>
+                                </div>
                             </DxFormLayoutItem>
                         }
                     </DxFormLayoutGroup>
@@ -590,6 +612,21 @@ else
             </DxFormLayoutItem>
             <DxFormLayoutItem Caption="Podmínka prodeje" ColSpanMd="12">
                 <DxTextBox @bind-Text="@shopEditSaleCondition" NullText="(bez podmínky)" />
+                @* Issue #270 — same quick-append helper as the Upravit tab. Same
+                   format ("Vyžaduje budovu: {Name}") so both surfaces produce
+                   identical strings the organizer can grep for. *@
+                <div class="d-flex gap-2 mt-1">
+                    <DxComboBox Data="@allBuildings" @bind-Value="@shopEditBuildingPickerId"
+                                TextFieldName="Name" ValueFieldName="Id"
+                                NullText="(vyber budovu)"
+                                SearchMode="ListSearchMode.AutoSearch"
+                                CssClass="flex-grow-1" />
+                    <button class="btn btn-sm btn-outline-primary" type="button"
+                            disabled="@(shopEditBuildingPickerId is null)"
+                            @onclick="AppendBuildingToShopEditSaleCondition">
+                        <i class="bi bi-plus-lg"></i> Vyžaduje budovu
+                    </button>
+                </div>
             </DxFormLayoutItem>
         </DxFormLayout>
         @if (shopEditError is not null)
@@ -663,6 +700,13 @@ else
     private string? shopEditSaleCondition;
     private string? shopEditError;
 
+    // Issue #270 — building catalog cache + picker selection for the Obchod
+    // sell-condition quick-append. Loaded once on first LoadAsync; the same
+    // cache feeds both the Upravit tab and the per-game popup.
+    private List<BuildingListDto> allBuildings = [];
+    private int? pgBuildingPickerId;
+    private int? shopEditBuildingPickerId;
+
     private static readonly List<EnumItem<ItemType>> itemTypeValues = Enum.GetValues<ItemType>()
         .Select(v => new EnumItem<ItemType>(v, v.GetDisplayName())).ToList();
     private static readonly List<EnumItem<PhysicalForm?>> physicalFormValues =
@@ -704,6 +748,17 @@ else
         _lastId = Id;
         try
         {
+            // Buildings catalog feeds the Obchod quick-append picker (#270).
+            // Lazy-load the first time we need it; the list rarely changes
+            // during a session and is small enough to cache for the lifetime
+            // of the page instance. Best-effort — failure shouldn't block
+            // the item itself from rendering.
+            if (allBuildings.Count == 0)
+            {
+                try { allBuildings = await Api.GetListAsync<BuildingListDto>("/api/buildings"); }
+                catch { allBuildings = []; }
+            }
+
             item = await Api.GetAsync<ItemDetailDto>($"/api/items/{Id}");
             if (item is not null)
             {
@@ -857,7 +912,38 @@ else
         shopEditIsSold = s.IsSold;
         shopEditIsFindable = s.IsFindable;
         shopEditSaleCondition = s.SaleCondition;
+        shopEditBuildingPickerId = null;
         isShopEditVisible = true;
+    }
+
+    // Issue #270 — append "Vyžaduje budovu: {Name}" to the active sale
+    // condition string. Separator " · " matches the dot-separator already
+    // used elsewhere in detail rows (e.g. ED. labels). No DB link, just a
+    // textual hint per the issue's explicit "just save it into the note".
+    private void AppendBuildingToPgSaleCondition()
+    {
+        if (pgBuildingPickerId is not int bid) return;
+        var building = allBuildings.FirstOrDefault(b => b.Id == bid);
+        pgBuildingPickerId = null;
+        if (building is null) return;
+        pgSaleCondition = AppendBuildingSnippet(pgSaleCondition, building.Name);
+    }
+
+    private void AppendBuildingToShopEditSaleCondition()
+    {
+        if (shopEditBuildingPickerId is not int bid) return;
+        var building = allBuildings.FirstOrDefault(b => b.Id == bid);
+        shopEditBuildingPickerId = null;
+        if (building is null) return;
+        shopEditSaleCondition = AppendBuildingSnippet(shopEditSaleCondition, building.Name);
+    }
+
+    private static string AppendBuildingSnippet(string? current, string buildingName)
+    {
+        var snippet = $"Vyžaduje budovu: {buildingName}";
+        return string.IsNullOrWhiteSpace(current)
+            ? snippet
+            : $"{current.TrimEnd()} · {snippet}";
     }
 
     private async Task SaveShopEditAsync()

--- a/src/OvcinaHra.Client/Pages/Tags/TagList.razor
+++ b/src/OvcinaHra.Client/Pages/Tags/TagList.razor
@@ -68,13 +68,25 @@ else
         isModalVisible = true;
     }
 
+    // Issue #234 — server now returns Czech ProblemDetails on validation
+    // failures (empty name, length, dup); switch to *WithProblemAsync so the
+    // server's `detail` round-trips into the existing error banner instead of
+    // being swallowed by EnsureSuccessStatusCode's generic exception message.
     private async Task SaveAsync()
     {
         error = null; isSaving = true;
         try
         {
-            if (editingId.HasValue) await Api.PutAsync($"/api/tags/{editingId}", new UpdateTagDto(name));
-            else await Api.PostAsync<CreateTagDto, TagDto>("/api/tags", new CreateTagDto(name, kind));
+            if (editingId.HasValue)
+            {
+                var (ok, problem) = await Api.PutWithProblemAsync($"/api/tags/{editingId}", new UpdateTagDto(name));
+                if (!ok) { error = problem ?? "Uložení tagu se nezdařilo."; return; }
+            }
+            else
+            {
+                var (ok, _, problem) = await Api.PostWithProblemAsync<CreateTagDto, TagDto>("/api/tags", new CreateTagDto(name, kind));
+                if (!ok) { error = problem ?? "Vytvoření tagu se nezdařilo."; return; }
+            }
             isModalVisible = false; await LoadAsync();
         }
         catch (Exception ex) { error = ex.Message; } finally { isSaving = false; }
@@ -82,7 +94,12 @@ else
 
     private async Task ConfirmDeleteAsync()
     {
-        try { await Api.DeleteAsync($"/api/tags/{editingId}"); isDeleteVisible = false; isModalVisible = false; await LoadAsync(); }
+        try
+        {
+            var (ok, problem) = await Api.DeleteWithProblemAsync($"/api/tags/{editingId}");
+            if (!ok) { error = problem ?? "Smazání tagu se nezdařilo."; return; }
+            isDeleteVisible = false; isModalVisible = false; await LoadAsync();
+        }
         catch (Exception ex) { error = ex.Message; }
     }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TagEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TagEndpointTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
@@ -18,6 +19,74 @@ public class TagEndpointTests(PostgresFixture postgres) : IntegrationTestBase(po
         var created = await response.Content.ReadFromJsonAsync<TagDto>();
         Assert.Equal("Nebezpečný", created!.Name);
         Assert.Equal(TagKind.Monster, created.Kind);
+    }
+
+    // Issue #234 — special characters round-trip through Create end-to-end.
+    // JSON body delivery means none of these need escaping; the server stores
+    // the name verbatim. Theory data covers `+` (the reported regression) plus
+    // the brief's smoke-test set: `&`, `:`, `'`, single space inside name.
+    [Theory]
+    [InlineData("C++")]
+    [InlineData("1+1")]
+    [InlineData("Boss & Goblin")]
+    [InlineData("Trap: floor")]
+    [InlineData("D'Artagnan")]
+    [InlineData("Two Words")]
+    public async Task Create_NameWithSpecialChars_RoundTripsVerbatim(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto(name, TagKind.Monster));
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var created = await response.Content.ReadFromJsonAsync<TagDto>();
+        Assert.Equal(name, created!.Name);
+
+        // Also confirm the persisted value is identical when fetched back.
+        var fetched = await Client.GetFromJsonAsync<TagDto>($"/api/tags/{created.Id}");
+        Assert.Equal(name, fetched!.Name);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateNameWithinKind_Returns400WithCzechProblemDetails()
+    {
+        await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("Plus+Tag", TagKind.Monster));
+
+        var response = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("Plus+Tag", TagKind.Monster));
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Uložení selhalo", problem!.Title);
+        Assert.Contains("už", problem.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Create_EmptyName_Returns400()
+    {
+        var response = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("   ", TagKind.Monster));
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Contains("prázd", problem!.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Create_NameTrimmedOnPersist()
+    {
+        var response = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("  Trimmed  ", TagKind.Quest));
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var created = await response.Content.ReadFromJsonAsync<TagDto>();
+        Assert.Equal("Trimmed", created!.Name);
+    }
+
+    [Fact]
+    public async Task Update_NameWithPlus_Persists()
+    {
+        var createResponse = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("Old", TagKind.Monster));
+        var created = await createResponse.Content.ReadFromJsonAsync<TagDto>();
+
+        var response = await Client.PutAsJsonAsync($"/api/tags/{created!.Id}", new UpdateTagDto("Foo+Bar"));
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var fetched = await Client.GetFromJsonAsync<TagDto>($"/api/tags/{created.Id}");
+        Assert.Equal("Foo+Bar", fetched!.Name);
     }
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TagEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TagEndpointTests.cs
@@ -47,7 +47,11 @@ public class TagEndpointTests(PostgresFixture postgres) : IntegrationTestBase(po
     [Fact]
     public async Task Create_DuplicateNameWithinKind_Returns400WithCzechProblemDetails()
     {
-        await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("Plus+Tag", TagKind.Monster));
+        var initialResponse = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("Plus+Tag", TagKind.Monster));
+        // Assert the Arrange step succeeded — without this, a regression in
+        // baseline Create would still pass the test for the wrong reason
+        // (both calls return 400). Per Copilot review on PR #282.
+        Assert.Equal(HttpStatusCode.Created, initialResponse.StatusCode);
 
         var response = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("Plus+Tag", TagKind.Monster));
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -80,6 +84,8 @@ public class TagEndpointTests(PostgresFixture postgres) : IntegrationTestBase(po
     public async Task Update_NameWithPlus_Persists()
     {
         var createResponse = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("Old", TagKind.Monster));
+        // Assert the Arrange step (Create) succeeded — per Copilot review on PR #282.
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
         var created = await createResponse.Content.ReadFromJsonAsync<TagDto>();
 
         var response = await Client.PutAsJsonAsync($"/api/tags/{created!.Id}", new UpdateTagDto("Foo+Bar"));


### PR DESCRIPTION
## Summary

Bundle of 5 cohesive Items / Recipe surface fixes.

### #234 — Tags can be created with `+` (and other special chars)
- Server (`TagEndpoints.cs`): `Create` + `Update` validate name (Trim, non-empty, max 100 chars matching `[MaxLength(100)]`, kind enum-defined check, dup-check within Kind) and return Czech `ProblemDetails(400)` instead of letting the DB throw or silently accepting bad input. `FindAsync`-before-validate on Update so a missing id wins as 404 (per `_review-instincts §1`).
- Client (`TagList.razor`): switched POST/PUT/DELETE to `*WithProblemAsync` so the server's Czech `detail` round-trips into the existing `error` banner instead of being lost behind the generic `EnsureSuccessStatusCode` exception message.
- Tests (`TagEndpointTests.cs`): `[Theory]` proves `C++`, `1+1`, `Boss & Goblin`, `Trap: floor`, `D'Artagnan`, `Two Words` all round-trip verbatim through Create + GetById. New tests for empty-name, dup-within-kind, trim-on-persist, and Update-with-`+`.

### #236 — Nový recept: make all things visible
- `RecipeEditPopup.razor` body now wraps in `max-height: 75vh; overflow-y: auto` so the Suroviny + Vyžaduje sections don't push the Save/Zrušit footer below the viewport on shorter laptop screens. Footer moved **outside** the scroll wrapper so it's always reachable.

### #269 — Items grid card images forced to 1:1
- `ItemEndpoints.cs` list / detail / by-game ImageUrl now points at the **`medium`** thumbnail preset (240×336, 5:7) instead of **`small`** (120×120, 1:1 crop). The previous `Small` preset's `ResizeMode.Crop` was stripping top + bottom of 5:7 portrait card photos to force a square — exactly the symptom in the issue screenshot. The grid tile container is already 5:7 with `object-fit: contain`, so the new bytes match the slot exactly with no further crop or letterbox.

### #270 — Sell condition: building requirement quick-append
- `ItemDetail.razor` per-game shop edit popup **and** Upravit tab "V této hře" group both grow a building picker — pick a building, click "Vyžaduje budovu", and ` · Vyžaduje budovu: {Name}` appends to the free-text SaleCondition note. **No DB link**, just a textual hint per the issue's explicit *"just save it into the note"*. Buildings catalog cached on first `LoadAsync` (best-effort with try/catch — failure doesn't block the item itself from rendering).

### #271 — Hide irrelevant Item detail tabs
- `Tvorba` / `Výskyt` / `Obchod` tab buttons only render when their respective usage counts > 0. An item with no recipes, drops, or shop assignments shows just `Karta` + `Upravit`. Counts come from the same `usage` aggregate that already feeds the badges, so no DTO/endpoint changes needed and the empty-state copy that used to live in those tabs is no longer reachable.

## Cross-cutting
- No migration.
- No csproj `<Version>` change — auto-bump CI handles it (`_review-instincts.md` rule #18).
- `LayoutKey` unchanged — no DxGrid column schema changes anywhere.
- Czech UI text + diacritics consistent.

## Test plan
- [x] `dotnet build OvcinaHra.slnx` — 0 warnings, 0 errors (`TreatWarningsAsErrors=true`)
- [x] `dotnet test tests/OvcinaHra.Api.Tests` — **433 passed, 0 failed** (52s)
- [ ] Manual smoke on prod after deploy:
  - [ ] Create tag `C++` from `/tags` — succeeds, no error banner
  - [ ] Create duplicate tag — Czech ProblemDetails surfaces in banner
  - [ ] Open `Nový recept` from `/recipes` → Vytvořit a otevřít → confirm RecipeEditPopup body scrolls and Save footer always visible on a 1366×768 laptop screen
  - [ ] `/items` (catalog + per-game): card images render at 5:7 with no top/bottom crop
  - [ ] Item detail Obchod tab → "Upravit nastavení v této hře" → pick a building → click "Vyžaduje budovu" → confirm `Vyžaduje budovu: {Name}` appears in the Podmínka prodeje field
  - [ ] Open an item with no recipes/drops/shops — confirm only Karta + Upravit tabs visible
- [ ] Playwright E2E deferred — `E2ETestBase` uses `WebApplicationFactory` in-memory server which Playwright's real browser cannot reach (`ERR_CONNECTION_REFUSED`). Tracked at #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)