### PR TITLE
fix(cipher): surface cipher editor action

### DIFF
--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -62,6 +62,9 @@ else
                     </button>
                     @if (IsGameScoped)
                     {
+                        <button class="btn btn-secondary" @onclick='() => SwitchTab("sifry")'>
+                            <i class="bi bi-grid-3x3-gap me-1"></i> Šifry
+                        </button>
                         <button class="btn oh-btn-ghost-bordeaux" @onclick="() => isRemoveFromGameVisible = true">
                             <i class="bi bi-bookmark-dash me-1"></i> Odebrat z této hry
                         </button>


### PR DESCRIPTION
## Summary
- adds an explicit Šifry button to the location detail title actions when the location is in the active game
- uses the same IsGameScoped gate as "Odebrat z této hry", so the cipher editor entry point is visible in the exact state shown by the user screenshot

## Verification
- `dotnet build src\OvcinaHra.Client --no-restore`
