### PR TITLE
chore: bump to 0.16.0 + lift nav-foot text contrast

### DIFF
--- a/src/OvcinaHra.Client/Layout/NavMenu.razor.css
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor.css
@@ -350,7 +350,7 @@
     padding: 8px 12px;
     font-size: 0.6875rem;
     font-family: var(--oh-font-mono);
-    color: rgba(255, 255, 255, 0.38);
+    color: rgba(255, 255, 255, 0.78);
     text-align: center;
     border-top: 1px solid rgba(255, 255, 255, 0.08);
     background: rgba(0, 0, 0, 0.2);

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.15.119</Version>
+    <Version>0.16.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Manual minor version bump `0.15.117` → `0.16.0` (auto-bump CI only handles patch increments; this is the deliberate minor cut)
- Nav footer text was at `rgba(255, 255, 255, 0.38)` since v0.14.0 (#73) — bump to `0.78` so the version actually reads against the muted brown footer background

## Test plan

- [x] `dotnet build OvcinaHra.slnx` — green, 0 warn / 0 err
- [ ] After deploy: confirm version reads as `v0.16.0` in the nav footer with visible contrast