### PR TITLE
fix(consult): polish drawer icon and enter send

### DIFF
--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor
@@ -1,5 +1,7 @@
 @inject ApiClient Api
 @inject IJSRuntime Js
+@inject ILogger<BotConsultDrawer> Logger
+@implements IAsyncDisposable
 
 @if (_enabled)
 {
@@ -17,7 +19,17 @@
         <section class="oh-bot-drawer @PersonaClass" aria-label="Zeptat se Drozda">
             <header class="oh-bot-header">
                 <div>
-                    <h2>Zeptat se Drozda</h2>
+                    <div class="oh-bot-title">
+                        @if (!_drozdIconFailed)
+                        {
+                            <img class="oh-bot-title-drozd"
+                                 src="img/drozd/drozd-idle.svg"
+                                 alt=""
+                                 aria-hidden="true"
+                                 @onerror="HideDrozdIcon" />
+                        }
+                        <h2>Zeptat se Drozda</h2>
+                    </div>
                     <div class="oh-bot-personas" role="tablist" aria-label="Drozdova odbornost">
                         <button type="button"
                                 class="@PersonaButtonClass("rulemaster")"
@@ -77,6 +89,7 @@
             <footer class="oh-bot-input">
                 <textarea @bind="_draft"
                           @bind:event="oninput"
+                          @ref="_draftInput"
                           disabled="@_sending"
                           rows="3"
                           maxlength="4000"
@@ -103,20 +116,29 @@
     private bool _enabled;
     private bool _open;
     private bool _sending;
+    private bool _drozdIconFailed;
+    private bool _draftShortcutAttached;
+    private bool _draftShortcutUnavailable;
     private string _persona = Loremaster;
     private string _draft = string.Empty;
+    private ElementReference _draftInput;
+    private IJSObjectReference? _keyboardModule;
+    private DotNetObjectReference<BotConsultDrawer>? _selfReference;
 
     private bool CanSend => !_sending && !string.IsNullOrWhiteSpace(_draft);
     private string PersonaClass => PersonaClassFor(_persona);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (!firstRender)
-            return;
+        if (firstRender)
+        {
+            await LoadAvailabilityAsync();
+            await LoadPersonaAsync();
+            StateHasChanged();
+        }
 
-        await LoadAvailabilityAsync();
-        await LoadPersonaAsync();
-        StateHasChanged();
+        if (_open && !_draftShortcutAttached && !_draftShortcutUnavailable)
+            await AttachDraftShortcutAsync();
     }
 
     private async Task LoadAvailabilityAsync()
@@ -154,9 +176,19 @@
         }
     }
 
-    private void Open() => _open = true;
+    private void Open()
+    {
+        _open = true;
+        _draftShortcutAttached = false;
+    }
 
-    private void Close() => _open = false;
+    private void Close()
+    {
+        _open = false;
+        _draftShortcutAttached = false;
+    }
+
+    private void HideDrozdIcon() => _drozdIconFailed = true;
 
     private async Task SetPersonaAsync(string persona)
     {
@@ -211,6 +243,55 @@
         {
             _sending = false;
         }
+    }
+
+    [JSInvokable]
+    public async Task SendDraftFromKeyboardAsync()
+    {
+        await SendAsync();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task AttachDraftShortcutAsync()
+    {
+        try
+        {
+            _keyboardModule ??= await Js.InvokeAsync<IJSObjectReference>(
+                "import",
+                "./Components/BotConsultDrawer.razor.js");
+            _selfReference ??= DotNetObjectReference.Create(this);
+            await _keyboardModule.InvokeVoidAsync("attachEnterToSend", _draftInput, _selfReference);
+            _draftShortcutAttached = true;
+        }
+        catch (JSException ex)
+        {
+            DisableDraftShortcut(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            DisableDraftShortcut(ex);
+        }
+    }
+
+    private void DisableDraftShortcut(Exception exception)
+    {
+        _draftShortcutUnavailable = true;
+        Logger.LogWarning(exception, "Bot consult drawer Enter-to-send shortcut failed to attach.");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_keyboardModule is not null)
+                await _keyboardModule.DisposeAsync();
+        }
+        catch (JSException ex)
+        {
+            Logger.LogDebug(ex, "Bot consult drawer keyboard module disposal failed.");
+        }
+
+        _selfReference?.Dispose();
     }
 
     private static string PersonaClassFor(string persona)

--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.css
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.css
@@ -58,11 +58,37 @@
 }
 
 .oh-bot-header h2 {
-    margin: 0 0 0.75rem;
+    margin: 0;
     font-family: var(--oh-font-heading);
     font-size: 1.05rem;
     font-weight: 700;
     letter-spacing: 0;
+}
+
+.oh-bot-title {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-bottom: 0.75rem;
+}
+
+.oh-bot-title-drozd {
+    width: 2.25rem;
+    height: 2.25rem;
+    flex: 0 0 auto;
+    filter: drop-shadow(0 2px 3px rgba(44, 24, 16, 0.3));
+    animation: oh-bot-drozd-bop 4.5s ease-in-out infinite;
+}
+
+@keyframes oh-bot-drozd-bop {
+    0%,
+    100% {
+        transform: translateY(0);
+    }
+
+    50% {
+        transform: translateY(-2px);
+    }
 }
 
 .oh-bot-icon-button {

--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.js
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.js
@@ -1,0 +1,42 @@
+export function attachEnterToSend(textarea, dotNetRef) {
+    if (!textarea) {
+        return;
+    }
+
+    if (textarea._ohBotEnterHandler) {
+        textarea.removeEventListener('keydown', textarea._ohBotEnterHandler);
+    }
+
+    let sending = false;
+    const handler = async (event) => {
+        if (event.key !== 'Enter'
+            || event.shiftKey
+            || event.altKey
+            || event.ctrlKey
+            || event.metaKey
+            || event.isComposing) {
+            return;
+        }
+
+        event.preventDefault();
+
+        if (event.repeat
+            || sending
+            || !textarea.value
+            || textarea.value.trim().length === 0) {
+            return;
+        }
+
+        sending = true;
+        try {
+            await dotNetRef.invokeMethodAsync('SendDraftFromKeyboardAsync');
+        } catch (error) {
+            console.warn('Bot consult drawer Enter-to-send failed.', error);
+        } finally {
+            sending = false;
+        }
+    };
+
+    textarea._ohBotEnterHandler = handler;
+    textarea.addEventListener('keydown', handler);
+}

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/BotConsultDrawerSmokeTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/BotConsultDrawerSmokeTests.cs
@@ -24,14 +24,28 @@ public class BotConsultDrawerSmokeTests
             "OvcinaHra.Client",
             "Components",
             "BotConsultDrawer.razor.css"));
+        var keyboardJs = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Components",
+            "BotConsultDrawer.razor.js"));
 
         Assert.Contains("<AuthorizeView>", layout);
         Assert.Contains("<BotConsultDrawer />", layout);
         Assert.Contains("/api/consult/available", drawer);
+        Assert.Contains("@inject ILogger<BotConsultDrawer> Logger", drawer);
         Assert.Contains("oh-bot-last-persona", drawer);
         Assert.Contains("rulemaster", drawer);
         Assert.Contains("loremaster", drawer);
         Assert.Contains("Zeptat se Drozda", drawer);
+        Assert.Contains("img/drozd/drozd-idle.svg", drawer);
+        Assert.Contains("@onerror=\"HideDrozdIcon\"", drawer);
+        Assert.Contains("@ref=\"_draftInput\"", drawer);
+        Assert.Contains("SendDraftFromKeyboardAsync", drawer);
+        Assert.Contains("./Components/BotConsultDrawer.razor.js", drawer);
+        Assert.Contains("_draftShortcutUnavailable", drawer);
+        Assert.Contains("Logger.LogWarning", drawer);
         Assert.Contains("Drozd přemýšlí…", drawer);
         Assert.Contains("Zeptej se Drozda…", drawer);
         Assert.Contains("Pravidla", drawer);
@@ -40,8 +54,17 @@ public class BotConsultDrawerSmokeTests
         Assert.Contains("Zavřít", drawer);
         Assert.Contains("--oh-color-forest-deep", css);
         Assert.Contains("--oh-color-azanulinbar", css);
+        Assert.Contains(".oh-bot-title-drozd", css);
         Assert.Contains("@media (max-width: 767.98px)", css);
         Assert.Contains("height: 100dvh;", css);
+
+        Assert.Contains("event.key !== 'Enter'", keyboardJs);
+        Assert.Contains("event.shiftKey", keyboardJs);
+        Assert.Contains("event.preventDefault();", keyboardJs);
+        Assert.Contains("event.repeat", keyboardJs);
+        Assert.Contains("await dotNetRef.invokeMethodAsync('SendDraftFromKeyboardAsync')", keyboardJs);
+        Assert.Contains("textarea.value.trim().length === 0", keyboardJs);
+        Assert.Contains("SendDraftFromKeyboardAsync", keyboardJs);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add the canonical Drozd idle SVG next to the bot consult drawer header, with a lightweight fallback if the local image ever fails to load.
- Add a drawer-local key handler so plain Enter sends, Shift+Enter keeps the textarea newline behavior, and empty Enter no-ops.
- Extend the drawer smoke assertions for the new icon and keyboard-send wiring.

## Verification
- `dotnet build OvcinaHra.slnx`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter "FullyQualifiedName~BotConsultDrawerSmokeTests"`
- `dotnet test OvcinaHra.slnx --no-build`
- Manual browser smoke with local API/client plus stub bot:
  1. local `dotnet run` API/client launched and drawer FAB became available
  2. drawer opened; Drozd icon visible at 34x34
  3. typed message + Enter sent `POST /api/consult/loremaster` and rendered the bot reply
  4. Shift+Enter inserted a newline and did not send
  5. empty textarea + Enter was a silent no-op
  6. mobile viewport 390x760 kept drawer layout usable, icon visible, and persona tabs visible

Closes #315.
