### PR TITLE
fix(search): harden NavSearch typeahead cancellation

### DIFF
--- a/src/OvcinaHra.Client/Layout/NavSearch.razor
+++ b/src/OvcinaHra.Client/Layout/NavSearch.razor
@@ -1,5 +1,6 @@
 @inject ApiClient Api
 @inject NavigationManager Nav
+@inject ILogger<NavSearch> Logger
 @implements IDisposable
 
 <div class="oh-nav-search"
@@ -111,7 +112,9 @@
 
     private async Task SearchAsync(bool force, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(query) || (!force && query.Length < MinimumTypeaheadLength))
+        var searchQuery = query.Trim();
+        if (string.IsNullOrWhiteSpace(searchQuery)
+            || (!force && searchQuery.Length < MinimumTypeaheadLength))
             return;
 
         searching = true;
@@ -120,17 +123,21 @@
 
         try
         {
-            var url = $"/api/search?q={Uri.EscapeDataString(query)}&limit={ResultLimit}";
-            var response = await Api.GetAsync<SearchResponseDto>(url);
+            var url = $"/api/search?q={Uri.EscapeDataString(searchQuery)}&limit={ResultLimit}";
+            var response = await Api.GetAsync<SearchResponseDto>(url, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
 
             results.Clear();
             if (response is not null)
                 results.AddRange(response.Results.Take(ResultLimit));
         }
-        catch when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
         {
             results.Clear();
+            LogSearchFailure(searchQuery, ex);
         }
         finally
         {
@@ -143,6 +150,21 @@
             }
         }
     }
+
+    private void LogSearchFailure(string searchQuery, Exception exception)
+    {
+        Logger.LogWarning(
+            exception,
+            "NavSearch typeahead failed for {Query} with status {StatusCode}. {Exception}",
+            searchQuery,
+            StatusCodeFrom(exception),
+            exception);
+    }
+
+    private static object? StatusCodeFrom(Exception exception)
+        => exception is HttpRequestException httpException
+            ? httpException.StatusCode
+            : null;
 
     private void ShowExistingResults()
     {

--- a/src/OvcinaHra.Client/Layout/NavSearch.razor
+++ b/src/OvcinaHra.Client/Layout/NavSearch.razor
@@ -133,6 +133,7 @@
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // Cancellation is expected when newer typeahead input supersedes this search.
         }
         catch (Exception ex)
         {
@@ -158,7 +159,7 @@
             "NavSearch typeahead failed for {Query} with status {StatusCode}. {Exception}",
             searchQuery,
             StatusCodeFrom(exception),
-            exception);
+            exception.GetType().Name);
     }
 
     private static object? StatusCodeFrom(Exception exception)

--- a/src/OvcinaHra.Client/Services/ApiClient.cs
+++ b/src/OvcinaHra.Client/Services/ApiClient.cs
@@ -25,13 +25,13 @@ public class ApiClient
         return await _http.GetFromJsonAsync<List<T>>(url, JsonOptions) ?? [];
     }
 
-    public async Task<T?> GetAsync<T>(string url)
+    public async Task<T?> GetAsync<T>(string url, CancellationToken cancellationToken = default)
     {
-        var response = await _http.GetAsync(url);
+        var response = await _http.GetAsync(url, cancellationToken);
         if (response.StatusCode == HttpStatusCode.NotFound)
             return default;
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<T>(JsonOptions);
+        return await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken);
     }
 
     public async Task<TResponse?> PostAsync<TRequest, TResponse>(string url, TRequest data)

--- a/src/OvcinaHra.Client/Services/ApiClient.cs
+++ b/src/OvcinaHra.Client/Services/ApiClient.cs
@@ -27,7 +27,7 @@ public class ApiClient
 
     public async Task<T?> GetAsync<T>(string url, CancellationToken cancellationToken = default)
     {
-        var response = await _http.GetAsync(url, cancellationToken);
+        using var response = await _http.GetAsync(url, cancellationToken);
         if (response.StatusCode == HttpStatusCode.NotFound)
             return default;
         response.EnsureSuccessStatusCode();

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/NavSearchRobustnessTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/NavSearchRobustnessTests.cs
@@ -1,0 +1,43 @@
+namespace OvcinaHra.Api.Tests.ClientSmoke;
+
+public class NavSearchRobustnessTests
+{
+    [Fact]
+    public void NavSearch_LogsTransientErrors_AndPassesCancellationToApiClient()
+    {
+        var root = FindRepoRoot();
+        var navSearch = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Layout",
+            "NavSearch.razor"));
+        var apiClient = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Services",
+            "ApiClient.cs"));
+
+        Assert.Contains("@inject ILogger<NavSearch> Logger", navSearch);
+        Assert.Contains("Api.GetAsync<SearchResponseDto>(url, cancellationToken)", navSearch);
+        Assert.Contains("catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)", navSearch);
+        Assert.Contains("Logger.LogWarning(", navSearch);
+        Assert.Contains("{Query}", navSearch);
+        Assert.Contains("{StatusCode}", navSearch);
+        Assert.Contains("{Exception}", navSearch);
+
+        Assert.Contains("GetAsync<T>(string url, CancellationToken cancellationToken = default)", apiClient);
+        Assert.Contains("_http.GetAsync(url, cancellationToken)", apiClient);
+        Assert.Contains("ReadFromJsonAsync<T>(JsonOptions, cancellationToken)", apiClient);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "OvcinaHra.slnx")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not find repository root.");
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/NavSearchRobustnessTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/NavSearchRobustnessTests.cs
@@ -26,9 +26,10 @@ public class NavSearchRobustnessTests
         Assert.Contains("{Query}", navSearch);
         Assert.Contains("{StatusCode}", navSearch);
         Assert.Contains("{Exception}", navSearch);
+        Assert.Contains("exception.GetType().Name", navSearch);
 
         Assert.Contains("GetAsync<T>(string url, CancellationToken cancellationToken = default)", apiClient);
-        Assert.Contains("_http.GetAsync(url, cancellationToken)", apiClient);
+        Assert.Contains("using var response = await _http.GetAsync(url, cancellationToken)", apiClient);
         Assert.Contains("ReadFromJsonAsync<T>(JsonOptions, cancellationToken)", apiClient);
     }
 


### PR DESCRIPTION
## Summary
- Adds a cancellation-aware `ApiClient.GetAsync<T>` overload and threads the NavSearch debounce token into the HTTP call.
- Logs non-cancel NavSearch typeahead failures at warning level with structured `{Query}`, `{StatusCode}`, and `{Exception}` fields while keeping the quiet no-results UX.
- Adds a client-smoke source test covering the logging and cancellation-token wiring.

Closes #302.

## Verification
- `dotnet build OvcinaHra.slnx` passed.
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter "FullyQualifiedName~NavSearchRobustness"` passed: 1/1.
- `dotnet test --no-build` result: API tests passed 479/479; existing E2E failure remains in `SkillsManagementTests.GameSkill_CannotBeRemoved_WhenReferencedByRecipe`, expected `NoContent` but got `Conflict` at `tests/OvcinaHra.E2E/SkillsManagementTests.cs:207`.

## Manual smoke
- Not run in-browser in this pass; verification is build + focused source smoke. The code now passes the debounce token directly into `HttpClient.GetAsync`, so stale typeahead requests are cancellable mid-flight.
