### PR TITLE
feat(cipher): add location cipher authoring [v0.15.112]

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/LocationCipherConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/LocationCipherConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class LocationCipherConfiguration : IEntityTypeConfiguration<LocationCipher>
+{
+    public void Configure(EntityTypeBuilder<LocationCipher> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.SkillKey).HasConversion<string>().HasMaxLength(40);
+        builder.Property(e => e.MessageRaw).IsRequired().HasMaxLength(500);
+        builder.Property(e => e.MessageNormalized).IsRequired().HasMaxLength(80);
+
+        builder.HasOne(e => e.Game).WithMany().HasForeignKey(e => e.GameId);
+        builder.HasOne(e => e.Location).WithMany().HasForeignKey(e => e.LocationId);
+        builder.HasOne(e => e.Quest).WithMany().HasForeignKey(e => e.QuestId).OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasIndex(e => new { e.GameId, e.LocationId, e.SkillKey }).IsUnique();
+        builder.HasIndex(e => new { e.GameId, e.LocationId });
+
+        builder.ToTable(t =>
+        {
+            t.HasCheckConstraint("CK_LocationCipher_MessageNormalized_NotEmpty",
+                "char_length(\"MessageNormalized\") > 0");
+            t.HasCheckConstraint("CK_LocationCipher_MessageNormalized_MaxBySkill",
+                $"(\"SkillKey\" = '{CipherSkillKey.Lezeni}' AND char_length(\"MessageNormalized\") <= 72) OR (\"SkillKey\" <> '{CipherSkillKey.Lezeni}' AND char_length(\"MessageNormalized\") <= 74)");
+        });
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -40,6 +40,7 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<QuestEncounter> QuestEncounters => Set<QuestEncounter>();
     public DbSet<QuestReward> QuestRewards => Set<QuestReward>();
     public DbSet<QuestWaypoint> QuestWaypoints => Set<QuestWaypoint>();
+    public DbSet<LocationCipher> LocationCiphers => Set<LocationCipher>();
     public DbSet<SecretStash> SecretStashes => Set<SecretStash>();
     public DbSet<GameSecretStash> GameSecretStashes => Set<GameSecretStash>();
     public DbSet<TreasureQuest> TreasureQuests => Set<TreasureQuest>();

--- a/src/OvcinaHra.Api/Endpoints/LocationCipherEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationCipherEndpoints.cs
@@ -70,6 +70,9 @@ public static class LocationCipherEndpoints
             return TypedResults.NotFound();
 
         var rawMessage = dto.MessageRaw?.Trim() ?? "";
+        if (rawMessage.Length > 500)
+            return TypedResults.BadRequest(ValidationProblem("Zpráva má příliš mnoho znaků. Maximum je 500 včetně mezer a interpunkce."));
+
         var normalized = CipherTextNormalizer.NormalizeMessage(rawMessage);
         var validationProblem = ValidateMessage(normalized, skillKey);
         if (validationProblem is not null)

--- a/src/OvcinaHra.Api/Endpoints/LocationCipherEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationCipherEndpoints.cs
@@ -1,0 +1,179 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Ciphers;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+using OvcinaHra.Shared.Extensions;
+
+namespace OvcinaHra.Api.Endpoints;
+
+public static class LocationCipherEndpoints
+{
+    public static RouteGroupBuilder MapLocationCipherEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/location-ciphers").WithTags("LocationCiphers");
+
+        group.MapGet("/{gameId:int}/{locationId:int}", GetByLocation);
+        group.MapPut("/{gameId:int}/{locationId:int}/{skillSlug}", Upsert);
+        group.MapDelete("/{gameId:int}/{locationId:int}/{skillSlug}", Delete);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<List<LocationCipherSlotDto>>, NotFound>> GetByLocation(
+        int gameId, int locationId, WorldDbContext db)
+    {
+        if (!await IsLocationInGameAsync(db, gameId, locationId))
+            return TypedResults.NotFound();
+
+        var rows = await db.LocationCiphers
+            .Where(c => c.GameId == gameId && c.LocationId == locationId)
+            .Select(c => new
+            {
+                c.Id,
+                c.GameId,
+                c.LocationId,
+                c.SkillKey,
+                c.MessageRaw,
+                c.MessageNormalized,
+                c.QuestId,
+                QuestName = c.Quest == null ? null : c.Quest.Name
+            })
+            .ToListAsync();
+
+        var bySkill = rows.ToDictionary(c => c.SkillKey, c => ToDto(
+            c.Id, c.GameId, c.LocationId, c.SkillKey, c.MessageRaw,
+            c.MessageNormalized, c.QuestId, c.QuestName));
+
+        var slots = CipherSkillKeyExtensions.All
+            .Select(skill => new LocationCipherSlotDto(
+                skill,
+                skill.GetSlug(),
+                skill.GetDisplayName(),
+                skill.GetMaxMessageLetters(),
+                bySkill.GetValueOrDefault(skill)))
+            .ToList();
+
+        return TypedResults.Ok(slots);
+    }
+
+    private static async Task<Results<NoContent, NotFound, BadRequest<ProblemDetails>>> Upsert(
+        int gameId, int locationId, string skillSlug, UpsertLocationCipherDto dto, WorldDbContext db)
+    {
+        if (!CipherSkillKeyExtensions.TryParseSlug(skillSlug, out var skillKey))
+            return TypedResults.BadRequest(ValidationProblem($"Neznámá šifrovací dovednost '{skillSlug}'."));
+
+        if (!await IsLocationInGameAsync(db, gameId, locationId))
+            return TypedResults.NotFound();
+
+        var rawMessage = dto.MessageRaw?.Trim() ?? "";
+        var normalized = CipherTextNormalizer.NormalizeMessage(rawMessage);
+        var validationProblem = ValidateMessage(normalized, skillKey);
+        if (validationProblem is not null)
+            return TypedResults.BadRequest(validationProblem);
+
+        if (dto.QuestId.HasValue && !await IsQuestValidForLocationAsync(db, gameId, locationId, dto.QuestId.Value))
+            return TypedResults.BadRequest(ValidationProblem("Vybraný quest nepatří k této lokaci v aktuální hře."));
+
+        var cipher = await db.LocationCiphers.FirstOrDefaultAsync(c =>
+            c.GameId == gameId && c.LocationId == locationId && c.SkillKey == skillKey);
+
+        if (cipher is null)
+        {
+            cipher = new LocationCipher
+            {
+                GameId = gameId,
+                LocationId = locationId,
+                SkillKey = skillKey,
+                MessageRaw = rawMessage,
+                MessageNormalized = normalized,
+                QuestId = dto.QuestId
+            };
+            db.LocationCiphers.Add(cipher);
+        }
+        else
+        {
+            cipher.MessageRaw = rawMessage;
+            cipher.MessageNormalized = normalized;
+            cipher.QuestId = dto.QuestId;
+        }
+
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound, BadRequest<ProblemDetails>>> Delete(
+        int gameId, int locationId, string skillSlug, WorldDbContext db)
+    {
+        if (!CipherSkillKeyExtensions.TryParseSlug(skillSlug, out var skillKey))
+            return TypedResults.BadRequest(ValidationProblem($"Neznámá šifrovací dovednost '{skillSlug}'."));
+
+        var cipher = await db.LocationCiphers.FirstOrDefaultAsync(c =>
+            c.GameId == gameId && c.LocationId == locationId && c.SkillKey == skillKey);
+        if (cipher is null)
+            return TypedResults.NotFound();
+
+        db.LocationCiphers.Remove(cipher);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<bool> IsLocationInGameAsync(WorldDbContext db, int gameId, int locationId) =>
+        await db.GameLocations.AnyAsync(gl => gl.GameId == gameId && gl.LocationId == locationId);
+
+    private static async Task<bool> IsQuestValidForLocationAsync(
+        WorldDbContext db, int gameId, int locationId, int questId) =>
+        await db.Quests.AnyAsync(q =>
+            q.Id == questId
+            && (q.GameId == null || q.GameId == gameId)
+            && q.QuestLocations.Any(ql => ql.LocationId == locationId));
+
+    private static ProblemDetails? ValidateMessage(string normalized, CipherSkillKey skillKey)
+    {
+        if (normalized.Length == 0)
+            return ValidationProblem("Zpráva musí obsahovat alespoň jedno písmeno A-Z.");
+
+        var max = skillKey.GetMaxMessageLetters();
+        if (normalized.Length > max)
+            return ValidationProblem($"Zpráva pro {skillKey.GetDisplayName()} má {normalized.Length} znaků po normalizaci. Maximum je {max}.");
+
+        return null;
+    }
+
+    private static LocationCipherDto ToDto(
+        int id,
+        int gameId,
+        int locationId,
+        CipherSkillKey skillKey,
+        string messageRaw,
+        string messageNormalized,
+        int? questId,
+        string? questName)
+    {
+        var encoded = $"XOX{messageNormalized}XOX";
+        return new LocationCipherDto(
+            id,
+            gameId,
+            locationId,
+            skillKey,
+            skillKey.GetSlug(),
+            skillKey.GetDisplayName(),
+            skillKey.GetMaxMessageLetters(),
+            messageRaw,
+            messageNormalized,
+            encoded,
+            encoded.Length,
+            questId,
+            questName);
+    }
+
+    private static ProblemDetails ValidationProblem(string detail) => new()
+    {
+        Title = "Šifru nejde uložit",
+        Detail = detail,
+        Status = StatusCodes.Status400BadRequest
+    };
+}

--- a/src/OvcinaHra.Api/Migrations/20260427184757_AddLocationCiphers.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260427184757_AddLocationCiphers.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260427184757_AddLocationCiphers")]
+    partial class AddLocationCiphers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260427184757_AddLocationCiphers.cs
+++ b/src/OvcinaHra.Api/Migrations/20260427184757_AddLocationCiphers.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLocationCiphers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LocationCiphers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    LocationId = table.Column<int>(type: "integer", nullable: false),
+                    SkillKey = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    MessageRaw = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    MessageNormalized = table.Column<string>(type: "character varying(80)", maxLength: 80, nullable: false),
+                    QuestId = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LocationCiphers", x => x.Id);
+                    table.CheckConstraint("CK_LocationCipher_MessageNormalized_MaxBySkill", "(\"SkillKey\" = 'Lezeni' AND char_length(\"MessageNormalized\") <= 72) OR (\"SkillKey\" <> 'Lezeni' AND char_length(\"MessageNormalized\") <= 74)");
+                    table.CheckConstraint("CK_LocationCipher_MessageNormalized_NotEmpty", "char_length(\"MessageNormalized\") > 0");
+                    table.ForeignKey(
+                        name: "FK_LocationCiphers_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LocationCiphers_Locations_LocationId",
+                        column: x => x.LocationId,
+                        principalTable: "Locations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LocationCiphers_Quests_QuestId",
+                        column: x => x.QuestId,
+                        principalTable: "Quests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LocationCiphers_GameId_LocationId",
+                table: "LocationCiphers",
+                columns: new[] { "GameId", "LocationId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LocationCiphers_GameId_LocationId_SkillKey",
+                table: "LocationCiphers",
+                columns: new[] { "GameId", "LocationId", "SkillKey" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LocationCiphers_LocationId",
+                table: "LocationCiphers",
+                column: "LocationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LocationCiphers_QuestId",
+                table: "LocationCiphers",
+                column: "QuestId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LocationCiphers");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -253,6 +253,7 @@ try
     app.MapCraftingEndpoints().RequireAuthorization();
     app.MapRecipeEndpoints().RequireAuthorization();
     app.MapBuildingRecipeEndpoints().RequireAuthorization();
+    app.MapLocationCipherEndpoints().RequireAuthorization();
     app.MapTreasureQuestEndpoints().RequireAuthorization();
     app.MapPersonalQuestEndpoints().RequireAuthorization();
     app.MapTreasurePlanningEndpoints().RequireAuthorization();

--- a/src/OvcinaHra.Client/Pages/Locations/LocationCiphersPanel.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationCiphersPanel.razor
@@ -1,0 +1,246 @@
+@inject ApiClient Api
+@using OvcinaHra.Shared.Ciphers
+@using OvcinaHra.Shared.Dtos
+
+<section class="oh-cipher-panel">
+    <div class="oh-cipher-panel-head">
+        <div>
+            <h2>Šifry</h2>
+            <p>@DefinedCount / 5 připraveno</p>
+        </div>
+    </div>
+
+    @if (loading)
+    {
+        <p class="text-muted">Načítám šifry…</p>
+    }
+    else if (loadError is not null)
+    {
+        <div class="oh-drozd-val mb-3">
+            <i class="bi bi-exclamation-circle oh-drozd-val-icon"></i>
+            <div>
+                <div class="oh-drozd-val-title">Šifry se nepodařilo načíst</div>
+                <div class="oh-drozd-val-msg">@loadError</div>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="oh-cipher-list">
+            @foreach (var state in states)
+            {
+                <article class="oh-cipher-slot @(state.HasCipher ? "has-cipher" : "")" @key="state.Slot.SkillSlug">
+                    <div class="oh-cipher-slot-head">
+                        <div>
+                            <h3>@state.Slot.SkillName</h3>
+                            @if (state.Slot.Cipher?.QuestName is { Length: > 0 } questName)
+                            {
+                                <p>@questName</p>
+                            }
+                        </div>
+                        <span class="oh-cipher-counter @(IsOverLimit(state) ? "over" : "")">
+                            @NormalizedLength(state) / @state.Slot.MaxMessageLetters
+                        </span>
+                    </div>
+
+                    <DxMemo @bind-Text="@state.MessageRaw" Rows="2" NullText="Zpráva bez diakritiky…" />
+
+                    <div class="oh-cipher-preview">
+                        <span>Náhled</span>
+                        <code>@EncodedPreview(state)</code>
+                    </div>
+
+                    @if (state.Error is not null)
+                    {
+                        <div class="oh-cipher-error">@state.Error</div>
+                    }
+
+                    <div class="oh-cipher-actions">
+                        <button class="btn btn-primary btn-sm" type="button"
+                                disabled="@(!CanSave(state))"
+                                @onclick="() => SaveAsync(state)">
+                            @if (state.IsSaving)
+                            {
+                                <span class="spinner-border spinner-border-sm me-1"></span>
+                            }
+                            Uložit
+                        </button>
+                        @if (state.HasCipher)
+                        {
+                            <button class="btn btn-outline-danger btn-sm" type="button"
+                                    disabled="@state.IsSaving"
+                                    @onclick="() => OpenDeleteConfirm(state)">
+                                <i class="bi bi-trash me-1"></i> Smazat
+                            </button>
+                        }
+                    </div>
+                </article>
+            }
+        </div>
+    }
+</section>
+
+<DxPopup @bind-Visible="@isDeleteVisible" HeaderText="Smazat šifru?" Width="420px">
+    <BodyContentTemplate>
+        <p>Smazat zprávu pro dovednost <strong>@deleteTarget?.Slot.SkillName</strong>?</p>
+        @if (deleteError is not null)
+        {
+            <div class="oh-drozd-val mb-3">
+                <i class="bi bi-exclamation-circle oh-drozd-val-icon"></i>
+                <div>
+                    <div class="oh-drozd-val-title">Smazání se nezdařilo</div>
+                    <div class="oh-drozd-val-msg">@deleteError</div>
+                </div>
+            </div>
+        }
+        <div class="d-flex justify-content-end gap-2">
+            <button class="btn btn-secondary" type="button" @onclick="CloseDeleteConfirm">Zrušit</button>
+            <button class="btn btn-danger" type="button" @onclick="ConfirmDeleteAsync" disabled="@(deleteTarget?.IsSaving == true)">
+                Smazat
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    [Parameter] public int GameId { get; set; }
+    [Parameter] public int LocationId { get; set; }
+
+    private readonly List<CipherEditState> states = [];
+    private bool loading = true;
+    private string? loadError;
+    private int? loadedGameId;
+    private int? loadedLocationId;
+    private bool isDeleteVisible;
+    private string? deleteError;
+    private CipherEditState? deleteTarget;
+
+    private int DefinedCount => states.Count(s => s.HasCipher);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (loadedGameId == GameId && loadedLocationId == LocationId)
+            return;
+
+        loadedGameId = GameId;
+        loadedLocationId = LocationId;
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        loadError = null;
+        states.Clear();
+
+        try
+        {
+            var slots = await Api.GetListAsync<LocationCipherSlotDto>(
+                $"/api/location-ciphers/{GameId}/{LocationId}");
+            states.AddRange(slots.Select(slot => new CipherEditState(slot)));
+        }
+        catch (Exception ex)
+        {
+            loadError = ex.Message;
+        }
+        finally
+        {
+            loading = false;
+        }
+    }
+
+    private async Task SaveAsync(CipherEditState state)
+    {
+        if (!CanSave(state)) return;
+
+        state.IsSaving = true;
+        state.Error = null;
+        try
+        {
+            var dto = new UpsertLocationCipherDto(state.MessageRaw, state.QuestId);
+            var (ok, problem) = await Api.PutWithProblemAsync(
+                $"/api/location-ciphers/{GameId}/{LocationId}/{state.Slot.SkillSlug}", dto);
+            if (!ok)
+            {
+                state.Error = problem ?? "Šifru se nepodařilo uložit.";
+                return;
+            }
+
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            state.Error = ex.Message;
+        }
+        finally
+        {
+            state.IsSaving = false;
+        }
+    }
+
+    private void OpenDeleteConfirm(CipherEditState state)
+    {
+        deleteTarget = state;
+        deleteError = null;
+        isDeleteVisible = true;
+    }
+
+    private void CloseDeleteConfirm()
+    {
+        isDeleteVisible = false;
+        deleteTarget = null;
+        deleteError = null;
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        if (deleteTarget is null) return;
+
+        deleteTarget.IsSaving = true;
+        deleteError = null;
+        try
+        {
+            var (ok, problem) = await Api.DeleteWithProblemAsync(
+                $"/api/location-ciphers/{GameId}/{LocationId}/{deleteTarget.Slot.SkillSlug}");
+            if (!ok)
+            {
+                deleteError = problem ?? "Šifru se nepodařilo smazat.";
+                return;
+            }
+
+            CloseDeleteConfirm();
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            deleteError = ex.Message;
+        }
+        finally
+        {
+            if (deleteTarget is not null)
+                deleteTarget.IsSaving = false;
+        }
+    }
+
+    private static bool CanSave(CipherEditState state) =>
+        !state.IsSaving && NormalizedLength(state) > 0 && !IsOverLimit(state);
+
+    private static bool IsOverLimit(CipherEditState state) =>
+        NormalizedLength(state) > state.Slot.MaxMessageLetters;
+
+    private static int NormalizedLength(CipherEditState state) =>
+        CipherTextNormalizer.NormalizeMessage(state.MessageRaw).Length;
+
+    private static string EncodedPreview(CipherEditState state) =>
+        CipherTextNormalizer.BuildEncodedPreview(state.MessageRaw);
+
+    private sealed class CipherEditState(LocationCipherSlotDto slot)
+    {
+        public LocationCipherSlotDto Slot { get; } = slot;
+        public string MessageRaw { get; set; } = slot.Cipher?.MessageRaw ?? "";
+        public int? QuestId { get; set; } = slot.Cipher?.QuestId;
+        public bool IsSaving { get; set; }
+        public string? Error { get; set; }
+        public bool HasCipher => Slot.Cipher is not null;
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -100,6 +100,12 @@ else
                     <span class="oh-lc-count">@locationQuests.Count</span>
                 </button>
             }
+            @if (IsGameScoped)
+            {
+                <button class="oh-lc-tab @(activeTab == "sifry" ? "active" : "")" @onclick='() => SwitchTab("sifry")'>
+                    <i class="bi bi-grid-3x3-gap"></i> Šifry
+                </button>
+            }
         </div>
 
         @if (error is not null)
@@ -408,6 +414,11 @@ else
                 }
             </div>
         }
+
+        @if (activeTab == "sifry" && GameContext.SelectedGameId is int cipherGameId)
+        {
+            <LocationCiphersPanel GameId="@cipherGameId" LocationId="@Id" />
+        }
     </div>
 }
 
@@ -617,6 +628,7 @@ else
     {
         if (tab == "skryse" && !HasStashes) return;
         if (tab == "questy" && !HasQuests) return;
+        if (tab == "sifry" && !IsGameScoped) return;
         activeTab = tab;
     }
 
@@ -624,6 +636,7 @@ else
     {
         if (activeTab == "skryse" && !HasStashes) activeTab = "karta";
         if (activeTab == "questy" && !HasQuests) activeTab = "karta";
+        if (activeTab == "sifry" && !IsGameScoped) activeTab = "karta";
     }
 
     private void OnParentLocationChanged(int? value)

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -4170,3 +4170,27 @@ body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label{display:block}
 .oh-rec-popup-section{padding:14px;background:#FFF8F0;border:1px solid #ead9b8;border-radius:8px}
 .oh-rec-popup-section h6{font:700 .9rem/1 var(--oh-font-headline,Merriweather,Georgia,serif);
     color:#5a3a18;margin:0 0 10px;display:flex;align-items:center;gap:6px}
+
+/* Location cipher authoring */
+.oh-cipher-panel{display:flex;flex-direction:column;gap:14px}
+.oh-cipher-panel-head{display:flex;justify-content:space-between;align-items:flex-end;gap:12px}
+.oh-cipher-panel-head h2{font:700 1.35rem/1.15 var(--oh-font-headline,Merriweather,Georgia,serif);
+    color:#2a2218;margin:0}
+.oh-cipher-panel-head p{margin:4px 0 0;color:#6f6248;font-size:.9rem}
+.oh-cipher-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:14px}
+.oh-cipher-slot{border:1px solid #d8c9a8;border-radius:8px;background:#fffaf0;padding:14px;
+    display:flex;flex-direction:column;gap:10px}
+.oh-cipher-slot.has-cipher{border-color:#b26223;box-shadow:inset 3px 0 0 #b26223}
+.oh-cipher-slot-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+.oh-cipher-slot-head h3{margin:0;color:#2a2218;font:700 1rem/1.2 var(--oh-font-headline,Merriweather,Georgia,serif)}
+.oh-cipher-slot-head p{margin:3px 0 0;color:#6f6248;font-size:.85rem}
+.oh-cipher-counter{white-space:nowrap;border-radius:999px;padding:3px 8px;background:#ece3cf;color:#4c422f;
+    font-weight:700;font-size:.8rem}
+.oh-cipher-counter.over{background:#f8d7da;color:#842029}
+.oh-cipher-preview{display:flex;flex-direction:column;gap:4px}
+.oh-cipher-preview span{color:#6f6248;font-size:.78rem;text-transform:uppercase;font-weight:700}
+.oh-cipher-preview code{display:block;min-height:34px;padding:7px 8px;border-radius:6px;background:#2a2218;color:#f8f0dc;
+    white-space:normal;word-break:break-word;font-size:.83rem}
+.oh-cipher-error{border-left:3px solid #842029;background:#f8d7da;color:#842029;border-radius:3px;padding:8px 10px;font-size:.88rem}
+.oh-cipher-actions{display:flex;justify-content:flex-end;gap:8px}
+@media (max-width:720px){.oh-cipher-actions{justify-content:flex-start;flex-wrap:wrap}}

--- a/src/OvcinaHra.Shared/Ciphers/CipherTextNormalizer.cs
+++ b/src/OvcinaHra.Shared/Ciphers/CipherTextNormalizer.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+using System.Text;
+
+namespace OvcinaHra.Shared.Ciphers;
+
+public static class CipherTextNormalizer
+{
+    public static string NormalizeMessage(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message)) return "";
+
+        var decomposed = message.Normalize(NormalizationForm.FormD);
+        var result = new StringBuilder(decomposed.Length);
+
+        foreach (var ch in decomposed)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) == UnicodeCategory.NonSpacingMark)
+                continue;
+
+            var upper = char.ToUpperInvariant(ch);
+            if (upper is >= 'A' and <= 'Z')
+                result.Append(upper);
+        }
+
+        return result.ToString();
+    }
+
+    public static string BuildEncodedPreview(string? message) =>
+        $"XOX{NormalizeMessage(message)}XOX";
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/LocationCipher.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/LocationCipher.cs
@@ -1,0 +1,18 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class LocationCipher
+{
+    public int Id { get; set; }
+    public int GameId { get; set; }
+    public int LocationId { get; set; }
+    public CipherSkillKey SkillKey { get; set; }
+    public required string MessageRaw { get; set; }
+    public required string MessageNormalized { get; set; }
+    public int? QuestId { get; set; }
+
+    public Game Game { get; set; } = null!;
+    public Location Location { get; set; } = null!;
+    public Quest? Quest { get; set; }
+}

--- a/src/OvcinaHra.Shared/Domain/Enums/CipherSkillKey.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/CipherSkillKey.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Domain.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum CipherSkillKey
+{
+    HledaniMagie,
+    Prohledavani,
+    SestySmysl,
+    ZnalostBytosti,
+    Lezeni
+}

--- a/src/OvcinaHra.Shared/Dtos/LocationCipherDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/LocationCipherDtos.cs
@@ -1,0 +1,27 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Dtos;
+
+public record LocationCipherSlotDto(
+    CipherSkillKey SkillKey,
+    string SkillSlug,
+    string SkillName,
+    int MaxMessageLetters,
+    LocationCipherDto? Cipher);
+
+public record LocationCipherDto(
+    int Id,
+    int GameId,
+    int LocationId,
+    CipherSkillKey SkillKey,
+    string SkillSlug,
+    string SkillName,
+    int MaxMessageLetters,
+    string MessageRaw,
+    string MessageNormalized,
+    string EncodedPreview,
+    int EncodedLength,
+    int? QuestId,
+    string? QuestName);
+
+public record UpsertLocationCipherDto(string MessageRaw, int? QuestId = null);

--- a/src/OvcinaHra.Shared/Extensions/CipherSkillKeyExtensions.cs
+++ b/src/OvcinaHra.Shared/Extensions/CipherSkillKeyExtensions.cs
@@ -1,0 +1,54 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Extensions;
+
+public static class CipherSkillKeyExtensions
+{
+    public static readonly IReadOnlyList<CipherSkillKey> All =
+    [
+        CipherSkillKey.HledaniMagie,
+        CipherSkillKey.Prohledavani,
+        CipherSkillKey.SestySmysl,
+        CipherSkillKey.ZnalostBytosti,
+        CipherSkillKey.Lezeni
+    ];
+
+    public static string GetDisplayName(this CipherSkillKey key) => key switch
+    {
+        CipherSkillKey.HledaniMagie => "Hledání magie",
+        CipherSkillKey.Prohledavani => "Prohledávání",
+        CipherSkillKey.SestySmysl => "Šestý smysl",
+        CipherSkillKey.ZnalostBytosti => "Znalost bytostí",
+        CipherSkillKey.Lezeni => "Lezení",
+        _ => key.ToString()
+    };
+
+    public static string GetSlug(this CipherSkillKey key) => key switch
+    {
+        CipherSkillKey.HledaniMagie => "hledani-magie",
+        CipherSkillKey.Prohledavani => "prohledavani",
+        CipherSkillKey.SestySmysl => "sesty-smysl",
+        CipherSkillKey.ZnalostBytosti => "znalost-bytosti",
+        CipherSkillKey.Lezeni => "lezeni",
+        _ => key.ToString()
+    };
+
+    public static int GetMaxMessageLetters(this CipherSkillKey key) =>
+        key == CipherSkillKey.Lezeni ? 72 : 74;
+
+    public static bool TryParseSlug(string value, out CipherSkillKey key)
+    {
+        foreach (var candidate in All)
+        {
+            if (string.Equals(candidate.GetSlug(), value, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(candidate.ToString(), value, StringComparison.OrdinalIgnoreCase))
+            {
+                key = candidate;
+                return true;
+            }
+        }
+
+        key = default;
+        return false;
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/LocationCipherEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/LocationCipherEndpointTests.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+public class LocationCipherEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    [Fact]
+    public async Task GetByLocation_ReturnsFiveCipherSlots()
+    {
+        var (game, location) = await CreateAssignedLocationAsync();
+
+        var slots = await Client.GetFromJsonAsync<List<LocationCipherSlotDto>>(
+            $"/api/location-ciphers/{game.Id}/{location.Id}");
+
+        Assert.NotNull(slots);
+        Assert.Equal(5, slots!.Count);
+        Assert.Contains(slots, s => s.SkillSlug == "hledani-magie" && s.MaxMessageLetters == 74);
+        Assert.Contains(slots, s => s.SkillSlug == "lezeni" && s.MaxMessageLetters == 72);
+        Assert.All(slots, s => Assert.Null(s.Cipher));
+    }
+
+    [Fact]
+    public async Task Put_NormalizesMessage_AndReturnsPreviewOnGet()
+    {
+        var (game, location) = await CreateAssignedLocationAsync();
+        var questId = await CreateLocationQuestAsync(game.Id, location.Id);
+
+        var response = await Client.PutAsJsonAsync(
+            $"/api/location-ciphers/{game.Id}/{location.Id}/hledani-magie",
+            new UpsertLocationCipherDto("Tady žije vlčí smečka!", questId));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var slots = await Client.GetFromJsonAsync<List<LocationCipherSlotDto>>(
+            $"/api/location-ciphers/{game.Id}/{location.Id}");
+        var cipher = slots!.Single(s => s.SkillSlug == "hledani-magie").Cipher;
+
+        Assert.NotNull(cipher);
+        Assert.Equal("TADYZIJEVLCISMECKA", cipher!.MessageNormalized);
+        Assert.Equal("XOXTADYZIJEVLCISMECKAXOX", cipher.EncodedPreview);
+        Assert.Equal(questId, cipher.QuestId);
+        Assert.Equal("Vlčí stopa", cipher.QuestName);
+    }
+
+    [Fact]
+    public async Task Put_UpdatesExistingCipherInsteadOfDuplicating()
+    {
+        var (game, location) = await CreateAssignedLocationAsync();
+
+        await Client.PutAsJsonAsync(
+            $"/api/location-ciphers/{game.Id}/{location.Id}/sesty-smysl",
+            new UpsertLocationCipherDto("První zpráva"));
+        var response = await Client.PutAsJsonAsync(
+            $"/api/location-ciphers/{game.Id}/{location.Id}/sesty-smysl",
+            new UpsertLocationCipherDto("Druhá zpráva"));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var ciphers = await db.LocationCiphers
+            .Where(c => c.GameId == game.Id && c.LocationId == location.Id && c.SkillKey == CipherSkillKey.SestySmysl)
+            .ToListAsync();
+        var cipher = Assert.Single(ciphers);
+        Assert.Equal("DRUHAZPRAVA", cipher.MessageNormalized);
+    }
+
+    [Fact]
+    public async Task Put_TooLongForLezeni_ReturnsBadRequest()
+    {
+        var (game, location) = await CreateAssignedLocationAsync();
+
+        var response = await Client.PutAsJsonAsync(
+            $"/api/location-ciphers/{game.Id}/{location.Id}/lezeni",
+            new UpsertLocationCipherDto(new string('A', 73)));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Put_QuestNotLinkedToLocation_ReturnsBadRequest()
+    {
+        var (game, location) = await CreateAssignedLocationAsync();
+        var questId = await CreateQuestWithoutLocationAsync(game.Id);
+
+        var response = await Client.PutAsJsonAsync(
+            $"/api/location-ciphers/{game.Id}/{location.Id}/prohledavani",
+            new UpsertLocationCipherDto("Otevri pytlik", questId));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesCipher()
+    {
+        var (game, location) = await CreateAssignedLocationAsync();
+        await Client.PutAsJsonAsync(
+            $"/api/location-ciphers/{game.Id}/{location.Id}/znalost-bytosti",
+            new UpsertLocationCipherDto("Nic tu neni"));
+
+        var response = await Client.DeleteAsync(
+            $"/api/location-ciphers/{game.Id}/{location.Id}/znalost-bytosti");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var slots = await Client.GetFromJsonAsync<List<LocationCipherSlotDto>>(
+            $"/api/location-ciphers/{game.Id}/{location.Id}");
+        Assert.Null(slots!.Single(s => s.SkillSlug == "znalost-bytosti").Cipher);
+    }
+
+    private async Task<(GameDetailDto Game, LocationDetailDto Location)> CreateAssignedLocationAsync()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Šifrová hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        gameResponse.EnsureSuccessStatusCode();
+        var game = (await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>())!;
+
+        var locationResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Vlčí jeskyně", LocationKind.Wilderness, 49.5m, 17.1m));
+        locationResponse.EnsureSuccessStatusCode();
+        var location = (await locationResponse.Content.ReadFromJsonAsync<LocationDetailDto>())!;
+
+        var assignResponse = await Client.PostAsJsonAsync("/api/locations/by-game",
+            new GameLocationDto(game.Id, location.Id));
+        assignResponse.EnsureSuccessStatusCode();
+
+        return (game, location);
+    }
+
+    private async Task<int> CreateLocationQuestAsync(int gameId, int locationId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var quest = new Quest
+        {
+            Name = "Vlčí stopa",
+            QuestType = QuestType.Location,
+            GameId = gameId
+        };
+        db.Quests.Add(quest);
+        await db.SaveChangesAsync();
+        db.QuestLocationLinks.Add(new QuestLocationLink { QuestId = quest.Id, LocationId = locationId });
+        await db.SaveChangesAsync();
+        return quest.Id;
+    }
+
+    private async Task<int> CreateQuestWithoutLocationAsync(int gameId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var quest = new Quest
+        {
+            Name = "Jiný quest",
+            QuestType = QuestType.Location,
+            GameId = gameId
+        };
+        db.Quests.Add(quest);
+        await db.SaveChangesAsync();
+        return quest.Id;
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/LocationCipherEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/LocationCipherEndpointTests.cs
@@ -84,6 +84,18 @@ public class LocationCipherEndpointTests(PostgresFixture postgres) : Integration
     }
 
     [Fact]
+    public async Task Put_RawMessageOverColumnLimit_ReturnsBadRequest()
+    {
+        var (game, location) = await CreateAssignedLocationAsync();
+
+        var response = await Client.PutAsJsonAsync(
+            $"/api/location-ciphers/{game.Id}/{location.Id}/hledani-magie",
+            new UpsertLocationCipherDto(new string('.', 501) + "A"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
     public async Task Put_QuestNotLinkedToLocation_ReturnsBadRequest()
     {
         var (game, location) = await CreateAssignedLocationAsync();


### PR DESCRIPTION
## Summary
- add game/location-scoped `LocationCipher` storage with fixed five cipher skill keys and 74/72 message length enforcement
- add `/api/location-ciphers/{gameId}/{locationId}` CRUD endpoints with shared A-Z normalization and XOX preview data
- add a message-only `Šifry` tab on Location detail for selected-game locations, with save/delete confirmation and live preview/counter

## Notes
- This is Phase 1 only: authoring + validation. Direct PDF download remains the next slice.
- The UI intentionally lets the GM edit only the raw message; no filler or quest controls are exposed.

## Verification
- `dotnet build OvcinaHra.slnx -v minimal`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter FullyQualifiedName~LocationCipherEndpointTests -v minimal`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj -v minimal`