### PR TITLE
fix(consult): suppress bot upstream detail leak

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ConsultEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ConsultEndpoints.cs
@@ -28,6 +28,7 @@ public static class ConsultEndpoints
         ConsultRequestDto request,
         ClaimsPrincipal user,
         IBotConsultClient bot,
+        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         if (!bot.IsEnabled)
@@ -69,9 +70,10 @@ public static class ConsultEndpoints
         }
         catch (BotConsultUpstreamException ex)
         {
+            LogUpstreamFailure(loggerFactory, persona, ex);
             return Results.Problem(
                 title: "Drozd se teď neozval",
-                detail: ex.Detail,
+                detail: "Drozd právě nemůže odpovědět, zkuste to prosím za chvíli.",
                 statusCode: StatusCodes.Status502BadGateway);
         }
     }
@@ -80,6 +82,7 @@ public static class ConsultEndpoints
         string persona,
         ClaimsPrincipal user,
         IBotConsultClient bot,
+        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         if (!bot.IsEnabled)
@@ -107,11 +110,26 @@ public static class ConsultEndpoints
         }
         catch (BotConsultUpstreamException ex)
         {
+            LogUpstreamFailure(loggerFactory, persona, ex);
             return Results.Problem(
                 title: "Drozd se teď neozval",
-                detail: ex.Detail,
+                detail: "Reset historie selhal, zkuste to prosím za chvíli.",
                 statusCode: StatusCodes.Status502BadGateway);
         }
+    }
+
+    private static void LogUpstreamFailure(
+        ILoggerFactory loggerFactory,
+        string persona,
+        BotConsultUpstreamException exception)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.ConsultEndpoints");
+        logger.LogWarning(
+            exception,
+            "Bot consult upstream failure for {Persona}: {StatusCode}. UpstreamDetail={UpstreamDetail}",
+            persona,
+            exception.UpstreamStatusCode,
+            exception.Detail);
     }
 
     private static string? GetUserEmail(ClaimsPrincipal user)

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ConsultEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ConsultEndpointTests.cs
@@ -1,5 +1,13 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using OvcinaHra.Api.Endpoints;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Dtos;
 
@@ -45,4 +53,167 @@ public class ConsultEndpointTests(PostgresFixture postgres)
 
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
     }
+
+    [Fact]
+    public async Task Ask_UpstreamFailure_UsesFixedCzechDetail_AndLogsRawDetail()
+    {
+        const string upstreamDetail = "Traceback: SECRET bot stack trace";
+        const string userDetail = "Drozd právě nemůže odpovědět, zkuste to prosím za chvíli.";
+        var logs = new CapturingLoggerProvider();
+        using var factory = CreateFailingBotFactory(
+            upstreamDetail,
+            logs,
+            failReset: false);
+        using var client = await CreateAuthenticatedClientAsync(factory);
+
+        var response = await client.PostAsJsonAsync(
+            "/api/consult/loremaster",
+            new ConsultRequestDto("Co ví Drozd?"));
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains(userDetail, body);
+        Assert.DoesNotContain(upstreamDetail, body);
+
+        var entry = Assert.Single(logs.Entries, e =>
+            e.Level == LogLevel.Warning
+            && e.State.ContainsKey("UpstreamDetail"));
+        Assert.Equal("loremaster", entry.State["Persona"]);
+        Assert.Equal(HttpStatusCode.InternalServerError, entry.State["StatusCode"]);
+        Assert.Equal(upstreamDetail, entry.State["UpstreamDetail"]);
+    }
+
+    [Fact]
+    public async Task Reset_UpstreamFailure_UsesFixedCzechDetail_AndLogsRawDetail()
+    {
+        const string upstreamDetail = "<html>SECRET upstream body</html>";
+        const string userDetail = "Reset historie selhal, zkuste to prosím za chvíli.";
+        var logs = new CapturingLoggerProvider();
+        using var factory = CreateFailingBotFactory(
+            upstreamDetail,
+            logs,
+            failReset: true);
+        using var client = await CreateAuthenticatedClientAsync(factory);
+
+        var response = await client.PostAsync("/api/consult/rulemaster/reset", null);
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains(userDetail, body);
+        Assert.DoesNotContain(upstreamDetail, body);
+
+        var entry = Assert.Single(logs.Entries, e =>
+            e.Level == LogLevel.Warning
+            && e.State.ContainsKey("UpstreamDetail"));
+        Assert.Equal("rulemaster", entry.State["Persona"]);
+        Assert.Equal(HttpStatusCode.InternalServerError, entry.State["StatusCode"]);
+        Assert.Equal(upstreamDetail, entry.State["UpstreamDetail"]);
+    }
+
+    private WebApplicationFactory<Program> CreateFailingBotFactory(
+        string upstreamDetail,
+        CapturingLoggerProvider logs,
+        bool failReset)
+        => Factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IBotConsultClient>();
+                services.AddSingleton<IBotConsultClient>(
+                    new FailingBotConsultClient(upstreamDetail, failReset));
+                services.RemoveAll<ILoggerFactory>();
+                services.AddSingleton<ILoggerFactory>(_ =>
+                    LoggerFactory.Create(logging => logging.AddProvider(logs)));
+            });
+        });
+
+    private static async Task<HttpClient> CreateAuthenticatedClientAsync(
+        WebApplicationFactory<Program> factory)
+    {
+        var client = factory.CreateClient();
+        var tokenResponse = await client.PostAsJsonAsync(
+            "/api/auth/dev-token",
+            new DevTokenRequest("consult-test", "consult@ovcina.cz", "Consult Tester"));
+        tokenResponse.EnsureSuccessStatusCode();
+
+        var token = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>()
+            ?? throw new InvalidOperationException("Dev-token endpoint returned an empty body.");
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token.Token);
+
+        return client;
+    }
+
+    private sealed class FailingBotConsultClient(string upstreamDetail, bool failReset)
+        : IBotConsultClient
+    {
+        public bool IsEnabled => true;
+
+        public Task<ConsultAnswerDto> AskAsync(
+            string persona,
+            string message,
+            string userEmail,
+            string userRole,
+            CancellationToken ct = default)
+            => failReset
+                ? Task.FromResult(new ConsultAnswerDto("ok", 0))
+                : throw new BotConsultUpstreamException(
+                    HttpStatusCode.InternalServerError,
+                    upstreamDetail);
+
+        public Task ResetAsync(
+            string persona,
+            string userEmail,
+            CancellationToken ct = default)
+            => failReset
+                ? throw new BotConsultUpstreamException(
+                    HttpStatusCode.InternalServerError,
+                    upstreamDetail)
+                : Task.CompletedTask;
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public ILogger CreateLogger(string categoryName)
+            => new CapturingLogger(categoryName, Entries);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class CapturingLogger(
+        string categoryName,
+        List<LogEntry> entries) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var structuredState = state as IEnumerable<KeyValuePair<string, object?>>;
+            entries.Add(new LogEntry(
+                logLevel,
+                categoryName,
+                formatter(state, exception),
+                structuredState?.ToDictionary(pair => pair.Key, pair => pair.Value)
+                    ?? new Dictionary<string, object?>()));
+        }
+    }
+
+    private sealed record LogEntry(
+        LogLevel Level,
+        string Category,
+        string Message,
+        IReadOnlyDictionary<string, object?> State);
 }


### PR DESCRIPTION
## Summary
- Stops forwarding raw `BotConsultUpstreamException.Detail` to user-facing ProblemDetails on consult ask/reset upstream failures.
- Logs the upstream body server-side at warning level with structured `{Persona}`, `{StatusCode}`, and `{UpstreamDetail}` fields.
- Adds upstream-failure coverage asserting fixed Czech ProblemDetails and captured raw upstream log details.

Closes #296.

## Verification
- `dotnet build OvcinaHra.slnx` passed.
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter "FullyQualifiedName~Consult"` passed: 11/11.
- `dotnet test --no-build` result: API tests passed 473/473; existing E2E failure remains in `SkillsManagementTests.GameSkill_CannotBeRemoved_WhenReferencedByRecipe`, expected `NoContent` but got `Conflict` at `tests/OvcinaHra.E2E/SkillsManagementTests.cs:207`.
