### PR TITLE
feat(consult): add Drozd bot consult drawer

### DIFF
--- a/src/OvcinaHra.Api/Configuration/BotConsultOptions.cs
+++ b/src/OvcinaHra.Api/Configuration/BotConsultOptions.cs
@@ -1,0 +1,11 @@
+namespace OvcinaHra.Api.Configuration;
+
+public sealed class BotConsultOptions
+{
+    public string? Url { get; set; }
+    public string? ApiKey { get; set; }
+
+    public bool IsConfigured =>
+        Uri.TryCreate(Url, UriKind.Absolute, out _)
+        && !string.IsNullOrWhiteSpace(ApiKey);
+}

--- a/src/OvcinaHra.Api/Endpoints/ConsultEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ConsultEndpoints.cs
@@ -1,0 +1,151 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http.HttpResults;
+using OvcinaHra.Api.Services;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Endpoints;
+
+public static class ConsultEndpoints
+{
+    public static RouteGroupBuilder MapConsultEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/consult")
+            .WithTags("Consult")
+            .RequireAuthorization();
+
+        group.MapGet("/available", GetAvailability);
+        group.MapPost("/{persona:regex(^(rulemaster|loremaster)$)}", AskAsync);
+        group.MapPost("/{persona:regex(^(rulemaster|loremaster)$)}/reset", ResetAsync);
+
+        return group;
+    }
+
+    private static Ok<ConsultAvailabilityDto> GetAvailability(IBotConsultClient bot)
+        => TypedResults.Ok(new ConsultAvailabilityDto(bot.IsEnabled));
+
+    private static async Task<IResult> AskAsync(
+        string persona,
+        ConsultRequestDto request,
+        ClaimsPrincipal user,
+        IBotConsultClient bot,
+        CancellationToken ct)
+    {
+        if (!bot.IsEnabled)
+            return UnavailableProblem();
+
+        var message = request.Message.Trim();
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return Results.Problem(
+                title: "Prázdná otázka",
+                detail: "Napiš otázku pro Drozda.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var email = GetUserEmail(user);
+        if (email is null)
+            return MissingEmailProblem();
+
+        try
+        {
+            var answer = await bot.AskAsync(
+                persona,
+                message,
+                email,
+                GetBotRole(user),
+                ct);
+            return TypedResults.Ok(answer);
+        }
+        catch (BotConsultTimeoutException)
+        {
+            return Results.Problem(
+                title: "Drozd neodpověděl včas",
+                detail: "Konzultační služba překročila časový limit.",
+                statusCode: StatusCodes.Status504GatewayTimeout);
+        }
+        catch (BotConsultUnavailableException)
+        {
+            return UnavailableProblem();
+        }
+        catch (BotConsultUpstreamException ex)
+        {
+            return Results.Problem(
+                title: "Drozd se teď neozval",
+                detail: ex.Detail,
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+    }
+
+    private static async Task<IResult> ResetAsync(
+        string persona,
+        ClaimsPrincipal user,
+        IBotConsultClient bot,
+        CancellationToken ct)
+    {
+        if (!bot.IsEnabled)
+            return UnavailableProblem();
+
+        var email = GetUserEmail(user);
+        if (email is null)
+            return MissingEmailProblem();
+
+        try
+        {
+            await bot.ResetAsync(persona, email, ct);
+            return TypedResults.Ok(new { ok = true });
+        }
+        catch (BotConsultTimeoutException)
+        {
+            return Results.Problem(
+                title: "Drozd neodpověděl včas",
+                detail: "Konzultační služba překročila časový limit.",
+                statusCode: StatusCodes.Status504GatewayTimeout);
+        }
+        catch (BotConsultUnavailableException)
+        {
+            return UnavailableProblem();
+        }
+        catch (BotConsultUpstreamException ex)
+        {
+            return Results.Problem(
+                title: "Drozd se teď neozval",
+                detail: ex.Detail,
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+    }
+
+    private static string? GetUserEmail(ClaimsPrincipal user)
+        => user.FindFirstValue("email") ?? user.FindFirstValue(ClaimTypes.Email);
+
+    private static string GetBotRole(ClaimsPrincipal user)
+    {
+        var roles = user.FindAll("role")
+            .Concat(user.FindAll(ClaimTypes.Role))
+            .Select(claim => claim.Value);
+
+        if (roles.Any(role =>
+                role.Equals("Admin", StringComparison.OrdinalIgnoreCase)
+                || role.Equals("Administrator", StringComparison.OrdinalIgnoreCase)))
+            return "admin";
+
+        if (roles.Any(role =>
+                role.Equals("Organizer", StringComparison.OrdinalIgnoreCase)
+                || role.Equals("Organizator", StringComparison.OrdinalIgnoreCase)
+                || role.Equals("Organizátor", StringComparison.OrdinalIgnoreCase)))
+            return "organizator";
+
+        return "hráč";
+    }
+
+    private static IResult MissingEmailProblem()
+        => Results.Problem(
+            title: "Chybí e-mail",
+            detail: "Přihlášený účet nemá e-mail potřebný pro konzultaci.",
+            statusCode: StatusCodes.Status400BadRequest);
+
+    private static IResult UnavailableProblem()
+        => Results.Problem(
+            title: "Drozd není dostupný",
+            detail: "Konzultace s Drozdem není nakonfigurovaná.",
+            statusCode: StatusCodes.Status503ServiceUnavailable);
+}

--- a/src/OvcinaHra.Api/OvcinaHra.Api.csproj
+++ b/src/OvcinaHra.Api/OvcinaHra.Api.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -5,10 +5,13 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using OvcinaHra.Api.Configuration;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Endpoints;
 using OvcinaHra.Api.Logging;
 using OvcinaHra.Api.Services;
+using Polly;
+using Polly.Extensions.Http;
 using Serilog;
 
 // Two-stage bootstrap: early logger catches startup errors
@@ -48,6 +51,14 @@ try
 
     builder.Services.AddHttpClient<RegistraceImportService>();
     builder.Services.AddHttpClient<RegistraceGameService>();
+    builder.Services.Configure<BotConsultOptions>(builder.Configuration.GetSection("BotConsult"));
+    builder.Services.AddHttpClient<IBotConsultClient, BotConsultClient>(client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(60);
+        })
+        .AddPolicyHandler(HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .WaitAndRetryAsync(1, _ => TimeSpan.FromMilliseconds(200)));
 
     builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
@@ -245,6 +256,7 @@ try
     app.MapTreasurePlanningEndpoints().RequireAuthorization();
     app.MapTimelineEndpoints().RequireAuthorization();
     app.MapDashboardEndpoints().RequireAuthorization();
+    app.MapConsultEndpoints();
     app.MapMapEndpoints().RequireAuthorization();
     app.MapGameEventEndpoints();
     app.MapSearchEndpoints().RequireAuthorization();

--- a/src/OvcinaHra.Api/Services/BotConsultClient.cs
+++ b/src/OvcinaHra.Api/Services/BotConsultClient.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Options;
+using OvcinaHra.Api.Configuration;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Services;
+
+public interface IBotConsultClient
+{
+    bool IsEnabled { get; }
+    Task<ConsultAnswerDto> AskAsync(
+        string persona,
+        string message,
+        string userEmail,
+        string userRole,
+        CancellationToken ct = default);
+
+    Task ResetAsync(
+        string persona,
+        string userEmail,
+        CancellationToken ct = default);
+}
+
+public sealed class BotConsultClient : IBotConsultClient
+{
+    private const string ApiKeyHeaderName = "X-Bot-Api-Key";
+
+    private readonly HttpClient _http;
+    private readonly BotConsultOptions _options;
+
+    public BotConsultClient(HttpClient http, IOptions<BotConsultOptions> options)
+    {
+        _http = http;
+        _options = options.Value;
+
+        if (_options.IsConfigured)
+        {
+            _http.BaseAddress = BuildBaseAddress(_options.Url!);
+            _http.DefaultRequestHeaders.Remove(ApiKeyHeaderName);
+            _http.DefaultRequestHeaders.Add(ApiKeyHeaderName, _options.ApiKey);
+        }
+    }
+
+    public bool IsEnabled => _options.IsConfigured;
+
+    public async Task<ConsultAnswerDto> AskAsync(
+        string persona,
+        string message,
+        string userEmail,
+        string userRole,
+        CancellationToken ct = default)
+    {
+        EnsureConfigured();
+
+        using var response = await PostAsync(
+            $"api/consult/{persona}",
+            new BotConsultBotRequest(message, userEmail, userRole),
+            ct);
+        await ThrowIfUnsuccessfulAsync(response, ct);
+
+        return await response.Content.ReadFromJsonAsync<ConsultAnswerDto>(cancellationToken: ct)
+            ?? throw new BotConsultUpstreamException(
+                HttpStatusCode.BadGateway,
+                "Bot returned an empty consult response.");
+    }
+
+    public async Task ResetAsync(
+        string persona,
+        string userEmail,
+        CancellationToken ct = default)
+    {
+        EnsureConfigured();
+
+        using var response = await PostAsync(
+            $"api/consult/{persona}/reset",
+            new BotConsultResetRequest(userEmail),
+            ct);
+        await ThrowIfUnsuccessfulAsync(response, ct);
+    }
+
+    private async Task<HttpResponseMessage> PostAsync<TRequest>(
+        string path,
+        TRequest request,
+        CancellationToken ct)
+    {
+        try
+        {
+            return await _http.PostAsJsonAsync(path, request, ct);
+        }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            throw new BotConsultTimeoutException(ex);
+        }
+    }
+
+    private static async Task ThrowIfUnsuccessfulAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        if (response.IsSuccessStatusCode)
+            return;
+
+        var detail = await response.Content.ReadAsStringAsync(ct);
+        throw new BotConsultUpstreamException(response.StatusCode, detail);
+    }
+
+    private void EnsureConfigured()
+    {
+        if (!IsEnabled)
+            throw new BotConsultUnavailableException();
+    }
+
+    private static Uri BuildBaseAddress(string url)
+    {
+        var baseUrl = url.EndsWith("/", StringComparison.Ordinal)
+            ? url
+            : $"{url}/";
+        return new Uri(baseUrl, UriKind.Absolute);
+    }
+
+    private sealed record BotConsultBotRequest(string Message, string UserEmail, string UserRole);
+    private sealed record BotConsultResetRequest(string UserEmail);
+}
+
+public sealed class BotConsultUnavailableException()
+    : InvalidOperationException("Bot consult is not configured.");
+
+public sealed class BotConsultTimeoutException(Exception innerException)
+    : TimeoutException("Bot consult timed out.", innerException);
+
+public sealed class BotConsultUpstreamException(HttpStatusCode statusCode, string? detail)
+    : HttpRequestException($"Bot consult failed with {(int)statusCode} {statusCode}. {detail}")
+{
+    public HttpStatusCode UpstreamStatusCode { get; } = statusCode;
+    public string? Detail { get; } = detail;
+}

--- a/src/OvcinaHra.Api/appsettings.json
+++ b/src/OvcinaHra.Api/appsettings.json
@@ -9,5 +9,9 @@
   "IntegrationApi": {
     "BaseUrl": "https://registrace.ovcina.cz",
     "ApiKey": ""
+  },
+  "BotConsult": {
+    "Url": "",
+    "ApiKey": ""
   }
 }

--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor
@@ -1,0 +1,228 @@
+@inject ApiClient Api
+@inject IJSRuntime Js
+
+@if (_enabled)
+{
+    <button type="button"
+            class="oh-bot-fab @PersonaClass"
+            title="Zeptat se Drozda"
+            aria-label="Zeptat se Drozda"
+            @onclick="Open">
+        <i class="bi bi-chat-dots-fill" aria-hidden="true"></i>
+    </button>
+
+    @if (_open)
+    {
+        <div class="oh-bot-backdrop" @onclick="Close"></div>
+        <section class="oh-bot-drawer @PersonaClass" aria-label="Zeptat se Drozda">
+            <header class="oh-bot-header">
+                <div>
+                    <h2>Zeptat se Drozda</h2>
+                    <div class="oh-bot-personas" role="tablist" aria-label="Drozdova odbornost">
+                        <button type="button"
+                                class="@PersonaButtonClass("rulemaster")"
+                                role="tab"
+                                aria-selected="@(_persona == "rulemaster")"
+                                @onclick='() => SetPersonaAsync("rulemaster")'>
+                            Pravidla
+                        </button>
+                        <button type="button"
+                                class="@PersonaButtonClass("loremaster")"
+                                role="tab"
+                                aria-selected="@(_persona == "loremaster")"
+                                @onclick='() => SetPersonaAsync("loremaster")'>
+                            Lore
+                        </button>
+                    </div>
+                </div>
+                <button type="button"
+                        class="oh-bot-icon-button"
+                        title="Zavřít"
+                        aria-label="Zavřít"
+                        @onclick="Close">
+                    <i class="bi bi-x-lg" aria-hidden="true"></i>
+                </button>
+            </header>
+
+            <div class="oh-bot-messages" aria-live="polite">
+                @if (_messages.Count == 0)
+                {
+                    <div class="oh-bot-empty">Zeptej se Drozda…</div>
+                }
+
+                @foreach (var message in _messages)
+                {
+                    <div class="oh-bot-message @(message.FromUser ? "oh-bot-message--user" : "oh-bot-message--drozd") @PersonaClassFor(message.Persona)">
+                        <div class="oh-bot-message-body">
+                            @if (message.FromUser)
+                            {
+                                @message.Text
+                            }
+                            else
+                            {
+                                <MarkdownRenderer Text="@message.Text" />
+                            }
+                        </div>
+                    </div>
+                }
+
+                @if (_sending)
+                {
+                    <div class="oh-bot-message oh-bot-message--drozd @PersonaClass">
+                        <div class="oh-bot-message-body oh-bot-thinking">Drozd přemýšlí…</div>
+                    </div>
+                }
+            </div>
+
+            <footer class="oh-bot-input">
+                <textarea @bind="_draft"
+                          @bind:event="oninput"
+                          disabled="@_sending"
+                          rows="3"
+                          maxlength="4000"
+                          placeholder="Zeptej se Drozda…"
+                          aria-label="Zeptej se Drozda…"></textarea>
+                <button type="button"
+                        class="oh-bot-send"
+                        disabled="@(!CanSend)"
+                        @onclick="SendAsync">
+                    <i class="bi bi-send-fill" aria-hidden="true"></i>
+                    <span>Odeslat</span>
+                </button>
+            </footer>
+        </section>
+    }
+}
+
+@code {
+    private const string PersonaStorageKey = "oh-bot-last-persona";
+    private const string Rulemaster = "rulemaster";
+    private const string Loremaster = "loremaster";
+
+    private readonly List<BotMessage> _messages = [];
+    private bool _enabled;
+    private bool _open;
+    private bool _sending;
+    private string _persona = Loremaster;
+    private string _draft = string.Empty;
+
+    private bool CanSend => !_sending && !string.IsNullOrWhiteSpace(_draft);
+    private string PersonaClass => PersonaClassFor(_persona);
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+            return;
+
+        await LoadAvailabilityAsync();
+        await LoadPersonaAsync();
+        StateHasChanged();
+    }
+
+    private async Task LoadAvailabilityAsync()
+    {
+        try
+        {
+            var availability = await Api.GetAsync<ConsultAvailabilityDto>("/api/consult/available");
+            _enabled = availability?.Enabled == true;
+        }
+        catch (HttpRequestException)
+        {
+            _enabled = false;
+        }
+        catch (InvalidOperationException)
+        {
+            _enabled = false;
+        }
+    }
+
+    private async Task LoadPersonaAsync()
+    {
+        try
+        {
+            var stored = await Js.InvokeAsync<string?>("localStorage.getItem", PersonaStorageKey);
+            if (IsPersona(stored))
+                _persona = stored!;
+        }
+        catch (JSException)
+        {
+            _persona = Loremaster;
+        }
+        catch (InvalidOperationException)
+        {
+            _persona = Loremaster;
+        }
+    }
+
+    private void Open() => _open = true;
+
+    private void Close() => _open = false;
+
+    private async Task SetPersonaAsync(string persona)
+    {
+        if (!IsPersona(persona))
+            return;
+
+        _persona = persona;
+
+        try
+        {
+            await Js.InvokeVoidAsync("localStorage.setItem", PersonaStorageKey, persona);
+        }
+        catch (JSException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+
+    private async Task SendAsync()
+    {
+        if (!CanSend)
+            return;
+
+        var persona = _persona;
+        var text = _draft.Trim();
+        _draft = string.Empty;
+        _messages.Add(new BotMessage(true, text, persona));
+        _sending = true;
+
+        try
+        {
+            var result = await Api.PostWithProblemAsync<ConsultRequestDto, ConsultAnswerDto>(
+                $"/api/consult/{persona}",
+                new ConsultRequestDto(text));
+
+            var answer = result.Ok && result.Value is not null
+                ? result.Value.Answer
+                : "Drozd se teď neozval. Zkus to prosím znovu.";
+            _messages.Add(new BotMessage(false, answer, persona));
+        }
+        catch (HttpRequestException)
+        {
+            _messages.Add(new BotMessage(false, "Drozd se teď neozval. Zkus to prosím znovu.", persona));
+        }
+        catch (InvalidOperationException)
+        {
+            _messages.Add(new BotMessage(false, "Drozd se teď neozval. Zkus to prosím znovu.", persona));
+        }
+        finally
+        {
+            _sending = false;
+        }
+    }
+
+    private static string PersonaClassFor(string persona)
+        => persona == Rulemaster ? "oh-bot--rulemaster" : "oh-bot--loremaster";
+
+    private string PersonaButtonClass(string persona)
+        => _persona == persona
+            ? $"oh-bot-persona is-active {PersonaClassFor(persona)}"
+            : $"oh-bot-persona {PersonaClassFor(persona)}";
+
+    private static bool IsPersona(string? persona)
+        => persona is Rulemaster or Loremaster;
+
+    private sealed record BotMessage(bool FromUser, string Text, string Persona);
+}

--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.css
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.css
@@ -150,6 +150,14 @@
     border-left: 4px solid var(--oh-primary);
 }
 
+.oh-bot-message--drozd.oh-bot--loremaster .oh-bot-message-body {
+    border-left-color: var(--oh-color-forest-deep, var(--oh-color-aradhryand, var(--oh-primary)));
+}
+
+.oh-bot-message--drozd.oh-bot--rulemaster .oh-bot-message-body {
+    border-left-color: var(--oh-color-azanulinbar, var(--oh-stage-endgame));
+}
+
 .oh-bot-thinking {
     color: var(--oh-text-secondary);
     font-style: italic;
@@ -220,4 +228,38 @@
     background: rgba(44, 24, 16, 0.08);
     border-radius: var(--oh-radius-sm);
     padding: 0.1rem 0.25rem;
+}
+
+.oh-bot--loremaster.oh-bot-fab,
+.oh-bot--loremaster.oh-bot-drawer .oh-bot-header {
+    background: var(--oh-color-forest-deep, var(--oh-color-aradhryand, var(--oh-primary)));
+}
+
+.oh-bot--rulemaster.oh-bot-fab,
+.oh-bot--rulemaster.oh-bot-drawer .oh-bot-header {
+    background: var(--oh-color-azanulinbar, var(--oh-stage-endgame));
+}
+
+@media (max-width: 767.98px) {
+    .oh-bot-drawer {
+        inset: 0;
+        width: 100vw;
+        height: 100dvh;
+        max-height: none;
+        border-radius: 0;
+        border: 0;
+    }
+
+    .oh-bot-fab {
+        right: 1rem;
+        bottom: 1rem;
+    }
+
+    .oh-bot-input {
+        grid-template-columns: 1fr;
+    }
+
+    .oh-bot-send {
+        justify-content: center;
+    }
 }

--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.css
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.css
@@ -1,0 +1,223 @@
+.oh-bot-fab {
+    position: fixed;
+    right: 1.25rem;
+    bottom: 1.25rem;
+    z-index: 1050;
+    width: 3.5rem;
+    height: 3.5rem;
+    border: 0;
+    border-radius: 50%;
+    background: var(--oh-primary);
+    color: var(--oh-header-text);
+    box-shadow: 0 0.4rem 1rem rgba(44, 24, 16, 0.28);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.35rem;
+    transition: transform var(--oh-transition), box-shadow var(--oh-transition);
+}
+
+.oh-bot-fab:hover,
+.oh-bot-fab:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 0.55rem 1.35rem rgba(44, 24, 16, 0.34);
+}
+
+.oh-bot-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1051;
+    background: rgba(44, 24, 16, 0.28);
+}
+
+.oh-bot-drawer {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 1052;
+    width: min(420px, calc(100vw - 2rem));
+    height: min(720px, calc(100vh - 2rem));
+    border: 1px solid var(--oh-border);
+    border-radius: var(--oh-radius);
+    background: var(--oh-surface);
+    color: var(--oh-text);
+    box-shadow: 0 0.75rem 2rem rgba(44, 24, 16, 0.28);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.oh-bot-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 1rem;
+    background: var(--oh-primary);
+    color: var(--oh-header-text);
+}
+
+.oh-bot-header h2 {
+    margin: 0 0 0.75rem;
+    font-family: var(--oh-font-heading);
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: 0;
+}
+
+.oh-bot-icon-button {
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid rgba(255, 248, 240, 0.34);
+    border-radius: 50%;
+    background: rgba(255, 248, 240, 0.12);
+    color: var(--oh-header-text);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.oh-bot-personas {
+    display: inline-flex;
+    padding: 0.2rem;
+    border: 1px solid rgba(255, 248, 240, 0.28);
+    border-radius: var(--oh-radius-sm);
+    background: rgba(255, 248, 240, 0.12);
+    gap: 0.15rem;
+}
+
+.oh-bot-persona {
+    border: 0;
+    border-radius: var(--oh-radius-sm);
+    background: transparent;
+    color: var(--oh-header-text);
+    padding: 0.35rem 0.65rem;
+    font-size: 0.875rem;
+}
+
+.oh-bot-persona.is-active {
+    background: var(--oh-surface);
+    color: var(--oh-text);
+    box-shadow: 0 1px 4px rgba(44, 24, 16, 0.18);
+}
+
+.oh-bot-messages {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    background: var(--oh-surface-alt);
+}
+
+.oh-bot-empty {
+    margin: auto;
+    color: var(--oh-text-secondary);
+    font-style: italic;
+}
+
+.oh-bot-message {
+    display: flex;
+}
+
+.oh-bot-message--user {
+    justify-content: flex-end;
+}
+
+.oh-bot-message--drozd {
+    justify-content: flex-start;
+}
+
+.oh-bot-message-body {
+    max-width: min(86%, 33rem);
+    border-radius: var(--oh-radius);
+    padding: 0.65rem 0.75rem;
+    background: var(--oh-surface);
+    border: 1px solid var(--oh-border);
+    overflow-wrap: anywhere;
+    word-break: normal;
+}
+
+.oh-bot-message--user .oh-bot-message-body {
+    background: var(--oh-primary);
+    border-color: var(--oh-primary);
+    color: var(--oh-header-text);
+}
+
+.oh-bot-message--drozd .oh-bot-message-body {
+    border-left: 4px solid var(--oh-primary);
+}
+
+.oh-bot-thinking {
+    color: var(--oh-text-secondary);
+    font-style: italic;
+}
+
+.oh-bot-input {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem;
+    padding: 0.9rem 1rem 1rem;
+    border-top: 1px solid var(--oh-border);
+    background: var(--oh-surface);
+}
+
+.oh-bot-input textarea {
+    width: 100%;
+    min-width: 0;
+    resize: none;
+    border: 1px solid var(--oh-border);
+    border-radius: var(--oh-radius-sm);
+    padding: 0.55rem 0.65rem;
+    color: var(--oh-text);
+    background: #fff;
+    font-family: var(--oh-font-body);
+}
+
+.oh-bot-input textarea:focus {
+    outline: none;
+    border-color: var(--oh-primary-light);
+    box-shadow: 0 0 0 0.15rem rgba(74, 124, 52, 0.18);
+}
+
+.oh-bot-send {
+    align-self: end;
+    min-height: 2.5rem;
+    border: 0;
+    border-radius: var(--oh-radius-sm);
+    padding: 0 0.9rem;
+    background: var(--oh-primary);
+    color: var(--oh-header-text);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-weight: 600;
+}
+
+.oh-bot-send:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.oh-bot-markdown :first-child {
+    margin-top: 0;
+}
+
+.oh-bot-markdown :last-child {
+    margin-bottom: 0;
+}
+
+.oh-bot-markdown p,
+.oh-bot-markdown ul,
+.oh-bot-markdown ol {
+    margin-bottom: 0.6rem;
+}
+
+.oh-bot-markdown code {
+    font-family: var(--oh-font-mono);
+    background: rgba(44, 24, 16, 0.08);
+    border-radius: var(--oh-radius-sm);
+    padding: 0.1rem 0.25rem;
+}

--- a/src/OvcinaHra.Client/Components/MarkdownRenderer.razor
+++ b/src/OvcinaHra.Client/Components/MarkdownRenderer.razor
@@ -1,0 +1,16 @@
+@using Markdig
+
+<div class="oh-bot-markdown">
+    @((MarkupString)Html)
+</div>
+
+@code {
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .DisableHtml()
+        .Build();
+
+    [Parameter] public string? Text { get; set; }
+
+    private string Html => Markdown.ToHtml(Text ?? string.Empty, Pipeline);
+}

--- a/src/OvcinaHra.Client/Layout/MainLayout.razor
+++ b/src/OvcinaHra.Client/Layout/MainLayout.razor
@@ -26,6 +26,12 @@
     </main>
 </div>
 
+<AuthorizeView>
+    <Authorized>
+        <BotConsultDrawer />
+    </Authorized>
+</AuthorizeView>
+
 @code {
     [Inject] private JwtAuthStateProvider AuthProvider { get; set; } = default!;
     [Inject] private NavigationManager Nav { get; set; } = default!;

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="DevExpress.Blazor" Version="25.2.5" />
     <PackageReference Include="DevExpress.Blazor.Themes" Version="25.2.5" />
+    <PackageReference Include="Markdig" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.4" PrivateAssets="all" />

--- a/src/OvcinaHra.Shared/Dtos/ConsultDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/ConsultDtos.cs
@@ -1,0 +1,5 @@
+namespace OvcinaHra.Shared.Dtos;
+
+public sealed record ConsultRequestDto(string Message);
+public sealed record ConsultAnswerDto(string Answer, int TokensUsed);
+public sealed record ConsultAvailabilityDto(bool Enabled);

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/BotConsultDrawerSmokeTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/BotConsultDrawerSmokeTests.cs
@@ -1,0 +1,84 @@
+namespace OvcinaHra.Api.Tests.ClientSmoke;
+
+public class BotConsultDrawerSmokeTests
+{
+    [Fact]
+    public void Drawer_IsAuthenticatedConfigGated_AndPersonaAware()
+    {
+        var root = FindRepoRoot();
+        var layout = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Layout",
+            "MainLayout.razor"));
+        var drawer = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Components",
+            "BotConsultDrawer.razor"));
+        var css = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Components",
+            "BotConsultDrawer.razor.css"));
+
+        Assert.Contains("<AuthorizeView>", layout);
+        Assert.Contains("<BotConsultDrawer />", layout);
+        Assert.Contains("/api/consult/available", drawer);
+        Assert.Contains("oh-bot-last-persona", drawer);
+        Assert.Contains("rulemaster", drawer);
+        Assert.Contains("loremaster", drawer);
+        Assert.Contains("Zeptat se Drozda", drawer);
+        Assert.Contains("Drozd přemýšlí…", drawer);
+        Assert.Contains("Zeptej se Drozda…", drawer);
+        Assert.Contains("Pravidla", drawer);
+        Assert.Contains("Lore", drawer);
+        Assert.Contains("Odeslat", drawer);
+        Assert.Contains("Zavřít", drawer);
+        Assert.Contains("--oh-color-forest-deep", css);
+        Assert.Contains("--oh-color-azanulinbar", css);
+        Assert.Contains("@media (max-width: 767.98px)", css);
+        Assert.Contains("height: 100dvh;", css);
+    }
+
+    [Fact]
+    public void MarkdownRenderer_UsesAdvancedExtensions_AndDisablesHtml()
+    {
+        var renderer = File.ReadAllText(Path.Combine(
+            FindRepoRoot(),
+            "src",
+            "OvcinaHra.Client",
+            "Components",
+            "MarkdownRenderer.razor"));
+
+        Assert.Contains(".UseAdvancedExtensions()", renderer);
+        Assert.Contains(".DisableHtml()", renderer);
+        Assert.Contains("Markdown.ToHtml", renderer);
+    }
+
+    [Fact]
+    public void Program_ConfiguresBotConsultRetry()
+    {
+        var program = File.ReadAllText(Path.Combine(
+            FindRepoRoot(),
+            "src",
+            "OvcinaHra.Api",
+            "Program.cs"));
+
+        Assert.Contains("AddHttpClient<IBotConsultClient, BotConsultClient>", program);
+        Assert.Contains("HttpPolicyExtensions", program);
+        Assert.Contains("WaitAndRetryAsync(1", program);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "OvcinaHra.slnx")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not find repository root.");
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ConsultEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ConsultEndpointTests.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using System.Net.Http.Json;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+public class ConsultEndpointTests(PostgresFixture postgres)
+    : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    [Fact]
+    public async Task Availability_WithoutBotConfig_ReturnsDisabled()
+    {
+        var availability = await Client.GetFromJsonAsync<ConsultAvailabilityDto>(
+            "/api/consult/available");
+
+        Assert.NotNull(availability);
+        Assert.False(availability.Enabled);
+    }
+
+    [Fact]
+    public async Task Availability_WithoutToken_ReturnsUnauthorized()
+    {
+        using var noAuthClient = Factory.CreateClient();
+
+        var response = await noAuthClient.GetAsync("/api/consult/available");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Ask_WithoutBotConfig_ReturnsUnavailable()
+    {
+        var response = await Client.PostAsJsonAsync(
+            "/api/consult/loremaster",
+            new ConsultRequestDto("Kde je Drozd?"));
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Reset_WithoutBotConfig_ReturnsUnavailable()
+    {
+        var response = await Client.PostAsync("/api/consult/rulemaster/reset", null);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Services/BotConsultClientTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Services/BotConsultClientTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using OvcinaHra.Api.Configuration;
+using OvcinaHra.Api.Services;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Services;
+
+public class BotConsultClientTests
+{
+    [Fact]
+    public async Task AskAsync_SendsLockedBotContract()
+    {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new ConsultAnswerDto("**Ano.**", 17))
+        });
+        var client = CreateClient(handler);
+
+        var answer = await client.AskAsync(
+            "loremaster",
+            "Kdo je Drozd?",
+            "test@ovcina.cz",
+            "organizator");
+
+        Assert.Equal("**Ano.**", answer.Answer);
+        Assert.Equal(17, answer.TokensUsed);
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal("https://bot.example/api/consult/loremaster", request.Uri);
+        Assert.Equal("test-secret", request.ApiKey);
+
+        using var json = JsonDocument.Parse(request.Body);
+        var root = json.RootElement;
+        Assert.Equal("Kdo je Drozd?", root.GetProperty("message").GetString());
+        Assert.Equal("test@ovcina.cz", root.GetProperty("userEmail").GetString());
+        Assert.Equal("organizator", root.GetProperty("userRole").GetString());
+    }
+
+    [Fact]
+    public async Task ResetAsync_SendsUserEmailOnly()
+    {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = CreateClient(handler);
+
+        await client.ResetAsync("rulemaster", "test@ovcina.cz");
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal("https://bot.example/api/consult/rulemaster/reset", request.Uri);
+        Assert.Equal("test-secret", request.ApiKey);
+
+        using var json = JsonDocument.Parse(request.Body);
+        var root = json.RootElement;
+        Assert.Equal("test@ovcina.cz", root.GetProperty("userEmail").GetString());
+        var property = Assert.Single(root.EnumerateObject());
+        Assert.Equal("userEmail", property.Name);
+    }
+
+    private static BotConsultClient CreateClient(HttpMessageHandler handler)
+        => new(
+            new HttpClient(handler),
+            Options.Create(new BotConsultOptions
+            {
+                Url = "https://bot.example",
+                ApiKey = "test-secret"
+            }));
+
+    private sealed class RecordingHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new(responses);
+
+        public List<RecordedRequest> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            Requests.Add(new RecordedRequest(
+                request.RequestUri?.ToString() ?? string.Empty,
+                request.Headers.TryGetValues("X-Bot-Api-Key", out var values)
+                    ? values.SingleOrDefault()
+                    : null,
+                body));
+
+            return _responses.Count > 0
+                ? _responses.Dequeue()
+                : new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private sealed record RecordedRequest(string Uri, string? ApiKey, string Body);
+}


### PR DESCRIPTION
## Summary
- Adds the OvcinaHra-side BotConsult proxy endpoints, typed client, options binding, API-key forwarding, and one Polly retry for transient bot failures.
- Adds authenticated consult availability gating plus the Blazor Drozd drawer with Markdig rendering, last persona localStorage, persona tinting, and mobile full-screen behavior.
- Adds focused API/client-smoke coverage for the locked bot contract, disabled config path, auth gating, Markdig HTML disabling, retry wiring, and drawer UI hooks.

Refs #284.

## Verification
- `dotnet build OvcinaHra.slnx --no-restore` passed.
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter "FullyQualifiedName~Consult|FullyQualifiedName~BotConsult"` passed: 9/9.
- `dotnet test OvcinaHra.slnx --no-build` result: API tests passed 471/471; E2E has the existing `SkillsManagementTests.GameSkill_CannotBeRemoved_WhenReferencedByRecipe` failure, expected `NoContent` but got `Conflict` at `tests/OvcinaHra.E2E/SkillsManagementTests.cs:207`.

## Notes
- #238/#241 deferred work was not touched; no `Location.StampImagePath` changes.
