### PR TITLE
test(skills): fix E2E baseline for copied template delete

### DIFF
--- a/tests/OvcinaHra.E2E/SkillsManagementTests.cs
+++ b/tests/OvcinaHra.E2E/SkillsManagementTests.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
 using OvcinaHra.E2E.Fixtures;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
@@ -200,17 +201,22 @@ public class SkillsManagementTests
         Assert.NotNull(stillThere);
         Assert.Contains(stillThere, gs => gs.Id == gameSkill.Id);
 
-        // Template DELETE is independently permitted now — it nulls out TemplateSkillId
-        // on any copy (cascade SetNull). The per-game copy survives the template being
-        // removed, which is the copy-on-assign guarantee.
+        // Because the recipe keeps the per-game copy alive, template DELETE is blocked
+        // by the catalog's usage guard and surfaces Czech ProblemDetails.
         var templateDeleteResp = await client.DeleteAsync($"/api/skills/{template.Id}");
-        Assert.Equal(System.Net.HttpStatusCode.NoContent, templateDeleteResp.StatusCode);
+        Assert.Equal(System.Net.HttpStatusCode.Conflict, templateDeleteResp.StatusCode);
 
-        var afterTemplateGone = await client.GetFromJsonAsync<List<GameSkillDto>>(
+        var problem = await templateDeleteResp.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Dovednost nelze smazat", problem.Title);
+        Assert.Equal((int)System.Net.HttpStatusCode.Conflict, problem.Status);
+        Assert.Contains("Šablona má kopie v 1 hrách.", problem.Detail);
+
+        var afterTemplateDeleteBlocked = await client.GetFromJsonAsync<List<GameSkillDto>>(
             $"/api/games/{game.Id}/skills");
-        Assert.NotNull(afterTemplateGone);
-        var orphan = Assert.Single(afterTemplateGone, gs => gs.Id == gameSkill.Id);
-        Assert.Null(orphan.TemplateSkillId);
-        Assert.Equal("Tichý krok", orphan.Name); // name preserved in the copy
+        Assert.NotNull(afterTemplateDeleteBlocked);
+        var copy = Assert.Single(afterTemplateDeleteBlocked, gs => gs.Id == gameSkill.Id);
+        Assert.Equal(template.Id, copy.TemplateSkillId);
+        Assert.Equal("Tichý krok", copy.Name); // name preserved in the copy
     }
 }


### PR DESCRIPTION
Closes #312.

## Investigation
- The failing assertion was `tests/OvcinaHra.E2E/SkillsManagementTests.cs:206-207`, on `DELETE /api/skills/{template.Id}`.
- The earlier `DELETE /api/games/{game.Id}/skills/{gameSkill.Id}` already asserted and received `409 Conflict` because `DeleteGameSkill` blocks removal when `CraftingSkillRequirements` reference the per-game copy.
- The template delete is also intentionally blocked by `SkillEndpoints.Delete`: it uses an atomic `DELETE ... WHERE NOT EXISTS` guard against existing `GameSkills.TemplateSkillId` copies and returns Czech `ProblemDetails` when copies exist.
- Scenario chosen: A, server is canonical and the test tail was stale. Nuance: the stale expectation was the template-delete tail, not the game-skill delete assertion.

## Change
- Updated the E2E test to expect `409 Conflict` + Czech `ProblemDetails` for deleting a copied skill template.
- Verified the per-game copy survives and remains linked to the template after the blocked delete.

## Verification
- Before: full `dotnet test` baseline had E2E 7/8 with `GameSkill_CannotBeRemoved_WhenReferencedByRecipe` failing `Expected: NoContent`, `Actual: Conflict`.
- `dotnet test tests/OvcinaHra.E2E/OvcinaHra.E2E.csproj --filter 'FullyQualifiedName~SkillsManagementTests.GameSkill_CannotBeRemoved_WhenReferencedByRecipe' --logger 'console;verbosity=minimal'` passed 1/1.
- `dotnet build OvcinaHra.slnx` passed, 0 warnings/errors.
- `dotnet test OvcinaHra.slnx --no-build --logger 'console;verbosity=minimal'` passed: E2E 8/8, API 479/479.
- `dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include tests/OvcinaHra.E2E/SkillsManagementTests.cs` passed.
- `git diff --check` passed.