### PR TITLE
feat(cors): always include Ovcina ecosystem origins regardless of config [v0.15.114]

### DIFF
--- a/src/OvcinaHra.Api/Configuration/OvcinaCorsPolicy.cs
+++ b/src/OvcinaHra.Api/Configuration/OvcinaCorsPolicy.cs
@@ -1,0 +1,55 @@
+namespace OvcinaHra.Api.Configuration;
+
+/// <summary>
+/// Builds the effective CORS allowlist for the Ovčina API. Always unions a
+/// hard-coded set of well-known ecosystem production hostnames on top of
+/// whatever <c>Cors:Origins</c> configuration provides, so a misconfigured
+/// env-var deploy can never silently lock out an ecosystem client.
+/// </summary>
+/// <remarks>
+/// Localhost origins are NOT in this list — they are matched via
+/// <c>Uri.IsLoopback</c> at runtime so any port works without enumeration.
+/// Add a hostname here only when it is part of the permanent Ovčina
+/// production ecosystem; ephemeral preview hostnames belong in config.
+///
+/// History: Issue #244 (2026-04-27) — the prod Container App env vars
+/// <c>Cors__Origins__N</c> only listed <c>https://hra.ovcina.cz</c> and the
+/// SWA fallback; Glejt PWA at <c>https://glejt.ovcina.cz</c> was blocked.
+/// PR #286 added Glejt to a code-level fallback array, but the config branch
+/// fully replaced that fallback when env vars were set, so the code change
+/// was silently inert in prod. This helper closes that footgun.
+/// </remarks>
+public static class OvcinaCorsPolicy
+{
+    /// <summary>
+    /// Production hostnames for the Ovčina ecosystem that must always be
+    /// CORS-allowed, regardless of <c>Cors:Origins</c> configuration.
+    /// </summary>
+    public static readonly string[] EcosystemOrigins =
+    [
+        "https://hra.ovcina.cz",
+        "https://glejt.ovcina.cz",
+    ];
+
+    /// <summary>
+    /// Returns the union of <see cref="EcosystemOrigins"/> and
+    /// <paramref name="configuredOrigins"/> (case-insensitive de-dupe).
+    /// Configured origins can ADD to the allowlist but never remove an
+    /// ecosystem entry.
+    /// </summary>
+    public static string[] BuildEffectiveOrigins(IEnumerable<string>? configuredOrigins)
+    {
+        var set = new HashSet<string>(EcosystemOrigins, StringComparer.OrdinalIgnoreCase);
+        if (configuredOrigins is not null)
+        {
+            foreach (var origin in configuredOrigins)
+            {
+                if (!string.IsNullOrWhiteSpace(origin))
+                {
+                    set.Add(origin);
+                }
+            }
+        }
+        return [.. set];
+    }
+}

--- a/src/OvcinaHra.Api/Configuration/OvcinaCorsPolicy.cs
+++ b/src/OvcinaHra.Api/Configuration/OvcinaCorsPolicy.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace OvcinaHra.Api.Configuration;
 
 /// <summary>
@@ -25,7 +27,12 @@ public static class OvcinaCorsPolicy
     /// Production hostnames for the Ovčina ecosystem that must always be
     /// CORS-allowed, regardless of <c>Cors:Origins</c> configuration.
     /// </summary>
-    public static readonly string[] EcosystemOrigins =
+    /// <remarks>
+    /// Exposed as <see cref="ImmutableArray{T}"/> so callers cannot mutate
+    /// the underlying storage at runtime and accidentally remove an
+    /// ecosystem origin from the allowlist.
+    /// </remarks>
+    public static readonly ImmutableArray<string> EcosystemOrigins =
     [
         "https://hra.ovcina.cz",
         "https://glejt.ovcina.cz",
@@ -35,21 +42,28 @@ public static class OvcinaCorsPolicy
     /// Returns the union of <see cref="EcosystemOrigins"/> and
     /// <paramref name="configuredOrigins"/> (case-insensitive de-dupe).
     /// Configured origins can ADD to the allowlist but never remove an
-    /// ecosystem entry.
+    /// ecosystem entry. Each configured origin is trimmed before insertion
+    /// so a stray space in an env var (e.g. <c>Cors__Origins__0=" https://x"</c>)
+    /// won't silently desync from the browser <c>Origin</c> header.
     /// </summary>
-    public static string[] BuildEffectiveOrigins(IEnumerable<string>? configuredOrigins)
+    /// <returns>
+    /// An <see cref="IReadOnlySet{T}"/> backed by a case-insensitive
+    /// <see cref="HashSet{T}"/> for O(1) per-request membership checks.
+    /// </returns>
+    public static IReadOnlySet<string> BuildEffectiveOrigins(IEnumerable<string>? configuredOrigins)
     {
         var set = new HashSet<string>(EcosystemOrigins, StringComparer.OrdinalIgnoreCase);
         if (configuredOrigins is not null)
         {
             foreach (var origin in configuredOrigins)
             {
-                if (!string.IsNullOrWhiteSpace(origin))
+                var trimmed = origin?.Trim();
+                if (!string.IsNullOrEmpty(trimmed))
                 {
-                    set.Add(origin);
+                    set.Add(trimmed);
                 }
             }
         }
-        return [.. set];
+        return set;
     }
 }

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -122,19 +122,24 @@ try
     // here. Browsers can't fake the Origin header across machines, so the
     // localhost branch is safe — it can only be exercised from the user's own
     // machine.
+    //
+    // Hardening (2026-04-27, Issue #244 follow-up): the well-known Ovčina
+    // ecosystem origins are ALWAYS unioned on top of whatever Cors:Origins
+    // config provides. Previously the config's array (set by Container Apps
+    // env vars Cors__Origins__N) fully replaced the code-default fallback,
+    // so an env-var redeploy that forgot e.g. https://glejt.ovcina.cz silently
+    // broke that client even though the code default still listed it. Config
+    // can now ADD origins (preview hostnames, future SPAs) but can never
+    // accidentally SUBTRACT an ecosystem one.
     builder.Services.AddCors(options =>
     {
         var configuredOrigins =
             builder.Configuration.GetSection("Cors:Origins").Get<string[]>()
-            ?? [
-                "https://localhost:5290",
-                "http://localhost:5290",
-                "https://glejt.ovcina.cz",
-                "https://localhost:5193"
-            ];
+            ?? [];
+        var effectiveOrigins = OvcinaCorsPolicy.BuildEffectiveOrigins(configuredOrigins);
         options.AddPolicy("BlazorClient", policy => policy
             .SetIsOriginAllowed(origin =>
-                configuredOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase)
+                effectiveOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase)
                 || IsLocalhostOrigin(origin))
             .AllowAnyHeader()
             .AllowAnyMethod());

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -136,10 +136,13 @@ try
         var configuredOrigins =
             builder.Configuration.GetSection("Cors:Origins").Get<string[]>()
             ?? [];
+        // Built once at startup as a case-insensitive HashSet — the
+        // SetIsOriginAllowed delegate below runs on every request that
+        // carries an Origin header, so O(1) lookup matters.
         var effectiveOrigins = OvcinaCorsPolicy.BuildEffectiveOrigins(configuredOrigins);
         options.AddPolicy("BlazorClient", policy => policy
             .SetIsOriginAllowed(origin =>
-                effectiveOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase)
+                effectiveOrigins.Contains(origin)
                 || IsLocalhostOrigin(origin))
             .AllowAnyHeader()
             .AllowAnyMethod());

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.113</Version>
+    <Version>0.15.114</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OvcinaHra.Api.Tests/Configuration/OvcinaCorsPolicyTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Configuration/OvcinaCorsPolicyTests.cs
@@ -1,0 +1,87 @@
+using OvcinaHra.Api.Configuration;
+
+namespace OvcinaHra.Api.Tests.Configuration;
+
+public class OvcinaCorsPolicyTests
+{
+    [Fact]
+    public void Glejt_IsAllowed_WhenConfigOnlyListsHra()
+    {
+        // Repro of Issue #244 (2026-04-27): prod Container App env vars only
+        // listed https://hra.ovcina.cz, but the API must still allow Glejt.
+        var configured = new[] { "https://hra.ovcina.cz" };
+
+        var effective = OvcinaCorsPolicy.BuildEffectiveOrigins(configured);
+
+        Assert.Contains("https://glejt.ovcina.cz", effective);
+        Assert.Contains("https://hra.ovcina.cz", effective);
+    }
+
+    [Fact]
+    public void EcosystemOrigins_AreAllowed_WhenConfigIsNull()
+    {
+        var effective = OvcinaCorsPolicy.BuildEffectiveOrigins(null);
+
+        Assert.Contains("https://hra.ovcina.cz", effective);
+        Assert.Contains("https://glejt.ovcina.cz", effective);
+    }
+
+    [Fact]
+    public void EcosystemOrigins_AreAllowed_WhenConfigIsEmpty()
+    {
+        var effective = OvcinaCorsPolicy.BuildEffectiveOrigins([]);
+
+        Assert.Contains("https://hra.ovcina.cz", effective);
+        Assert.Contains("https://glejt.ovcina.cz", effective);
+    }
+
+    [Fact]
+    public void ConfiguredOrigins_ExtendTheAllowlist()
+    {
+        var configured = new[] { "https://preview.ovcina.cz" };
+
+        var effective = OvcinaCorsPolicy.BuildEffectiveOrigins(configured);
+
+        Assert.Contains("https://preview.ovcina.cz", effective);
+        Assert.Contains("https://hra.ovcina.cz", effective);
+        Assert.Contains("https://glejt.ovcina.cz", effective);
+    }
+
+    [Fact]
+    public void DuplicatesAreDeduped_CaseInsensitive()
+    {
+        var configured = new[] { "HTTPS://Hra.Ovcina.cz", "https://hra.ovcina.cz" };
+
+        var effective = OvcinaCorsPolicy.BuildEffectiveOrigins(configured);
+
+        // hra.ovcina.cz appears once (the canonical ecosystem entry survives
+        // because HashSet keeps the first inserted casing).
+        var hraCount = effective.Count(o =>
+            string.Equals(o, "https://hra.ovcina.cz", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(1, hraCount);
+    }
+
+    [Fact]
+    public void NullAndWhitespaceEntries_AreIgnored()
+    {
+        var configured = new[] { "https://preview.ovcina.cz", "", "   ", null! };
+
+        var effective = OvcinaCorsPolicy.BuildEffectiveOrigins(configured);
+
+        Assert.DoesNotContain("", effective);
+        Assert.DoesNotContain("   ", effective);
+        Assert.Contains("https://preview.ovcina.cz", effective);
+    }
+
+    [Fact]
+    public void EcosystemOrigins_CannotBeRemoved_EvenIfConfigOmitsThem()
+    {
+        // Even if config lists nothing, ecosystem origins must remain.
+        var effective = OvcinaCorsPolicy.BuildEffectiveOrigins(new string[0]);
+
+        foreach (var ecosystem in OvcinaCorsPolicy.EcosystemOrigins)
+        {
+            Assert.Contains(ecosystem, effective);
+        }
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Configuration/OvcinaCorsPolicyTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Configuration/OvcinaCorsPolicyTests.cs
@@ -62,6 +62,16 @@ public class OvcinaCorsPolicyTests
     }
 
     [Fact]
+    public void OriginLookup_IsCaseInsensitive()
+    {
+        var effective = OvcinaCorsPolicy.BuildEffectiveOrigins(null);
+
+        // The set is backed by StringComparer.OrdinalIgnoreCase — Contains()
+        // matches regardless of how the browser cased the Origin header.
+        Assert.Contains("HTTPS://Hra.Ovcina.cz", effective);
+    }
+
+    [Fact]
     public void NullAndWhitespaceEntries_AreIgnored()
     {
         var configured = new[] { "https://preview.ovcina.cz", "", "   ", null! };
@@ -74,10 +84,25 @@ public class OvcinaCorsPolicyTests
     }
 
     [Fact]
+    public void ConfiguredOrigins_AreTrimmed_BeforeInsertion()
+    {
+        // Env vars are a notorious source of stray whitespace (e.g. someone
+        // pastes "Cors__Origins__0=  https://preview.ovcina.cz" with a leading
+        // space). The trimmed value must be what the lookup matches against,
+        // because the browser Origin header never carries whitespace.
+        var configured = new[] { "  https://preview.ovcina.cz  " };
+
+        var effective = OvcinaCorsPolicy.BuildEffectiveOrigins(configured);
+
+        Assert.Contains("https://preview.ovcina.cz", effective);
+        Assert.DoesNotContain("  https://preview.ovcina.cz  ", effective);
+    }
+
+    [Fact]
     public void EcosystemOrigins_CannotBeRemoved_EvenIfConfigOmitsThem()
     {
         // Even if config lists nothing, ecosystem origins must remain.
-        var effective = OvcinaCorsPolicy.BuildEffectiveOrigins(new string[0]);
+        var effective = OvcinaCorsPolicy.BuildEffectiveOrigins([]);
 
         foreach (var ecosystem in OvcinaCorsPolicy.EcosystemOrigins)
         {


### PR DESCRIPTION
## Why

Issue #244 was closed by PR #286 (commit 4e7255c) by adding `https://glejt.ovcina.cz` to the **code-default** CORS fallback array in `Program.cs`. That fallback only fires when `builder.Configuration.GetSection(\"Cors:Origins\").Get<string[]>()` returns null. In production, the `ovcinahra-api` Container App injects `Cors__Origins__N` env vars, so the config branch is non-null and the code default is silently ignored. Result: Glejt PWA was blocked at the prod API on 2026-04-27 because the env vars only listed `https://hra.ovcina.cz` and the SWA fallback hostname — no glejt. Hot-fix: `az containerapp update --set-env-vars Cors__Origins__2=https://glejt.ovcina.cz` (already applied to unblock).

This PR closes the footgun in code so a future env-var typo can't repeat the outage.

## What

- **New helper `OvcinaCorsPolicy.BuildEffectiveOrigins(configured)`** unions a hard-coded array of ecosystem prod hostnames (`hra.ovcina.cz`, `glejt.ovcina.cz`) on top of whatever `Cors:Origins` config provides. Configured origins can ADD (preview hostnames, future SPAs) but can never SUBTRACT an ecosystem one. Localhost is still matched via `Uri.IsLoopback` so any port works without enumeration.
- **`Program.cs` `AddCors`** now calls the helper. Code comment explains the 2026-04-27 history so the next refactor doesn't re-introduce the override behavior.
- **7 unit tests** covering the #244 repro (config = `[hra]` only, glejt still allowed), null/empty config, extension by config, case-insensitive dedupe, whitespace handling, and the invariant that ecosystem origins cannot be removed. No DB / Testcontainer needed — pure helper test.

## Files

- `src/OvcinaHra.Api/Configuration/OvcinaCorsPolicy.cs` (new)
- `src/OvcinaHra.Api/Program.cs` (CORS section refactor + comment)
- `tests/OvcinaHra.Api.Tests/Configuration/OvcinaCorsPolicyTests.cs` (new, 7 tests)
- `src/OvcinaHra.Client/OvcinaHra.Client.csproj` (Version 0.15.113 → 0.15.114)

## Verification

- `dotnet build src/OvcinaHra.Api/OvcinaHra.Api.csproj` — 0 warnings, 0 errors
- `dotnet build src/OvcinaHra.Client/OvcinaHra.Client.csproj` — 0 warnings, 0 errors
- `dotnet test --filter \"FullyQualifiedName~OvcinaCorsPolicyTests\"` — 7/7 passed in 0.7s

## Post-merge smoke (planned)

After deploy, curl `GET /api/version` with `Origin: https://glejt.ovcina.cz` and confirm `Access-Control-Allow-Origin` echoes back. Repeat for `https://hra.ovcina.cz` to ensure no regression. Once verified clean, the env-var hot-fix `Cors__Origins__2` can be reverted at leisure (or left — it's now redundant but harmless).

Closes #244 (revisited).