### PR TITLE
fix(quickfix): canonical Drozd svg + log-off OIDC re-auth (closes #233 #261)

### DIFF
--- a/src/OvcinaHra.Client/Components/DrozdWelcome.razor
+++ b/src/OvcinaHra.Client/Components/DrozdWelcome.razor
@@ -11,16 +11,21 @@
     <div class="oh-home-takeover" @onclick="Dismiss" role="dialog" aria-label="Vítej v OvčinaHře">
         <div class="oh-home-drozd-card" @onclick:stopPropagation>
             <div class="oh-home-drozd-art">
-                @* Inline SVG placeholder until designer ships drozd-welcome.png.
-                   Single warm-tone silhouette — keeps the takeover from looking
-                   broken before the real asset lands. *@
-                <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                    <circle cx="100" cy="100" r="92" fill="#F2EBD8" stroke="#8B5A2B" stroke-width="3" />
-                    <ellipse cx="100" cy="118" rx="42" ry="50" fill="#8B5A2B" />
-                    <circle cx="100" cy="76" r="32" fill="#A4733E" />
-                    <polygon points="128,80 152,72 128,90" fill="#C19A3A" />
-                    <circle cx="92" cy="74" r="3.5" fill="#2A2A2A" />
-                </svg>
+                @* Issue #233 — was an inline placeholder silhouette ("until
+                   designer ships drozd-welcome.png"). The canonical Drozd
+                   assets live at /img/drozd/drozd-{idle,confused,knocking}.svg
+                   (already shipped, used by the empty-state on /map and /items).
+                   Idle pose is the welcome variant. State-flag fallback keeps
+                   the takeover usable if the asset 404s. *@
+                @if (!_artFailed)
+                {
+                    <img src="/img/drozd/drozd-idle.svg" alt="Drozd"
+                         @onerror="() => { _artFailed = true; StateHasChanged(); }" />
+                }
+                else
+                {
+                    <i class="bi bi-feather oh-home-drozd-art-fallback" aria-hidden="true"></i>
+                }
             </div>
             <div class="oh-home-drozd-greet">
                 <h2>Dobrý den, @(UserName ?? "organizátore")!</h2>
@@ -34,6 +39,7 @@
 @code {
     private const string SessionFlag = "oh-drozd-welcome-dismissed";
     private bool _visible;
+    private bool _artFailed;
     private CancellationTokenSource? _autoDismissCts;
 
     [Parameter] public string? UserName { get; set; }

--- a/src/OvcinaHra.Client/Layout/MainLayout.razor
+++ b/src/OvcinaHra.Client/Layout/MainLayout.razor
@@ -28,12 +28,24 @@
 
 @code {
     [Inject] private JwtAuthStateProvider AuthProvider { get; set; } = default!;
+    [Inject] private NavigationManager Nav { get; set; } = default!;
 
     private bool sidebarCollapsed;
     private void ToggleSidebar() => sidebarCollapsed = !sidebarCollapsed;
 
+    // Issue #261 — clearing the token alone left the user on whatever
+    // protected page they were on; AuthorizeView would re-render empty,
+    // [Authorize] would redirect to /login, and /login's auto-redirect
+    // back into OIDC would silently re-authenticate via the still-valid
+    // IdP cookie. We now navigate to /login?logout=1 with forceLoad:true
+    // so the WASM app reboots clean (no stale refresh timer, no race),
+    // and Login.razor reads the query param to suppress its auto-redirect
+    // — the user sees a deliberate "logged out" card and clicks to sign
+    // back in. The IdP cookie is still alive, but that's a UX choice:
+    // any explicit re-login goes through SSO, no fresh password needed.
     private async Task Logout()
     {
         await AuthProvider.ClearTokenAsync();
+        Nav.NavigateTo("/login?logout=1", forceLoad: true);
     }
 }

--- a/src/OvcinaHra.Client/Pages/Login.razor
+++ b/src/OvcinaHra.Client/Pages/Login.razor
@@ -23,10 +23,23 @@
                 </div>
             }
 
+            @* Issue #261 — explicit logout banner. MainLayout.Logout navigates
+               here with ?logout=1 + forceLoad so the WASM app reboots clean.
+               Without this banner the user would see the auto-redirect spinner
+               and assume nothing happened; the manual sign-in button below
+               replaces auto-redirect for this branch. *@
+            @if (LoggedOut)
+            {
+                <div class="alert alert-success">
+                    <i class="bi bi-check-circle me-1"></i>
+                    Byl jsi odhlášen. Pro pokračování klikni níže.
+                </div>
+            }
+
             @* Production: OIDC login via registrace *@
             @if (!string.IsNullOrEmpty(oidcAuthority))
             {
-                @if (Error is null && autoRedirectError is null)
+                @if (Error is null && autoRedirectError is null && !LoggedOut)
                 {
                     @* Auto-redirect path — spinner with a fallback link so the user
                        isn't stuck on an infinite spinner if JS interop or a slow
@@ -104,6 +117,12 @@
 @code {
     [Inject] private IConfiguration Config { get; set; } = null!;
     [SupplyParameterFromQuery] private string? Error { get; set; }
+    // Issue #261 — set by MainLayout.Logout's redirect (/login?logout=1).
+    // Suppresses the auto-redirect into OIDC so the user actually lands on
+    // the login page after pressing Odhlásit, instead of being silently
+    // re-authenticated via the still-valid IdP cookie.
+    [SupplyParameterFromQuery(Name = "logout")] private string? Logout { get; set; }
+    private bool LoggedOut => Logout == "1";
 
     private string? oidcAuthority => Config["OidcAuthority"];
     private string? oidcClientId => Config["OidcClientId"];
@@ -120,6 +139,7 @@
         if (!firstRender) return;
         if (autoFired) return;
         if (Error is not null) return;                    // let the user see the message first
+        if (LoggedOut) return;                            // #261 — explicit logout, manual sign-in
         if (string.IsNullOrEmpty(oidcAuthority)) return;  // dev mode — keep manual form
         autoFired = true;
         try


### PR DESCRIPTION
## Summary

Two-issue quickfix bundle. Closes #233 + #261. **#272 parked with diagnosis** — root cause is upstream, follow-up issue recommended.

### #233 — Welcome page Drozd uses correct canonical svg
`Components/DrozdWelcome.razor` was shipping an inline placeholder silhouette ("until designer ships drozd-welcome.png" — see the comment that's now removed). The canonical assets already exist at `wwwroot/img/drozd/drozd-{idle,confused,knocking}.svg` (used elsewhere on `/map` and `/items` empty-states). Swapped the takeover to `drozd-idle` (welcome pose) with state-flag fallback so a 404 doesn't break the welcome.

### #261 — Log-off no longer silently re-auths
**Root cause:** `MainLayout.Logout` only called `AuthProvider.ClearTokenAsync()` then nothing. The user stayed on the protected page → `AuthorizeView` re-rendered empty → `[Authorize]` redirected to `/login` → `Login.razor`'s `OnAfterRenderAsync` auto-redirected into OIDC → IdP cookie still valid → silent re-auth dropped a fresh token back into localStorage → user re-logged-in within milliseconds.

**Fix (split across `MainLayout.razor` + `Login.razor`):**
- `MainLayout.Logout` now navigates to `/login?logout=1` with `forceLoad:true` after clearing the token. The full reload guarantees no stale refresh-timer race or in-flight `/api/auth/me` writing back state.
- `Login.razor` reads `?logout=1` via `[SupplyParameterFromQuery]`:
  - Shows a `Byl jsi odhlášen` success banner.
  - Suppresses the `OnAfterRenderAsync` auto-redirect into OIDC so the user actually lands on the page.
  - Hides the auto-redirect spinner card when `LoggedOut` is true.

The manual sign-in card stays available — clicking it goes through SSO via the still-valid IdP cookie. Deliberate UX trade-off: explicit re-login is fine via cookie, but the silent loop is broken.

### #272 — Parked with diagnosis (follow-up issue recommended)

Investigated, ruling out the local proxy as the hang point:
- Server `/api/games/registrace-available` (`GameEndpoints.GetRegistraceAvailable`) catches `HttpRequestException` → 502, returns `RegistraceGameDto[]` cleanly otherwise.
- Client `LinkToRegistracePopup` uses `PostWithProblemAsync` + try/catch + `finally(loading=false)` — no spinner-stuck-on-error path.
- `RegistraceGameService` is registered via `AddHttpClient<T>()` (modern correct pattern) — not a singleton DI bug.
- Default `HttpClient.Timeout = 100s` means an upstream hang stalls the spinner for ~100 seconds before any error surfaces.

**Most likely cause: upstream `registrace.ovcina.cz` API itself stalls the connection** (or the parallel character-import path on the same upstream sits there too). Fix would require either tightening the proxy timeout + adding telemetry, or diagnosis on the registrace repo.

Per the brief, opening a follow-up issue with these findings rather than shipping a band-aid.

## Cross-agent collision watch

- **Hra1 PR #283 (Locations bundle)** and **Hra2 (Glejt 5-pack)** both merged while I was working — diff was rebased onto fresh `origin/main` before push. Final base = current `main` HEAD. Diff is exactly 3 files I touched.
- No overlap on Welcome page / auth flow with any in-flight work.

## Self-audit (per `_review-instincts`)

- ✅ §17 — `using NavigationManager` already in scope via `@inject`; no new usings needed.
- ✅ §18 — `csproj <Version>` NOT in diff.
- ✅ §20.2 — diff vs `origin/main` shows only my 3 files (49 +, 11 −) after rebase. No incidental deletions.

## Test plan

- [x] `dotnet build OvcinaHra.slnx` — 0 warnings, 0 errors (`TreatWarningsAsErrors=true`)
- [x] `dotnet test tests/OvcinaHra.Api.Tests` — **455 passed, 0 failed** (46s)
- [ ] Manual smoke after deploy:
  - [ ] `/` (home) — Drozd takeover shows the canonical bird, not the placeholder silhouette
  - [ ] Log in → click `Odhlásit` — page reloads to `/login?logout=1` with success banner, no silent re-auth
  - [ ] Click `Přihlásit přes registrace.ovcina.cz` from logout banner — SSO works through still-valid IdP cookie

🤖 Generated with [Claude Code](https://claude.com/claude-code)