### PR TITLE
fix(pwa): bypass API fetches in service worker

### DIFF
--- a/src/OvcinaHra.Client/wwwroot/service-worker.published.js
+++ b/src/OvcinaHra.Client/wwwroot/service-worker.published.js
@@ -38,18 +38,43 @@ async function onActivate(event) {
 }
 
 async function onFetch(event) {
-    let cachedResponse = null;
-    if (event.request.method === 'GET') {
-        // For all navigation requests, try to serve index.html from cache,
-        // unless that request is for an offline resource.
-        // If you need some URLs to be server-rendered, edit the following check to exclude those URLs
-        const shouldServeIndexHtml = event.request.mode === 'navigate'
-            && !manifestUrlList.some(url => url === event.request.url);
-
-        const request = shouldServeIndexHtml ? 'index.html' : event.request;
-        const cache = await caches.open(cacheName);
-        cachedResponse = await cache.match(request);
+    const request = event.request;
+    if (shouldBypassOfflineCache(request) || request.method !== 'GET') {
+        return networkFetch(request);
     }
 
-    return cachedResponse || fetch(event.request);
+    // For all navigation requests, try to serve index.html from cache,
+    // unless that request is for an offline resource.
+    // If you need some URLs to be server-rendered, edit the following check to exclude those URLs
+    const shouldServeIndexHtml = request.mode === 'navigate'
+        && !manifestUrlList.some(url => url === request.url);
+
+    const cacheRequest = shouldServeIndexHtml ? 'index.html' : request;
+    const cache = await caches.open(cacheName);
+    const cachedResponse = await cache.match(cacheRequest);
+
+    if (cachedResponse) {
+        return cachedResponse;
+    }
+
+    return networkFetch(shouldServeIndexHtml ? 'index.html' : request);
+}
+
+function shouldBypassOfflineCache(request) {
+    const url = new URL(request.url);
+    return url.origin === self.location.origin && url.pathname.startsWith('/api/');
+}
+
+async function networkFetch(request) {
+    try {
+        return await fetch(request);
+    } catch {
+        return new Response('Network request failed before the application API responded.', {
+            status: 503,
+            statusText: 'Service Unavailable',
+            headers: {
+                'Content-Type': 'text/plain; charset=utf-8'
+            }
+        });
+    }
 }

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/ServiceWorkerFetchSmokeTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/ServiceWorkerFetchSmokeTests.cs
@@ -1,0 +1,37 @@
+namespace OvcinaHra.Api.Tests.ClientSmoke;
+
+public class ServiceWorkerFetchSmokeTests
+{
+    [Fact]
+    public void PublishedServiceWorker_BypassesApiFetches_AndReturnsHttpFailureOnNetworkErrors()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(),
+            "src",
+            "OvcinaHra.Client",
+            "wwwroot",
+            "service-worker.published.js"));
+
+        Assert.Contains("shouldBypassOfflineCache(request)", source);
+        Assert.Contains("url.pathname.startsWith('/api/')", source);
+        Assert.Contains("return networkFetch(request);", source);
+        Assert.Contains("async function networkFetch(request)", source);
+        Assert.Contains("return await fetch(request);", source);
+        Assert.Contains("status: 503", source);
+        Assert.DoesNotContain("fetch(event.request)", source);
+
+        var onFetchIndex = source.IndexOf("async function onFetch(event)", StringComparison.Ordinal);
+        var bypassIndex = source.IndexOf("shouldBypassOfflineCache(request)", onFetchIndex, StringComparison.Ordinal);
+        var cacheOpenIndex = source.IndexOf("caches.open(cacheName)", onFetchIndex, StringComparison.Ordinal);
+        Assert.True(bypassIndex >= 0 && cacheOpenIndex > bypassIndex);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "OvcinaHra.slnx")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not find repository root.");
+    }
+}


### PR DESCRIPTION
## Summary
- bypass same-origin `/api/*` requests from the offline app-shell cache path in the published service worker
- wrap service-worker network fetch fallback so a failed registrace proxy request resolves as HTTP 503 instead of rejecting the FetchEvent with `TypeError: Failed to fetch`
- add a source smoke test guarding the API bypass and 503 fallback behavior

## Verification
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter FullyQualifiedName~ClientSmoke --logger console;verbosity=minimal`
- `dotnet publish src/OvcinaHra.Client/OvcinaHra.Client.csproj -c Release -o $env:TEMP\ovcinahra-swfetch-publish --nologo`; verified generated `wwwroot/service-worker.js` contains the fix
- Manual browser smoke against published worker:
  - before: controlled page fetch to `/api/games/registrace-available` threw `TypeError: Failed to fetch`; network observation `net::ERR_FAILED`
  - after: same fetch returned `503 Service Unavailable` with no page-level request failure; no FetchEvent TypeError in console capture

Closes #272