### PR TITLE
fix(registrace): timeout proxy calls

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
@@ -259,11 +259,11 @@ public static class CharacterEndpoints
     }
 
     private static async Task<Results<Ok<ImportResultDto>, ProblemHttpResult>> ImportFromRegistrace(
-        int gameId, RegistraceImportService importService)
+        int gameId, RegistraceImportService importService, CancellationToken ct)
     {
         try
         {
-            var result = await importService.ImportAsync(gameId);
+            var result = await importService.ImportAsync(gameId, ct);
             return TypedResults.Ok(result);
         }
         catch (GameNotFoundException)
@@ -283,7 +283,7 @@ public static class CharacterEndpoints
                 title: RegistraceImportProblems.NotLinkedTitle,
                 statusCode: StatusCodes.Status400BadRequest);
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
         {
             return TypedResults.Problem(
                 detail: RegistraceImportProblems.TimeoutDetail,
@@ -305,7 +305,7 @@ public static class CharacterEndpoints
     /// local roster wiped while the upstream is unreachable.
     /// </remarks>
     private static async Task<Results<Ok<ReimportCharactersResponse>, ProblemHttpResult>> ReimportFromRegistrace(
-        int gameId, RegistraceImportService importService, WorldDbContext db)
+        int gameId, RegistraceImportService importService, WorldDbContext db, CancellationToken ct)
     {
         // Pre-validate BEFORE opening the SERIALIZABLE transaction. A bogus
         // gameId would otherwise hold locks on Characters / CharacterAssignments
@@ -319,13 +319,13 @@ public static class CharacterEndpoints
             var preCheck = await db.Games
                 .Where(g => g.Id == gameId)
                 .Select(g => new { g.ExternalGameId })
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(ct);
             if (preCheck is null)
                 throw new GameNotFoundException(gameId);
             if (preCheck.ExternalGameId is null)
                 throw new GameNotLinkedToRegistraceException(gameId);
 
-            await using var tx = await db.Database.BeginTransactionAsync(IsolationLevel.Serializable);
+            await using var tx = await db.Database.BeginTransactionAsync(IsolationLevel.Serializable, ct);
 
             // 1. Null parent self-references ONLY on imported characters that
             //    are about to be wiped in step 3 (i.e. those whose only
@@ -339,13 +339,13 @@ public static class CharacterEndpoints
                     && db.CharacterAssignments
                         .Where(a => a.CharacterId == c.Id)
                         .All(a => a.GameId == gameId))
-                .ExecuteUpdateAsync(s => s.SetProperty(c => c.ParentCharacterId, _ => (int?)null));
+                .ExecuteUpdateAsync(s => s.SetProperty(c => c.ParentCharacterId, _ => (int?)null), ct);
 
             // 2. Hard-delete this game's assignments. Cascades CharacterEvents
             //    via the required FK on CharacterEvent.CharacterAssignmentId.
             var wipedAssignments = await db.CharacterAssignments
                 .Where(a => a.GameId == gameId)
-                .ExecuteDeleteAsync();
+                .ExecuteDeleteAsync(ct);
 
             // 3. Hard-delete imported Character rows that no longer have any
             //    assignment (orphans across all games). Cascades
@@ -356,7 +356,7 @@ public static class CharacterEndpoints
                 .IgnoreQueryFilters()
                 .Where(c => c.ExternalPersonId != null
                     && !db.CharacterAssignments.Any(a => a.CharacterId == c.Id))
-                .ExecuteDeleteAsync();
+                .ExecuteDeleteAsync(ct);
 
             // 4. Run the regular import — recreates Character rows for the
             //    registrace roster and seeds fresh CharacterAssignments.
@@ -365,9 +365,9 @@ public static class CharacterEndpoints
             ImportResultDto imported;
             try
             {
-                imported = await importService.ImportOrThrowAsync(gameId);
+                imported = await importService.ImportOrThrowAsync(gameId, ct);
             }
-            catch (TaskCanceledException)
+            catch (TaskCanceledException) when (!ct.IsCancellationRequested)
             {
                 // Don't commit — rollback on dispose preserves the original
                 // roster instead of leaving an empty database.
@@ -386,7 +386,7 @@ public static class CharacterEndpoints
                     statusCode: StatusCodes.Status502BadGateway);
             }
 
-            await tx.CommitAsync();
+            await tx.CommitAsync(ct);
 
             return TypedResults.Ok(new ReimportCharactersResponse(
                 WipedAssignments: wipedAssignments,

--- a/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/CharacterEndpoints.cs
@@ -283,6 +283,13 @@ public static class CharacterEndpoints
                 title: RegistraceImportProblems.NotLinkedTitle,
                 statusCode: StatusCodes.Status400BadRequest);
         }
+        catch (TaskCanceledException)
+        {
+            return TypedResults.Problem(
+                detail: RegistraceImportProblems.TimeoutDetail,
+                title: RegistraceImportProblems.TimeoutTitle,
+                statusCode: StatusCodes.Status504GatewayTimeout);
+        }
     }
 
     /// <summary>
@@ -359,6 +366,15 @@ public static class CharacterEndpoints
             try
             {
                 imported = await importService.ImportOrThrowAsync(gameId);
+            }
+            catch (TaskCanceledException)
+            {
+                // Don't commit — rollback on dispose preserves the original
+                // roster instead of leaving an empty database.
+                return TypedResults.Problem(
+                    detail: RegistraceImportProblems.TimeoutDetail,
+                    title: RegistraceImportProblems.TimeoutTitle,
+                    statusCode: StatusCodes.Status504GatewayTimeout);
             }
             catch (HttpRequestException ex)
             {

--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -241,9 +241,10 @@ public static class GameEndpoints
     /// <summary>
     /// Issue #3 — returns the registrace games available for linking.
     /// Filters out games already linked locally so the picker only shows
-    /// candidates the organizer can actually pick. Wraps upstream
-    /// timeouts in a 504 and other failures in a 502 so callers can
-    /// distinguish "registrace unreachable/unauthorized" from an internal 500.
+    /// candidates the organizer can actually pick. Wraps upstream timeouts
+    /// in a 504 ProblemDetails and other upstream failures in a 502
+    /// ProblemDetails so callers can distinguish "registrace timed out",
+    /// "registrace unreachable/unauthorized", and an internal 500.
     /// </summary>
     private static async Task<Results<Ok<List<RegistraceGameDto>>, ProblemHttpResult>> GetRegistraceAvailable(
         RegistraceGameService registrace, WorldDbContext db, CancellationToken ct)

--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -242,8 +242,8 @@ public static class GameEndpoints
     /// Issue #3 — returns the registrace games available for linking.
     /// Filters out games already linked locally so the picker only shows
     /// candidates the organizer can actually pick. Wraps upstream
-    /// failures in a 502 so callers can distinguish "registrace
-    /// unreachable/unauthorized" from an internal 500.
+    /// timeouts in a 504 and other failures in a 502 so callers can
+    /// distinguish "registrace unreachable/unauthorized" from an internal 500.
     /// </summary>
     private static async Task<Results<Ok<List<RegistraceGameDto>>, ProblemHttpResult>> GetRegistraceAvailable(
         RegistraceGameService registrace, WorldDbContext db, CancellationToken ct)
@@ -252,6 +252,13 @@ public static class GameEndpoints
         try
         {
             upstream = await registrace.GetAvailableAsync(ct);
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return TypedResults.Problem(
+                detail: RegistraceImportProblems.TimeoutDetail,
+                title: RegistraceImportProblems.TimeoutTitle,
+                statusCode: StatusCodes.Status504GatewayTimeout);
         }
         catch (HttpRequestException ex)
         {

--- a/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
@@ -32,11 +32,11 @@ public static class NpcEndpoints
     }
 
     private static async Task<Results<Ok<List<RegistraceAdultDto>>, ProblemHttpResult>> GetAvailablePlayers(
-        int gameId, RegistraceImportService registrace)
+        int gameId, RegistraceImportService registrace, CancellationToken ct)
     {
         try
         {
-            var adults = await registrace.FetchAdultsAsync(gameId);
+            var adults = await registrace.FetchAdultsAsync(gameId, ct);
             return TypedResults.Ok(adults);
         }
         catch (GameNotFoundException)
@@ -55,7 +55,7 @@ public static class NpcEndpoints
                 title: RegistraceImportProblems.NotLinkedTitle,
                 statusCode: StatusCodes.Status400BadRequest);
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
         {
             return TypedResults.Problem(
                 detail: RegistraceImportProblems.TimeoutDetail,

--- a/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
@@ -55,6 +55,13 @@ public static class NpcEndpoints
                 title: RegistraceImportProblems.NotLinkedTitle,
                 statusCode: StatusCodes.Status400BadRequest);
         }
+        catch (TaskCanceledException)
+        {
+            return TypedResults.Problem(
+                detail: RegistraceImportProblems.TimeoutDetail,
+                title: RegistraceImportProblems.TimeoutTitle,
+                statusCode: StatusCodes.Status504GatewayTimeout);
+        }
         catch (HttpRequestException ex)
         {
             return TypedResults.Problem(

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -49,8 +49,10 @@ try
     var oidcAuthority = builder.Configuration["Oidc:Authority"];
     var jwtKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!));
 
-    builder.Services.AddHttpClient<RegistraceImportService>();
-    builder.Services.AddHttpClient<RegistraceGameService>();
+    builder.Services.AddHttpClient<RegistraceImportService>(client =>
+        client.Timeout = TimeSpan.FromSeconds(15));
+    builder.Services.AddHttpClient<RegistraceGameService>(client =>
+        client.Timeout = TimeSpan.FromSeconds(15));
     builder.Services.Configure<BotConsultOptions>(builder.Configuration.GetSection("BotConsult"));
     builder.Services.AddHttpClient<IBotConsultClient, BotConsultClient>(client =>
         {

--- a/src/OvcinaHra.Api/Services/RegistraceGameService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceGameService.cs
@@ -53,17 +53,23 @@ public class RegistraceGameService(
         try
         {
             var response = await httpClient.SendAsync(request, ct);
-            logger.LogInformation(
-                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
-                endpoint,
-                sw.ElapsedMilliseconds,
-                response.IsSuccessStatusCode ? "success" : "error",
-                response.StatusCode);
+            if (response.IsSuccessStatusCode)
+            {
+                logger.LogInformation(
+                    "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
+                    endpoint, sw.ElapsedMilliseconds, "success", response.StatusCode);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
+                    endpoint, sw.ElapsedMilliseconds, "error", response.StatusCode);
+            }
             return response;
         }
         catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
         {
-            logger.LogInformation(
+            logger.LogWarning(
                 ex,
                 "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
                 endpoint, sw.ElapsedMilliseconds, "timeout");
@@ -79,7 +85,7 @@ public class RegistraceGameService(
         }
         catch (Exception ex)
         {
-            logger.LogInformation(
+            logger.LogError(
                 ex,
                 "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
                 endpoint, sw.ElapsedMilliseconds, "error");

--- a/src/OvcinaHra.Api/Services/RegistraceGameService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceGameService.cs
@@ -35,7 +35,7 @@ public class RegistraceGameService(
         if (!string.IsNullOrWhiteSpace(_apiKey))
             request.Headers.Add("X-Api-Key", _apiKey);
 
-        var response = await SendAsync(request, endpoint, ct);
+        using var response = await SendAsync(request, endpoint, ct);
         response.EnsureSuccessStatusCode();
 
         var games = await response.Content.ReadFromJsonAsync<List<RegistraceGameDto>>(JsonOptions, ct);
@@ -45,7 +45,7 @@ public class RegistraceGameService(
     private async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, string endpoint, CancellationToken ct)
     {
-        using var activity = logger.BeginScope(new Dictionary<string, object?>
+        using var scope = logger.BeginScope(new Dictionary<string, object?>
         {
             ["Endpoint"] = endpoint
         });
@@ -54,20 +54,33 @@ public class RegistraceGameService(
         {
             var response = await httpClient.SendAsync(request, ct);
             logger.LogInformation(
-                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
-                endpoint, sw.ElapsedMilliseconds, response.IsSuccessStatusCode ? "success" : "error");
+                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
+                endpoint,
+                sw.ElapsedMilliseconds,
+                response.IsSuccessStatusCode ? "success" : "error",
+                response.StatusCode);
             return response;
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
         {
             logger.LogInformation(
+                ex,
                 "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
                 endpoint, sw.ElapsedMilliseconds, "timeout");
             throw;
         }
-        catch (Exception)
+        catch (TaskCanceledException ex) when (ct.IsCancellationRequested)
         {
             logger.LogInformation(
+                ex,
+                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
+                endpoint, sw.ElapsedMilliseconds, "error");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogInformation(
+                ex,
                 "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
                 endpoint, sw.ElapsedMilliseconds, "error");
             throw;

--- a/src/OvcinaHra.Api/Services/RegistraceGameService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceGameService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Text.Json;
 using OvcinaHra.Shared.Dtos;
@@ -12,7 +13,10 @@ namespace OvcinaHra.Api.Services;
 /// Mirrors the auth + base-URL pattern used by
 /// <see cref="RegistraceImportService"/>.
 /// </summary>
-public class RegistraceGameService(HttpClient httpClient, IConfiguration configuration)
+public class RegistraceGameService(
+    HttpClient httpClient,
+    IConfiguration configuration,
+    ILogger<RegistraceGameService> logger)
 {
     private readonly string _baseUrl = configuration["IntegrationApi:BaseUrl"] ?? "https://registrace.ovcina.cz";
     private readonly string? _apiKey = configuration["IntegrationApi:ApiKey"];
@@ -24,16 +28,49 @@ public class RegistraceGameService(HttpClient httpClient, IConfiguration configu
 
     public async Task<IReadOnlyList<RegistraceGameDto>> GetAvailableAsync(CancellationToken ct = default)
     {
+        const string endpoint = "/api/v1/games";
         var request = new HttpRequestMessage(HttpMethod.Get,
-            $"{_baseUrl.TrimEnd('/')}/api/v1/games");
+            $"{_baseUrl.TrimEnd('/')}{endpoint}");
 
         if (!string.IsNullOrWhiteSpace(_apiKey))
             request.Headers.Add("X-Api-Key", _apiKey);
 
-        var response = await httpClient.SendAsync(request, ct);
+        var response = await SendAsync(request, endpoint, ct);
         response.EnsureSuccessStatusCode();
 
         var games = await response.Content.ReadFromJsonAsync<List<RegistraceGameDto>>(JsonOptions, ct);
         return games ?? [];
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, string endpoint, CancellationToken ct)
+    {
+        using var activity = logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["Endpoint"] = endpoint
+        });
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var response = await httpClient.SendAsync(request, ct);
+            logger.LogInformation(
+                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
+                endpoint, sw.ElapsedMilliseconds, response.IsSuccessStatusCode ? "success" : "error");
+            return response;
+        }
+        catch (TaskCanceledException)
+        {
+            logger.LogInformation(
+                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
+                endpoint, sw.ElapsedMilliseconds, "timeout");
+            throw;
+        }
+        catch (Exception)
+        {
+            logger.LogInformation(
+                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
+                endpoint, sw.ElapsedMilliseconds, "error");
+            throw;
+        }
     }
 }

--- a/src/OvcinaHra.Api/Services/RegistraceImportService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceImportService.cs
@@ -254,7 +254,7 @@ public class RegistraceImportService(
         if (!string.IsNullOrWhiteSpace(_apiKey))
             request.Headers.Add("X-Api-Key", _apiKey);
 
-        var response = await SendAsync(request, endpoint);
+        using var response = await SendAsync(request, endpoint);
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync();
@@ -280,7 +280,7 @@ public class RegistraceImportService(
         if (!string.IsNullOrWhiteSpace(_apiKey))
             request.Headers.Add("X-Api-Key", _apiKey);
 
-        var response = await SendAsync(request, endpoint);
+        using var response = await SendAsync(request, endpoint);
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync();
@@ -290,7 +290,7 @@ public class RegistraceImportService(
 
     private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, string endpoint)
     {
-        using var activity = logger.BeginScope(new Dictionary<string, object?>
+        using var scope = logger.BeginScope(new Dictionary<string, object?>
         {
             ["Endpoint"] = endpoint
         });
@@ -299,20 +299,25 @@ public class RegistraceImportService(
         {
             var response = await httpClient.SendAsync(request);
             logger.LogInformation(
-                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
-                endpoint, sw.ElapsedMilliseconds, response.IsSuccessStatusCode ? "success" : "error");
+                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
+                endpoint,
+                sw.ElapsedMilliseconds,
+                response.IsSuccessStatusCode ? "success" : "error",
+                response.StatusCode);
             return response;
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException ex)
         {
             logger.LogInformation(
+                ex,
                 "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
                 endpoint, sw.ElapsedMilliseconds, "timeout");
             throw;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             logger.LogInformation(
+                ex,
                 "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
                 endpoint, sw.ElapsedMilliseconds, "error");
             throw;

--- a/src/OvcinaHra.Api/Services/RegistraceImportService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceImportService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.EntityFrameworkCore;
@@ -47,9 +48,17 @@ public static class RegistraceImportProblems
     public const string NotFoundTitle = "Hra nenalezena.";
     public static string NotFoundDetail(int localGameId) =>
         $"Hra s ID {localGameId} v této instanci OvčinaHra neexistuje.";
+
+    public const string TimeoutTitle = "Registrační služba neodpovídá.";
+    public const string TimeoutDetail =
+        "Registrační služba neodpovídá v čase, zkuste to prosím za chvíli.";
 }
 
-public class RegistraceImportService(HttpClient httpClient, IConfiguration configuration, WorldDbContext db)
+public class RegistraceImportService(
+    HttpClient httpClient,
+    IConfiguration configuration,
+    WorldDbContext db,
+    ILogger<RegistraceImportService> logger)
 {
     private readonly string _baseUrl = configuration["IntegrationApi:BaseUrl"] ?? "https://registrace.ovcina.cz";
     private readonly string? _apiKey = configuration["IntegrationApi:ApiKey"];
@@ -89,9 +98,11 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
     /// to (and should not) hand over a registrace id directly.
     /// Network/parse failures are folded into <c>ImportResultDto.Errors</c>
     /// — the original behavior the standalone "Importovat" button relies on.
-    /// Catches <see cref="HttpRequestException"/>, <see cref="TaskCanceledException"/>
-    /// (timeouts), and <see cref="System.Text.Json.JsonException"/> (malformed
-    /// upstream payload) so the button surfaces a Czech error rather than a 500.
+    /// Catches <see cref="HttpRequestException"/> and
+    /// <see cref="System.Text.Json.JsonException"/> (malformed upstream payload)
+    /// so the button surfaces a Czech error rather than a 500.
+    /// <see cref="TaskCanceledException"/> is intentionally left for endpoints
+    /// to translate into 504 Gateway Timeout.
     /// </summary>
     public async Task<ImportResultDto> ImportAsync(int localGameId)
     {
@@ -102,10 +113,6 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
         catch (HttpRequestException ex)
         {
             return new ImportResultDto(0, 0, 0, [$"Failed to fetch from registrace: {ex.Message}"]);
-        }
-        catch (TaskCanceledException ex)
-        {
-            return new ImportResultDto(0, 0, 0, [$"Timed out while fetching from registrace: {ex.Message}"]);
         }
         catch (JsonException ex)
         {
@@ -240,13 +247,14 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
 
     private async Task<List<RegistraceCharacterRecord>> FetchCharactersAsync(int externalGameId)
     {
+        var endpoint = $"/api/v1/games/{externalGameId}/characters";
         var request = new HttpRequestMessage(HttpMethod.Get,
-            $"{_baseUrl.TrimEnd('/')}/api/v1/games/{externalGameId}/characters");
+            $"{_baseUrl.TrimEnd('/')}{endpoint}");
 
         if (!string.IsNullOrWhiteSpace(_apiKey))
             request.Headers.Add("X-Api-Key", _apiKey);
 
-        var response = await httpClient.SendAsync(request);
+        var response = await SendAsync(request, endpoint);
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync();
@@ -265,18 +273,50 @@ public class RegistraceImportService(HttpClient httpClient, IConfiguration confi
     {
         var externalGameId = await ResolveExternalGameIdAsync(localGameId);
 
+        var endpoint = $"/api/v1/games/{externalGameId}/adults";
         var request = new HttpRequestMessage(HttpMethod.Get,
-            $"{_baseUrl.TrimEnd('/')}/api/v1/games/{externalGameId}/adults");
+            $"{_baseUrl.TrimEnd('/')}{endpoint}");
 
         if (!string.IsNullOrWhiteSpace(_apiKey))
             request.Headers.Add("X-Api-Key", _apiKey);
 
-        var response = await httpClient.SendAsync(request);
+        var response = await SendAsync(request, endpoint);
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<List<RegistraceAdultDto>>(json,
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, string endpoint)
+    {
+        using var activity = logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["Endpoint"] = endpoint
+        });
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var response = await httpClient.SendAsync(request);
+            logger.LogInformation(
+                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
+                endpoint, sw.ElapsedMilliseconds, response.IsSuccessStatusCode ? "success" : "error");
+            return response;
+        }
+        catch (TaskCanceledException)
+        {
+            logger.LogInformation(
+                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
+                endpoint, sw.ElapsedMilliseconds, "timeout");
+            throw;
+        }
+        catch (Exception)
+        {
+            logger.LogInformation(
+                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
+                endpoint, sw.ElapsedMilliseconds, "error");
+            throw;
+        }
     }
 
     private sealed record RegistraceCharacterRecord(

--- a/src/OvcinaHra.Api/Services/RegistraceImportService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceImportService.cs
@@ -74,7 +74,8 @@ public class RegistraceImportService(
     /// The two exception types let endpoints return 400 vs 404 distinctly
     /// — pre-fixup the missing-game case was masquerading as not-linked.
     /// </summary>
-    private async Task<int> ResolveExternalGameIdAsync(int localGameId)
+    private async Task<int> ResolveExternalGameIdAsync(
+        int localGameId, CancellationToken ct = default)
     {
         // Fetch a wrapper struct so a null ExternalGameId on an existing
         // game doesn't collapse to the same "no row" sentinel. Without
@@ -83,7 +84,7 @@ public class RegistraceImportService(
         var row = await db.Games
             .Where(g => g.Id == localGameId)
             .Select(g => new { g.ExternalGameId })
-            .FirstOrDefaultAsync();
+            .FirstOrDefaultAsync(ct);
         if (row is null)
             throw new GameNotFoundException(localGameId);
         if (row.ExternalGameId is null)
@@ -104,11 +105,12 @@ public class RegistraceImportService(
     /// <see cref="TaskCanceledException"/> is intentionally left for endpoints
     /// to translate into 504 Gateway Timeout.
     /// </summary>
-    public async Task<ImportResultDto> ImportAsync(int localGameId)
+    public async Task<ImportResultDto> ImportAsync(
+        int localGameId, CancellationToken ct = default)
     {
         try
         {
-            return await ImportOrThrowAsync(localGameId);
+            return await ImportOrThrowAsync(localGameId, ct);
         }
         catch (HttpRequestException ex)
         {
@@ -128,20 +130,21 @@ public class RegistraceImportService(
     /// without it we'd commit an empty database after silently swallowing
     /// the fetch failure.
     /// </summary>
-    public async Task<ImportResultDto> ImportOrThrowAsync(int localGameId)
+    public async Task<ImportResultDto> ImportOrThrowAsync(
+        int localGameId, CancellationToken ct = default)
     {
-        var externalGameId = await ResolveExternalGameIdAsync(localGameId);
+        var externalGameId = await ResolveExternalGameIdAsync(localGameId, ct);
         var created = 0;
         var updated = 0;
         var skipped = 0;
         var errors = new List<string>();
 
-        var records = await FetchCharactersAsync(externalGameId);
+        var records = await FetchCharactersAsync(externalGameId, ct);
 
         // Kingdom-name → id lookup, loaded once per import. Names from registrace
         // are matched case-insensitively against the Kingdom lookup table.
         var kingdomByName = await db.Kingdoms
-            .ToDictionaryAsync(k => k.Name, k => k.Id, StringComparer.OrdinalIgnoreCase);
+            .ToDictionaryAsync(k => k.Name, k => k.Id, StringComparer.OrdinalIgnoreCase, ct);
 
         foreach (var record in records)
         {
@@ -150,7 +153,7 @@ public class RegistraceImportService(
                 // Look up Character by ExternalPersonId (including deleted)
                 var character = await db.Characters
                     .IgnoreQueryFilters()
-                    .FirstOrDefaultAsync(c => c.ExternalPersonId == record.PersonId);
+                    .FirstOrDefaultAsync(c => c.ExternalPersonId == record.PersonId, ct);
 
                 if (character is null)
                 {
@@ -195,7 +198,7 @@ public class RegistraceImportService(
                 // local id and registrace id ever diverge. Now resolved
                 // separately at the top of ImportAsync.
                 var assignment = await db.CharacterAssignments
-                    .FirstOrDefaultAsync(a => a.GameId == localGameId && a.ExternalPersonId == record.PersonId);
+                    .FirstOrDefaultAsync(a => a.GameId == localGameId && a.ExternalPersonId == record.PersonId, ct);
 
                 PlayerClass? playerClass = null;
                 if (!string.IsNullOrWhiteSpace(record.ClassOrType))
@@ -233,7 +236,7 @@ public class RegistraceImportService(
                     updated++;
                 }
 
-                await db.SaveChangesAsync();
+                await db.SaveChangesAsync(ct);
             }
             catch (Exception ex)
             {
@@ -245,7 +248,8 @@ public class RegistraceImportService(
         return new ImportResultDto(created, updated, skipped, errors);
     }
 
-    private async Task<List<RegistraceCharacterRecord>> FetchCharactersAsync(int externalGameId)
+    private async Task<List<RegistraceCharacterRecord>> FetchCharactersAsync(
+        int externalGameId, CancellationToken ct = default)
     {
         var endpoint = $"/api/v1/games/{externalGameId}/characters";
         var request = new HttpRequestMessage(HttpMethod.Get,
@@ -254,10 +258,10 @@ public class RegistraceImportService(
         if (!string.IsNullOrWhiteSpace(_apiKey))
             request.Headers.Add("X-Api-Key", _apiKey);
 
-        using var response = await SendAsync(request, endpoint);
+        using var response = await SendAsync(request, endpoint, ct);
         response.EnsureSuccessStatusCode();
 
-        var json = await response.Content.ReadAsStringAsync();
+        var json = await response.Content.ReadAsStringAsync(ct);
         return JsonSerializer.Deserialize<List<RegistraceCharacterRecord>>(json,
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
     }
@@ -269,9 +273,10 @@ public class RegistraceImportService(
     /// <c>Game.ExternalGameId</c> internally — see <see cref="ImportAsync"/>
     /// for the same #191 contract.
     /// </summary>
-    public async Task<List<RegistraceAdultDto>> FetchAdultsAsync(int localGameId)
+    public async Task<List<RegistraceAdultDto>> FetchAdultsAsync(
+        int localGameId, CancellationToken ct = default)
     {
-        var externalGameId = await ResolveExternalGameIdAsync(localGameId);
+        var externalGameId = await ResolveExternalGameIdAsync(localGameId, ct);
 
         var endpoint = $"/api/v1/games/{externalGameId}/adults";
         var request = new HttpRequestMessage(HttpMethod.Get,
@@ -280,15 +285,16 @@ public class RegistraceImportService(
         if (!string.IsNullOrWhiteSpace(_apiKey))
             request.Headers.Add("X-Api-Key", _apiKey);
 
-        using var response = await SendAsync(request, endpoint);
+        using var response = await SendAsync(request, endpoint, ct);
         response.EnsureSuccessStatusCode();
 
-        var json = await response.Content.ReadAsStringAsync();
+        var json = await response.Content.ReadAsStringAsync(ct);
         return JsonSerializer.Deserialize<List<RegistraceAdultDto>>(json,
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
     }
 
-    private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, string endpoint)
+    private async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, string endpoint, CancellationToken ct)
     {
         using var scope = logger.BeginScope(new Dictionary<string, object?>
         {
@@ -297,26 +303,40 @@ public class RegistraceImportService(
         var sw = Stopwatch.StartNew();
         try
         {
-            var response = await httpClient.SendAsync(request);
-            logger.LogInformation(
-                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
-                endpoint,
-                sw.ElapsedMilliseconds,
-                response.IsSuccessStatusCode ? "success" : "error",
-                response.StatusCode);
+            var response = await httpClient.SendAsync(request, ct);
+            if (response.IsSuccessStatusCode)
+            {
+                logger.LogInformation(
+                    "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
+                    endpoint, sw.ElapsedMilliseconds, "success", response.StatusCode);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
+                    endpoint, sw.ElapsedMilliseconds, "error", response.StatusCode);
+            }
             return response;
         }
-        catch (TaskCanceledException ex)
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
         {
-            logger.LogInformation(
+            logger.LogWarning(
                 ex,
                 "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
                 endpoint, sw.ElapsedMilliseconds, "timeout");
             throw;
         }
-        catch (Exception ex)
+        catch (TaskCanceledException ex) when (ct.IsCancellationRequested)
         {
             logger.LogInformation(
+                ex,
+                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
+                endpoint, sw.ElapsedMilliseconds, "error");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
                 ex,
                 "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
                 endpoint, sw.ElapsedMilliseconds, "error");

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameLinkEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameLinkEndpointTests.cs
@@ -33,7 +33,7 @@ public class GameLinkEndpointTests(PostgresFixture postgres)
             services.AddHttpClient<RegistraceGameService>(client =>
                 client.Timeout = TimeSpan.FromSeconds(15))
                 .ConfigurePrimaryHttpMessageHandler(() =>
-                    new SlowRegistraceHandler(TimeSpan.FromSeconds(30)));
+                    new SlowHttpMessageHandler(TimeSpan.FromSeconds(30)));
         });
 
         await using (timeoutFactory)
@@ -165,16 +165,4 @@ public class GameLinkEndpointTests(PostgresFixture postgres)
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
     }
 
-    private sealed class SlowRegistraceHandler(TimeSpan delay) : HttpMessageHandler
-    {
-        protected override async Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            await Task.Delay(delay, cancellationToken);
-            return new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = JsonContent.Create(Array.Empty<RegistraceGameDto>())
-            };
-        }
-    }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameLinkEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameLinkEndpointTests.cs
@@ -1,16 +1,18 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
 // Issue #3 — POST/DELETE /api/games/{id}/link contract.
-// Codifies the round-trip + the new UNIQUE INDEX 409 path. The matching
-// /api/games/registrace-available endpoint is a thin proxy over the
-// registrace integration API; covering it here would require mocking
-// HttpClient — out of scope, that path is integration-tested by hand.
+// Codifies the round-trip, UNIQUE INDEX 409 path, and the timeout guard for
+// the matching /api/games/registrace-available proxy.
 public class GameLinkEndpointTests(PostgresFixture postgres)
     : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
@@ -20,6 +22,38 @@ public class GameLinkEndpointTests(PostgresFixture postgres)
             new CreateGameDto(name, 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    [Fact]
+    public async Task RegistraceAvailable_UpstreamTimeout_ReturnsGatewayTimeoutWithinConfiguredTimeout()
+    {
+        var (timeoutFactory, timeoutClient) = await Postgres.CreateClientAsync(services =>
+        {
+            services.RemoveAll<RegistraceGameService>();
+            services.AddHttpClient<RegistraceGameService>(client =>
+                client.Timeout = TimeSpan.FromSeconds(15))
+                .ConfigurePrimaryHttpMessageHandler(() =>
+                    new SlowRegistraceHandler(TimeSpan.FromSeconds(30)));
+        });
+
+        await using (timeoutFactory)
+        using (timeoutClient)
+        {
+            var sw = Stopwatch.StartNew();
+            var response = await timeoutClient.GetAsync("/api/games/registrace-available");
+            sw.Stop();
+
+            Assert.Equal(HttpStatusCode.GatewayTimeout, response.StatusCode);
+            Assert.True(
+                sw.Elapsed < TimeSpan.FromSeconds(20),
+                $"Expected the 15s registrace timeout, got {sw.Elapsed.TotalSeconds:F1}s.");
+
+            var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+            Assert.NotNull(problem);
+            Assert.Equal((int)HttpStatusCode.GatewayTimeout, problem.Status);
+            Assert.Equal(RegistraceImportProblems.TimeoutTitle, problem.Title);
+            Assert.Equal(RegistraceImportProblems.TimeoutDetail, problem.Detail);
+        }
     }
 
     [Fact]
@@ -129,5 +163,18 @@ public class GameLinkEndpointTests(PostgresFixture postgres)
         var response = await Client.PostAsJsonAsync($"/api/games/{second.Id}/link",
             new LinkGameDto(77));
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    private sealed class SlowRegistraceHandler(TimeSpan delay) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(delay, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(Array.Empty<RegistraceGameDto>())
+            };
+        }
     }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/RegistraceImportNotLinkedTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/RegistraceImportNotLinkedTests.cs
@@ -100,7 +100,7 @@ public class RegistraceImportNotLinkedTests(PostgresFixture postgres)
             services.AddHttpClient<RegistraceImportService>(client =>
                 client.Timeout = TimeSpan.FromSeconds(15))
                 .ConfigurePrimaryHttpMessageHandler(() =>
-                    new SlowRegistraceHandler(TimeSpan.FromSeconds(30)));
+                    new SlowHttpMessageHandler(TimeSpan.FromSeconds(30)));
         });
 
         await using (timeoutFactory)
@@ -124,16 +124,4 @@ public class RegistraceImportNotLinkedTests(PostgresFixture postgres)
         }
     }
 
-    private sealed class SlowRegistraceHandler(TimeSpan delay) : HttpMessageHandler
-    {
-        protected override async Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            await Task.Delay(delay, cancellationToken);
-            return new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = JsonContent.Create(Array.Empty<object>())
-            };
-        }
-    }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/RegistraceImportNotLinkedTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/RegistraceImportNotLinkedTests.cs
@@ -62,6 +62,43 @@ public class RegistraceImportNotLinkedTests(PostgresFixture postgres)
     }
 
     [Fact]
+    public async Task AvailablePlayers_GameLinkedButRegistraceTimeout_Returns504WithinConfiguredTimeout()
+    {
+        var game = await CreateGameAsync("NPC timeout");
+        var link = await Client.PostAsJsonAsync($"/api/games/{game.Id}/link",
+            new LinkGameDto(654321));
+        link.EnsureSuccessStatusCode();
+
+        var (timeoutFactory, timeoutClient) = await Postgres.CreateClientAsync(services =>
+        {
+            services.RemoveAll<RegistraceImportService>();
+            services.AddHttpClient<RegistraceImportService>(client =>
+                client.Timeout = TimeSpan.FromSeconds(15))
+                .ConfigurePrimaryHttpMessageHandler(() =>
+                    new SlowHttpMessageHandler(TimeSpan.FromSeconds(30)));
+        });
+
+        await using (timeoutFactory)
+        using (timeoutClient)
+        {
+            var sw = Stopwatch.StartNew();
+            var response = await timeoutClient.GetAsync($"/api/npcs/available-players/{game.Id}");
+            sw.Stop();
+
+            Assert.Equal(HttpStatusCode.GatewayTimeout, response.StatusCode);
+            Assert.True(
+                sw.Elapsed < TimeSpan.FromSeconds(20),
+                $"Expected the 15s registrace timeout, got {sw.Elapsed.TotalSeconds:F1}s.");
+
+            var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+            Assert.NotNull(problem);
+            Assert.Equal((int)HttpStatusCode.GatewayTimeout, problem.Status);
+            Assert.Equal(RegistraceImportProblems.TimeoutTitle, problem.Title);
+            Assert.Equal(RegistraceImportProblems.TimeoutDetail, problem.Detail);
+        }
+    }
+
+    [Fact]
     public async Task Import_GameLinkedButRegistraceUnreachable_DoesNotShortCircuitWith400()
     {
         // When ExternalGameId is set we expect the service to reach the
@@ -123,5 +160,4 @@ public class RegistraceImportNotLinkedTests(PostgresFixture postgres)
             Assert.Equal(RegistraceImportProblems.TimeoutDetail, problem.Detail);
         }
     }
-
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/RegistraceImportNotLinkedTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/RegistraceImportNotLinkedTests.cs
@@ -1,6 +1,10 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Dtos;
 
@@ -11,10 +15,10 @@ namespace OvcinaHra.Api.Tests.Endpoints;
 // GET /api/npcs/available-players/{id}) must return 400 ProblemDetails
 // before ever reaching out to registrace. This codifies the contract.
 //
-// Happy-path import is intentionally not tested here — it would require a
-// live registrace integration API or a stubbed HttpMessageHandler, both
-// outside the test fixture's scope. The 400 path runs entirely against
-// the local DB so it's deterministic.
+// Happy-path import is intentionally not tested here — it would require
+// modelling registrace's full payload. The 400 path runs entirely against
+// the local DB so it's deterministic; the timeout path uses a slow stubbed
+// HttpMessageHandler.
 public class RegistraceImportNotLinkedTests(PostgresFixture postgres)
     : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
 {
@@ -80,5 +84,56 @@ public class RegistraceImportNotLinkedTests(PostgresFixture postgres)
         Assert.Equal(0, result.Created);
         Assert.Equal(0, result.Updated);
         Assert.NotEmpty(result.Errors); // network failure surfaced, not a 400
+    }
+
+    [Fact]
+    public async Task Import_GameLinkedButRegistraceTimeout_Returns504WithinConfiguredTimeout()
+    {
+        var game = await CreateGameAsync("Propojená timeout");
+        var link = await Client.PostAsJsonAsync($"/api/games/{game.Id}/link",
+            new LinkGameDto(123456));
+        link.EnsureSuccessStatusCode();
+
+        var (timeoutFactory, timeoutClient) = await Postgres.CreateClientAsync(services =>
+        {
+            services.RemoveAll<RegistraceImportService>();
+            services.AddHttpClient<RegistraceImportService>(client =>
+                client.Timeout = TimeSpan.FromSeconds(15))
+                .ConfigurePrimaryHttpMessageHandler(() =>
+                    new SlowRegistraceHandler(TimeSpan.FromSeconds(30)));
+        });
+
+        await using (timeoutFactory)
+        using (timeoutClient)
+        {
+            var sw = Stopwatch.StartNew();
+            var response = await timeoutClient.PostAsJsonAsync(
+                $"/api/characters/import/{game.Id}", new { });
+            sw.Stop();
+
+            Assert.Equal(HttpStatusCode.GatewayTimeout, response.StatusCode);
+            Assert.True(
+                sw.Elapsed < TimeSpan.FromSeconds(20),
+                $"Expected the 15s registrace timeout, got {sw.Elapsed.TotalSeconds:F1}s.");
+
+            var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+            Assert.NotNull(problem);
+            Assert.Equal((int)HttpStatusCode.GatewayTimeout, problem.Status);
+            Assert.Equal(RegistraceImportProblems.TimeoutTitle, problem.Title);
+            Assert.Equal(RegistraceImportProblems.TimeoutDetail, problem.Detail);
+        }
+    }
+
+    private sealed class SlowRegistraceHandler(TimeSpan delay) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(delay, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(Array.Empty<object>())
+            };
+        }
     }
 }

--- a/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
@@ -12,10 +12,14 @@ namespace OvcinaHra.Api.Tests.Fixtures;
 public class ApiWebApplicationFactory : WebApplicationFactory<Program>
 {
     private readonly string _connectionString;
+    private readonly Action<IServiceCollection>? _configureServices;
 
-    public ApiWebApplicationFactory(string connectionString)
+    public ApiWebApplicationFactory(
+        string connectionString,
+        Action<IServiceCollection>? configureServices = null)
     {
         _connectionString = connectionString;
+        _configureServices = configureServices;
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -64,6 +68,8 @@ public class ApiWebApplicationFactory : WebApplicationFactory<Program>
                 d => d.ImplementationType == typeof(ThumbnailBackfillHostedService));
             if (hostedDescriptor != null)
                 services.Remove(hostedDescriptor);
+
+            _configureServices?.Invoke(services);
         });
     }
 }

--- a/tests/OvcinaHra.Api.Tests/Fixtures/PostgresFixture.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/PostgresFixture.cs
@@ -79,15 +79,46 @@ public class PostgresFixture : IAsyncLifetime
             WafGate.Release();
         }
 
+        await AuthenticateAsync(Client);
+    }
+
+    public async Task<(ApiWebApplicationFactory Factory, HttpClient Client)> CreateClientAsync(
+        Action<IServiceCollection> configureServices)
+    {
+        await WafGate.WaitAsync();
+        ApiWebApplicationFactory? factory = null;
+        HttpClient? client = null;
+        try
+        {
+            factory = new ApiWebApplicationFactory(ConnectionString, configureServices);
+            client = factory.CreateClient();
+            await AuthenticateAsync(client);
+            return (factory, client);
+        }
+        catch
+        {
+            client?.Dispose();
+            if (factory is not null)
+                await factory.DisposeAsync();
+            throw;
+        }
+        finally
+        {
+            WafGate.Release();
+        }
+    }
+
+    private static async Task AuthenticateAsync(HttpClient client)
+    {
         // Authenticate once per class — the dev-token is good for the
         // whole class lifetime, no need to re-auth per test.
-        var tokenResponse = await Client.PostAsJsonAsync("/api/auth/dev-token",
+        var tokenResponse = await client.PostAsJsonAsync("/api/auth/dev-token",
             new DevTokenRequest("test-user", "test@ovcina.cz", "Test Organizátor"));
         tokenResponse.EnsureSuccessStatusCode();
         var token = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>()
             ?? throw new InvalidOperationException(
                 "Dev-token endpoint returned an empty body — test fixture cannot authenticate.");
-        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
     }
 
     public async Task DisposeAsync()

--- a/tests/OvcinaHra.Api.Tests/Fixtures/SlowHttpMessageHandler.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/SlowHttpMessageHandler.cs
@@ -1,0 +1,17 @@
+using System.Net;
+using System.Text;
+
+namespace OvcinaHra.Api.Tests.Fixtures;
+
+public sealed class SlowHttpMessageHandler(TimeSpan delay) : HttpMessageHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        await Task.Delay(delay, cancellationToken);
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("[]", Encoding.UTF8, "application/json")
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #289
- Set registrace typed HttpClient timeout to 15s for game linking and import calls.
- Added upstream telemetry with endpoint, elapsed ms, and success/timeout/error outcome.
- Translate registrace timeouts to 504 ProblemDetails with the Czech retry detail on game picker, character import/reimport, and NPC adult picker.
- Added slow-handler integration coverage for the game picker and character import timeout paths.

## Verification
- dotnet build OvcinaHra.slnx --no-restore
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter 'FullyQualifiedName~GameLinkEndpointTests|FullyQualifiedName~RegistraceImportNotLinkedTests'
- dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include <changed files>
- git diff --check

Note: full-solution dotnet format --verify-no-changes still reports pre-existing whitespace issues in unrelated files (TreasurePlanningEndpoints.cs, MonsterCategory.cs, MapOverlayDto.cs), so I used the scoped changed-file check.