### PR TITLE
fix(locations): catalog Smazat uses DeleteWithProblemAsync

### DIFF
--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -726,10 +726,10 @@ else
         error = null;
         try
         {
-            var deleted = await Api.DeleteAsync($"/api/locations/{Id}");
-            if (!deleted)
+            var (ok, problem) = await Api.DeleteWithProblemAsync($"/api/locations/{Id}");
+            if (!ok)
             {
-                error = "Smazání lokace se nezdařilo.";
+                error = problem ?? "Smazání lokace se nezdařilo.";
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Closes #301
- Mirror the game-scoped remove handler by using `DeleteWithProblemAsync` for catalog-mode Location `Smazat`.
- Surface server ProblemDetails text in the existing error area, with the existing Czech fallback unchanged.

## Verification
- `dotnet build OvcinaHra.slnx` — passed, 0 warnings
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build` — passed, 476 tests
- `dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor` — passed
- `git diff --check` — passed

## Note
- Full `dotnet test OvcinaHra.slnx --no-build` is currently blocked by an unrelated E2E baseline failure: `OvcinaHra.E2E.SkillsManagementTests.GameSkill_CannotBeRemoved_WhenReferencedByRecipe` expects `NoContent` but receives `Conflict`. The same single test fails when rerun alone; this PR only changes `LocationDetail.razor`.