### PR TITLE
chore(registrace): add diagnostic logging for link flow

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -247,15 +249,40 @@ public static class GameEndpoints
     /// "registrace unreachable/unauthorized", and an internal 500.
     /// </summary>
     private static async Task<Results<Ok<List<RegistraceGameDto>>, ProblemHttpResult>> GetRegistraceAvailable(
-        RegistraceGameService registrace, WorldDbContext db, CancellationToken ct)
+        RegistraceGameService registrace,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct,
+        int? localGameId = null)
     {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.GameEndpoints");
+        var userId = http.User.FindFirstValue("sub")
+            ?? http.User.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? "(unknown)";
+        logger.LogInformation(
+            "[registrace] proxy entry from userId={UserId} localGameId={LocalGameId}",
+            userId,
+            localGameId);
+
+        var sw = Stopwatch.StartNew();
         IReadOnlyList<RegistraceGameDto> upstream;
         try
         {
+            logger.LogInformation("[registrace] proxy calling RegistraceGameService.GetAvailableAsync");
             upstream = await registrace.GetAvailableAsync(ct);
+            logger.LogInformation(
+                "[registrace] proxy upstream returned {Count} games in {ElapsedMs}ms",
+                upstream.Count,
+                sw.ElapsedMilliseconds);
         }
-        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
         {
+            logger.LogWarning(
+                ex,
+                "[registrace] proxy upstream timeout after {ElapsedMs}ms localGameId={LocalGameId}",
+                sw.ElapsedMilliseconds,
+                localGameId);
             return TypedResults.Problem(
                 detail: RegistraceImportProblems.TimeoutDetail,
                 title: RegistraceImportProblems.TimeoutTitle,
@@ -263,10 +290,24 @@ public static class GameEndpoints
         }
         catch (HttpRequestException ex)
         {
+            logger.LogWarning(
+                ex,
+                "[registrace] proxy upstream HTTP exception after {ElapsedMs}ms localGameId={LocalGameId}",
+                sw.ElapsedMilliseconds,
+                localGameId);
             return TypedResults.Problem(
                 detail: ex.Message,
                 title: "Registrace nedostupná.",
                 statusCode: StatusCodes.Status502BadGateway);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "[registrace] proxy unexpected exception after {ElapsedMs}ms localGameId={LocalGameId}",
+                sw.ElapsedMilliseconds,
+                localGameId);
+            throw;
         }
 
         var alreadyLinked = await db.Games
@@ -275,6 +316,11 @@ public static class GameEndpoints
             .ToListAsync(ct);
         var linkedSet = alreadyLinked.ToHashSet();
         var filtered = upstream.Where(g => !linkedSet.Contains(g.Id)).ToList();
+        logger.LogInformation(
+            "[registrace] proxy filtered linkedCount={LinkedCount} returnedCount={ReturnedCount} localGameId={LocalGameId}",
+            linkedSet.Count,
+            filtered.Count,
+            localGameId);
         return TypedResults.Ok(filtered);
     }
 

--- a/src/OvcinaHra.Api/Services/RegistraceGameService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceGameService.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Net.Http.Json;
 using System.Text.Json;
 using OvcinaHra.Shared.Dtos;
 
@@ -29,17 +28,36 @@ public class RegistraceGameService(
     public async Task<IReadOnlyList<RegistraceGameDto>> GetAvailableAsync(CancellationToken ct = default)
     {
         const string endpoint = "/api/v1/games";
+        var url = $"{_baseUrl.TrimEnd('/')}{endpoint}";
+        var host = new Uri(url).Host;
         var request = new HttpRequestMessage(HttpMethod.Get,
-            $"{_baseUrl.TrimEnd('/')}{endpoint}");
+            url);
 
         if (!string.IsNullOrWhiteSpace(_apiKey))
             request.Headers.Add("X-Api-Key", _apiKey);
 
+        logger.LogInformation(
+            "[registrace] upstream request prepared endpoint={Endpoint} host={Host} hasApiKey={HasApiKey}",
+            endpoint,
+            host,
+            !string.IsNullOrWhiteSpace(_apiKey));
+
         using var response = await SendAsync(request, endpoint, ct);
         response.EnsureSuccessStatusCode();
 
-        var games = await response.Content.ReadFromJsonAsync<List<RegistraceGameDto>>(JsonOptions, ct);
-        return games ?? [];
+        var body = await response.Content.ReadAsStringAsync(ct);
+        logger.LogInformation(
+            "[registrace] upstream response body read endpoint={Endpoint} statusCode={StatusCode} bodyLen={BodyLength}",
+            endpoint,
+            (int)response.StatusCode,
+            body.Length);
+
+        var games = JsonSerializer.Deserialize<List<RegistraceGameDto>>(body, JsonOptions) ?? [];
+        logger.LogInformation(
+            "[registrace] upstream parsed {Count} games endpoint={Endpoint}",
+            games.Count,
+            endpoint);
+        return games;
     }
 
     private async Task<HttpResponseMessage> SendAsync(
@@ -56,13 +74,13 @@ public class RegistraceGameService(
             if (response.IsSuccessStatusCode)
             {
                 logger.LogInformation(
-                    "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
+                    "[registrace] upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
                     endpoint, sw.ElapsedMilliseconds, "success", response.StatusCode);
             }
             else
             {
                 logger.LogWarning(
-                    "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
+                    "[registrace] upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}. StatusCode: {StatusCode}",
                     endpoint, sw.ElapsedMilliseconds, "error", response.StatusCode);
             }
             return response;
@@ -71,7 +89,7 @@ public class RegistraceGameService(
         {
             logger.LogWarning(
                 ex,
-                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
+                "[registrace] upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
                 endpoint, sw.ElapsedMilliseconds, "timeout");
             throw;
         }
@@ -79,15 +97,15 @@ public class RegistraceGameService(
         {
             logger.LogInformation(
                 ex,
-                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
-                endpoint, sw.ElapsedMilliseconds, "error");
+                "[registrace] upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
+                endpoint, sw.ElapsedMilliseconds, "cancelled");
             throw;
         }
         catch (Exception ex)
         {
             logger.LogError(
                 ex,
-                "Registrace upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
+                "[registrace] upstream {Endpoint} completed in {ElapsedMs} ms with {Outcome}",
                 endpoint, sw.ElapsedMilliseconds, "error");
             throw;
         }

--- a/src/OvcinaHra.Client/Pages/Games/LinkToRegistracePopup.razor
+++ b/src/OvcinaHra.Client/Pages/Games/LinkToRegistracePopup.razor
@@ -94,6 +94,7 @@
         await base.SetParametersAsync(parameters);
         if (Visible && !_wasVisible)
         {
+            Console.WriteLine($"[registrace] popup opened gameId={GameId}");
             _selectedId = null;
             linkError = null;
             await LoadAsync();
@@ -103,21 +104,33 @@
 
     private async Task LoadAsync()
     {
+        var url = $"/api/games/registrace-available?localGameId={GameId}";
+        Console.WriteLine($"[registrace] fetching games for game {GameId}");
         loading = true;
         loadError = null;
         try
         {
-            var fetched = await Api.GetListAsync<RegistraceGameDto>("/api/games/registrace-available");
+            Console.WriteLine($"[registrace] calling Api.GetListAsync<RegistraceGameDto>('{url}')");
+            var fetched = await Api.GetListAsync<RegistraceGameDto>(url);
+            Console.WriteLine($"[registrace] response received, count={fetched.Count}");
+            Console.WriteLine($"[registrace] parsed {fetched.Count} games");
+
             _games = fetched
                 .OrderBy(g => g.StartsAtUtc)
                 .ToList();
+            Console.WriteLine($"[registrace] state updated, rendering grid count={_games.Count}");
         }
         catch (Exception ex)
         {
+            Console.WriteLine($"[registrace] caught {ex.GetType().Name}: {ex.Message}");
             _games = new();
             loadError = $"Nepodařilo se načíst hry z registrace: {ex.Message}";
         }
-        finally { loading = false; }
+        finally
+        {
+            loading = false;
+            Console.WriteLine($"[registrace] state cleanup, loading={loading}");
+        }
     }
 
     private async Task LinkAsync()

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/RegistraceDiagnosticLoggingTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/RegistraceDiagnosticLoggingTests.cs
@@ -1,0 +1,63 @@
+namespace OvcinaHra.Api.Tests.ClientSmoke;
+
+public class RegistraceDiagnosticLoggingTests
+{
+    [Fact]
+    public void RegistraceLinkFlow_HasDiagnosticLogsAcrossPopupProxyAndUpstream()
+    {
+        var root = FindRepoRoot();
+        var popup = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Pages",
+            "Games",
+            "LinkToRegistracePopup.razor"));
+        var endpoints = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Api",
+            "Endpoints",
+            "GameEndpoints.cs"));
+        var service = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Api",
+            "Services",
+            "RegistraceGameService.cs"));
+
+        Assert.Contains("[registrace] popup opened gameId={GameId}", popup);
+        Assert.Contains("[registrace] fetching games for game {GameId}", popup);
+        Assert.Contains("[registrace] calling Api.GetListAsync<RegistraceGameDto>", popup);
+        Assert.Contains("[registrace] response received, count={fetched.Count}", popup);
+        Assert.Contains("[registrace] parsed {fetched.Count} games", popup);
+        Assert.Contains("[registrace] state updated, rendering grid", popup);
+        Assert.Contains("[registrace] caught {ex.GetType().Name}: {ex.Message}", popup);
+        Assert.Contains("[registrace] state cleanup, loading={loading}", popup);
+        Assert.Contains("Api.GetListAsync<RegistraceGameDto>(url)", popup);
+        Assert.DoesNotContain("Http.GetAsync", popup);
+
+        Assert.Contains("[registrace] proxy entry from userId={UserId} localGameId={LocalGameId}", endpoints);
+        Assert.Contains("[registrace] proxy calling RegistraceGameService.GetAvailableAsync", endpoints);
+        Assert.Contains("[registrace] proxy upstream returned {Count} games in {ElapsedMs}ms", endpoints);
+        Assert.Contains("[registrace] proxy filtered linkedCount={LinkedCount} returnedCount={ReturnedCount}", endpoints);
+        Assert.Contains("[registrace] proxy upstream timeout", endpoints);
+        Assert.Contains("[registrace] proxy upstream HTTP exception", endpoints);
+        Assert.Contains("[registrace] proxy unexpected exception", endpoints);
+
+        Assert.Contains("[registrace] upstream request prepared", service);
+        Assert.Contains("[registrace] upstream {Endpoint} completed in {ElapsedMs} ms", service);
+        Assert.Contains("\"cancelled\"", service);
+        Assert.Contains("[registrace] upstream response body read", service);
+        Assert.Contains("[registrace] upstream parsed {Count} games", service);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "OvcinaHra.slnx")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not find repository root.");
+    }
+}


### PR DESCRIPTION
## Summary
- add `[registrace]` browser-console diagnostics to the link-to-registrace popup open/load/response/parse/state transitions
- add `[registrace]` API diagnostics at `/api/games/registrace-available` entry, upstream call, handled failures, and filtering
- add `[registrace]` upstream-service diagnostics for request preparation, response status, body length, parsed count, and existing timeout/outcome telemetry
- add a source smoke test to guard the diagnostic markers

## Verification
- `dotnet build OvcinaHra.slnx --nologo`
- `dotnet test OvcinaHra.slnx --no-build --logger console;verbosity=minimal`

Refs #272. Diagnostic logging only; does not close #272.