### PR TITLE
fix(dashboard): use IsLocated for locations without GPS

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
@@ -54,9 +54,16 @@ public static class DashboardEndpoints
     private static async Task<Ok<DashboardIssuesDto>> GetIssues(int gameId, WorldDbContext db)
     {
         // Sequential awaits — same DbContext concurrency rule as Stats above.
-        var locationsNoGps = await db.GameLocations
-            .Where(gl => gl.GameId == gameId && gl.Location.Coordinates == null)
-            .CountAsync();
+        var locationRows = await db.GameLocations
+            .Where(gl => gl.GameId == gameId)
+            .Select(gl => new LocationEndpoints.LocationCoordinateState(
+                gl.LocationId,
+                gl.Location.Coordinates != null ? gl.Location.Coordinates.Latitude : (decimal?)null,
+                gl.Location.Coordinates != null ? gl.Location.Coordinates.Longitude : (decimal?)null,
+                gl.Location.ParentLocationId))
+            .ToListAsync();
+        var locationLookup = await LocationEndpoints.BuildLocationStateLookupAsync(db, locationRows);
+        var locationsNoGps = locationRows.Count(row => !LocationEndpoints.IsLocated(locationLookup, row.Id));
         var itemsNoPrice = await db.GameItems
             .Where(gi => gi.GameId == gameId && gi.IsSold && gi.Price == null)
             .CountAsync();

--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -12,7 +12,7 @@ public static class LocationEndpoints
 {
     private const int LocationInheritanceMaxDepth = 3;
 
-    private sealed record LocationCoordinateState(
+    internal sealed record LocationCoordinateState(
         int Id,
         decimal? Latitude,
         decimal? Longitude,
@@ -351,7 +351,7 @@ public static class LocationEndpoints
         return TypedResults.Ok(dtos);
     }
 
-    private static async Task<Dictionary<int, LocationCoordinateState>> BuildLocationStateLookupAsync(
+    internal static async Task<Dictionary<int, LocationCoordinateState>> BuildLocationStateLookupAsync(
         WorldDbContext db,
         IEnumerable<LocationCoordinateState> seed)
     {
@@ -389,7 +389,7 @@ public static class LocationEndpoints
             .Select(id => id!.Value)
             .ToHashSet();
 
-    private static bool IsLocated(
+    internal static bool IsLocated(
         IReadOnlyDictionary<int, LocationCoordinateState> lookup,
         int? locationId,
         int depth = 0)

--- a/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
@@ -5,6 +5,7 @@ using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Domain.ValueObjects;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
@@ -90,6 +91,44 @@ public class DashboardEndpointsTests(PostgresFixture postgres)
         var noGpsIssue = Assert.Single(issues.Issues, i => i.Key == "locations-no-gps");
         Assert.Equal(1, noGpsIssue.Count);
         Assert.Equal("/locations", noGpsIssue.TargetRoute);
+    }
+
+    [Fact]
+    public async Task Issues_LocationsWithoutGps_UsesInheritedParentGps()
+    {
+        var game = await CreateGameAsync();
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var parent = new Location
+            {
+                Name = "Parent coords",
+                LocationKind = LocationKind.Wilderness,
+                Coordinates = new GpsCoordinates(49.4532m, 18.0203m)
+            };
+            db.Locations.Add(parent);
+            await db.SaveChangesAsync();
+
+            var child = new Location
+            {
+                Name = "Child inherits coords",
+                LocationKind = LocationKind.Wilderness,
+                ParentLocationId = parent.Id
+            };
+            db.Locations.Add(child);
+            await db.SaveChangesAsync();
+
+            db.GameLocations.Add(new GameLocation { GameId = game.Id, LocationId = child.Id });
+            await db.SaveChangesAsync();
+        }
+
+        var issues = await Client.GetFromJsonAsync<DashboardIssuesDto>(
+            $"/api/dashboard/issues?gameId={game.Id}");
+
+        Assert.NotNull(issues);
+        var noGpsIssue = Assert.Single(issues.Issues, i => i.Key == "locations-no-gps");
+        Assert.Equal(0, noGpsIssue.Count);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #311.

## Summary
- Changed the dashboard `locations-no-gps` issue count to use the same parent-chain `IsLocated` rule that powers location list DTOs.
- Exposed the existing location coordinate-state lookup and `IsLocated` helper internally so the dashboard does not reimplement the inheritance rule.
- Added a regression test where a game-linked child location has no direct GPS but inherits coordinates from its parent and therefore does not count as "Lokace bez GPS".

## Verification
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter 'FullyQualifiedName~DashboardEndpointsTests' --logger 'console;verbosity=minimal'` passed: 11/11.
- `dotnet build OvcinaHra.slnx` passed, 0 warnings/errors.
- `dotnet test OvcinaHra.slnx --no-build --logger 'console;verbosity=minimal'` passed: API 488/488, E2E 8/8.
- `dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include ...` passed.
- `git diff --check` passed.