### PR TITLE
Glejt companion PWA API enablement

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/CharacterConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/CharacterConfiguration.cs
@@ -44,3 +44,22 @@ public class CharacterEventConfiguration : IEntityTypeConfiguration<CharacterEve
         builder.HasIndex(e => e.CharacterAssignmentId);
     }
 }
+
+public class EventIdempotencyConfiguration : IEntityTypeConfiguration<EventIdempotency>
+{
+    public void Configure(EntityTypeBuilder<EventIdempotency> builder)
+    {
+        builder.HasKey(e => new { e.CharacterAssignmentId, e.IdempotencyKey });
+        builder.Property(e => e.IdempotencyKey).HasMaxLength(200);
+
+        builder.HasOne(e => e.Assignment)
+            .WithMany()
+            .HasForeignKey(e => e.CharacterAssignmentId);
+        builder.HasOne(e => e.Event)
+            .WithMany()
+            .HasForeignKey(e => e.EventId);
+
+        builder.HasIndex(e => e.EventId);
+        builder.HasIndex(e => e.CreatedAtUtc);
+    }
+}

--- a/src/OvcinaHra.Api/Data/Configurations/TreasureConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/TreasureConfiguration.cs
@@ -55,3 +55,31 @@ public class TreasureItemConfiguration : IEntityTypeConfiguration<TreasureItem>
         builder.HasIndex(e => new { e.GameId, e.TreasureQuestId });
     }
 }
+
+public class TreasureQuestVerificationConfiguration : IEntityTypeConfiguration<TreasureQuestVerification>
+{
+    public void Configure(EntityTypeBuilder<TreasureQuestVerification> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.OrganizerUserId).IsRequired().HasMaxLength(200);
+        builder.Property(e => e.OrganizerName).IsRequired().HasMaxLength(200);
+        builder.Property(e => e.Reason).HasMaxLength(500);
+
+        builder.HasOne(e => e.TreasureQuest)
+            .WithMany()
+            .HasForeignKey(e => e.TreasureQuestId);
+        builder.HasOne(e => e.Assignment)
+            .WithMany()
+            .HasForeignKey(e => e.CharacterAssignmentId);
+        builder.HasOne(e => e.Event)
+            .WithMany()
+            .HasForeignKey(e => e.CharacterEventId);
+        builder.HasOne(e => e.VerifiedStash)
+            .WithMany()
+            .HasForeignKey(e => e.VerifiedStashId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(e => new { e.TreasureQuestId, e.CharacterAssignmentId }).IsUnique();
+        builder.HasIndex(e => e.CharacterAssignmentId);
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -52,6 +52,7 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<Kingdom> Kingdoms => Set<Kingdom>();
     public DbSet<CharacterAssignment> CharacterAssignments => Set<CharacterAssignment>();
     public DbSet<CharacterEvent> CharacterEvents => Set<CharacterEvent>();
+    public DbSet<EventIdempotency> EventIdempotencies => Set<EventIdempotency>();
     public DbSet<GameEvent> GameEvents => Set<GameEvent>();
     public DbSet<GameEventTimeSlot> GameEventTimeSlots => Set<GameEventTimeSlot>();
     public DbSet<GameEventLocation> GameEventLocations => Set<GameEventLocation>();

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -44,6 +44,7 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<GameSecretStash> GameSecretStashes => Set<GameSecretStash>();
     public DbSet<TreasureQuest> TreasureQuests => Set<TreasureQuest>();
     public DbSet<TreasureItem> TreasureItems => Set<TreasureItem>();
+    public DbSet<TreasureQuestVerification> TreasureQuestVerifications => Set<TreasureQuestVerification>();
     public DbSet<GameTimeSlot> GameTimeSlots => Set<GameTimeSlot>();
     public DbSet<BattlefieldBonus> BattlefieldBonuses => Set<BattlefieldBonus>();
     public DbSet<LocalUser> LocalUsers => Set<LocalUser>();

--- a/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
@@ -20,6 +20,7 @@ public static class DashboardEndpoints
         group.MapGet("/issues", GetIssues);
         group.MapGet("/activity", GetActivity);
         group.MapGet("/timeline", GetTimeline);
+        group.MapGet("/events/recent", GetRecentEvents);
 
         return group;
     }
@@ -195,5 +196,38 @@ public static class DashboardEndpoints
             .ToList();
 
         return TypedResults.Ok(timeline);
+    }
+
+    private static async Task<Ok<List<DashboardRecentEventDto>>> GetRecentEvents(
+        int gameId, WorldDbContext db, DateTime? since = null)
+    {
+        var query = db.CharacterEvents
+            .Where(e => e.Assignment.GameId == gameId);
+
+        if (since is not null)
+        {
+            var sinceUtc = since.Value.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(since.Value, DateTimeKind.Utc)
+                : since.Value.ToUniversalTime();
+            query = query.Where(e => e.Timestamp > sinceUtc);
+        }
+
+        var rows = await query
+            .OrderByDescending(e => e.Timestamp)
+            .ThenByDescending(e => e.Id)
+            .Take(50)
+            .Select(e => new DashboardRecentEventDto(
+                e.Id,
+                e.CharacterAssignmentId,
+                e.Assignment.CharacterId,
+                e.Assignment.Character.Name,
+                e.EventType,
+                e.Data,
+                e.Location,
+                e.OrganizerName,
+                e.Timestamp))
+            .ToListAsync();
+
+        return TypedResults.Ok(rows);
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -11,6 +11,9 @@ namespace OvcinaHra.Api.Endpoints;
 
 public static class ScanEndpoints
 {
+    private const string IdempotencyHeader = "X-Idempotency-Key";
+    private const int MaxIdempotencyKeyLength = 200;
+
     public static RouteGroupBuilder MapScanEndpoints(this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/scan").WithTags("Scan").RequireAuthorization();
@@ -80,7 +83,7 @@ public static class ScanEndpoints
             currentLevel, totalXp, skills, recentEvents));
     }
 
-    private static async Task<Results<Created<CharacterEventDto>, NotFound, BadRequest<string>>> PostEvent(
+    private static async Task<IResult> PostEvent(
         int personId, CreateCharacterEventDto dto, WorldDbContext db, HttpContext httpContext)
     {
         var assignment = await db.CharacterAssignments
@@ -89,6 +92,12 @@ public static class ScanEndpoints
             .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
 
         if (assignment is null) return TypedResults.NotFound();
+
+        var idempotencyKey = GetIdempotencyKey(httpContext);
+        if (await TryGetIdempotentEventAsync(db, assignment.Id, idempotencyKey) is { } replay)
+            return TypedResults.Ok(replay);
+        if (!IsValidIdempotencyKey(idempotencyKey))
+            return SaveFailed("Hlavička X-Idempotency-Key je příliš dlouhá.");
 
         var organizer = GetOrganizer(httpContext);
 
@@ -134,13 +143,13 @@ public static class ScanEndpoints
         };
 
         db.CharacterEvents.Add(ev);
+        TrackIdempotency(db, assignment.Id, idempotencyKey, ev);
         await db.SaveChangesAsync();
 
-        var result = new CharacterEventDto(ev.Id, ev.EventType, ev.Data, ev.Location, ev.OrganizerName, ev.Timestamp);
-        return TypedResults.Created($"/api/scan/{personId}/events/{ev.Id}", result);
+        return TypedResults.Created($"/api/scan/{personId}/events/{ev.Id}", ToDto(ev));
     }
 
-    private static async Task<Results<Ok<CharacterEventDto>, NotFound>> DeleteLastLevelUp(
+    private static async Task<IResult> DeleteLastLevelUp(
         int personId, WorldDbContext db, HttpContext httpContext)
     {
         var assignment = await db.CharacterAssignments
@@ -149,6 +158,10 @@ public static class ScanEndpoints
 
         if (assignment is null) return TypedResults.NotFound();
 
+        var idempotencyKey = GetIdempotencyKey(httpContext);
+        if (await TryGetIdempotentEventAsync(db, assignment.Id, idempotencyKey) is { } replay)
+            return TypedResults.Ok(replay);
+
         var levelUp = assignment.Events
             .Where(e => e.EventType == CharacterEventType.LevelUp)
             .OrderByDescending(e => e.Timestamp)
@@ -156,6 +169,8 @@ public static class ScanEndpoints
             .FirstOrDefault();
 
         if (levelUp is null) return TypedResults.NotFound();
+        if (!IsValidIdempotencyKey(idempotencyKey))
+            return SaveFailed("Hlavička X-Idempotency-Key je příliš dlouhá.");
 
         var organizer = GetOrganizer(httpContext);
         var audit = new CharacterEvent
@@ -175,6 +190,7 @@ public static class ScanEndpoints
 
         db.CharacterEvents.Remove(levelUp);
         db.CharacterEvents.Add(audit);
+        TrackIdempotency(db, assignment.Id, idempotencyKey, audit);
         await db.SaveChangesAsync();
 
         return TypedResults.Ok(ToDto(audit));
@@ -239,6 +255,10 @@ public static class ScanEndpoints
 
         if (assignment is null) return TypedResults.NotFound();
 
+        var idempotencyKey = GetIdempotencyKey(httpContext);
+        if (await TryGetIdempotentEventAsync(db, assignment.Id, idempotencyKey) is { } replay)
+            return TypedResults.Ok(replay);
+
         var quest = await db.TreasureQuests
             .Include(t => t.SecretStash)
             .Include(t => t.TreasureItems)
@@ -252,6 +272,8 @@ public static class ScanEndpoints
         var alreadyVerified = await db.TreasureQuestVerifications.AnyAsync(v =>
             v.TreasureQuestId == quest.Id && v.CharacterAssignmentId == assignment.Id);
         if (alreadyVerified) return TypedResults.NotFound();
+        if (!IsValidIdempotencyKey(idempotencyKey))
+            return SaveFailed("Hlavička X-Idempotency-Key je příliš dlouhá.");
 
         var reason = string.IsNullOrWhiteSpace(dto.Reason) ? null : dto.Reason.Trim();
         if (dto.Override && reason is null)
@@ -307,6 +329,7 @@ public static class ScanEndpoints
             OrganizerUserId = organizer.UserId,
             OrganizerName = organizer.Name
         });
+        TrackIdempotency(db, assignment.Id, idempotencyKey, ev);
         await db.SaveChangesAsync();
 
         return TypedResults.Created($"/api/scan/{personId}/events/{ev.Id}", ToDto(ev));
@@ -314,6 +337,55 @@ public static class ScanEndpoints
 
     private static CharacterEventDto ToDto(CharacterEvent ev) =>
         new(ev.Id, ev.EventType, ev.Data, ev.Location, ev.OrganizerName, ev.Timestamp);
+
+    private static string? GetIdempotencyKey(HttpContext httpContext)
+    {
+        if (!httpContext.Request.Headers.TryGetValue(IdempotencyHeader, out var values))
+            return null;
+
+        var key = values.FirstOrDefault();
+        return string.IsNullOrWhiteSpace(key) ? null : key.Trim();
+    }
+
+    private static bool IsValidIdempotencyKey(string? key) =>
+        key is null || key.Length <= MaxIdempotencyKeyLength;
+
+    private static async Task<CharacterEventDto?> TryGetIdempotentEventAsync(
+        WorldDbContext db,
+        int assignmentId,
+        string? key)
+    {
+        if (key is null) return null;
+
+        return await db.EventIdempotencies
+            .Where(e => e.CharacterAssignmentId == assignmentId && e.IdempotencyKey == key)
+            .Select(e => new CharacterEventDto(
+                e.Event.Id,
+                e.Event.EventType,
+                e.Event.Data,
+                e.Event.Location,
+                e.Event.OrganizerName,
+                e.Event.Timestamp))
+            .FirstOrDefaultAsync();
+    }
+
+    private static void TrackIdempotency(
+        WorldDbContext db,
+        int assignmentId,
+        string? key,
+        CharacterEvent ev)
+    {
+        if (key is null) return;
+
+        db.EventIdempotencies.Add(new EventIdempotency
+        {
+            CharacterAssignmentId = assignmentId,
+            IdempotencyKey = key,
+            EventId = ev.Id,
+            Event = ev,
+            CreatedAtUtc = DateTime.UtcNow
+        });
+    }
 
     private static IResult SaveFailed(string detail) =>
         TypedResults.Problem(

--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -17,6 +17,7 @@ public static class ScanEndpoints
 
         group.MapGet("/{personId:int}", GetCharacterProfile);
         group.MapPost("/{personId:int}/events", PostEvent);
+        group.MapDelete("/{personId:int}/events/last-levelup", DeleteLastLevelUp);
         group.MapGet("/{personId:int}/events", GetRecentEvents);
 
         return group;
@@ -87,9 +88,7 @@ public static class ScanEndpoints
 
         if (assignment is null) return TypedResults.NotFound();
 
-        var user = httpContext.User;
-        var organizerUserId = user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier) ?? "unknown";
-        var organizerName = user.FindFirstValue("name") ?? user.FindFirstValue(ClaimTypes.Name) ?? "Unknown";
+        var organizer = GetOrganizer(httpContext);
 
         string eventData = dto.Data;
 
@@ -125,8 +124,8 @@ public static class ScanEndpoints
         {
             CharacterAssignmentId = assignment.Id,
             Timestamp = DateTime.UtcNow,
-            OrganizerUserId = organizerUserId,
-            OrganizerName = organizerName,
+            OrganizerUserId = organizer.UserId,
+            OrganizerName = organizer.Name,
             EventType = dto.EventType,
             Data = eventData,
             Location = dto.Location
@@ -137,6 +136,46 @@ public static class ScanEndpoints
 
         var result = new CharacterEventDto(ev.Id, ev.EventType, ev.Data, ev.Location, ev.OrganizerName, ev.Timestamp);
         return TypedResults.Created($"/api/scan/{personId}/events/{ev.Id}", result);
+    }
+
+    private static async Task<Results<Ok<CharacterEventDto>, NotFound>> DeleteLastLevelUp(
+        int personId, WorldDbContext db, HttpContext httpContext)
+    {
+        var assignment = await db.CharacterAssignments
+            .Include(a => a.Events)
+            .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
+
+        if (assignment is null) return TypedResults.NotFound();
+
+        var levelUp = assignment.Events
+            .Where(e => e.EventType == CharacterEventType.LevelUp)
+            .OrderByDescending(e => e.Timestamp)
+            .ThenByDescending(e => e.Id)
+            .FirstOrDefault();
+
+        if (levelUp is null) return TypedResults.NotFound();
+
+        var organizer = GetOrganizer(httpContext);
+        var audit = new CharacterEvent
+        {
+            CharacterAssignmentId = assignment.Id,
+            Timestamp = DateTime.UtcNow,
+            OrganizerUserId = organizer.UserId,
+            OrganizerName = organizer.Name,
+            EventType = CharacterEventType.LevelUpReverted,
+            Data = JsonSerializer.Serialize(new
+            {
+                revertedEventId = levelUp.Id,
+                revertedLevel = ExtractLevel(levelUp.Data)
+            }),
+            Location = levelUp.Location
+        };
+
+        db.CharacterEvents.Remove(levelUp);
+        db.CharacterEvents.Add(audit);
+        await db.SaveChangesAsync();
+
+        return TypedResults.Ok(ToDto(audit));
     }
 
     private static async Task<Results<Ok<List<CharacterEventDto>>, NotFound>> GetRecentEvents(
@@ -155,5 +194,31 @@ public static class ScanEndpoints
             .ToListAsync();
 
         return TypedResults.Ok(events);
+    }
+
+    private static CharacterEventDto ToDto(CharacterEvent ev) =>
+        new(ev.Id, ev.EventType, ev.Data, ev.Location, ev.OrganizerName, ev.Timestamp);
+
+    private static int? ExtractLevel(string data)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(data);
+            return doc.RootElement.TryGetProperty("level", out var level) && level.TryGetInt32(out var value)
+                ? value
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static (string UserId, string Name) GetOrganizer(HttpContext httpContext)
+    {
+        var user = httpContext.User;
+        return (
+            user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier) ?? "unknown",
+            user.FindFirstValue("name") ?? user.FindFirstValue(ClaimTypes.Name) ?? "Unknown");
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -19,6 +19,8 @@ public static class ScanEndpoints
         group.MapPost("/{personId:int}/events", PostEvent);
         group.MapDelete("/{personId:int}/events/last-levelup", DeleteLastLevelUp);
         group.MapGet("/{personId:int}/events", GetRecentEvents);
+        group.MapGet("/{personId:int}/treasure-quests/pending", GetPendingTreasureQuests);
+        group.MapPost("/{personId:int}/treasure-quests/{questId:int}/verify", VerifyTreasureQuest);
 
         return group;
     }
@@ -196,8 +198,128 @@ public static class ScanEndpoints
         return TypedResults.Ok(events);
     }
 
+    private static async Task<Results<Ok<List<PendingTreasureQuestDto>>, NotFound>> GetPendingTreasureQuests(
+        int personId, WorldDbContext db)
+    {
+        var assignment = await db.CharacterAssignments
+            .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
+
+        if (assignment is null) return TypedResults.NotFound();
+
+        var quests = await db.TreasureQuests
+            .Where(t => t.GameId == assignment.GameId && t.SecretStashId != null)
+            .Where(t => !db.TreasureQuestVerifications.Any(v =>
+                v.TreasureQuestId == t.Id && v.CharacterAssignmentId == assignment.Id))
+            .OrderBy(t => t.Title)
+            .Select(t => new PendingTreasureQuestDto(
+                t.Id,
+                t.Title,
+                t.SecretStashId!.Value,
+                t.SecretStash!.Name,
+                db.GameSecretStashes
+                    .Where(gs => gs.GameId == assignment.GameId && gs.SecretStashId == t.SecretStashId)
+                    .Select(gs => (int?)gs.LocationId)
+                    .FirstOrDefault(),
+                db.GameSecretStashes
+                    .Where(gs => gs.GameId == assignment.GameId && gs.SecretStashId == t.SecretStashId)
+                    .Select(gs => gs.Location.Name)
+                    .FirstOrDefault(),
+                null,
+                null))
+            .ToListAsync();
+
+        return TypedResults.Ok(quests);
+    }
+
+    private static async Task<IResult> VerifyTreasureQuest(
+        int personId, int questId, VerifyTreasureQuestDto dto, WorldDbContext db, HttpContext httpContext)
+    {
+        var assignment = await db.CharacterAssignments
+            .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
+
+        if (assignment is null) return TypedResults.NotFound();
+
+        var quest = await db.TreasureQuests
+            .Include(t => t.SecretStash)
+            .Include(t => t.TreasureItems)
+            .ThenInclude(ti => ti.Item)
+            .FirstOrDefaultAsync(t => t.Id == questId
+                && t.GameId == assignment.GameId
+                && t.SecretStashId != null);
+
+        if (quest is null) return TypedResults.NotFound();
+
+        var alreadyVerified = await db.TreasureQuestVerifications.AnyAsync(v =>
+            v.TreasureQuestId == quest.Id && v.CharacterAssignmentId == assignment.Id);
+        if (alreadyVerified) return TypedResults.NotFound();
+
+        var reason = string.IsNullOrWhiteSpace(dto.Reason) ? null : dto.Reason.Trim();
+        if (dto.Override && reason is null)
+        {
+            return SaveFailed("Při ručním přepsání musíš uvést důvod.");
+        }
+
+        if (dto.StashId != quest.SecretStashId!.Value && !dto.Override)
+        {
+            return SaveFailed("Razítko neodpovídá očekávané skrýši.");
+        }
+
+        var organizer = GetOrganizer(httpContext);
+        var rewards = quest.TreasureItems
+            .OrderBy(ti => ti.Item.Name)
+            .Select(ti => new { itemId = ti.ItemId, itemName = ti.Item.Name, count = ti.Count })
+            .ToList();
+        var now = DateTime.UtcNow;
+        var ev = new CharacterEvent
+        {
+            CharacterAssignmentId = assignment.Id,
+            Timestamp = now,
+            OrganizerUserId = organizer.UserId,
+            OrganizerName = organizer.Name,
+            EventType = CharacterEventType.TreasureQuestStampVerified,
+            Data = JsonSerializer.Serialize(new
+            {
+                questId = quest.Id,
+                questName = quest.Title,
+                expectedStashId = quest.SecretStashId.Value,
+                expectedStashName = quest.SecretStash!.Name,
+                stashId = dto.StashId,
+                matchConfidence = dto.MatchConfidence,
+                @override = dto.Override,
+                reason,
+                rewards
+            }),
+            Location = quest.SecretStash.Name
+        };
+
+        db.CharacterEvents.Add(ev);
+        db.TreasureQuestVerifications.Add(new TreasureQuestVerification
+        {
+            TreasureQuestId = quest.Id,
+            CharacterAssignmentId = assignment.Id,
+            CharacterEventId = ev.Id,
+            Event = ev,
+            VerifiedStashId = dto.StashId,
+            MatchConfidence = dto.MatchConfidence,
+            Override = dto.Override,
+            Reason = reason,
+            VerifiedAtUtc = now,
+            OrganizerUserId = organizer.UserId,
+            OrganizerName = organizer.Name
+        });
+        await db.SaveChangesAsync();
+
+        return TypedResults.Created($"/api/scan/{personId}/events/{ev.Id}", ToDto(ev));
+    }
+
     private static CharacterEventDto ToDto(CharacterEvent ev) =>
         new(ev.Id, ev.EventType, ev.Data, ev.Location, ev.OrganizerName, ev.Timestamp);
+
+    private static IResult SaveFailed(string detail) =>
+        TypedResults.Problem(
+            title: "Uložení selhalo",
+            detail: detail,
+            statusCode: StatusCodes.Status400BadRequest);
 
     private static int? ExtractLevel(string data)
     {

--- a/src/OvcinaHra.Api/Migrations/20260427081804_AddTreasureQuestVerifications.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260427081804_AddTreasureQuestVerifications.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260427081804_AddTreasureQuestVerifications")]
+    partial class AddTreasureQuestVerifications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260427081804_AddTreasureQuestVerifications.cs
+++ b/src/OvcinaHra.Api/Migrations/20260427081804_AddTreasureQuestVerifications.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTreasureQuestVerifications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TreasureQuestVerifications",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TreasureQuestId = table.Column<int>(type: "integer", nullable: false),
+                    CharacterAssignmentId = table.Column<int>(type: "integer", nullable: false),
+                    CharacterEventId = table.Column<int>(type: "integer", nullable: false),
+                    VerifiedStashId = table.Column<int>(type: "integer", nullable: false),
+                    MatchConfidence = table.Column<double>(type: "double precision", nullable: true),
+                    Override = table.Column<bool>(type: "boolean", nullable: false),
+                    Reason = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    VerifiedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    OrganizerUserId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    OrganizerName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TreasureQuestVerifications", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TreasureQuestVerifications_CharacterAssignments_CharacterAs~",
+                        column: x => x.CharacterAssignmentId,
+                        principalTable: "CharacterAssignments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TreasureQuestVerifications_CharacterEvents_CharacterEventId",
+                        column: x => x.CharacterEventId,
+                        principalTable: "CharacterEvents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TreasureQuestVerifications_SecretStashes_VerifiedStashId",
+                        column: x => x.VerifiedStashId,
+                        principalTable: "SecretStashes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TreasureQuestVerifications_TreasureQuests_TreasureQuestId",
+                        column: x => x.TreasureQuestId,
+                        principalTable: "TreasureQuests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TreasureQuestVerifications_CharacterAssignmentId",
+                table: "TreasureQuestVerifications",
+                column: "CharacterAssignmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TreasureQuestVerifications_CharacterEventId",
+                table: "TreasureQuestVerifications",
+                column: "CharacterEventId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TreasureQuestVerifications_TreasureQuestId_CharacterAssignm~",
+                table: "TreasureQuestVerifications",
+                columns: new[] { "TreasureQuestId", "CharacterAssignmentId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TreasureQuestVerifications_VerifiedStashId",
+                table: "TreasureQuestVerifications",
+                column: "VerifiedStashId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TreasureQuestVerifications");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Migrations/20260427082435_AddEventIdempotencies.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260427082435_AddEventIdempotencies.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260427082435_AddEventIdempotencies")]
+    partial class AddEventIdempotencies
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260427082435_AddEventIdempotencies.cs
+++ b/src/OvcinaHra.Api/Migrations/20260427082435_AddEventIdempotencies.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEventIdempotencies : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EventIdempotencies",
+                columns: table => new
+                {
+                    CharacterAssignmentId = table.Column<int>(type: "integer", nullable: false),
+                    IdempotencyKey = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    EventId = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EventIdempotencies", x => new { x.CharacterAssignmentId, x.IdempotencyKey });
+                    table.ForeignKey(
+                        name: "FK_EventIdempotencies_CharacterAssignments_CharacterAssignment~",
+                        column: x => x.CharacterAssignmentId,
+                        principalTable: "CharacterAssignments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_EventIdempotencies_CharacterEvents_EventId",
+                        column: x => x.EventId,
+                        principalTable: "CharacterEvents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EventIdempotencies_CreatedAtUtc",
+                table: "EventIdempotencies",
+                column: "CreatedAtUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EventIdempotencies_EventId",
+                table: "EventIdempotencies",
+                column: "EventId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EventIdempotencies");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -102,16 +102,22 @@ try
     builder.Services.AddSingleton(logBuffer);
     builder.Logging.AddProvider(new RingBufferLoggerProvider(logBuffer));
 
-    // CORS for Blazor WASM client. Configured origins (prod hostname) plus
-    // any localhost / 127.0.0.1 origin so a developer can run the Client
-    // locally with appsettings.LocalAgainstProd.json pointing here. Browsers
-    // can't fake the Origin header across machines, so the localhost branch
-    // is safe — it can only be exercised from the user's own machine.
+    // CORS for Blazor WASM and Glejt companion clients. Configured origins
+    // (prod hostnames) plus any localhost / 127.0.0.1 origin so a developer can
+    // run either client locally with appsettings.LocalAgainstProd.json pointing
+    // here. Browsers can't fake the Origin header across machines, so the
+    // localhost branch is safe — it can only be exercised from the user's own
+    // machine.
     builder.Services.AddCors(options =>
     {
         var configuredOrigins =
             builder.Configuration.GetSection("Cors:Origins").Get<string[]>()
-            ?? ["https://localhost:5290", "http://localhost:5290"];
+            ?? [
+                "https://localhost:5290",
+                "http://localhost:5290",
+                "https://glejt.ovcina.cz",
+                "https://localhost:5193"
+            ];
         options.AddPolicy("BlazorClient", policy => policy
             .SetIsOriginAllowed(origin =>
                 configuredOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase)

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -96,6 +96,7 @@ try
     // thumbnail presets so list pages never pay the cold-resize cost at
     // runtime. Runs in the background — does not block startup.
     builder.Services.AddHostedService<ThumbnailBackfillHostedService>();
+    builder.Services.AddHostedService<EventIdempotencyCleanupService>();
 
     // In-memory log ring buffer for production debugging
     var logBuffer = new LogRingBuffer();

--- a/src/OvcinaHra.Api/Services/EventIdempotencyCleanupService.cs
+++ b/src/OvcinaHra.Api/Services/EventIdempotencyCleanupService.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+
+namespace OvcinaHra.Api.Services;
+
+public sealed class EventIdempotencyCleanupService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<EventIdempotencyCleanupService> logger) : BackgroundService
+{
+    private static readonly TimeSpan CleanupInterval = TimeSpan.FromHours(12);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await CleanupOnceAsync(stoppingToken);
+
+        using var timer = new PeriodicTimer(CleanupInterval);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await CleanupOnceAsync(stoppingToken);
+        }
+    }
+
+    public static Task<int> CleanupAsync(
+        WorldDbContext db,
+        DateTime utcNow,
+        CancellationToken cancellationToken = default)
+    {
+        var cutoff = utcNow.AddDays(-7);
+        return db.EventIdempotencies
+            .Where(e => e.CreatedAtUtc < cutoff)
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+
+    private async Task CleanupOnceAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var deleted = await CleanupAsync(db, DateTime.UtcNow, cancellationToken);
+            if (deleted > 0)
+                logger.LogInformation("Deleted {Count} expired event idempotency keys.", deleted);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Event idempotency cleanup failed.");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Components/RecentActivityPanel.razor
+++ b/src/OvcinaHra.Client/Components/RecentActivityPanel.razor
@@ -1,0 +1,279 @@
+@using System.Text.Json
+@inject IDashboardEventStream EventStream
+@implements IAsyncDisposable
+
+@if (_takeover is not null)
+{
+    <div class="oh-home-takeover oh-home-event-takeover" @onclick="DismissTakeover" role="dialog" aria-label="Drozdova událost">
+        <div class="oh-home-drozd-card oh-home-drozd-card--event" @onclick:stopPropagation>
+            <div class="oh-home-drozd-art">
+                <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <circle cx="100" cy="100" r="92" fill="#F2EBD8" stroke="#8B5A2B" stroke-width="3" />
+                    <ellipse cx="100" cy="118" rx="42" ry="50" fill="#8B5A2B" />
+                    <circle cx="100" cy="76" r="32" fill="#A4733E" />
+                    <polygon points="128,80 152,72 128,90" fill="#C19A3A" />
+                    <circle cx="92" cy="74" r="3.5" fill="#2A2A2A" />
+                </svg>
+            </div>
+            <div class="oh-home-drozd-greet">
+                <h2>@TakeoverTitle(_takeover)</h2>
+                <p>@EventMessage(_takeover)</p>
+                <button class="btn btn-primary" type="button" @onclick="DismissTakeover">Beru na vědomí</button>
+            </div>
+        </div>
+    </div>
+}
+
+<section class="oh-home-act oh-home-recent" aria-labelledby="oh-home-recent-title">
+    <header class="oh-home-act-head oh-home-recent-head">
+        <h2 id="oh-home-recent-title">Živé události</h2>
+        <span class="oh-home-live-chip">Živě</span>
+    </header>
+
+    @if (_rows is null)
+    {
+        @for (var i = 0; i < 3; i++)
+        {
+            <div class="oh-home-act-row oh-home-act-skel">
+                <span class="oh-home-act-thumb"></span>
+                <span class="oh-home-skel-line-lg"></span>
+            </div>
+        }
+    }
+    else if (_rows.Count == 0)
+    {
+        <p class="text-muted small fst-italic mb-0">Zatím žádné události.</p>
+    }
+    else
+    {
+        @foreach (var row in _rows.Take(8))
+        {
+            <div class="oh-home-act-row oh-home-event-row">
+                <span class="oh-home-act-thumb oh-home-event-icon">
+                    <i class="bi @IconFor(row.EventType)"></i>
+                </span>
+                <span class="oh-home-act-body">
+                    <span class="oh-home-act-name">@EventMessage(row)</span>
+                    <span class="oh-home-act-meta text-muted small">
+                        @Age(row.Timestamp) · @row.OrganizerName
+                    </span>
+                </span>
+            </div>
+        }
+    }
+</section>
+
+@code {
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+    private readonly HashSet<int> _seenTakeovers = [];
+    private CancellationTokenSource? _pollCts;
+    private CancellationTokenSource? _takeoverCts;
+    private int? _activeGameId;
+    private DateTime? _latestTimestamp;
+    private List<DashboardRecentEventDto>? _rows;
+    private DashboardRecentEventDto? _takeover;
+
+    [Parameter] public int? GameId { get; set; }
+    [Parameter] public bool IsRunning { get; set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!IsRunning || GameId is null)
+        {
+            StopPolling();
+            _rows = null;
+            return;
+        }
+
+        if (_activeGameId == GameId && _pollCts is not null) return;
+
+        StopPolling();
+        _activeGameId = GameId.Value;
+        _rows = null;
+        _latestTimestamp = null;
+        _pollCts = new CancellationTokenSource();
+        await LoadAsync(GameId.Value, sinceUtc: null, showTakeover: false, _pollCts.Token);
+        _ = PollAsync(GameId.Value, _pollCts.Token);
+    }
+
+    private async Task PollAsync(int gameId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(PollInterval, cancellationToken);
+                await LoadAsync(gameId, _latestTimestamp, showTakeover: true, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task LoadAsync(
+        int gameId,
+        DateTime? sinceUtc,
+        bool showTakeover,
+        CancellationToken cancellationToken)
+    {
+        var incoming = await EventStream.GetRecentEventsAsync(gameId, sinceUtc, cancellationToken);
+        if (cancellationToken.IsCancellationRequested) return;
+
+        if (_rows is null || sinceUtc is null)
+        {
+            _rows = incoming.OrderByDescending(r => r.Timestamp).ThenByDescending(r => r.EventId).ToList();
+        }
+        else if (incoming.Count > 0)
+        {
+            _rows = incoming
+                .Concat(_rows)
+                .GroupBy(r => r.EventId)
+                .Select(g => g.First())
+                .OrderByDescending(r => r.Timestamp)
+                .ThenByDescending(r => r.EventId)
+                .Take(50)
+                .ToList();
+        }
+
+        _latestTimestamp = _rows.FirstOrDefault()?.Timestamp ?? _latestTimestamp;
+        if (showTakeover)
+        {
+            var takeover = incoming
+                .Where(IsTakeoverEvent)
+                .OrderByDescending(r => r.Timestamp)
+                .ThenByDescending(r => r.EventId)
+                .FirstOrDefault(r => _seenTakeovers.Add(r.EventId));
+            if (takeover is not null) ShowTakeover(takeover);
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private void ShowTakeover(DashboardRecentEventDto row)
+    {
+        _takeover = row;
+        _takeoverCts?.Cancel();
+        _takeoverCts?.Dispose();
+        _takeoverCts = new CancellationTokenSource();
+        var token = _takeoverCts.Token;
+        _ = AutoDismissTakeoverAsync(token);
+    }
+
+    private async Task AutoDismissTakeoverAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+            if (!cancellationToken.IsCancellationRequested)
+                await InvokeAsync(DismissTakeover);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private void DismissTakeover()
+    {
+        _takeover = null;
+        _takeoverCts?.Cancel();
+        StateHasChanged();
+    }
+
+    private void StopPolling()
+    {
+        _pollCts?.Cancel();
+        _pollCts?.Dispose();
+        _pollCts = null;
+        _activeGameId = null;
+        _latestTimestamp = null;
+    }
+
+    private static bool IsTakeoverEvent(DashboardRecentEventDto row) => row.EventType is
+        CharacterEventType.LevelUp or
+        CharacterEventType.ClassChosen or
+        CharacterEventType.TreasureQuestStampVerified;
+
+    private static string IconFor(CharacterEventType eventType) => eventType switch
+    {
+        CharacterEventType.LevelUp => "bi-stars",
+        CharacterEventType.ClassChosen => "bi-person-badge",
+        CharacterEventType.TreasureQuestStampVerified => "bi-patch-check",
+        CharacterEventType.LevelUpReverted => "bi-arrow-counterclockwise",
+        CharacterEventType.SkillGained => "bi-lightning-charge",
+        _ => "bi-dot"
+    };
+
+    private static string TakeoverTitle(DashboardRecentEventDto row) => row.EventType switch
+    {
+        CharacterEventType.LevelUp => "Drozd hlásí postup",
+        CharacterEventType.ClassChosen => "Drozd zapsal povolání",
+        CharacterEventType.TreasureQuestStampVerified => "Drozd ověřil razítko",
+        _ => "Drozd hlásí událost"
+    };
+
+    private static string EventMessage(DashboardRecentEventDto row) => row.EventType switch
+    {
+        CharacterEventType.LevelUp => $"{row.CharacterName} dosáhl {ReadInt(row.Data, "level")?.ToString() ?? "nové"}. úrovně",
+        CharacterEventType.LevelUpReverted => $"{row.CharacterName} má vrácenou úroveň",
+        CharacterEventType.ClassChosen => $"{row.CharacterName} zvolil povolání {ClassName(row.Data)}",
+        CharacterEventType.TreasureQuestStampVerified => $"{row.CharacterName} ověřil pokladové razítko",
+        CharacterEventType.SkillGained => $"{row.CharacterName} získal dovednost {ReadString(row.Data, "skill") ?? ""}".Trim(),
+        CharacterEventType.Note => $"{row.CharacterName} má novou poznámku",
+        _ => $"{row.CharacterName} · {row.EventType.GetDisplayName()}"
+    };
+
+    private static string ClassName(string data)
+    {
+        var raw = ReadString(data, "class");
+        if (raw is not null && Enum.TryParse<PlayerClass>(raw, ignoreCase: true, out var playerClass))
+            return playerClass.GetDisplayName();
+
+        return raw ?? "neznámé";
+    }
+
+    private static int? ReadInt(string data, string property)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(data);
+            return doc.RootElement.TryGetProperty(property, out var value) && value.TryGetInt32(out var result)
+                ? result
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ReadString(string data, string property)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(data);
+            return doc.RootElement.TryGetProperty(property, out var value) ? value.GetString() : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string Age(DateTime timestamp)
+    {
+        var delta = DateTime.UtcNow - timestamp.ToUniversalTime();
+        if (delta.TotalMinutes < 1) return "teď";
+        if (delta.TotalMinutes < 60) return $"{(int)delta.TotalMinutes} m";
+        if (delta.TotalHours < 24) return $"{(int)delta.TotalHours} h";
+        return timestamp.ToLocalTime().ToString("d. M.");
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        StopPolling();
+        _takeoverCts?.Cancel();
+        _takeoverCts?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Home.razor
+++ b/src/OvcinaHra.Client/Pages/Home.razor
@@ -52,8 +52,10 @@
                 }
 
                 <div class="oh-home-bottom-row">
-                    @* RecentActivityFeed removed pending real audit log — see issue #247.
-                       Stub feed (per-entity UpdatedAtUtc) was too noisy to keep on the dashboard. *@
+                    @if (_isGameRunning)
+                    {
+                        <RecentActivityPanel GameId="GameContext.SelectedGameId" IsRunning="_isGameRunning" />
+                    }
                     <QuickLaunchTiles />
                 </div>
             </div>

--- a/src/OvcinaHra.Client/Program.cs
+++ b/src/OvcinaHra.Client/Program.cs
@@ -33,6 +33,7 @@ builder.Services.AddScoped<JwtAuthStateProvider>();
 builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<JwtAuthStateProvider>());
 builder.Services.AddScoped<TokenRefreshService>();
 builder.Services.AddScoped<GameContextService>();
+builder.Services.AddScoped<IDashboardEventStream, PollingDashboardEventStream>();
 builder.Services.AddScoped<SkillService>();
 builder.Services.AddScoped<PersonalQuestService>();
 builder.Services.AddScoped<VersionDriftService>();

--- a/src/OvcinaHra.Client/Services/IDashboardEventStream.cs
+++ b/src/OvcinaHra.Client/Services/IDashboardEventStream.cs
@@ -1,0 +1,11 @@
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Client.Services;
+
+public interface IDashboardEventStream
+{
+    Task<IReadOnlyList<DashboardRecentEventDto>> GetRecentEventsAsync(
+        int gameId,
+        DateTime? sinceUtc,
+        CancellationToken cancellationToken = default);
+}

--- a/src/OvcinaHra.Client/Services/PollingDashboardEventStream.cs
+++ b/src/OvcinaHra.Client/Services/PollingDashboardEventStream.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Client.Services;
+
+public sealed class PollingDashboardEventStream(ApiClient api) : IDashboardEventStream
+{
+    public async Task<IReadOnlyList<DashboardRecentEventDto>> GetRecentEventsAsync(
+        int gameId,
+        DateTime? sinceUtc,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var url = $"/api/dashboard/events/recent?gameId={gameId}";
+        if (sinceUtc is not null)
+        {
+            var since = sinceUtc.Value.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+            url += $"&since={Uri.EscapeDataString(since)}";
+        }
+
+        var rows = await api.GetListAsync<DashboardRecentEventDto>(url);
+        cancellationToken.ThrowIfCancellationRequested();
+        return rows;
+    }
+}

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3312,6 +3312,14 @@
 .oh-home-act-body{display:flex;flex-direction:column;min-width:0;flex:1}
 .oh-home-act-name{font-weight:600;text-overflow:ellipsis;overflow:hidden;white-space:nowrap}
 .oh-home-act-skel{align-items:center}
+.oh-home-bottom-row > .oh-home-qlaunch:only-child{grid-column:1/-1}
+.oh-home-recent-head{display:flex;align-items:center;justify-content:space-between;gap:10px}
+.oh-home-live-chip{display:inline-flex;align-items:center;padding:2px 8px;border-radius:999px;
+    background:rgba(45,80,22,.1);color:#2D5016;font:700 .7rem var(--oh-font-body);text-transform:uppercase}
+.oh-home-event-row{min-height:56px}
+.oh-home-event-icon{background:rgba(45,80,22,.08)}
+.oh-home-event-icon i{color:#2D5016}
+.oh-home-drozd-card--event{box-shadow:0 18px 42px rgba(20,16,8,.28)}
 
 /* Quick launch tiles */
 .oh-home-qlaunch-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}

--- a/src/OvcinaHra.Shared/Domain/Entities/EventIdempotency.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/EventIdempotency.cs
@@ -1,0 +1,12 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class EventIdempotency
+{
+    public int CharacterAssignmentId { get; set; }
+    public required string IdempotencyKey { get; set; }
+    public int EventId { get; set; }
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public CharacterAssignment Assignment { get; set; } = null!;
+    public CharacterEvent Event { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/TreasureQuestVerification.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/TreasureQuestVerification.cs
@@ -1,0 +1,21 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class TreasureQuestVerification
+{
+    public int Id { get; set; }
+    public int TreasureQuestId { get; set; }
+    public int CharacterAssignmentId { get; set; }
+    public int CharacterEventId { get; set; }
+    public int VerifiedStashId { get; set; }
+    public double? MatchConfidence { get; set; }
+    public bool Override { get; set; }
+    public string? Reason { get; set; }
+    public DateTime VerifiedAtUtc { get; set; } = DateTime.UtcNow;
+    public required string OrganizerUserId { get; set; }
+    public required string OrganizerName { get; set; }
+
+    public TreasureQuest TreasureQuest { get; set; } = null!;
+    public CharacterAssignment Assignment { get; set; } = null!;
+    public CharacterEvent Event { get; set; } = null!;
+    public SecretStash VerifiedStash { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs
@@ -9,6 +9,9 @@ public enum CharacterEventType
     [Display(Name = "Zvýšení úrovně")]
     LevelUp,
 
+    [Display(Name = "Vrácení úrovně")]
+    LevelUpReverted,
+
     [Display(Name = "Získání dovednosti")]
     SkillGained,
 

--- a/src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs
@@ -22,5 +22,8 @@ public enum CharacterEventType
     Note,
 
     [Display(Name = "Volba povolání")]
-    ClassChosen
+    ClassChosen,
+
+    [Display(Name = "Ověření pokladového razítka")]
+    TreasureQuestStampVerified
 }

--- a/src/OvcinaHra.Shared/Dtos/DashboardDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/DashboardDtos.cs
@@ -1,3 +1,5 @@
+using OvcinaHra.Shared.Domain.Enums;
+
 namespace OvcinaHra.Shared.Dtos;
 
 // Issue #158 — DTOs powering the Home cockpit (`/api/dashboard/...`).
@@ -49,6 +51,17 @@ public record DashboardActivityDto(
     string Verb,        /* vytvořil | upravil | smazal — currently always "upravil" */
     string ActorName,
     DateTime OccurredUtc);
+
+public record DashboardRecentEventDto(
+    int EventId,
+    int CharacterAssignmentId,
+    int CharacterId,
+    string CharacterName,
+    CharacterEventType EventType,
+    string Data,
+    string? Location,
+    string OrganizerName,
+    DateTime Timestamp);
 
 /// <summary>
 /// One row in the TimelinePreview. <see cref="IsRunning"/> is computed

--- a/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
@@ -28,6 +28,22 @@ public record UpdateTreasureQuestDto(
 public record TreasureItemDto(int Id, int ItemId, string ItemName, int Count, int? TreasureQuestId);
 public record AddTreasureItemDto(int ItemId, int Count = 1);
 
+public record PendingTreasureQuestDto(
+    int QuestId,
+    string QuestName,
+    int ExpectedStashId,
+    string ExpectedStashName,
+    int? ExpectedLocationId,
+    string? ExpectedLocationName,
+    DateTime? IssuedAt,
+    string? IssuedBy);
+
+public record VerifyTreasureQuestDto(
+    int StashId,
+    double? MatchConfidence = null,
+    bool Override = false,
+    string? Reason = null);
+
 // --- Treasure Pool DTOs ---
 
 public record TreasurePoolItemDto(int Id, int ItemId, string ItemName, ItemType ItemType, int Count, int GameId)

--- a/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
@@ -207,4 +207,121 @@ public class DashboardEndpointsTests(PostgresFixture postgres)
         var row = Assert.Single(rows);
         Assert.True(row.IsRunning);
     }
+
+    [Fact]
+    public async Task RecentEvents_ReturnsCharacterEventsScopedByGameAndSince()
+    {
+        var game = await CreateGameAsync();
+        var otherGame = await CreateGameAsync();
+        var cutoff = DateTime.UtcNow.AddMinutes(-10);
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var character = new Character { Name = "Mireček", IsPlayedCharacter = true };
+            var otherCharacter = new Character { Name = "Cizí", IsPlayedCharacter = true };
+            db.Characters.AddRange(character, otherCharacter);
+            await db.SaveChangesAsync();
+
+            var assignment = new CharacterAssignment
+            {
+                CharacterId = character.Id,
+                GameId = game.Id,
+                ExternalPersonId = 3001
+            };
+            var otherAssignment = new CharacterAssignment
+            {
+                CharacterId = otherCharacter.Id,
+                GameId = otherGame.Id,
+                ExternalPersonId = 3002
+            };
+            db.CharacterAssignments.AddRange(assignment, otherAssignment);
+            await db.SaveChangesAsync();
+
+            db.CharacterEvents.AddRange(
+                new CharacterEvent
+                {
+                    CharacterAssignmentId = assignment.Id,
+                    Timestamp = cutoff.AddMinutes(-1),
+                    OrganizerUserId = "old",
+                    OrganizerName = "Old",
+                    EventType = CharacterEventType.Note,
+                    Data = "{}"
+                },
+                new CharacterEvent
+                {
+                    CharacterAssignmentId = assignment.Id,
+                    Timestamp = cutoff.AddMinutes(1),
+                    OrganizerUserId = "tom",
+                    OrganizerName = "Tomáš",
+                    EventType = CharacterEventType.LevelUp,
+                    Data = """{"level":2}"""
+                },
+                new CharacterEvent
+                {
+                    CharacterAssignmentId = otherAssignment.Id,
+                    Timestamp = cutoff.AddMinutes(2),
+                    OrganizerUserId = "other",
+                    OrganizerName = "Other",
+                    EventType = CharacterEventType.LevelUp,
+                    Data = """{"level":9}"""
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var rows = await Client.GetFromJsonAsync<List<DashboardRecentEventDto>>(
+            $"/api/dashboard/events/recent?gameId={game.Id}&since={Uri.EscapeDataString(cutoff.ToString("O"))}");
+
+        Assert.NotNull(rows);
+        var row = Assert.Single(rows);
+        Assert.Equal("Mireček", row.CharacterName);
+        Assert.Equal(CharacterEventType.LevelUp, row.EventType);
+        Assert.Equal("Tomáš", row.OrganizerName);
+    }
+
+    [Fact]
+    public async Task RecentEvents_CapsAt50NewestRows()
+    {
+        var game = await CreateGameAsync();
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var character = new Character { Name = "Blesk", IsPlayedCharacter = true };
+            db.Characters.Add(character);
+            await db.SaveChangesAsync();
+
+            var assignment = new CharacterAssignment
+            {
+                CharacterId = character.Id,
+                GameId = game.Id,
+                ExternalPersonId = 3003
+            };
+            db.CharacterAssignments.Add(assignment);
+            await db.SaveChangesAsync();
+
+            var start = DateTime.UtcNow.AddHours(-1);
+            for (var i = 0; i < 55; i++)
+            {
+                db.CharacterEvents.Add(new CharacterEvent
+                {
+                    CharacterAssignmentId = assignment.Id,
+                    Timestamp = start.AddMinutes(i),
+                    OrganizerUserId = "tom",
+                    OrganizerName = "Tomáš",
+                    EventType = CharacterEventType.Note,
+                    Data = $$"""{"index":{{i}}}"""
+                });
+            }
+            await db.SaveChangesAsync();
+        }
+
+        var rows = await Client.GetFromJsonAsync<List<DashboardRecentEventDto>>(
+            $"/api/dashboard/events/recent?gameId={game.Id}");
+
+        Assert.NotNull(rows);
+        Assert.Equal(50, rows.Count);
+        Assert.Contains("\"index\":54", rows[0].Data);
+        Assert.DoesNotContain(rows, r => r.Data.Contains("\"index\":0", StringComparison.Ordinal));
+    }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
@@ -12,6 +13,30 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
     {
         var kingdoms = await Client.GetFromJsonAsync<List<KingdomDto>>("/api/kingdoms");
         return kingdoms!.First(k => k.Name == name).Id;
+    }
+
+    private async Task<GameDetailDto> CreateGameAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto(name, 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    private async Task<LocationDetailDto> CreateLocationAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto(name, LocationKind.Wilderness, 49.5m, 17.1m));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<LocationDetailDto>())!;
+    }
+
+    private async Task<SecretStashDetailDto> CreateSecretStashAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/secret-stashes",
+            new CreateSecretStashDto(name));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<SecretStashDetailDto>())!;
     }
 
     private async Task<(CharacterDetailDto character, CharacterAssignmentDto assignment)> SeedCharacterWithAssignment(
@@ -164,4 +189,91 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
+
+    [Fact]
+    public async Task PendingTreasureQuests_ReturnsUnverifiedStashQuest()
+    {
+        var game = await CreateGameAsync("Scan poklad");
+        var location = await CreateLocationAsync("Stará studna");
+        var stash = await CreateSecretStashAsync("Dutý pařez");
+        await Client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+            new CreateGameSecretStashDto(game.Id, stash.Id, location.Id));
+        await SeedCharacterWithAssignment(externalPersonId: 107, gameId: game.Id);
+
+        var createQuest = await Client.PostAsJsonAsync("/api/treasure-quests",
+            new CreateTreasureQuestDto("Razítko ve skrýši", GameTimePhase.Early, game.Id, SecretStashId: stash.Id));
+        var quest = await createQuest.Content.ReadFromJsonAsync<TreasureQuestListDto>();
+
+        var pending = await Client.GetFromJsonAsync<List<PendingTreasureQuestDto>>(
+            "/api/scan/107/treasure-quests/pending");
+
+        Assert.NotNull(pending);
+        var row = Assert.Single(pending);
+        Assert.Equal(quest!.Id, row.QuestId);
+        Assert.Equal(stash.Id, row.ExpectedStashId);
+        Assert.Equal(stash.Name, row.ExpectedStashName);
+        Assert.Equal(location.Id, row.ExpectedLocationId);
+        Assert.Equal(location.Name, row.ExpectedLocationName);
+    }
+
+    [Fact]
+    public async Task VerifyTreasureQuest_CreatesEventCreditsRewards_AndRemovesFromPending()
+    {
+        var game = await CreateGameAsync("Scan ověření");
+        var location = await CreateLocationAsync("Dračí kámen");
+        var stash = await CreateSecretStashAsync("Pod kamenem");
+        await Client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+            new CreateGameSecretStashDto(game.Id, stash.Id, location.Id));
+        await SeedCharacterWithAssignment(externalPersonId: 108, gameId: game.Id);
+
+        var createQuest = await Client.PostAsJsonAsync("/api/treasure-quests",
+            new CreateTreasureQuestDto("Dračí razítko", GameTimePhase.Midgame, game.Id, SecretStashId: stash.Id));
+        var quest = await createQuest.Content.ReadFromJsonAsync<TreasureQuestListDto>();
+        var itemResponse = await Client.PostAsJsonAsync("/api/items", new CreateItemDto("Dračí šupina", ItemType.Weapon));
+        var item = await itemResponse.Content.ReadFromJsonAsync<ItemDetailDto>();
+        await Client.PostAsJsonAsync($"/api/treasure-quests/{quest!.Id}/items",
+            new AddTreasureItemDto(item!.Id, 2));
+
+        var response = await Client.PostAsJsonAsync(
+            $"/api/scan/108/treasure-quests/{quest.Id}/verify",
+            new VerifyTreasureQuestDto(stash.Id, MatchConfidence: 0.98));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var ev = await response.Content.ReadFromJsonAsync<CharacterEventDto>();
+        Assert.NotNull(ev);
+        Assert.Equal(CharacterEventType.TreasureQuestStampVerified, ev.EventType);
+        Assert.Equal("Test Organizátor", ev.OrganizerName);
+        using var doc = JsonDocument.Parse(ev.Data);
+        var reward = doc.RootElement.GetProperty("rewards")[0];
+        Assert.Equal("Dračí šupina", reward.GetProperty("itemName").GetString());
+        Assert.Equal(2, reward.GetProperty("count").GetInt32());
+
+        var pending = await Client.GetFromJsonAsync<List<PendingTreasureQuestDto>>(
+            "/api/scan/108/treasure-quests/pending");
+        Assert.NotNull(pending);
+        Assert.Empty(pending);
+    }
+
+    [Fact]
+    public async Task VerifyTreasureQuest_OverrideWithoutReason_ReturnsProblemDetails()
+    {
+        var game = await CreateGameAsync("Scan override");
+        var stash = await CreateSecretStashAsync("Správná skrýš");
+        await SeedCharacterWithAssignment(externalPersonId: 109, gameId: game.Id);
+        var createQuest = await Client.PostAsJsonAsync("/api/treasure-quests",
+            new CreateTreasureQuestDto("Přepis razítka", GameTimePhase.Early, game.Id, SecretStashId: stash.Id));
+        var quest = await createQuest.Content.ReadFromJsonAsync<TreasureQuestListDto>();
+
+        var response = await Client.PostAsJsonAsync(
+            $"/api/scan/109/treasure-quests/{quest!.Id}/verify",
+            new VerifyTreasureQuestDto(stash.Id, Override: true));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Uložení selhalo", problem.Title);
+        Assert.Equal("Při ručním přepsání musíš uvést důvod.", problem.Detail);
+    }
+
+    private sealed record ProblemDetails(string? Title, string? Detail, int? Status);
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
@@ -1,6 +1,10 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
@@ -37,6 +41,26 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
             new CreateSecretStashDto(name));
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<SecretStashDetailDto>())!;
+    }
+
+    private async Task<HttpResponseMessage> PostJsonWithIdempotencyAsync<T>(
+        string url,
+        T payload,
+        string key)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = JsonContent.Create(payload)
+        };
+        request.Headers.Add("X-Idempotency-Key", key);
+        return await Client.SendAsync(request);
+    }
+
+    private async Task<HttpResponseMessage> DeleteWithIdempotencyAsync(string url, string key)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+        request.Headers.Add("X-Idempotency-Key", key);
+        return await Client.SendAsync(request);
     }
 
     private async Task<(CharacterDetailDto character, CharacterAssignmentDto assignment)> SeedCharacterWithAssignment(
@@ -99,6 +123,35 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
         Assert.NotNull(profile);
         Assert.Equal(1, profile.CurrentLevel);
         Assert.Equal(1, profile.TotalXp);
+    }
+
+    [Fact]
+    public async Task PostEvent_WithSameIdempotencyKey_ReplaysOriginalEvent()
+    {
+        await SeedCharacterWithAssignment(externalPersonId: 111);
+        var payload = new CreateCharacterEventDto(CharacterEventType.LevelUp, "{}");
+
+        var firstResponse = await PostJsonWithIdempotencyAsync(
+            "/api/scan/111/events", payload, "scan-level-111");
+        var secondResponse = await PostJsonWithIdempotencyAsync(
+            "/api/scan/111/events", payload, "scan-level-111");
+
+        Assert.Equal(HttpStatusCode.Created, firstResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        var first = await firstResponse.Content.ReadFromJsonAsync<CharacterEventDto>();
+        var second = await secondResponse.Content.ReadFromJsonAsync<CharacterEventDto>();
+        Assert.Equal(first!.Id, second!.Id);
+
+        var profile = await Client.GetFromJsonAsync<ScanCharacterDto>("/api/scan/111");
+        Assert.Equal(1, profile!.CurrentLevel);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var key = await db.EventIdempotencies.SingleAsync();
+        key.CreatedAtUtc = DateTime.UtcNow.AddDays(-8);
+        await db.SaveChangesAsync();
+        var deleted = await EventIdempotencyCleanupService.CleanupAsync(db, DateTime.UtcNow);
+        Assert.Equal(1, deleted);
     }
 
     [Fact]
@@ -191,6 +244,30 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
     }
 
     [Fact]
+    public async Task DeleteLastLevelUp_WithSameIdempotencyKey_ReplaysAuditEvent()
+    {
+        await SeedCharacterWithAssignment(externalPersonId: 112);
+        await Client.PostAsJsonAsync("/api/scan/112/events",
+            new CreateCharacterEventDto(CharacterEventType.LevelUp, "{}"));
+
+        var firstResponse = await DeleteWithIdempotencyAsync(
+            "/api/scan/112/events/last-levelup", "undo-level-112");
+        var secondResponse = await DeleteWithIdempotencyAsync(
+            "/api/scan/112/events/last-levelup", "undo-level-112");
+
+        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        var first = await firstResponse.Content.ReadFromJsonAsync<CharacterEventDto>();
+        var second = await secondResponse.Content.ReadFromJsonAsync<CharacterEventDto>();
+        Assert.Equal(first!.Id, second!.Id);
+
+        var events = await Client.GetFromJsonAsync<List<CharacterEventDto>>("/api/scan/112/events");
+        Assert.NotNull(events);
+        Assert.DoesNotContain(events, e => e.EventType == CharacterEventType.LevelUp);
+        Assert.Single(events, e => e.EventType == CharacterEventType.LevelUpReverted);
+    }
+
+    [Fact]
     public async Task PendingTreasureQuests_ReturnsUnverifiedStashQuest()
     {
         var game = await CreateGameAsync("Scan poklad");
@@ -252,6 +329,29 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
             "/api/scan/108/treasure-quests/pending");
         Assert.NotNull(pending);
         Assert.Empty(pending);
+    }
+
+    [Fact]
+    public async Task VerifyTreasureQuest_WithSameIdempotencyKey_ReplaysOriginalEvent()
+    {
+        var game = await CreateGameAsync("Scan idempotence");
+        var stash = await CreateSecretStashAsync("Idempotentní skrýš");
+        await SeedCharacterWithAssignment(externalPersonId: 113, gameId: game.Id);
+        var createQuest = await Client.PostAsJsonAsync("/api/treasure-quests",
+            new CreateTreasureQuestDto("Jedno razítko", GameTimePhase.Early, game.Id, SecretStashId: stash.Id));
+        var quest = await createQuest.Content.ReadFromJsonAsync<TreasureQuestListDto>();
+        var payload = new VerifyTreasureQuestDto(stash.Id);
+
+        var firstResponse = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/113/treasure-quests/{quest!.Id}/verify", payload, "verify-113");
+        var secondResponse = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/113/treasure-quests/{quest.Id}/verify", payload, "verify-113");
+
+        Assert.Equal(HttpStatusCode.Created, firstResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        var first = await firstResponse.Content.ReadFromJsonAsync<CharacterEventDto>();
+        var second = await secondResponse.Content.ReadFromJsonAsync<CharacterEventDto>();
+        Assert.Equal(first!.Id, second!.Id);
     }
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
@@ -124,4 +124,44 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
         Assert.Equal(CharacterEventType.Note, events[0].EventType);
         Assert.Equal(CharacterEventType.LevelUp, events[1].EventType);
     }
+
+    [Fact]
+    public async Task DeleteLastLevelUp_RemovesMostRecentLevelUp_AndWritesAudit()
+    {
+        await SeedCharacterWithAssignment(externalPersonId: 105);
+
+        await Client.PostAsJsonAsync("/api/scan/105/events",
+            new CreateCharacterEventDto(CharacterEventType.LevelUp, "{}"));
+        await Client.PostAsJsonAsync("/api/scan/105/events",
+            new CreateCharacterEventDto(CharacterEventType.LevelUp, "{}"));
+
+        var response = await Client.DeleteAsync("/api/scan/105/events/last-levelup");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var audit = await response.Content.ReadFromJsonAsync<CharacterEventDto>();
+        Assert.NotNull(audit);
+        Assert.Equal(CharacterEventType.LevelUpReverted, audit.EventType);
+        Assert.Equal("Test Organizátor", audit.OrganizerName);
+        Assert.Contains("\"revertedLevel\":2", audit.Data);
+
+        var profile = await Client.GetFromJsonAsync<ScanCharacterDto>("/api/scan/105");
+        Assert.NotNull(profile);
+        Assert.Equal(1, profile.CurrentLevel);
+        Assert.Equal(1, profile.TotalXp);
+
+        var events = await Client.GetFromJsonAsync<List<CharacterEventDto>>("/api/scan/105/events");
+        Assert.NotNull(events);
+        Assert.Equal(1, events.Count(e => e.EventType == CharacterEventType.LevelUp));
+        Assert.Contains(events, e => e.EventType == CharacterEventType.LevelUpReverted);
+    }
+
+    [Fact]
+    public async Task DeleteLastLevelUp_WhenNoLevelUp_ReturnsNotFound()
+    {
+        await SeedCharacterWithAssignment(externalPersonId: 106);
+
+        var response = await Client.DeleteAsync("/api/scan/106/events/last-levelup");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
 }


### PR DESCRIPTION
## Summary
- allow Glejt production/local companion-PWA CORS origins
- add scan event undo, treasure-quest pending/verify endpoints, and X-Idempotency-Key replay ledger with cleanup
- add dashboard recent-events API plus Home recent-activity panel and Drozd takeover

## Verification
- PASS: dotnet build OvcinaHra.slnx
- PARTIAL: dotnet test -> OvcinaHra.Api.Tests passed 449/449; OvcinaHra.E2E has existing unrelated failure in SkillsManagementTests.GameSkill_CannotBeRemoved_WhenReferencedByRecipe (expected NoContent, actual Conflict)

## Deferred
- #238 and #241 intentionally untouched; no Location.StampImagePath or stamp-list endpoint changes.