### PR TITLE
feat(map): bundle D — zoom labels + tear-drop pins + print views + PATCH

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -26,6 +26,11 @@ public static class LocationEndpoints
         group.MapPost("/by-game", AssignToGame);
         group.MapDelete("/by-game/{gameId:int}/{locationId:int}", RemoveFromGame);
 
+        // Issue #252 — drag-drop coordinate patch. Mounted last so the
+        // route table reads top-to-bottom in lifecycle order (CRUD →
+        // queries → game-link → narrow patches).
+        group.MapPatch("/{id:int}/coordinates", PatchCoordinates);
+
         return group;
     }
 
@@ -321,6 +326,49 @@ public static class LocationEndpoints
             return TypedResults.NotFound();
 
         db.GameLocations.Remove(gl);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Issue #252 — PATCH /api/locations/{id}/coordinates
+    //
+    // Drag-drop relocate path. Replaces the prior GET LocationDetailDto →
+    // PUT UpdateLocationDto round-trip in MapPage.ConfirmDragAsync, which
+    // could clobber concurrent organizer edits on Description / Details /
+    // NpcInfo / etc. since UpdateLocationDto's nullable string fields would
+    // overwrite anything the GET picked up before another organizer's
+    // SaveChangesAsync landed.
+    //
+    // Validation:
+    //   1. 404 first if the location id is missing (per _review-instincts §1).
+    //   2. Then 400 ProblemDetails(czech) on out-of-range lat / lng.
+    //
+    // No audit log added — there's no LocationAudit infrastructure today
+    // (verified via grep of LocationEndpoints + Domain/Entities). Adding
+    // one solely for the coordinate patch would be the first audit on the
+    // Location surface; defer until a broader audit need surfaces. See
+    // Phase-0 Q&A on PR #284.
+    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> PatchCoordinates(
+        int id, LocationCoordinatesPatchDto dto, WorldDbContext db)
+    {
+        var loc = await db.Locations.FindAsync(id);
+        if (loc is null)
+            return TypedResults.NotFound();
+
+        if (dto.Latitude < -90m || dto.Latitude > 90m)
+            return TypedResults.Problem(
+                title: "Neplatná souřadnice",
+                detail: "Zeměpisná šířka musí být v rozsahu -90 až 90 stupňů.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        if (dto.Longitude < -180m || dto.Longitude > 180m)
+            return TypedResults.Problem(
+                title: "Neplatná souřadnice",
+                detail: "Zeměpisná délka musí být v rozsahu -180 až 180 stupňů.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        loc.Coordinates = new GpsCoordinates(dto.Latitude, dto.Longitude);
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -455,23 +455,23 @@
         _pendingDragSaving = true;
         try
         {
-            // Round-trip GET → PUT so we don't accidentally wipe Description /
-            // Details / NpcInfo when only GPS is changing. UpdateLocationDto's
-            // string fields all default to null and would clear the row otherwise.
-            var detail = await Api.GetAsync<LocationDetailDto>($"/api/locations/{id}");
-            if (detail is null) { _pendingDragError = "Lokace nenalezena."; return; }
-            await Api.PutAsync($"/api/locations/{id}",
-                new UpdateLocationDto(
-                    detail.Name, detail.LocationKind,
-                    Latitude: (decimal)_pendingDragLat, Longitude: (decimal)_pendingDragLng,
-                    Description: detail.Description,
-                    Details: detail.Details,
-                    GamePotential: detail.GamePotential,
-                    Prompt: detail.Prompt,
-                    Region: detail.Region,
-                    NpcInfo: detail.NpcInfo,
-                    SetupNotes: detail.SetupNotes,
-                    ParentLocationId: detail.ParentLocationId));
+            // Issue #252 — PATCH /api/locations/{id}/coordinates writes only
+            // Latitude + Longitude, so a concurrent organizer edit on
+            // Description / Details / NpcInfo / etc. can't be clobbered.
+            // Replaces the prior GET LocationDetailDto → PUT UpdateLocationDto
+            // round-trip whose nullable string fields would overwrite anything
+            // saved between GET and PUT. ProblemDetails surfaces server-side
+            // lat/lng range errors into the confirm popup banner.
+            var (ok, problem) = await Api.PatchWithProblemAsync(
+                $"/api/locations/{id}/coordinates",
+                new LocationCoordinatesPatchDto(
+                    (decimal)_pendingDragLat,
+                    (decimal)_pendingDragLng));
+            if (!ok)
+            {
+                _pendingDragError = problem ?? "Uložení souřadnic selhalo.";
+                return;
+            }
             _pendingDragVisible = false;
             _pendingDragId = null;
             // Reload so the peek + pin position pick up the saved GPS.

--- a/src/OvcinaHra.Client/Pages/Map/MapPrint.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPrint.razor
@@ -1,0 +1,166 @@
+@page "/map/print"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject GameContextService GameContext
+@inject IJSRuntime JS
+@inject NavigationManager Nav
+@implements IDisposable
+@using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Domain.Enums
+
+@* Issue #259 — printable map view. Two modes:
+     ?mode=labeled — full parent location names, force-shown regardless
+                     of zoom (the label-by-zoom gate from #273 doesn't
+                     apply to print handouts; players can't pinch).
+     ?mode=blind   — numeric ID at each pin position; the printed
+                     legend cross-references IDs to names.
+   Chrome (toolbar / layer rail / peek) is intentionally absent — this
+   page is rendered solo and printed via window.print(). The body
+   class .oh-map-print toggles a print-friendly stylesheet so even the
+   thin in-page toolbar above disappears in @media print. *@
+
+<AuthorizeView>
+    <Authorized>
+        @if (GameContext.SelectedGameId is null)
+        {
+            <MapEmptyState />
+        }
+        else
+        {
+            <div class="oh-map-print-page">
+                <div class="oh-map-print-toolbar oh-no-print">
+                    <button class="btn btn-sm btn-outline-secondary" type="button"
+                            @onclick='() => Nav.NavigateTo("/map")'>
+                        <i class="bi bi-arrow-left"></i> Mapa
+                    </button>
+                    <h1 class="oh-map-print-title">Tisk mapy</h1>
+                    <div class="oh-map-print-pills" role="group" aria-label="Režim tisku">
+                        <a class="oh-map-print-pill @(_mode == "labeled" ? "is-on" : "")"
+                           href="/map/print?mode=labeled">S názvy</a>
+                        <a class="oh-map-print-pill @(_mode == "blind" ? "is-on" : "")"
+                           href="/map/print?mode=blind">Slepá</a>
+                    </div>
+                    <button class="btn btn-sm btn-primary" type="button"
+                            @onclick="PrintAsync">
+                        <i class="bi bi-printer"></i> Tisknout
+                    </button>
+                </div>
+
+                <div class="oh-map-print-canvas">
+                    <MapView @ref="_mapView"
+                             Height="calc(100vh - 90px)"
+                             GameId="@GameContext.SelectedGameId"
+                             OnStyleLoaded="OnMapReadyAsync" />
+                </div>
+
+                @if (_mode == "blind" && _data is not null)
+                {
+                    @* Blind-mode legend — printed under the map as page 2 so
+                       referees can decode pin IDs back to names without
+                       cluttering the map itself. *@
+                    <section class="oh-map-print-legend">
+                        <h2>Legenda — slepá mapa</h2>
+                        <ol class="oh-map-print-legend-list">
+                            @foreach (var l in _legendOrdered)
+                            {
+                                <li><span class="oh-map-print-legend-id">@l.Id</span>@l.Name</li>
+                            }
+                        </ol>
+                    </section>
+                }
+            </div>
+        }
+    </Authorized>
+    <NotAuthorized>
+        <p>Pro pokračování se prosím přihlaste.</p>
+    </NotAuthorized>
+</AuthorizeView>
+
+@code {
+    [SupplyParameterFromQuery(Name = "mode")] public string? ModeParam { get; set; }
+
+    private MapView? _mapView;
+    private MapDataDto? _data;
+    private string _mode = "labeled";
+    private List<MapLocationDto> _legendOrdered = [];
+    private bool _bodyClassApplied;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        GameContext.OnGameChanged += HandleGameChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        var next = string.Equals(ModeParam, "blind", StringComparison.OrdinalIgnoreCase) ? "blind" : "labeled";
+        if (next == _mode && _bodyClassApplied) return;
+        _mode = next;
+        await ApplyBodyClassAsync();
+        await ReloadDataAndPaintAsync();
+    }
+
+    private void HandleGameChanged() => _ = InvokeAsync(ReloadDataAndPaintAsync);
+
+    private async Task ApplyBodyClassAsync()
+    {
+        // Body classes drive the print stylesheet. .oh-map-print toggles
+        // chrome-hide rules in @media print; .oh-map-print-labeled forces
+        // the label-zoom gate open so every parent name paints.
+        try
+        {
+            await JS.InvokeVoidAsync("ovcinaMapPrint.applyBodyMode", _mode);
+            _bodyClassApplied = true;
+        }
+        catch { /* JS bootstrap not loaded yet — ApplyBodyClassAsync is re-run on style load */ }
+    }
+
+    private async Task OnMapReadyAsync()
+    {
+        await ApplyBodyClassAsync();
+        await ReloadDataAndPaintAsync();
+    }
+
+    private async Task ReloadDataAndPaintAsync()
+    {
+        if (GameContext.SelectedGameId is not int gid) { _data = null; return; }
+        try
+        {
+            _data = await Api.GetAsync<MapDataDto>($"/api/map/data?gameId={gid}");
+        }
+        catch { _data = null; }
+
+        _legendOrdered = _data?.Locations
+            .OrderBy(l => l.Name)
+            .ToList() ?? [];
+
+        await JS.InvokeVoidAsync("ovcinaMap.clearMapPagePins");
+        if (_data is null) return;
+
+        // Per-mode label: blind uses the location's stable DB id; labeled
+        // uses the actual name. The kind argument carries through unchanged
+        // so the per-kind tear-drop color and glyph still apply (the print
+        // sheet wants the icons too — they read as map symbols).
+        foreach (var l in _data.Locations)
+        {
+            var label = _mode == "blind" ? $"#{l.Id}" : l.Name;
+            await JS.InvokeVoidAsync("ovcinaMap.addLocationPin",
+                l.Id, l.Lat, l.Lon, label, l.Kind.ToString());
+        }
+        // Stash pins intentionally omitted — print sheets focus on parent
+        // locations; secret-stash detail belongs in the organizer's tablet.
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private Task PrintAsync() => JS.InvokeVoidAsync("window.print").AsTask();
+
+    public void Dispose()
+    {
+        GameContext.OnGameChanged -= HandleGameChanged;
+        // Best-effort: strip the body classes when navigating away so the
+        // regular /map view doesn't inherit print-mode label rules.
+        try { _ = JS.InvokeVoidAsync("ovcinaMapPrint.applyBodyMode", "off"); }
+        catch { /* JS may already be torn down on circuit drop */ }
+    }
+}

--- a/src/OvcinaHra.Client/Services/ApiClient.cs
+++ b/src/OvcinaHra.Client/Services/ApiClient.cs
@@ -126,6 +126,19 @@ public class ApiClient
         return (false, await ReadProblemDetailAsync(response));
     }
 
+    // Issue #252 — PATCH variant of *WithProblemAsync. Used by the map's
+    // drag-drop relocate (LocationCoordinatesPatchDto) so the server's
+    // Czech ProblemDetails on out-of-range lat/lng round-trips into the
+    // confirm popup banner. Same read-body-once shape as the others.
+    public async Task<(bool Ok, string? ProblemDetail)> PatchWithProblemAsync<TRequest>(string url, TRequest data)
+    {
+        using var content = JsonContent.Create(data, options: JsonOptions);
+        using var request = new HttpRequestMessage(HttpMethod.Patch, url) { Content = content };
+        var response = await _http.SendAsync(request);
+        if (response.IsSuccessStatusCode) return (true, null);
+        return (false, await ReadProblemDetailAsync(response));
+    }
+
     private static async Task<string?> ReadProblemDetailAsync(HttpResponseMessage response)
     {
         var raw = await response.Content.ReadAsStringAsync();

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3650,43 +3650,124 @@
 .oh-map-style-btn{padding:3px 9px;border-radius:99px;border:none;background:transparent;
     color:var(--oh-text,#2a2a2a);font:600 .72rem var(--oh-font-body);cursor:pointer}
 .oh-map-style-btn.is-active{background:#2D5016;color:#fff}
-.oh-map-pin{position:relative;width:18px;height:18px;border-radius:50%;
-    border:2px solid #fff;cursor:pointer;box-shadow:0 1px 3px rgba(0,0,0,.45)}
-.oh-map-pin-loc{background:var(--oh-kind-village,#2D5016)}
-/* Per-LocationKind pin colors — palette tokens in app.css.
-   Wilderness is white so it gets a dark border to stay visible. */
-.oh-map-pin-loc[data-kind="town"]            {background:var(--oh-kind-town)}
-.oh-map-pin-loc[data-kind="village"]         {background:var(--oh-kind-village)}
-.oh-map-pin-loc[data-kind="magical"]         {background:var(--oh-kind-magical)}
-.oh-map-pin-loc[data-kind="hobbit"]          {background:var(--oh-kind-hobbit)}
-.oh-map-pin-loc[data-kind="wilderness"]      {background:var(--oh-kind-wilderness);border-color:#2a2a2a}
-.oh-map-pin-loc[data-kind="dungeon"]         {background:var(--oh-kind-dungeon)}
-.oh-map-pin-loc[data-kind="pointofinterest"] {background:var(--oh-kind-pointofinterest)}
-.oh-map-pin-stash{background:#C19A3A;width:20px;height:20px}
+/* Issue #257 — tear-drop pins. Outer .oh-map-pin is a transparent
+   anchor box; the round bubble + downward tail are painted by
+   .oh-map-pin-bg and its ::after triangle. Per-kind colors flow via
+   a single CSS variable (--pin-color) so the bubble and tail stay in
+   sync. The bi-* glyph slides in via .oh-map-pin-glyph. Anchor stays
+   on bottom-center so MapLibre lands the tip exactly on the GPS
+   coordinate. */
+.oh-map-pin{position:relative;width:30px;height:36px;background:transparent;
+    border:none;box-shadow:none;cursor:pointer}
+.oh-map-pin-loc{--pin-color:var(--oh-kind-village,#2D5016);--pin-glyph:#fff}
+.oh-map-pin-loc[data-kind="town"]            {--pin-color:var(--oh-kind-town)}
+.oh-map-pin-loc[data-kind="village"]         {--pin-color:var(--oh-kind-village)}
+.oh-map-pin-loc[data-kind="magical"]         {--pin-color:var(--oh-kind-magical)}
+.oh-map-pin-loc[data-kind="hobbit"]          {--pin-color:var(--oh-kind-hobbit)}
+.oh-map-pin-loc[data-kind="wilderness"]      {--pin-color:var(--oh-kind-wilderness);--pin-glyph:#2a2a2a}
+.oh-map-pin-loc[data-kind="dungeon"]         {--pin-color:var(--oh-kind-dungeon)}
+.oh-map-pin-loc[data-kind="pointofinterest"] {--pin-color:var(--oh-kind-pointofinterest)}
+.oh-map-pin-bg{position:absolute;top:0;left:0;width:30px;height:30px;
+    background:var(--pin-color);border:2px solid #fff;border-radius:50%;
+    box-shadow:0 1px 3px rgba(0,0,0,.45);
+    display:flex;align-items:center;justify-content:center}
+.oh-map-pin-bg::after{content:'';position:absolute;top:22px;left:50%;
+    width:0;height:0;transform:translateX(-50%);
+    border-left:7px solid transparent;border-right:7px solid transparent;
+    border-top:14px solid var(--pin-color);
+    filter:drop-shadow(0 1px 1px rgba(0,0,0,.45));z-index:-1}
+.oh-map-pin-glyph{font-size:.95rem;line-height:1;color:var(--pin-glyph);
+    text-shadow:0 0 2px rgba(0,0,0,.35)}
+/* Stash pins keep the simpler circular shape — they ride on top of a
+   location pin and a second tear-drop would clutter the host site. The
+   stage-based color stays. */
+.oh-map-pin-stash{width:22px;height:22px;border-radius:50%;
+    background:#C19A3A;border:2px solid #fff;box-shadow:0 1px 3px rgba(0,0,0,.45)}
 .oh-map-pin-stash[data-stage="Start"]   {background:#7FA657}
 .oh-map-pin-stash[data-stage="Early"]   {background:#D4A63C}
 .oh-map-pin-stash[data-stage="Midgame"] {background:#C17B3D}
 .oh-map-pin-stash[data-stage="Lategame"]{background:#8C2423}
-.oh-map-pin-count{position:absolute;top:-6px;right:-6px;background:#fff;color:#2a2a2a;
+/* Cream-bordered count badge — offset to the upper-right of the pin
+   bubble per the designer mockup. Border picks up the parchment cream
+   `--oh-border` token so the badge reads as a deliberate sticker
+   rather than a stray dot. */
+.oh-map-pin-count{position:absolute;top:-4px;right:-4px;background:#FAF6EC;color:#2a2a2a;
     border-radius:99px;padding:0 4px;font:700 .65rem var(--oh-font-body);
-    border:1px solid var(--oh-border,#d8d2be);min-width:14px;text-align:center}
+    border:1.5px solid var(--oh-border,#d8d2be);min-width:14px;text-align:center;
+    box-shadow:0 1px 2px rgba(0,0,0,.18);z-index:3}
 /* Ctrl/Meta held over the map → crosshair cursor (visual hint that
    Ctrl+Click will place an ungeocoded location, Ctrl+Shift+Click will
    move an existing one). Class toggled by map-interop.js keydown/keyup. */
 .oh-map-ctrl-held .maplibregl-canvas-container,
 .oh-map-ctrl-held .maplibregl-canvas{cursor:crosshair !important}
 
-/* Issue #258 — zoom-conditional location labels. Default hidden so
-   tightly-clustered pins (e.g. 22 in 280 m) don't render an unreadable
-   blob at low zoom. Towns (kingdom seats) override the default and are
-   always visible — they're the most important wayfinding anchors. */
+/* Issue #273 — graduated location labels. Each pin advertises a
+   `data-minzoom` (set in JS from KIND_MIN_ZOOM) and the zoomend handler
+   flips `.oh-pin-label-on` once the current zoom reaches that threshold.
+   Towns surface from zoom 0; villages from 6; magical/hobbit from 8;
+   wilderness from 9; dungeon/POI only from 10-11. Replaces the binary
+   `.oh-map-zoomed-in` toggle from #258. */
 .oh-map-pin-label{display:none;position:absolute;top:100%;left:50%;
     transform:translate(-50%,4px);white-space:nowrap;
     font:600 .72rem var(--oh-font-body,sans-serif);color:#1a1a2e;
     text-shadow:0 0 3px #fff,0 0 3px #fff,0 0 3px #fff,0 0 3px #fff;
     pointer-events:none;user-select:none;z-index:1}
-.oh-map-pin-loc[data-kind="town"] .oh-map-pin-label{display:block}
-.oh-map-zoomed-in .oh-map-pin-label{display:block}
+.oh-map-pin.oh-pin-label-on .oh-map-pin-label{display:block}
+/* Print mode (#259) overrides the zoom gate for the labeled-print body
+   class so every parent label paints regardless of map zoom — physical
+   handouts can't pinch-zoom. */
+body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label{display:block}
+
+/* Issue #273 — zoom indicator next to the Scale control. MapLibre's
+   own .maplibregl-ctrl styling supplies the rounded-rect chrome; we
+   only override font + padding to match the kingdom-seal palette. */
+.oh-map-zoom-indicator{padding:3px 9px;font:600 .72rem var(--oh-font-body,sans-serif);
+    color:var(--oh-text,#2a2a2a);background:rgba(250,246,236,.92);
+    box-shadow:0 1px 4px rgba(0,0,0,.12);border-radius:99px;
+    user-select:none;letter-spacing:.02em}
+
+/* Issue #259 — printable map view. Slim in-page toolbar above the map
+   in screen mode; the @media print block below strips it so only the
+   map (and the legend in blind mode) prints. */
+.oh-map-print-page{display:flex;flex-direction:column;min-height:100vh;background:var(--oh-surface,#FAF6EC)}
+.oh-map-print-toolbar{display:flex;align-items:center;gap:14px;padding:10px 16px;
+    border-bottom:1px solid var(--oh-border,#d8d2be);background:#fff}
+.oh-map-print-title{margin:0;font:700 1.1rem var(--oh-font-heading)}
+.oh-map-print-pills{display:flex;gap:4px;margin-left:auto;background:rgba(216,210,190,.4);
+    padding:3px;border-radius:99px}
+.oh-map-print-pill{padding:4px 12px;border-radius:99px;font:600 .8rem var(--oh-font-body);
+    color:var(--oh-text,#2a2a2a);text-decoration:none}
+.oh-map-print-pill:hover{background:rgba(255,255,255,.6)}
+.oh-map-print-pill.is-on{background:#2D5016;color:#fff}
+.oh-map-print-canvas{flex:1;position:relative}
+.oh-map-print-legend{padding:18px 24px;border-top:1px solid var(--oh-border,#d8d2be);
+    page-break-before:always}
+.oh-map-print-legend h2{font:700 1.15rem var(--oh-font-heading);margin:0 0 12px}
+.oh-map-print-legend-list{list-style:none;padding:0;margin:0;
+    columns:2;column-gap:32px;column-rule:1px solid var(--oh-border,#d8d2be)}
+.oh-map-print-legend-list li{break-inside:avoid;padding:3px 0;font:.9rem/1.3 var(--oh-font-body);
+    display:flex;gap:10px;align-items:baseline}
+.oh-map-print-legend-id{font-weight:700;color:var(--oh-primary,#2D5016);min-width:36px;
+    font-variant-numeric:tabular-nums}
+
+/* Print stylesheet — runs only when printing or generating a PDF.
+   Hides every screen-only chrome element so the printed page contains
+   just the map canvas + (in blind mode) the legend overflow. */
+@media print {
+    body.oh-map-print .oh-no-print,
+    body.oh-map-print nav,
+    body.oh-map-print header,
+    body.oh-map-print .oh-map-style-toolbar,
+    body.oh-map-print .maplibregl-ctrl-top-right,
+    body.oh-map-print .oh-map-zoom-indicator{display:none !important}
+    body.oh-map-print{background:#fff !important}
+    body.oh-map-print .oh-map-print-page{min-height:auto}
+    body.oh-map-print .oh-map-print-canvas{height:100vh}
+    /* Browsers add a default margin to printed pages — keep it modest
+       so the map fills the A4 sheet. Page-break controls live on the
+       legend section in screen CSS above. */
+    @page {margin:8mm}
+}
 .oh-map-peek-backdrop{position:fixed;inset:0;background:rgba(20,16,8,.32);z-index:1070}
 .oh-map-peek{position:fixed;top:64px;right:0;bottom:0;width:min(420px,90vw);
     background:var(--oh-surface,#FAF6EC);border-left:1px solid var(--oh-border,#d8d2be);

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -92,22 +92,47 @@ window.ovcinaMap = {
             }
         });
 
-        // Issue #258 — zoom-conditional labels. Toggle .oh-map-zoomed-in
-        // on the map container at zoom >= 15 so non-town labels become
-        // visible only when pins are spread out enough to avoid overlap.
-        // Town pins (kingdom seats) are always-visible via a separate
-        // CSS rule that doesn't depend on this class.
-        var LABEL_ZOOM_THRESHOLD = 15;
-        var mc = this._map.getContainer();
-        var applyZoomLabelClass = () => {
-            if (this._map.getZoom() >= LABEL_ZOOM_THRESHOLD) {
-                mc.classList.add('oh-map-zoomed-in');
-            } else {
-                mc.classList.remove('oh-map-zoomed-in');
+        // Issue #273 — per-LocationKind label visibility. Each pin advertises
+        // its kind via `data-kind` and a numeric `data-minzoom`, set in
+        // addLocationPin from KIND_MIN_ZOOM. This handler iterates the
+        // currently painted pins and toggles `oh-pin-label-on` based on the
+        // current zoom — so Towns appear from zoom 0, Villages from 6,
+        // smaller features only at 9-11. Replaces the binary
+        // `oh-map-zoomed-in` toggle (#258) with a graduated reveal.
+        //
+        // Stash pins reuse the same gate keyed off their host location's
+        // kind so a Stash inside Esgaroth shows its label as soon as
+        // Esgaroth's would. Stash kind is captured via `data-kind` in
+        // addStashPin (defaults to "village" when host kind isn't known).
+        var applyZoomLabels = () => {
+            if (!this._map) return;
+            var z = this._map.getZoom();
+            var indicatorEl = document.querySelector('.oh-map-zoom-indicator');
+            if (indicatorEl) indicatorEl.textContent = 'Z ' + z.toFixed(1);
+            var apply = (pin) => {
+                var mz = parseFloat(pin.getAttribute('data-minzoom'));
+                if (isNaN(mz)) return;
+                if (z >= mz) pin.classList.add('oh-pin-label-on');
+                else pin.classList.remove('oh-pin-label-on');
+            };
+            for (var lid in this._mapPagePins.loc) {
+                var lel = this._mapPagePins.loc[lid].getElement();
+                if (lel) {
+                    var lpin = lel.querySelector('.oh-map-pin');
+                    if (lpin) apply(lpin);
+                }
+            }
+            for (var sid in this._mapPagePins.stash) {
+                var sel = this._mapPagePins.stash[sid].getElement();
+                if (sel) {
+                    var spin = sel.querySelector('.oh-map-pin');
+                    if (spin) apply(spin);
+                }
             }
         };
-        applyZoomLabelClass(); // initial state
-        this._map.on('zoomend', applyZoomLabelClass);
+        this._applyZoomLabels = applyZoomLabels;
+        this._map.on('zoomend', applyZoomLabels);
+        this._map.on('zoom', applyZoomLabels); // continuous update for the indicator
 
         // Crosshair cursor while Ctrl/Meta is held — visual hint that
         // Ctrl+Click will place an ungeocoded location. Pure CSS via a
@@ -157,6 +182,29 @@ window.ovcinaMap = {
 
         this._map.addControl(new maplibregl.NavigationControl(), 'top-right');
         this._map.addControl(new maplibregl.ScaleControl(), 'bottom-left');
+
+        // Issue #273 — zoom-level indicator next to the Scale control. Bare-
+        // bones IControl: a styled DIV that the zoom listener above updates
+        // via .textContent. Position 'bottom-left' stacks it under the scale
+        // bar in the same MapLibre control container so dimensions stay
+        // consistent across themes.
+        var ZoomIndicatorControl = function () { };
+        ZoomIndicatorControl.prototype.onAdd = function (map) {
+            var c = document.createElement('div');
+            c.className = 'maplibregl-ctrl maplibregl-ctrl-group oh-map-zoom-indicator';
+            c.title = 'Zoom (úroveň přiblížení)';
+            c.textContent = 'Z ' + map.getZoom().toFixed(1);
+            this._container = c;
+            this._map = map;
+            return c;
+        };
+        ZoomIndicatorControl.prototype.onRemove = function () {
+            if (this._container && this._container.parentNode) {
+                this._container.parentNode.removeChild(this._container);
+            }
+            this._map = undefined;
+        };
+        this._map.addControl(new ZoomIndicatorControl(), 'bottom-left');
     },
 
     switchStyle: function (styleKey) {
@@ -881,6 +929,46 @@ window.ovcinaBboxMap = {
 // ======================================================================
 window.ovcinaMap._mapPagePins = { loc: {}, stash: {} };
 
+// Issue #273 — per-LocationKind minimum zoom thresholds. A pin's text label
+// becomes visible once the map's zoom level reaches the value below for its
+// kind. Town stays at 0 (always visible — kingdom seats are the most
+// important wayfinding anchors). Other kinds graduate so smaller features
+// don't clutter at low zoom. Tweak this single block to retune cadence.
+window.ovcinaMap._kindMinZoom = {
+    town: 0,
+    village: 6,
+    magical: 8,
+    hobbit: 8,
+    wilderness: 9,
+    dungeon: 10,
+    pointofinterest: 11
+};
+window.ovcinaMap._kindMinZoomFor = function (kindRaw) {
+    var k = (kindRaw || 'wilderness').toLowerCase();
+    var mz = this._kindMinZoom[k];
+    return (typeof mz === 'number') ? mz : 11; // unknown kinds → most-conservative
+};
+
+// Issue #257 — per-LocationKind Bootstrap-Icon glyph for the tear-drop pin.
+// The class names map directly to bi-* CSS — no font swap, no SVG sprite.
+// Town gets a shield (kingdom seat anchor), Hobbit gets a filled tree
+// (settled), Wilderness gets an outlined tree (uninhabited), Dungeon gets
+// bricks. Stay aligned with the issue's spec or update the issue when
+// adding a new LocationKind.
+window.ovcinaMap._kindIcon = {
+    town: 'bi-shield-fill',
+    village: 'bi-house-fill',
+    magical: 'bi-stars',
+    hobbit: 'bi-tree-fill',
+    wilderness: 'bi-tree',
+    dungeon: 'bi-bricks',
+    pointofinterest: 'bi-flag'
+};
+window.ovcinaMap._kindIconFor = function (kindRaw) {
+    var k = (kindRaw || 'wilderness').toLowerCase();
+    return this._kindIcon[k] || 'bi-geo-alt-fill';
+};
+
 window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     if (!this._map) {
         if (this._pinDiag()) console.warn('[pin-diag] addLocationPin called but no map — id=' + id);
@@ -911,16 +999,27 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     wrapper.style.cursor = 'pointer';
     var pin = document.createElement('div');
     pin.className = 'oh-map-pin oh-map-pin-loc';
-    pin.setAttribute('data-kind', (kind || 'wilderness').toLowerCase());
+    var kindKey = (kind || 'wilderness').toLowerCase();
+    pin.setAttribute('data-kind', kindKey);
+    // Issue #273 — graduated label-visibility-by-zoom. Each pin advertises
+    // its minzoom; the zoomend handler in init() flips `oh-pin-label-on`
+    // when map.getZoom() >= this value. Initial state set inline below
+    // so a pin added between zoomend events shows / hides correctly.
+    var minZoom = this._kindMinZoomFor(kindKey);
+    pin.setAttribute('data-minzoom', String(minZoom));
+    if (this._map.getZoom() >= minZoom) pin.classList.add('oh-pin-label-on');
     wrapper.title = name || '';
-    // Issue #258 — zoom-conditional labels. The label is always rendered,
-    // CSS controls visibility:
-    //   - Town pins (kingdom seats): always shown
-    //   - Other kinds: only shown when the map container has class
-    //     `oh-map-zoomed-in` (set by the zoom listener in init() once
-    //     map.getZoom() >= 15)
-    // pointer-events:none + position:absolute keep the wrapper at 18×18
-    // so MapLibre's drag hit-test stays accurate.
+    // Issue #257 — tear-drop pin chrome. The bubble (oh-map-pin-bg) carries
+    // the per-kind background and the downward triangle tail (::after); the
+    // glyph (Bootstrap-Icons bi-*) sits inside. Anchor moves to 'bottom' so
+    // the tail tip lands on the GPS coord.
+    var bg = document.createElement('div');
+    bg.className = 'oh-map-pin-bg';
+    var glyph = document.createElement('i');
+    glyph.className = 'oh-map-pin-glyph bi ' + this._kindIconFor(kindKey);
+    glyph.setAttribute('aria-hidden', 'true');
+    bg.appendChild(glyph);
+    pin.appendChild(bg);
     if (name) {
         var label = document.createElement('div');
         label.className = 'oh-map-pin-label';
@@ -946,7 +1045,11 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     } else if (typeof navigator !== 'undefined' && typeof navigator.maxTouchPoints === 'number') {
         draggable = navigator.maxTouchPoints === 0;
     }
-    var marker = new maplibregl.Marker({ element: wrapper, anchor: 'center', draggable: draggable })
+    // Issue #257 — anchor:'bottom' lands the tear-drop tip exactly on the
+    // GPS coord; the previous 'center' put the bubble's centroid there
+    // which felt wrong for a balloon-shaped pin. Stash pins (circular)
+    // keep anchor:'center' below.
+    var marker = new maplibregl.Marker({ element: wrapper, anchor: 'bottom', draggable: draggable })
         .setLngLat([lon, lat])
         .addTo(this._map);
     if (draggable) {
@@ -1044,3 +1147,20 @@ window.ovcinaMap.setMapPageLayerVisibility = function (layer, visible) {
         };
     }
 })();
+
+// Issue #259 — print-mode body class toggle. The print stylesheet is
+// gated behind body.oh-map-print so the regular /map page never picks
+// up @media print's chrome-hide rules accidentally. The labeled variant
+// also force-shows location names regardless of zoom.
+window.ovcinaMapPrint = {
+    applyBodyMode: function (mode) {
+        var b = document.body;
+        if (!b) return;
+        b.classList.remove('oh-map-print', 'oh-map-print-labeled', 'oh-map-print-blind');
+        if (mode === 'labeled') {
+            b.classList.add('oh-map-print', 'oh-map-print-labeled');
+        } else if (mode === 'blind') {
+            b.classList.add('oh-map-print', 'oh-map-print-blind');
+        }
+    }
+};

--- a/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
@@ -128,3 +128,10 @@ public record NearbyLocationDto(
     decimal Latitude,
     decimal Longitude,
     double DistanceKm);
+
+// Issue #252 — drag-drop relocate now PATCHes coordinates only (instead of
+// GET→PUT round-tripping the whole UpdateLocationDto). A concurrent edit on
+// Description / Details / NpcInfo / etc. by another organizer can't be
+// clobbered because the request body never carries those fields. Decimal
+// matches the GpsCoordinates value-object types persisted in the DB.
+public record LocationCoordinatesPatchDto(decimal Latitude, decimal Longitude);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Tests.Fixtures;
@@ -352,5 +353,104 @@ public class LocationEndpointTests(PostgresFixture postgres) : IntegrationTestBa
     {
         var resp = await Client.GetAsync("/api/locations/nearby?lat=95&lng=0&radiusKm=5");
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // ── Issue #252 — PATCH /api/locations/{id}/coordinates ────────────────
+    // Drag-drop relocate path: only writes Latitude + Longitude so concurrent
+    // edits on Description / Details / NpcInfo can't be clobbered. Validates
+    // 404 ordering, lat/lng range guards, and the no-clobber guarantee.
+
+    [Fact]
+    public async Task PatchCoordinates_UpdatesLatLng_PreservesOtherFields()
+    {
+        var createResp = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Šedý dub", LocationKind.Magical, 49.50m, 17.10m,
+                Description: "Tichý strážce mýtiny.",
+                Details: "Listí svítí v noci",
+                NpcInfo: "Mluví se starcem Lubomírem"));
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+        var created = await createResp.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        var patchResp = await Client.PatchAsJsonAsync(
+            $"/api/locations/{created!.Id}/coordinates",
+            new LocationCoordinatesPatchDto(50.123456m, 18.654321m));
+        Assert.Equal(HttpStatusCode.NoContent, patchResp.StatusCode);
+
+        var fetched = await Client.GetFromJsonAsync<LocationDetailDto>($"/api/locations/{created.Id}");
+        Assert.NotNull(fetched);
+        Assert.Equal(50.123456m, fetched!.Latitude);
+        Assert.Equal(18.654321m, fetched.Longitude);
+        // No-clobber guarantee — the prior Description / Details / NpcInfo
+        // round-trip through the PATCH unchanged. This is the core reason
+        // for the new endpoint over GET-LocationDetailDto → PUT-UpdateLocationDto.
+        Assert.Equal("Tichý strážce mýtiny.", fetched.Description);
+        Assert.Equal("Listí svítí v noci", fetched.Details);
+        Assert.Equal("Mluví se starcem Lubomírem", fetched.NpcInfo);
+    }
+
+    [Fact]
+    public async Task PatchCoordinates_MissingId_Returns404_NotValidationFirst()
+    {
+        // 404 must beat 400 on a missing id even when the body is also bad
+        // — REST semantics + _review-instincts §1. lat=999 alone would
+        // trigger a 400, so this proves the FindAsync-first ordering.
+        var resp = await Client.PatchAsJsonAsync(
+            "/api/locations/9999999/coordinates",
+            new LocationCoordinatesPatchDto(999m, 999m));
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PatchCoordinates_LatitudeOutOfRange_Returns400WithCzechProblemDetails()
+    {
+        var createResp = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("X", LocationKind.Wilderness, 49m, 17m));
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+        var created = await createResp.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        var resp = await Client.PatchAsJsonAsync(
+            $"/api/locations/{created!.Id}/coordinates",
+            new LocationCoordinatesPatchDto(95m, 17m));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var problem = await resp.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Neplatná souřadnice", problem!.Title);
+        Assert.Contains("šířka", problem.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PatchCoordinates_LongitudeOutOfRange_Returns400WithCzechProblemDetails()
+    {
+        var createResp = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Y", LocationKind.Wilderness, 49m, 17m));
+        var created = await createResp.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        var resp = await Client.PatchAsJsonAsync(
+            $"/api/locations/{created!.Id}/coordinates",
+            new LocationCoordinatesPatchDto(49m, 200m));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var problem = await resp.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Neplatná souřadnice", problem!.Title);
+        Assert.Contains("délka", problem.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PatchCoordinates_BoundaryValues_Accepted()
+    {
+        var createResp = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Edge", LocationKind.PointOfInterest, 0m, 0m));
+        var created = await createResp.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        // Exact bounds should round-trip — accept any valid lat/lng (Phase-0
+        // Q5 stance, no game-bbox clamp). Includes the corner cases at
+        // ±90 / ±180.
+        foreach (var (lat, lng) in new[] { (90m, 180m), (-90m, -180m), (0m, 0m) })
+        {
+            var resp = await Client.PatchAsJsonAsync(
+                $"/api/locations/{created!.Id}/coordinates",
+                new LocationCoordinatesPatchDto(lat, lng));
+            Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Bundle D — four cohesive map-surface fixes. Closes #252 #257 #259 #273.

### #273 — Zoom-aware labels + zoom indicator
- Per-LocationKind `KIND_MIN_ZOOM` lookup in `map-interop.js` — Town visible from zoom 0, Village from 6, Magical/Hobbit from 8, Wilderness from 9, Dungeon from 10, POI from 11. Single block, easy to retune.
- Pin DOM advertises `data-minzoom`; the new `applyZoomLabels` handler flips `.oh-pin-label-on` per pin on `zoomend` + `zoom`. Replaces the binary `.oh-map-zoomed-in` toggle from #258 with a graduated reveal.
- Custom `IControl` 'Z X.X' indicator added at `bottom-left` next to `ScaleControl`, updated continuously as the user zooms.

### #257 — Tear-drop pins with per-kind glyph + cream count badge
- New `.oh-map-pin-bg` paints the round bubble; `::after` triangle paints the downward tail in the same kind color (`var(--pin-color)` flows through both). Bootstrap-Icon glyph (`bi-shield-fill` / `bi-house-fill` / `bi-stars` / `bi-tree-fill` / `bi-tree` / `bi-bricks` / `bi-flag` per LocationKind) sits inside the bubble.
- Marker anchor swapped from `'center'` to `'bottom'` so the tail tip lands exactly on the GPS coord. Stash pins keep their circular shape + `'center'` anchor.
- Cream-bordered count badge (`var(--oh-border)`) offset to upper-right per the designer mockup, `z-index:3` above the bubble.

### #259 — Printable map views
- New `/map/print` Razor page with `?mode=labeled|blind`.
- Slim in-page toolbar hidden via `@media print`. Body class `oh-map-print` drives chrome-hide rules; `oh-map-print-labeled` force-shows location labels regardless of zoom; `oh-map-print-blind` renders `#42`-style ids and prints a 2-column legend cross-reference under the map (`page-break-before:always`).
- `ovcinaMapPrint.applyBodyMode` JS toggles body classes; cleared on `Dispose` so `/map` doesn't inherit print rules.

### #252 — PATCH /api/locations/{id}/coordinates
- New endpoint writes only `Coordinates`; every other field is untouched, so concurrent organizer edits on Description / Details / NpcInfo can't be clobbered by a stale `UpdateLocationDto` round-trip.
- Tight `LocationCoordinatesPatchDto(decimal Latitude, decimal Longitude)` matching the existing `GpsCoordinates` value object.
- 404 before 400 (per `_review-instincts §1`); range guards (`-90..90` lat, `-180..180` lng) return Czech `ProblemDetails`.
- `ApiClient.PatchWithProblemAsync` mirrors the existing `Put/Post/Delete` helpers; `MapPage.ConfirmDragAsync` swapped from GET→PUT to single PATCH. Ctrl+Click Place flow keeps PUT (Phase-0 Q4).
- 5 new tests: no-clobber roundtrip, 404-before-validation ordering, lat/lng range guards (Czech ProblemDetails assertions), boundary values (`±90 / ±180 / 0,0`).

## Phase-0 design Q&A — confirmations + one push-back
| Q | Stance |
|---|---|
| 1. Concurrency | Last-write-wins, **no RowVersion** (confirms orchestrator) |
| 2. DTO shape | New tight `LocationCoordinatesPatchDto` (confirms) |
| 3. Audit event | **No audit log** — searched the codebase, no `LocationAudit` infrastructure exists today, no audit calls in `LocationEndpoints`. Adding one solely for the coordinate patch would be the first audit on the Location surface. Deferred to a separate issue if a broader need surfaces. |
| 4. Frontend swap | Drag-drop only (confirms) — `ConfirmPlaceAsync` keeps PUT |
| 5. Bounds validation | Accept any valid lat/lng (confirms) — no game-bbox clamp |

## Cross-agent collision watch
- **Hra1 PR #283** still in flight on `LocationEndpoints.cs` + `Location` entity — my PATCH appended at the **end** of the route registration AND the end of the file (after `RemoveFromGame`) so the conflict surface is one tiny hunk if either PR rebases.
- **Hra2** untouched files. No overlap.

## Self-audit (per `_review-instincts`)
- ✅ §1 — `PatchCoordinates` checks `FindAsync` before validation.
- ✅ §2 — Server uses `TypedResults.Problem` with Czech title+detail; client uses `PatchWithProblemAsync`; tests assert `ProblemDetails` body fields.
- ✅ §17 — `using Microsoft.AspNetCore.Mvc;` added to `LocationEndpointTests.cs` for `ProblemDetails`.
- ✅ §18 — `csproj <Version>` NOT in diff.
- ✅ §20.2 — pure additions on `map-interop.js` / theme CSS; old binary `.oh-map-zoomed-in` rule cleanly replaced with graduated per-kind logic, no incidental deletions.

## Test plan
- [x] `dotnet build OvcinaHra.slnx` — 0 warnings, 0 errors (`TreatWarningsAsErrors=true`)
- [x] `dotnet test tests/OvcinaHra.Api.Tests` — **439 passed, 0 failed** (44s)
- [ ] Manual smoke after deploy:
  - [ ] `/map` — pins are tear-drops with kind-specific glyphs; count badges are cream-bordered; tear-drop tips sit on GPS
  - [ ] Zoom 0 → only Town labels visible; zoom 7 → +Villages; zoom 10 → +Wilderness/Magical/Hobbit; zoom 12 → +Dungeons + POIs
  - [ ] Bottom-left zoom indicator updates continuously
  - [ ] `/map/print?mode=labeled` — every parent label visible, chrome hidden, browser print produces clean A4
  - [ ] `/map/print?mode=blind` — pins show `#id`, legend prints on page 2
  - [ ] Drag-drop a pin → confirm popup → save: PATCH visible in DevTools, GPS persists, Description/Details unchanged after a parallel edit on the location detail page
- [ ] Playwright E2E deferred — `E2ETestBase` infra still broken (#92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)