### PR TITLE
fix(registrace): render popup after available games load

### DIFF
--- a/src/OvcinaHra.Client/Pages/Games/LinkToRegistracePopup.razor
+++ b/src/OvcinaHra.Client/Pages/Games/LinkToRegistracePopup.razor
@@ -89,17 +89,18 @@
     private int? _selectedId;
     private bool _wasVisible;
 
-    public override async Task SetParametersAsync(ParameterView parameters)
+    protected override async Task OnParametersSetAsync()
     {
-        await base.SetParametersAsync(parameters);
-        if (Visible && !_wasVisible)
+        var shouldLoad = Visible && !_wasVisible;
+        _wasVisible = Visible;
+
+        if (shouldLoad)
         {
             Console.WriteLine($"[registrace] popup opened gameId={GameId}");
             _selectedId = null;
             linkError = null;
             await LoadAsync();
         }
-        _wasVisible = Visible;
     }
 
     private async Task LoadAsync()


### PR DESCRIPTION
## Summary
- move the registrace popup load trigger from a custom SetParametersAsync override into Blazor's normal OnParametersSetAsync lifecycle
- keep the existing Api.GetListAsync diagnostics and ProblemDetails-aware API helper path unchanged

Closes #272

## Marker diagnosis
Last-firing marker from user repro:
`[registrace] state cleanup, loading=False`

First missing behavior:
the popup body never re-rendered from `Načítám hry z registrace...` to the loaded game row, even though `[registrace] response received, count=1` and `[registrace] state updated, rendering grid count=1` fired.

Root cause: the component started `LoadAsync` after `base.SetParametersAsync(parameters)` had already run its lifecycle render. The async state changes completed outside the normal parameter lifecycle render scheduling, so DxPopup stayed on the stale loading branch. `OnParametersSetAsync` lets ComponentBase render once after `loading=true` and again after the awaited load completes.

## Verification
- `git diff --check`
- `dotnet restore OvcinaHra.slnx`
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include src/OvcinaHra.Client/Pages/Games/LinkToRegistracePopup.razor`

Local repro note: this was diagnosed from production markers and screenshot because the failing transition is a live OIDC/registrace popup render path. Post-deploy verification should confirm the popup row appears after `state cleanup, loading=False`.