### PR TITLE
[v0.15.90] Fix Location detail and game-removal suite

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -40,6 +40,7 @@ public static class GameEndpoints
         group.MapPut("/{gameId:int}/skills/{gameSkillId:int}", UpdateGameSkill);
         group.MapDelete("/{gameId:int}/skills/{gameSkillId:int}", DeleteGameSkill);
         group.MapPost("/{gameId:int}/quests/bulk", BulkAddQuests);
+        group.MapDelete("/{gameId:int}/locations/{locationId:int}", RemoveLocationFromGame);
 
         return group;
     }
@@ -570,6 +571,17 @@ public static class GameEndpoints
         }
 
         db.GameSkills.Remove(gameSkill);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound>> RemoveLocationFromGame(
+        int gameId, int locationId, WorldDbContext db)
+    {
+        var link = await db.GameLocations.FindAsync(gameId, locationId);
+        if (link is null) return TypedResults.NotFound();
+
+        db.GameLocations.Remove(link);
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -10,6 +10,14 @@ namespace OvcinaHra.Api.Endpoints;
 
 public static class LocationEndpoints
 {
+    private const int LocationInheritanceMaxDepth = 3;
+
+    private sealed record LocationCoordinateState(
+        int Id,
+        decimal? Latitude,
+        decimal? Longitude,
+        int? ParentLocationId);
+
     public static RouteGroupBuilder MapLocationEndpoints(this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/locations").WithTags("Locations");
@@ -58,15 +66,9 @@ public static class LocationEndpoints
             })
             .ToListAsync();
 
-        var lookup = rows.ToDictionary(r => r.Id);
-        bool IsLocated(int? locationId, int depth = 0)
-        {
-            if (locationId is null || depth > 3 || !lookup.TryGetValue(locationId.Value, out var row))
-                return false;
-            if (row.Latitude.HasValue && row.Longitude.HasValue)
-                return true;
-            return IsLocated(row.ParentLocationId, depth + 1);
-        }
+        var lookup = await BuildLocationStateLookupAsync(
+            db,
+            rows.Select(r => new LocationCoordinateState(r.Id, r.Latitude, r.Longitude, r.ParentLocationId)));
 
         var locations = rows.Select(r => new LocationListDto(
             r.Id, r.Name, r.LocationKind,
@@ -82,7 +84,7 @@ public static class LocationEndpoints
             ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
             StampImagePath: r.StampImagePath,
             StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"),
-            IsLocated: IsLocated(r.Id))).ToList();
+            IsLocated: IsLocated(lookup, r.Id))).ToList();
 
         return TypedResults.Ok(locations);
     }
@@ -164,9 +166,12 @@ public static class LocationEndpoints
             return TypedResults.NotFound();
 
         var variants = loc.Variants.Select(v => new LocationVariantDto(v.Id, v.Name, v.LocationKind)).ToList();
+        decimal? latitude = loc.ParentLocationId.HasValue ? null : loc.Coordinates?.Latitude;
+        decimal? longitude = loc.ParentLocationId.HasValue ? null : loc.Coordinates?.Longitude;
+
         return TypedResults.Ok(new LocationDetailDto(
             loc.Id, loc.Name, loc.Description, loc.Details, loc.GamePotential, loc.Prompt, loc.Region, loc.LocationKind,
-            loc.Coordinates?.Latitude, loc.Coordinates?.Longitude,
+            latitude, longitude,
             loc.ImagePath, loc.PlacementPhotoPath, loc.StampImagePath, loc.NpcInfo, loc.SetupNotes,
             loc.ParentLocationId, variants));
     }
@@ -318,23 +323,9 @@ public static class LocationEndpoints
             })
             .ToListAsync();
 
-        var lookup = await db.Locations
-            .Select(l => new
-            {
-                l.Id,
-                Latitude = l.Coordinates != null ? l.Coordinates.Latitude : (decimal?)null,
-                Longitude = l.Coordinates != null ? l.Coordinates.Longitude : (decimal?)null,
-                l.ParentLocationId
-            })
-            .ToDictionaryAsync(l => l.Id);
-        bool IsLocated(int? locationId, int depth = 0)
-        {
-            if (locationId is null || depth > 3 || !lookup.TryGetValue(locationId.Value, out var row))
-                return false;
-            if (row.Latitude.HasValue && row.Longitude.HasValue)
-                return true;
-            return IsLocated(row.ParentLocationId, depth + 1);
-        }
+        var lookup = await BuildLocationStateLookupAsync(
+            db,
+            rows.Select(r => new LocationCoordinateState(r.Id, r.Latitude, r.Longitude, r.ParentLocationId)));
 
         var dtos = rows.Select(r => new LocationListDto(
             r.Id, r.Name, r.LocationKind,
@@ -355,9 +346,65 @@ public static class LocationEndpoints
             ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
             StampImagePath: r.StampImagePath,
             StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"),
-            IsLocated: IsLocated(r.Id))).ToList();
+            IsLocated: IsLocated(lookup, r.Id))).ToList();
 
         return TypedResults.Ok(dtos);
+    }
+
+    private static async Task<Dictionary<int, LocationCoordinateState>> BuildLocationStateLookupAsync(
+        WorldDbContext db,
+        IEnumerable<LocationCoordinateState> seed)
+    {
+        var lookup = seed.ToDictionary(s => s.Id);
+        var missingParentIds = MissingParentIds(lookup.Values, lookup);
+
+        for (var depth = 0; depth < LocationInheritanceMaxDepth && missingParentIds.Count > 0; depth++)
+        {
+            var parents = await db.Locations
+                .Where(l => missingParentIds.Contains(l.Id))
+                .Select(l => new LocationCoordinateState(
+                    l.Id,
+                    l.Coordinates != null ? l.Coordinates.Latitude : (decimal?)null,
+                    l.Coordinates != null ? l.Coordinates.Longitude : (decimal?)null,
+                    l.ParentLocationId))
+                .ToListAsync();
+
+            foreach (var parent in parents)
+            {
+                lookup[parent.Id] = parent;
+            }
+
+            missingParentIds = MissingParentIds(parents, lookup);
+        }
+
+        return lookup;
+    }
+
+    private static HashSet<int> MissingParentIds(
+        IEnumerable<LocationCoordinateState> locations,
+        IReadOnlyDictionary<int, LocationCoordinateState> lookup) =>
+        locations
+            .Select(l => l.ParentLocationId)
+            .Where(id => id.HasValue && !lookup.ContainsKey(id.Value))
+            .Select(id => id!.Value)
+            .ToHashSet();
+
+    private static bool IsLocated(
+        IReadOnlyDictionary<int, LocationCoordinateState> lookup,
+        int? locationId,
+        int depth = 0)
+    {
+        if (locationId is null
+            || depth > LocationInheritanceMaxDepth
+            || !lookup.TryGetValue(locationId.Value, out var row))
+        {
+            return false;
+        }
+
+        if (!row.ParentLocationId.HasValue && row.Latitude.HasValue && row.Longitude.HasValue)
+            return true;
+
+        return IsLocated(lookup, row.ParentLocationId, depth + 1);
     }
 
     private static async Task<Results<Created, Conflict>> AssignToGame(GameLocationDto dto, WorldDbContext db)

--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -17,6 +17,7 @@ public static class LocationEndpoints
         group.MapGet("/", GetAll);
         group.MapGet("/nearby", GetNearby);
         group.MapGet("/{id:int}", GetById);
+        group.MapGet("/{id:int}/quests", GetQuests);
         group.MapPost("/", Create);
         group.MapPut("/{id:int}", Update);
         group.MapDelete("/{id:int}", Delete);
@@ -57,6 +58,16 @@ public static class LocationEndpoints
             })
             .ToListAsync();
 
+        var lookup = rows.ToDictionary(r => r.Id);
+        bool IsLocated(int? locationId, int depth = 0)
+        {
+            if (locationId is null || depth > 3 || !lookup.TryGetValue(locationId.Value, out var row))
+                return false;
+            if (row.Latitude.HasValue && row.Longitude.HasValue)
+                return true;
+            return IsLocated(row.ParentLocationId, depth + 1);
+        }
+
         var locations = rows.Select(r => new LocationListDto(
             r.Id, r.Name, r.LocationKind,
             r.Region,
@@ -70,7 +81,8 @@ public static class LocationEndpoints
             ImagePath: r.ImagePath,
             ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
             StampImagePath: r.StampImagePath,
-            StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"))).ToList();
+            StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"),
+            IsLocated: IsLocated(r.Id))).ToList();
 
         return TypedResults.Ok(locations);
     }
@@ -112,7 +124,9 @@ public static class LocationEndpoints
                 && (excludeId == null || l.Id != excludeId.Value))
             .Select(l => new
             {
-                l.Id, l.Name, l.LocationKind,
+                l.Id,
+                l.Name,
+                l.LocationKind,
                 Latitude = l.Coordinates!.Latitude,
                 Longitude = l.Coordinates!.Longitude
             })
@@ -157,13 +171,33 @@ public static class LocationEndpoints
             loc.ParentLocationId, variants));
     }
 
+    private static async Task<Results<Ok<List<LocationQuestSummaryDto>>, NotFound>> GetQuests(
+        int id, WorldDbContext db, int? gameId = null)
+    {
+        var locationExists = await db.Locations.AnyAsync(l => l.Id == id);
+        if (!locationExists)
+            return TypedResults.NotFound();
+
+        var quests = await db.QuestLocationLinks
+            .Where(ql => ql.LocationId == id
+                && (gameId == null || ql.Quest.GameId == null || ql.Quest.GameId == gameId))
+            .OrderBy(ql => ql.Quest.Name)
+            .Select(ql => new LocationQuestSummaryDto(
+                ql.QuestId,
+                ql.Quest.Name,
+                ql.Quest.QuestType))
+            .ToListAsync();
+
+        return TypedResults.Ok(quests);
+    }
+
     private static async Task<Created<LocationDetailDto>> Create(CreateLocationDto dto, WorldDbContext db)
     {
         var loc = new Location
         {
             Name = dto.Name,
             LocationKind = dto.LocationKind,
-            Coordinates = dto.Latitude.HasValue && dto.Longitude.HasValue
+            Coordinates = !dto.ParentLocationId.HasValue && dto.Latitude.HasValue && dto.Longitude.HasValue
                 ? new GpsCoordinates(dto.Latitude.Value, dto.Longitude.Value) : null,
             Description = dto.Description,
             Details = dto.Details,
@@ -195,7 +229,7 @@ public static class LocationEndpoints
 
         loc.Name = dto.Name;
         loc.LocationKind = dto.LocationKind;
-        loc.Coordinates = dto.Latitude.HasValue && dto.Longitude.HasValue
+        loc.Coordinates = !dto.ParentLocationId.HasValue && dto.Latitude.HasValue && dto.Longitude.HasValue
             ? new GpsCoordinates(dto.Latitude.Value, dto.Longitude.Value) : null;
         loc.Description = dto.Description;
         loc.Details = dto.Details;
@@ -284,6 +318,24 @@ public static class LocationEndpoints
             })
             .ToListAsync();
 
+        var lookup = await db.Locations
+            .Select(l => new
+            {
+                l.Id,
+                Latitude = l.Coordinates != null ? l.Coordinates.Latitude : (decimal?)null,
+                Longitude = l.Coordinates != null ? l.Coordinates.Longitude : (decimal?)null,
+                l.ParentLocationId
+            })
+            .ToDictionaryAsync(l => l.Id);
+        bool IsLocated(int? locationId, int depth = 0)
+        {
+            if (locationId is null || depth > 3 || !lookup.TryGetValue(locationId.Value, out var row))
+                return false;
+            if (row.Latitude.HasValue && row.Longitude.HasValue)
+                return true;
+            return IsLocated(row.ParentLocationId, depth + 1);
+        }
+
         var dtos = rows.Select(r => new LocationListDto(
             r.Id, r.Name, r.LocationKind,
             r.Region,
@@ -302,7 +354,8 @@ public static class LocationEndpoints
             ImagePath: r.ImagePath,
             ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
             StampImagePath: r.StampImagePath,
-            StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"))).ToList();
+            StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"),
+            IsLocated: IsLocated(r.Id))).ToList();
 
         return TypedResults.Ok(dtos);
     }

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -60,9 +60,18 @@ else
                     <button class="btn btn-secondary" @onclick='() => SwitchTab("upravit")'>
                         <i class="bi bi-pencil me-1"></i> Upravit
                     </button>
-                    <button class="btn oh-btn-ghost-bordeaux" @onclick="() => isDeleteVisible = true">
-                        <i class="bi bi-trash me-1"></i> Smazat
-                    </button>
+                    @if (IsGameScoped)
+                    {
+                        <button class="btn oh-btn-ghost-bordeaux" @onclick="() => isRemoveFromGameVisible = true">
+                            <i class="bi bi-bookmark-dash me-1"></i> Odebrat z této hry
+                        </button>
+                    }
+                    else
+                    {
+                        <button class="btn oh-btn-ghost-bordeaux" @onclick="() => isDeleteVisible = true">
+                            <i class="bi bi-trash me-1"></i> Smazat
+                        </button>
+                    }
                 }
             </div>
         </div>
@@ -77,13 +86,20 @@ else
             <button class="oh-lc-tab @(activeTab == "lore" ? "active" : "")" @onclick='() => SwitchTab("lore")'>
                 <i class="bi bi-book"></i> Lore
             </button>
-            <button class="oh-lc-tab @(activeTab == "skryse" ? "active" : "")" @onclick='() => SwitchTab("skryse")'>
-                <i class="bi bi-safe"></i> Skrýše
-                @if ((loc.Stashes?.Count ?? 0) > 0)
-                {
+            @if (HasStashes)
+            {
+                <button class="oh-lc-tab @(activeTab == "skryse" ? "active" : "")" @onclick='() => SwitchTab("skryse")'>
+                    <i class="bi bi-safe"></i> Skrýše
                     <span class="oh-lc-count">@loc.Stashes!.Count</span>
-                }
-            </button>
+                </button>
+            }
+            @if (HasQuests)
+            {
+                <button class="oh-lc-tab @(activeTab == "questy" ? "active" : "")" @onclick='() => SwitchTab("questy")'>
+                    <i class="bi bi-journal-text"></i> Questy
+                    <span class="oh-lc-count">@locationQuests.Count</span>
+                </button>
+            }
         </div>
 
         @if (error is not null)
@@ -112,6 +128,28 @@ else
                         <div class="oh-lc-empty-title">Tato lokace ještě čeká na popis</div>
                         <div class="oh-lc-empty-copy">Napiš první popis a nahraj obrázek na záložce <strong>Upravit</strong>.</div>
                     </div>
+                    @if (parent is not null || variants.Count > 0)
+                    {
+                        <div class="oh-lc-card-variants">
+                            @if (parent is not null)
+                            {
+                                <span class="oh-lc-vlbl">Rodičovská lokace:</span>
+                                <NavLink class="oh-lc-vchip" href="@($"/locations/{parent.Id}")">
+                                    <i class="bi bi-arrow-up-short"></i> @parent.Name
+                                </NavLink>
+                            }
+                            @if (variants.Count > 0)
+                            {
+                                <span class="oh-lc-vlbl">Podřízené lokace:</span>
+                            }
+                            @foreach (var v in variants)
+                            {
+                                <NavLink class="oh-lc-vchip" href="@($"/locations/{v.Id}")">
+                                    <i class="bi bi-arrow-right-short"></i> @v.Name
+                                </NavLink>
+                            }
+                        </div>
+                    }
                 </div>
             }
             else
@@ -154,15 +192,25 @@ else
                         </div>
                     }
 
-                    @if (variants.Count > 0)
+                    @if (parent is not null || variants.Count > 0)
                     {
                         <div class="oh-lc-card-variants">
-                            <span class="oh-lc-vlbl">Varianty (@variants.Count):</span>
+                            @if (parent is not null)
+                            {
+                                <span class="oh-lc-vlbl">Rodičovská lokace:</span>
+                                <NavLink class="oh-lc-vchip" href="@($"/locations/{parent.Id}")">
+                                    <i class="bi bi-arrow-up-short"></i> @parent.Name
+                                </NavLink>
+                            }
+                            @if (variants.Count > 0)
+                            {
+                                <span class="oh-lc-vlbl">Podřízené lokace:</span>
+                            }
                             @foreach (var v in variants)
                             {
-                                <a class="oh-lc-vchip" href="/locations/@v.Id">
+                                <NavLink class="oh-lc-vchip" href="@($"/locations/{v.Id}")">
                                     <i class="bi bi-arrow-right-short"></i> @v.Name
-                                </a>
+                                </NavLink>
                             }
                         </div>
                     }
@@ -189,7 +237,8 @@ else
                     </DxFormLayoutItem>
                     <DxFormLayoutItem Caption="Rodič" ColSpanMd="6">
                         <DxComboBox TData="LocationListDto" TValue="int?"
-                                    Data="@parentCandidates" @bind-Value="@parentLocationId"
+                                    Data="@parentCandidates" Value="@parentLocationId"
+                                    ValueChanged="@OnParentLocationChanged"
                                     TextFieldName="Name" ValueFieldName="Id"
                                     NullText="(žádný)" SearchMode="ListSearchMode.AutoSearch" />
                     </DxFormLayoutItem>
@@ -215,10 +264,14 @@ else
                 <div class="oh-lc-sect-label"><i class="bi bi-geo-alt"></i> Mapa a vizuál</div>
                 <div class="oh-lc-mv-gps">
                     <label>Lat</label>
-                    <DxTextBox @bind-Text="@latitudeStr" NullText="49,4543192" CssClass="oh-lc-mv-gps-input" />
+                    <DxTextBox @bind-Text="@latitudeStr" NullText="49,4543192" CssClass="oh-lc-mv-gps-input" ReadOnly="@parentLocationId.HasValue" />
                     <label>Lon</label>
-                    <DxTextBox @bind-Text="@longitudeStr" NullText="18,0203280" CssClass="oh-lc-mv-gps-input" />
+                    <DxTextBox @bind-Text="@longitudeStr" NullText="18,0203280" CssClass="oh-lc-mv-gps-input" ReadOnly="@parentLocationId.HasValue" />
                 </div>
+                @if (parentLocationId.HasValue)
+                {
+                    <div class="text-muted small mt-1">Zděděno z rodiče: @InheritedCoordinatesText</div>
+                }
                 <div class="oh-lc-mv-row">
                     <div class="oh-lc-mv-col oh-lc-mv-map-col">
                         @if (HasGps)
@@ -310,7 +363,7 @@ else
         }
 
         @* ── Tab: Skrýše (MTG tiles) ── *@
-        @if (activeTab == "skryse")
+        @if (activeTab == "skryse" && HasStashes)
         {
             <div class="oh-lc-stash-head">
                 <h3>
@@ -323,22 +376,37 @@ else
                 </a>
             </div>
 
-            @if ((loc.Stashes?.Count ?? 0) == 0)
-            {
-                <div class="oh-lc-card-empty">
-                    <div class="oh-lc-empty-title">Žádné skrýše zatím nejsou přiřazené</div>
-                    <div class="oh-lc-empty-copy">Přiřaď skrýš k této lokaci přes stránku <strong>Tajné skrýše</strong>.</div>
-                </div>
-            }
-            else
-            {
-                <div class="oh-lc-stash-grid">
-                    @foreach (var stash in loc.Stashes!)
-                    {
-                        <LocationStashTile @key="stash.Id" Stash="stash" />
-                    }
-                </div>
-            }
+            <div class="oh-lc-stash-grid">
+                @foreach (var stash in loc.Stashes!)
+                {
+                    <LocationStashTile @key="stash.Id" Stash="stash" />
+                }
+            </div>
+        }
+
+        @* ── Tab: Questy ── *@
+        @if (activeTab == "questy" && HasQuests)
+        {
+            <div class="oh-lc-stash-head">
+                <h3>
+                    <i class="bi bi-journal-text"></i>
+                    Questy v této lokaci
+                    <span class="oh-lc-stash-count">(@locationQuests.Count)</span>
+                </h3>
+                <a class="btn btn-outline-secondary" href="/quests">
+                    <i class="bi bi-plus-lg me-1"></i> Spravovat questy
+                </a>
+            </div>
+
+            <div class="oh-lc-card-variants">
+                @foreach (var quest in locationQuests)
+                {
+                    <NavLink class="oh-lc-vchip" href="@($"/quests/{quest.Id}")">
+                        <i class="bi bi-journal-text"></i> @quest.Name
+                        <span class="text-muted">(@quest.QuestTypeDisplay)</span>
+                    </NavLink>
+                }
+            </div>
         }
     </div>
 }
@@ -354,6 +422,16 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+<DxPopup @bind-Visible="@isRemoveFromGameVisible" HeaderText="Odebrat lokaci z této hry?" Width="420px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete odebrat lokaci <strong>@loc?.Name</strong> z této hry? Lokace zůstane v katalogu.</p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isRemoveFromGameVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmRemoveFromGameAsync">Odebrat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @code {
     [Parameter] public int Id { get; set; }
 
@@ -361,13 +439,15 @@ else
     private LocationListDto? parent;
     private List<LocationListDto> variants = [];
     private List<LocationListDto> parentCandidates = [];
+    private List<LocationQuestSummaryDto> locationQuests = [];
     // Cached so the mini-map can paint surrounding orientation pins (issue #74)
     // without re-fetching the catalog on every render.
     private List<LocationListDto> allLocations = [];
     private string? mainImageUrl;
 
     private string activeTab = "karta";
-    private bool loading = true, isSaving, isDeleteVisible;
+    private bool loading = true, isSaving, isDeleteVisible, isRemoveFromGameVisible;
+    private bool isInSelectedGame;
     private string? error;
 
     // Form state (duplicate of loc for edit mode)
@@ -401,6 +481,19 @@ else
     private string? lastMiniMapElementId;
 
     private bool HasGps => ParseGps(out _, out _);
+    private bool HasStashes => (loc?.Stashes?.Count ?? 0) > 0;
+    private bool HasQuests => locationQuests.Count > 0;
+    private bool IsGameScoped => GameContext.SelectedGameId.HasValue && isInSelectedGame;
+    private string InheritedCoordinatesText
+    {
+        get
+        {
+            var coords = GetEffectiveCoordinates(parentLocationId);
+            return coords is null
+                ? "rodič nemá GPS"
+                : $"{coords.Value.Latitude.ToString(System.Globalization.CultureInfo.InvariantCulture)}, {coords.Value.Longitude.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+        }
+    }
 
     private bool ParseGps(out decimal lat, out decimal lon)
     {
@@ -422,6 +515,8 @@ else
     private async Task LoadAsync()
     {
         loading = true; error = null;
+        isInSelectedGame = false;
+        locationQuests = [];
         try
         {
             var detail = await Api.GetAsync<LocationDetailDto>($"/api/locations/{Id}");
@@ -445,6 +540,7 @@ else
                     var inGame = gameList.FirstOrDefault(l => l.Id == Id);
                     if (inGame is not null)
                     {
+                        isInSelectedGame = true;
                         stashes = inGame.Stashes;
                         quests = inGame.Quests;
                         locationTreasureQuests = inGame.LocationTreasureQuests;
@@ -463,6 +559,15 @@ else
 
             PopulateFormFromDto(detail);
 
+            try
+            {
+                var query = GameContext.SelectedGameId.HasValue
+                    ? $"?gameId={GameContext.SelectedGameId.Value}"
+                    : "";
+                locationQuests = await Api.GetListAsync<LocationQuestSummaryDto>($"/api/locations/{Id}/quests{query}");
+            }
+            catch { locationQuests = []; }
+
             // Parent + variants (and cached for the mini-map orientation pins, issue #74).
             allLocations = await Api.GetListAsync<LocationListDto>("/api/locations");
             parentCandidates = allLocations.Where(l => l.Id != Id).ToList();
@@ -470,6 +575,8 @@ else
                 ? allLocations.FirstOrDefault(l => l.Id == detail.ParentLocationId.Value)
                 : null;
             variants = allLocations.Where(l => l.ParentLocationId == Id).ToList();
+            RefreshInheritedCoordinates();
+            NormalizeActiveTab();
 
             // Main image (ImagePicker has its own fetch, but we also render img on Karta)
             try
@@ -500,7 +607,57 @@ else
         loreText = d.Description;
     }
 
-    private void SwitchTab(string tab) => activeTab = tab;
+    private void SwitchTab(string tab)
+    {
+        if (tab == "skryse" && !HasStashes) return;
+        if (tab == "questy" && !HasQuests) return;
+        activeTab = tab;
+    }
+
+    private void NormalizeActiveTab()
+    {
+        if (activeTab == "skryse" && !HasStashes) activeTab = "karta";
+        if (activeTab == "questy" && !HasQuests) activeTab = "karta";
+    }
+
+    private void OnParentLocationChanged(int? value)
+    {
+        parentLocationId = value;
+        if (parentLocationId.HasValue)
+        {
+            RefreshInheritedCoordinates();
+            return;
+        }
+
+        latitudeStr = loc?.Latitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "";
+        longitudeStr = loc?.Longitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "";
+    }
+
+    private void RefreshInheritedCoordinates()
+    {
+        if (!parentLocationId.HasValue) return;
+        var coords = GetEffectiveCoordinates(parentLocationId);
+        if (coords is { } c)
+        {
+            latitudeStr = c.Latitude.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            longitudeStr = c.Longitude.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            latitudeStr = "";
+            longitudeStr = "";
+        }
+    }
+
+    private (decimal Latitude, decimal Longitude)? GetEffectiveCoordinates(int? locationId, int depth = 0)
+    {
+        if (locationId is null || depth > 3) return null;
+        var location = allLocations.FirstOrDefault(l => l.Id == locationId.Value);
+        if (location is null) return null;
+        if (location.Latitude.HasValue && location.Longitude.HasValue)
+            return (location.Latitude.Value, location.Longitude.Value);
+        return GetEffectiveCoordinates(location.ParentLocationId, depth + 1);
+    }
 
     private async Task SaveAsync()
     {
@@ -533,12 +690,15 @@ else
     private UpdateLocationDto BuildUpdateDto()
     {
         decimal? lat = null, lon = null;
-        if (decimal.TryParse(latitudeStr?.Replace(',', '.'), System.Globalization.NumberStyles.Float,
-                System.Globalization.CultureInfo.InvariantCulture, out var la))
-            lat = la;
-        if (decimal.TryParse(longitudeStr?.Replace(',', '.'), System.Globalization.NumberStyles.Float,
-                System.Globalization.CultureInfo.InvariantCulture, out var lo))
-            lon = lo;
+        if (!parentLocationId.HasValue)
+        {
+            if (decimal.TryParse(latitudeStr?.Replace(',', '.'), System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var la))
+                lat = la;
+            if (decimal.TryParse(longitudeStr?.Replace(',', '.'), System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var lo))
+                lon = lo;
+        }
 
         return new UpdateLocationDto(
             Name: name,
@@ -571,6 +731,27 @@ else
             Nav.NavigateTo("/locations");
         }
         catch (Exception ex) { error = ex.Message; isDeleteVisible = false; }
+    }
+
+    private async Task ConfirmRemoveFromGameAsync()
+    {
+        if (!GameContext.SelectedGameId.HasValue) return;
+
+        error = null;
+        try
+        {
+            var (ok, problem) = await Api.DeleteWithProblemAsync(
+                $"/api/games/{GameContext.SelectedGameId.Value}/locations/{Id}");
+            if (!ok)
+            {
+                error = problem ?? "Odebrání lokace z této hry se nezdařilo.";
+                return;
+            }
+
+            isRemoveFromGameVisible = false;
+            Nav.NavigateTo("/locations");
+        }
+        catch (Exception ex) { error = ex.Message; isRemoveFromGameVisible = false; }
     }
 
     private void OpenFullMap() => Nav.NavigateTo($"/map?focus={Id}");

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -426,8 +426,14 @@ else
     <BodyContentTemplate Context="popupContext">
         <p>Opravdu chcete odebrat lokaci <strong>@loc?.Name</strong> z této hry? Lokace zůstane v katalogu.</p>
         <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="() => isRemoveFromGameVisible = false">Zrušit</button>
-            <button class="btn btn-danger" @onclick="ConfirmRemoveFromGameAsync">Odebrat</button>
+            <button class="btn btn-secondary" @onclick="() => isRemoveFromGameVisible = false" disabled="@isSaving">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmRemoveFromGameAsync" disabled="@isSaving">
+                @if (isSaving)
+                {
+                    <span class="spinner-border spinner-border-sm me-1"></span>
+                }
+                Odebrat
+            </button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
@@ -735,9 +741,10 @@ else
 
     private async Task ConfirmRemoveFromGameAsync()
     {
-        if (!GameContext.SelectedGameId.HasValue) return;
+        if (!GameContext.SelectedGameId.HasValue || isSaving) return;
 
         error = null;
+        isSaving = true;
         try
         {
             var (ok, problem) = await Api.DeleteWithProblemAsync(
@@ -751,7 +758,8 @@ else
             isRemoveFromGameVisible = false;
             Nav.NavigateTo("/locations");
         }
-        catch (Exception ex) { error = ex.Message; isRemoveFromGameVisible = false; }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isSaving = false; }
     }
 
     private void OpenFullMap() => Nav.NavigateTo($"/map?focus={Id}");

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -94,7 +94,7 @@ else
 {
     <OvcinaGrid Data="@visibleRows"
                 KeyFieldName="Id"
-                LayoutKey="grid-layout-locations-v5"
+                LayoutKey="grid-layout-locations-v6"
                 RowClick="@OnGridRowClick">
         <Columns>
             @* Actions — moved to first column per issue #94. Destructive
@@ -126,12 +126,12 @@ else
                                 var isAssigned = assignedLocationIds.Contains(loc.Id);
                                 @if (isAssigned)
                                 {
-                                    <button type="button"
-                                            title="Odebrat z aktuální hry"
-                                            @onclick="() => UnassignLocationAsync(loc.Id)"
-                                            @onclick:stopPropagation="true">
-                                        <i class="bi bi-bookmark-dash"></i>
-                                    </button>
+                                     <button type="button"
+                                             title="Odebrat z aktuální hry"
+                                             @onclick="() => PromptUnassign(loc)"
+                                             @onclick:stopPropagation="true">
+                                         <i class="bi bi-bookmark-dash"></i>
+                                     </button>
                                 }
                                 else
                                 {
@@ -207,13 +207,13 @@ else
                             @if (variantCount > 0)
                             {
                                 <span class="oh-lg-vcap">
-                                    <i class="bi bi-diagram-3"></i>@variantCount @PluralCz(variantCount, "varianta", "varianty", "variant") · pin jen na rodiči
+                                    <i class="bi bi-diagram-3"></i>@variantCount @PluralCz(variantCount, "varianta", "varianty", "variant")
                                 </span>
                             }
                         </div>
-                        @if (!isVariant && loc.Latitude.HasValue && loc.Longitude.HasValue)
+                        @if (loc.IsLocated)
                         {
-                            <i class="bi bi-geo-alt-fill oh-lg-pin-hint" title="Zobrazeno na mapě"></i>
+                            <i class="bi bi-geo-alt-fill oh-lg-pin-hint" title="Lokace má GPS"></i>
                         }
                     </div>
                 </CellDisplayTemplate>
@@ -241,6 +241,17 @@ else
                     {
                         <div class="oh-lg-region"><i class="bi bi-compass"></i>@loc.Region</div>
                     }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="IsLocated" Caption="GPS" Width="100px">
+                <CellDisplayTemplate>
+                    @{
+                        var loc = (LocationListDto)context.DataItem;
+                    }
+                    <span class="@(loc.IsLocated ? "oh-lg-assigned" : "oh-lg-notassigned")">
+                        <i class="bi @(loc.IsLocated ? "bi-geo-alt-fill" : "bi-geo")"></i>@(loc.IsLocated ? "Ano" : "Ne")
+                    </span>
                 </CellDisplayTemplate>
             </DxGridDataColumn>
 
@@ -362,12 +373,12 @@ else
                         }
                         @if (isAssigned)
                         {
-                            <span class="oh-lg-assigned"><i class="bi bi-check-lg"></i>Ano</span>
-                            <button class="oh-lg-assign-btn"
-                                    @onclick="() => UnassignLocationAsync(loc.Id)"
-                                    @onclick:stopPropagation="true"
-                                    title="Odebrat z aktuální hry">
-                                <i class="bi bi-dash-lg"></i>Odebrat
+                             <span class="oh-lg-assigned"><i class="bi bi-check-lg"></i>Ano</span>
+                             <button class="oh-lg-assign-btn"
+                                     @onclick="() => PromptUnassign(loc)"
+                                     @onclick:stopPropagation="true"
+                                     title="Odebrat z aktuální hry">
+                                 <i class="bi bi-dash-lg"></i>Odebrat
                             </button>
                         }
                         else
@@ -415,8 +426,6 @@ else
             <DxGridDataColumn FieldName="Description" Caption="Popis" Width="300px" Visible="false" />
             <DxGridDataColumn FieldName="Details" Caption="Podrobnosti" Width="300px" Visible="false" />
             <DxGridDataColumn FieldName="NpcInfo" Caption="NPC" Width="220px" Visible="false" />
-            <DxGridDataColumn FieldName="Latitude" Caption="Šířka" Width="120px" DisplayFormat="F5" Visible="false" />
-            <DxGridDataColumn FieldName="Longitude" Caption="Délka" Width="120px" DisplayFormat="F5" Visible="false" />
             @* Rubber stamp thumbnail — hidden by default; organizers reveal via
                the column chooser. Filter/sort on the URL is not meaningful, so
                both are disabled. *@
@@ -538,10 +547,24 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+<DxPopup @bind-Visible="@isUnassignVisible" HeaderText="Odebrat lokaci z aktuální hry?" Width="420px">
+    <BodyContentTemplate Context="popupContext">
+        <p>Opravdu chcete odebrat lokaci <strong>@unassignTarget?.Name</strong> z aktuální hry? Lokace zůstane v katalogu.</p>
+        @if (unassignError is not null)
+        {
+            <div class="alert alert-danger py-2">@unassignError</div>
+        }
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isUnassignVisible = false">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmUnassignLocationAsync" disabled="@isSaving">Odebrat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @* Destructive delete now lives on the Location detail page — per issue #94
    the list no longer ships a delete button, and this confirmation popup is
    gone with it. If reintroduced, remember the MEMORY destructive-action-
-   confirm rule and keep the Api.DeleteAsync bool-return check. *@
+   confirm rule and surface failed deletes in the existing error area. *@
 
 @code {
     [SupplyParameterFromQuery]
@@ -557,6 +580,7 @@ else
     private bool confusedFailed; // flips true if /img/drozd/drozd-confused.svg 404s (in-grid no-rows, #149)
     private bool isGpsVisible;
     private bool isLinkVisible;
+    private bool isUnassignVisible;
     private bool isSaving;
 
     // Toolbar filter state
@@ -585,6 +609,8 @@ else
     private int? linkParentId;
     private List<LocationListDto> linkCandidates = [];
     private string? linkError;
+    private LocationListDto? unassignTarget;
+    private string? unassignError;
 
     private record KindFilterOption(LocationKind Value, string Label);
 
@@ -820,7 +846,8 @@ else
                         gpsParsed.Value.lat, gpsParsed.Value.lon,
                         detail.Description,
                         Details: detail.Details, GamePotential: detail.GamePotential, Region: detail.Region,
-                        NpcInfo: detail.NpcInfo, SetupNotes: detail.SetupNotes));
+                        NpcInfo: detail.NpcInfo, SetupNotes: detail.SetupNotes,
+                        ParentLocationId: detail.ParentLocationId));
             }
             isGpsVisible = false;
             await LoadDataAsync();
@@ -929,10 +956,41 @@ else
         StateHasChanged();
     }
 
-    private async Task UnassignLocationAsync(int locationId)
+    private void PromptUnassign(LocationListDto loc)
     {
-        await Api.DeleteAsync($"/api/locations/by-game/{gameId}/{locationId}");
-        assignedLocationIds.Remove(locationId);
-        StateHasChanged();
+        unassignTarget = loc;
+        unassignError = null;
+        isUnassignVisible = true;
+    }
+
+    private async Task ConfirmUnassignLocationAsync()
+    {
+        if (unassignTarget is null) return;
+        unassignError = null;
+        isSaving = true;
+        try
+        {
+            var (ok, problem) = await Api.DeleteWithProblemAsync(
+                $"/api/games/{gameId}/locations/{unassignTarget.Id}");
+            if (!ok)
+            {
+                unassignError = problem ?? "Nepodařilo se odebrat lokaci z aktuální hry.";
+                return;
+            }
+
+            assignedLocationIds.Remove(unassignTarget.Id);
+            isUnassignVisible = false;
+            unassignTarget = null;
+            await LoadDataAsync();
+        }
+        catch (Exception ex)
+        {
+            unassignError = ex.Message;
+        }
+        finally
+        {
+            isSaving = false;
+            StateHasChanged();
+        }
     }
 }

--- a/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
@@ -23,7 +23,8 @@ public record LocationListDto(
     string? ImagePath = null,
     string? ImageUrl = null,
     string? StampImagePath = null,
-    string? StampImageUrl = null)
+    string? StampImageUrl = null,
+    bool IsLocated = false)
 {
     [JsonIgnore]
     public string LocationKindDisplay => LocationKind.GetDisplayName();
@@ -55,6 +56,15 @@ public record LocationQuestRewardItemDto(
     int ItemId,
     string ItemName,
     int Quantity);
+
+public record LocationQuestSummaryDto(
+    int Id,
+    string Name,
+    QuestType QuestType)
+{
+    [JsonIgnore]
+    public string QuestTypeDisplay => QuestType.GetDisplayName();
+}
 
 public record LocationTreasureQuestDto(
     int Id,

--- a/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Tests.Fixtures;
@@ -76,6 +77,52 @@ public class LocationEndpointTests(PostgresFixture postgres) : IntegrationTestBa
     }
 
     [Fact]
+    public async Task RemoveFromGame_NewGameRoute_PreservesCatalogLocation()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Remove Location Test", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Catalog location", LocationKind.Village, 49.5m, 17.1m));
+        var loc = await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        await Client.PostAsJsonAsync("/api/locations/by-game", new GameLocationDto(game!.Id, loc!.Id));
+
+        var response = await Client.DeleteAsync($"/api/games/{game.Id}/locations/{loc.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var gameLocations = await Client.GetFromJsonAsync<List<LocationListDto>>(
+            $"/api/locations/by-game/{game.Id}");
+        Assert.Empty(gameLocations!);
+
+        var catalogLocation = await Client.GetFromJsonAsync<LocationDetailDto>($"/api/locations/{loc.Id}");
+        Assert.NotNull(catalogLocation);
+        Assert.Equal("Catalog location", catalogLocation!.Name);
+    }
+
+    [Fact]
+    public async Task Delete_CatalogLocation_RemovesGameAssociation()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Delete Cascade Test", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Cascade location", LocationKind.Village, 49.5m, 17.1m));
+        var loc = await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        await Client.PostAsJsonAsync("/api/locations/by-game", new GameLocationDto(game!.Id, loc!.Id));
+
+        var response = await Client.DeleteAsync($"/api/locations/{loc.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        Assert.False(await db.GameLocations.AnyAsync(gl => gl.GameId == game.Id && gl.LocationId == loc.Id));
+    }
+
+    [Fact]
     public async Task AssignToGame_Duplicate_ReturnsConflict()
     {
         var gameResponse = await Client.PostAsJsonAsync("/api/games",
@@ -106,6 +153,54 @@ public class LocationEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         var updated = await Client.GetFromJsonAsync<LocationDetailDto>($"/api/locations/{created.Id}");
         Assert.Equal(50.0m, updated!.Latitude);
         Assert.Equal(18.0m, updated.Longitude);
+    }
+
+    [Fact]
+    public async Task Create_WithParent_IgnoresClientCoordinates_AndInheritsIsLocated()
+    {
+        var parentResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Parent", LocationKind.PointOfInterest, 49.0m, 17.0m));
+        var parent = await parentResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        var childResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Child", LocationKind.PointOfInterest, 50.0m, 18.0m,
+                ParentLocationId: parent!.Id));
+
+        Assert.Equal(HttpStatusCode.Created, childResponse.StatusCode);
+        var child = await childResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+        Assert.Null(child!.Latitude);
+        Assert.Null(child.Longitude);
+        Assert.Equal(parent.Id, child.ParentLocationId);
+
+        var locations = (await Client.GetFromJsonAsync<List<LocationListDto>>("/api/locations"))!;
+        Assert.True(locations.Single(l => l.Id == parent.Id).IsLocated);
+        Assert.True(locations.Single(l => l.Id == child.Id).IsLocated);
+    }
+
+    [Fact]
+    public async Task Update_WithParent_ClearsClientCoordinates()
+    {
+        var parentResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Update Parent", LocationKind.PointOfInterest, 49.0m, 17.0m));
+        var parent = await parentResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        var childResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Update Child", LocationKind.PointOfInterest, 50.0m, 18.0m));
+        var child = await childResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        var updateDto = new UpdateLocationDto(
+            "Update Child",
+            LocationKind.PointOfInterest,
+            51.0m,
+            19.0m,
+            ParentLocationId: parent!.Id);
+        var response = await Client.PutAsJsonAsync($"/api/locations/{child!.Id}", updateDto);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var updated = await Client.GetFromJsonAsync<LocationDetailDto>($"/api/locations/{child.Id}");
+        Assert.Null(updated!.Latitude);
+        Assert.Null(updated.Longitude);
+        Assert.Equal(parent.Id, updated.ParentLocationId);
     }
 
     [Fact]
@@ -298,6 +393,44 @@ public class LocationEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         Assert.Single(dto.LocationTreasureQuests);
         Assert.Equal(locationTreasureId, dto.LocationTreasureQuests[0].Id);
         Assert.Equal("Poklad v dole", dto.LocationTreasureQuests[0].Title);
+    }
+
+    [Fact]
+    public async Task GetQuests_ReturnsLinkedQuestSummaries()
+    {
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Quest place", LocationKind.PointOfInterest));
+        var loc = await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        int questId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var quest = new Quest
+            {
+                Name = "Najít stopu",
+                QuestType = QuestType.Location
+            };
+            db.Quests.Add(quest);
+            await db.SaveChangesAsync();
+
+            db.QuestLocationLinks.Add(new QuestLocationLink
+            {
+                QuestId = quest.Id,
+                LocationId = loc!.Id
+            });
+            await db.SaveChangesAsync();
+            questId = quest.Id;
+        }
+
+        var quests = await Client.GetFromJsonAsync<List<LocationQuestSummaryDto>>(
+            $"/api/locations/{loc!.Id}/quests");
+
+        Assert.NotNull(quests);
+        var questDto = Assert.Single(quests);
+        Assert.Equal(questId, questDto.Id);
+        Assert.Equal("Najít stopu", questDto.Name);
+        Assert.Equal(QuestType.Location, questDto.QuestType);
     }
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
@@ -204,6 +204,52 @@ public class LocationEndpointTests(PostgresFixture postgres) : IntegrationTestBa
     }
 
     [Fact]
+    public async Task ChildWithLegacyCoordinates_HidesCoordinates_AndInheritsLocatedOnlyFromParent()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Legacy Child GPS Test", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        int parentId, childId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var parent = new Location
+            {
+                Name = "Legacy Parent Without GPS",
+                LocationKind = LocationKind.PointOfInterest
+            };
+            var child = new Location
+            {
+                Name = "Legacy Child With Own GPS",
+                LocationKind = LocationKind.PointOfInterest,
+                ParentLocation = parent,
+                Coordinates = new GpsCoordinates(49.0m, 17.0m)
+            };
+            db.Locations.AddRange(parent, child);
+            await db.SaveChangesAsync();
+
+            db.GameLocations.Add(new GameLocation { GameId = game!.Id, LocationId = child.Id });
+            await db.SaveChangesAsync();
+
+            parentId = parent.Id;
+            childId = child.Id;
+        }
+
+        var detail = await Client.GetFromJsonAsync<LocationDetailDto>($"/api/locations/{childId}");
+        Assert.Null(detail!.Latitude);
+        Assert.Null(detail.Longitude);
+
+        var catalogLocations = (await Client.GetFromJsonAsync<List<LocationListDto>>("/api/locations"))!;
+        Assert.False(catalogLocations.Single(l => l.Id == parentId).IsLocated);
+        Assert.False(catalogLocations.Single(l => l.Id == childId).IsLocated);
+
+        var gameLocations = (await Client.GetFromJsonAsync<List<LocationListDto>>(
+            $"/api/locations/by-game/{game!.Id}"))!;
+        Assert.False(Assert.Single(gameLocations).IsLocated);
+    }
+
+    [Fact]
     public async Task Create_WithLoreFields_ReturnsAllFields()
     {
         var dto = new CreateLocationDto("Aradhrynd", LocationKind.Town,


### PR DESCRIPTION
**Report @ 07:45**

Branch: `hra1/location-suite-251-280`
Commit: `627bd9c`

Diff stat:
```text
src/OvcinaHra.Api/Endpoints/GameEndpoints.cs       |  12 +
src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs   |  63 ++++-
src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor | 263 +++++++++++++++++----
src/OvcinaHra.Client/Pages/Locations/LocationList.razor   | 106 +++++++--
src/OvcinaHra.Shared/Dtos/LocationDtos.cs          |  12 +-
tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs | 133 +++++++++++
6 files changed, 518 insertions(+), 71 deletions(-)
```

Per-issue checklist:
- ✅ #251 Parent locations own GPS; child create/update persists null lat/lng and detail edit shows inherited read-only coordinates.
- ✅ #274 Added `DELETE /api/games/{gameId}/locations/{locationId}` and routed game-scoped removal through confirmation popups.
- ✅ #275 Location detail shows parent and child `NavLink`s.
- ✅ #276 Empty Skrýše tab is hidden.
- ✅ #277 Location detail shows linked quests in a hidden-when-empty Questy tab backed by `GET /api/locations/{id}/quests`.
- ✅ #279 `LocationListDto.IsLocated` is computed server-side with parent recursion; grid uses the new column and removes lat/lng columns; `LayoutKey` bumped to `grid-layout-locations-v6`.
- ✅ #280 Removed the `pin jen na rodiči` suffix.

Verification:
- ✅ `dotnet build OvcinaHra.slnx`
- ✅ `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter FullyQualifiedName~LocationEndpointTests --no-build` — 19/19 passed
- ✅ API portion of `dotnet test --no-build` — 428/428 passed
- ⚠️ Full `dotnet test --no-build` still fails in unrelated E2E test `OvcinaHra.E2E.SkillsManagementTests.GameSkill_CannotBeRemoved_WhenReferencedByRecipe`: expected `NoContent`, actual `Conflict` at `SkillsManagementTests.cs:207` for template skill delete.
- ✅ `dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include <changed files>`
- ⚠️ Full `dotnet format ... --verify-no-changes` still reports pre-existing whitespace issues in untouched files such as `BuildingEndpoints.cs`, `QuestEndpoints.cs`, and enum/DTO files.

Closes #251
Closes #274
Closes #275
Closes #276
Closes #277
Closes #279
Closes #280