### PR TITLE
fix(dashboard): RecentActivityPanel poll loop swallows transient API errors

### DIFF
--- a/src/OvcinaHra.Client/Components/RecentActivityPanel.razor
+++ b/src/OvcinaHra.Client/Components/RecentActivityPanel.razor
@@ -1,5 +1,6 @@
 @using System.Text.Json
 @inject IDashboardEventStream EventStream
+@inject ILogger<RecentActivityPanel> Logger
 @implements IAsyncDisposable
 
 @if (_takeover is not null)
@@ -61,6 +62,12 @@
             </div>
         }
     }
+    @if (_pollingFailed)
+    {
+        <p class="oh-home-recent-warning">
+            <i class="bi bi-wifi-off"></i>Spojení přerušeno, obnovuji…
+        </p>
+    }
 </section>
 
 @code {
@@ -72,6 +79,7 @@
     private DateTime? _latestTimestamp;
     private List<DashboardRecentEventDto>? _rows;
     private DashboardRecentEventDto? _takeover;
+    private bool _pollingFailed;
 
     [Parameter] public int? GameId { get; set; }
     [Parameter] public bool IsRunning { get; set; }
@@ -91,6 +99,7 @@
         _activeGameId = GameId.Value;
         _rows = null;
         _latestTimestamp = null;
+        _pollingFailed = false;
         _pollCts = new CancellationTokenSource();
         await LoadAsync(GameId.Value, sinceUtc: null, showTakeover: false, _pollCts.Token);
         _ = PollAsync(GameId.Value, _pollCts.Token);
@@ -117,34 +126,47 @@
         bool showTakeover,
         CancellationToken cancellationToken)
     {
-        var incoming = await EventStream.GetRecentEventsAsync(gameId, sinceUtc, cancellationToken);
-        if (cancellationToken.IsCancellationRequested) return;
+        try
+        {
+            var incoming = await EventStream.GetRecentEventsAsync(gameId, sinceUtc, cancellationToken);
+            if (cancellationToken.IsCancellationRequested) return;
 
-        if (_rows is null || sinceUtc is null)
-        {
-            _rows = incoming.OrderByDescending(r => r.Timestamp).ThenByDescending(r => r.EventId).ToList();
-        }
-        else if (incoming.Count > 0)
-        {
-            _rows = incoming
-                .Concat(_rows)
-                .GroupBy(r => r.EventId)
-                .Select(g => g.First())
-                .OrderByDescending(r => r.Timestamp)
-                .ThenByDescending(r => r.EventId)
-                .Take(50)
-                .ToList();
-        }
+            if (_rows is null || sinceUtc is null)
+            {
+                _rows = incoming.OrderByDescending(r => r.Timestamp).ThenByDescending(r => r.EventId).ToList();
+            }
+            else if (incoming.Count > 0)
+            {
+                _rows = incoming
+                    .Concat(_rows)
+                    .GroupBy(r => r.EventId)
+                    .Select(g => g.First())
+                    .OrderByDescending(r => r.Timestamp)
+                    .ThenByDescending(r => r.EventId)
+                    .Take(50)
+                    .ToList();
+            }
 
-        _latestTimestamp = _rows.FirstOrDefault()?.Timestamp ?? _latestTimestamp;
-        if (showTakeover)
+            _pollingFailed = false;
+            _latestTimestamp = _rows.FirstOrDefault()?.Timestamp ?? _latestTimestamp;
+            if (showTakeover)
+            {
+                var takeover = incoming
+                    .Where(IsTakeoverEvent)
+                    .OrderByDescending(r => r.Timestamp)
+                    .ThenByDescending(r => r.EventId)
+                    .FirstOrDefault(r => _seenTakeovers.Add(r.EventId));
+                if (takeover is not null) ShowTakeover(takeover);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            var takeover = incoming
-                .Where(IsTakeoverEvent)
-                .OrderByDescending(r => r.Timestamp)
-                .ThenByDescending(r => r.EventId)
-                .FirstOrDefault(r => _seenTakeovers.Add(r.EventId));
-            if (takeover is not null) ShowTakeover(takeover);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _pollingFailed = true;
+            Logger.LogWarning(ex, "Recent activity polling failed; retrying on the next tick.");
         }
 
         await InvokeAsync(StateHasChanged);

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3319,6 +3319,8 @@
 .oh-home-event-row{min-height:56px}
 .oh-home-event-icon{background:rgba(45,80,22,.08)}
 .oh-home-event-icon i{color:#2D5016}
+.oh-home-recent-warning{display:flex;align-items:center;gap:6px;margin:8px 6px 0;
+    color:#7a5520;font:600 .78rem var(--oh-font-body)}
 .oh-home-drozd-card--event{box-shadow:0 18px 42px rgba(20,16,8,.28)}
 
 /* Quick launch tiles */

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/RecentActivityPanelPollingTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/RecentActivityPanelPollingTests.cs
@@ -1,0 +1,31 @@
+namespace OvcinaHra.Api.Tests.ClientSmoke;
+
+public class RecentActivityPanelPollingTests
+{
+    [Fact]
+    public void RecentActivityPanel_SwallowsTransientPollErrors_AndKeepsCancellationPathSeparate()
+    {
+        var panelPath = Path.Combine(
+            FindRepoRoot(),
+            "src",
+            "OvcinaHra.Client",
+            "Components",
+            "RecentActivityPanel.razor");
+
+        var source = File.ReadAllText(panelPath);
+
+        Assert.Contains("catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)", source);
+        Assert.Contains("catch (Exception ex)", source);
+        Assert.Contains("Logger.LogWarning(ex, \"Recent activity polling failed; retrying on the next tick.\");", source);
+        Assert.Contains("Spojení přerušeno, obnovuji…", source);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "OvcinaHra.slnx")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not find repository root.");
+    }
+}


### PR DESCRIPTION
## Summary
- keep `RecentActivityPanel` polling alive after transient stream/API failures
- log retryable poll failures and show a small Czech retry indicator
- add a smoke test that guards the cancellation path, catch/log behavior, and visible retry copy

## Verification
- PASS: `dotnet build OvcinaHra.slnx`
- PASS: `dotnet test tests\OvcinaHra.Api.Tests\OvcinaHra.Api.Tests.csproj --filter FullyQualifiedName~RecentActivityPanelPollingTests --no-restore --verbosity minimal`
- PARTIAL: `dotnet test` -> `OvcinaHra.Api.Tests` passed 456/456; `OvcinaHra.E2E` still has the unrelated baseline failure in `SkillsManagementTests.GameSkill_CannotBeRemoved_WhenReferencedByRecipe` (expected `NoContent`, actual `Conflict`)

## Manual smoke
Not run: no interactive running-game cockpit session available in this automation context. The code path is covered by the targeted smoke guard above.