### PR TITLE
refactor(items): extract DeriveIsSold helper

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -7,6 +7,7 @@ using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Domain.ValueObjects;
 using OvcinaHra.Shared.Dtos;
 using OvcinaHra.Shared.Extensions;
+using OvcinaHra.Shared.Utils;
 
 namespace OvcinaHra.Api.Endpoints;
 
@@ -268,7 +269,7 @@ public static class ItemEndpoints
             ItemId = dto.ItemId,
             Price = dto.Price,
             StockCount = dto.StockCount,
-            IsSold = dto.Price is > 0,
+            IsSold = PriceRules.DeriveIsSold(dto.Price),
             SaleCondition = dto.SaleCondition,
             IsFindable = dto.IsFindable
         };
@@ -312,7 +313,7 @@ public static class ItemEndpoints
 
         gi.Price = dto.Price;
         gi.StockCount = dto.StockCount;
-        gi.IsSold = dto.Price is > 0;
+        gi.IsSold = PriceRules.DeriveIsSold(dto.Price);
         gi.SaleCondition = string.IsNullOrWhiteSpace(saleCondition) ? null : saleCondition;
         gi.IsFindable = dto.IsFindable;
 

--- a/src/OvcinaHra.Client/Pages/Items/ItemList.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemList.razor
@@ -4,6 +4,7 @@
 @inject GameContextService GameContext
 @inject NavigationManager Nav
 @inject SkillService SkillSvc
+@using OvcinaHra.Shared.Utils
 
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">@(Catalog ? "Katalog předmětů" : "Předměty")</h1>
@@ -701,7 +702,7 @@ else
                         <DxFormLayoutItem Caption="Cena" ColSpanMd="4">
                             <DxSpinEdit Value="@giPrice"
                                         ValueExpression="@(() => giPrice)"
-                                        ValueChanged="@((int? v) => { giPrice = v; giIsSold = v is > 0; })"
+                                        ValueChanged="@((int? v) => { giPrice = v; giIsSold = PriceRules.DeriveIsSold(v); })"
                                         MinValue="0" NullText="(žádná)" />
                         </DxFormLayoutItem>
                         <DxFormLayoutItem Caption="Počet na skladě" ColSpanMd="4">
@@ -1046,7 +1047,7 @@ else
         var normalizedEffect = string.IsNullOrWhiteSpace(buf.Effect) ? null : buf.Effect.Trim();
         var normalizedSale = string.IsNullOrWhiteSpace(buf.SaleCondition) ? null : buf.SaleCondition.Trim();
         var normalizedNote = string.IsNullOrWhiteSpace(buf.Note) ? null : buf.Note.Trim();
-        var derivedIsSold = buf.Price is > 0;
+        var derivedIsSold = PriceRules.DeriveIsSold(buf.Price);
 
         var perGameChanged = buf.Price != src.Price
             || buf.StockCount != src.StockCount
@@ -1456,7 +1457,7 @@ else
         isSaving = true;
         try
         {
-            giIsSold = giPrice is > 0;
+            giIsSold = PriceRules.DeriveIsSold(giPrice);
             await Api.PutAsync($"/api/items/game-item/{GameContext.SelectedGameId}/{editingId}",
                 new UpdateGameItemDto(giPrice, giStockCount, giIsSold, giSaleCondition, giIsFindable));
         }
@@ -1546,7 +1547,7 @@ else
                 error = "Cena nesmí být záporná.";
                 return;
             }
-            giIsSold = giPrice is > 0;
+            giIsSold = PriceRules.DeriveIsSold(giPrice);
         }
 
         isSaving = true;
@@ -1566,7 +1567,7 @@ else
                 // (e.g. the #99 GameItem-in-use block).
                 if (gameItemExists && GameContext.SelectedGameId is int gid)
                 {
-                    giIsSold = giPrice is > 0;
+                    giIsSold = PriceRules.DeriveIsSold(giPrice);
                     var (ok, problem) = await Api.PutWithProblemAsync(
                         $"/api/items/game-item/{gid}/{editingId}",
                         new UpdateGameItemDto(giPrice, giStockCount, giIsSold, giSaleCondition, giIsFindable));

--- a/src/OvcinaHra.Shared/Utils/PriceRules.cs
+++ b/src/OvcinaHra.Shared/Utils/PriceRules.cs
@@ -1,0 +1,12 @@
+namespace OvcinaHra.Shared.Utils;
+
+public static class PriceRules
+{
+    /// <summary>
+    /// Server canonical rule: an item is "sold" iff its price is greater than zero.
+    /// Setting <c>Price = 0</c> or <c>null</c> auto-clears <c>IsSold</c> to <c>false</c>;
+    /// setting <c>Price &gt; 0</c> auto-sets <c>IsSold</c> to <c>true</c>.
+    /// Use this single helper everywhere the rule is applied so the canon stays single.
+    /// </summary>
+    public static bool DeriveIsSold(int? price) => price is > 0;
+}


### PR DESCRIPTION
Closes #306.

## Summary
- Added `PriceRules.DeriveIsSold(int? price)` in `OvcinaHra.Shared/Utils` as the single C# canon for `Price > 0 -> IsSold`.
- Replaced all target-surface derivations in `ItemList.razor` and `ItemEndpoints.cs` with the helper.
- Left behavior unchanged: `null`/`0` derive `false`, positive prices derive `true`.

## Replaced Sites
- `ItemList.razor`: game-item price editor `ValueChanged` lambda.
- `ItemList.razor`: inline grid buffer save derivation.
- `ItemList.razor`: `SaveGameItemAsync` pre-save guard.
- `ItemList.razor`: `SaveAsync` pre-save guard.
- `ItemList.razor`: `SaveAsync` per-game PUT guard.
- `ItemEndpoints.cs`: create handler.
- `ItemEndpoints.cs`: update handler.

## Verification
- `dotnet build OvcinaHra.slnx` passed, 0 warnings/errors.
- `dotnet test OvcinaHra.slnx --no-build --logger 'console;verbosity=minimal'`: API tests passed 478/478; E2E had the existing unrelated `SkillsManagementTests.GameSkill_CannotBeRemoved_WhenReferencedByRecipe` failure expecting `NoContent` but receiving `Conflict`.
- `dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include ...` passed.
- `git diff --check` passed.