### PR TITLE
Tweak locations grid UX

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/LocationCipherEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationCipherEndpoints.cs
@@ -17,6 +17,7 @@ public static class LocationCipherEndpoints
     {
         var group = routes.MapGroup("/api/location-ciphers").WithTags("LocationCiphers");
 
+        group.MapGet("/{gameId:int}", GetByGame);
         group.MapGet("/{gameId:int}/{locationId:int}", GetByLocation);
         group.MapGet("/{gameId:int}/{locationId:int}/pdf", DownloadLocationPdf);
         group.MapGet("/{gameId:int}/{locationId:int}/{skillSlug}/pdf", DownloadSinglePdf);
@@ -24,6 +25,33 @@ public static class LocationCipherEndpoints
         group.MapDelete("/{gameId:int}/{locationId:int}/{skillSlug}", Delete);
 
         return group;
+    }
+
+    private static async Task<Ok<List<LocationCipherDto>>> GetByGame(int gameId, WorldDbContext db)
+    {
+        var rows = await db.LocationCiphers
+            .Where(c => c.GameId == gameId
+                && c.Location.GameLocations.Any(gl => gl.GameId == gameId))
+            .OrderBy(c => c.LocationId)
+            .ThenBy(c => c.SkillKey)
+            .Select(c => new
+            {
+                c.Id,
+                c.GameId,
+                c.LocationId,
+                c.SkillKey,
+                c.MessageRaw,
+                c.MessageNormalized,
+                c.QuestId,
+                QuestName = c.Quest == null ? null : c.Quest.Name
+            })
+            .ToListAsync();
+
+        return TypedResults.Ok(rows
+            .Select(c => ToDto(
+                c.Id, c.GameId, c.LocationId, c.SkillKey, c.MessageRaw,
+                c.MessageNormalized, c.QuestId, c.QuestName))
+            .ToList());
     }
 
     private static async Task<Results<Ok<List<LocationCipherSlotDto>>, NotFound>> GetByLocation(

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -18,7 +18,7 @@
     </div>
 </div>
 
-@* Toolbar: Hledat, Druh, Oblast, jen s poklady, jen s questy, (catalog) jen nepřiřazené *@
+@* Toolbar: Hledat, Druh, Oblast, grid toggles *@
 <div class="oh-lg-toolbar mb-2">
     <DxTextBox Text="@searchText"
                TextChanged="@(v => { searchText = v; StateHasChanged(); })"
@@ -51,6 +51,20 @@
             @onclick="() => { filterOnlyWithQuests = !filterOnlyWithQuests; StateHasChanged(); }">
         <span class="oh-lg-sw"></span>jen s questy
     </button>
+    <button type="button"
+            class="oh-lg-tb-toggle @(filterOnlyWithoutGps ? "oh-lg-on" : "")"
+            @onclick="() => { filterOnlyWithoutGps = !filterOnlyWithoutGps; StateHasChanged(); }">
+        <span class="oh-lg-sw"></span>Bez umístění
+    </button>
+    @if (!Catalog)
+    {
+        <button type="button"
+                class="oh-lg-tb-toggle @(showCiphers ? "oh-lg-on" : "")"
+                disabled="@ciphersLoading"
+                @onclick="ToggleCiphersAsync">
+            <span class="oh-lg-sw"></span>@(showCiphers ? "Skrýt šifry" : "Ukaž šifry")
+        </button>
+    }
     @if (Catalog)
     {
         <button type="button"
@@ -60,6 +74,11 @@
         </button>
     }
 </div>
+
+@if (!string.IsNullOrWhiteSpace(cipherGridError))
+{
+    <div class="alert alert-danger py-2 mb-2">@cipherGridError</div>
+}
 
 @if (loading)
 {
@@ -94,7 +113,9 @@ else
 {
     <OvcinaGrid Data="@visibleRows"
                 KeyFieldName="Id"
-                LayoutKey="grid-layout-locations-v6"
+                LayoutKey="grid-layout-locations-v7"
+                TextWrapEnabled="false"
+                ShowColumnChooserButton="true"
                 RowClick="@OnGridRowClick">
         <Columns>
             @* Actions — moved to first column per issue #94. Destructive
@@ -163,8 +184,9 @@ else
                 </CellDisplayTemplate>
             </DxGridDataColumn>
 
-            @* Marker dot — 40px, fixed left *@
-            <DxGridDataColumn FieldName="LocationKind" Caption="" Width="40px"
+            @* Marker dot — hidden by default, still available via column chooser. *@
+            <DxGridDataColumn FieldName="LocationKind" Caption="Druh (značka)" Width="40px"
+                              Visible="false"
                               AllowSort="false" AllowGroup="false"
                               FixedPosition="GridColumnFixedPosition.Left">
                 <CellDisplayTemplate>
@@ -220,7 +242,7 @@ else
             </DxGridDataColumn>
 
             @* Kind chip *@
-            <DxGridDataColumn FieldName="LocationKindDisplay" Caption="Druh" Width="140px">
+            <DxGridDataColumn FieldName="LocationKindDisplay" Caption="Druh" Width="140px" Visible="false">
                 <CellDisplayTemplate>
                     @{
                         var loc = (LocationListDto)context.DataItem;
@@ -360,6 +382,49 @@ else
                         </span>
                     </CellDisplayTemplate>
                 </DxGridDataColumn>
+            }
+
+            @if (!Catalog && showCiphers)
+            {
+                @foreach (var cipherColumn in CipherColumns)
+                {
+                    <DxGridDataColumn Caption="@cipherColumn.SkillName" Width="260px"
+                                      AllowSort="false" AllowGroup="false">
+                        <CellDisplayTemplate>
+                            @{
+                                var loc = (LocationListDto)context.DataItem;
+                                var cipherState = GetCipherState(loc.Id, cipherColumn);
+                            }
+                            <div class="oh-lg-cipher-cell" @onclick:stopPropagation="true">
+                                <div class="oh-lg-cipher-editor">
+                                    <DxTextBox Text="@cipherState.MessageRaw"
+                                               TextExpression="@(() => cipherState.MessageRaw)"
+                                               TextChanged="@((string? v) => OnCipherTextChanged(cipherState, v))"
+                                               NullText="(bez šifry)"
+                                               CssClass="oh-lg-cipher-input" />
+                                    <button type="button"
+                                            class="oh-lg-cipher-save"
+                                            title="@GetCipherSaveTitle(cipherState)"
+                                            disabled="@(!CanSaveCipher(cipherState))"
+                                            @onclick="() => SaveCipherAsync(loc.Id, cipherColumn)">
+                                        @if (cipherState.IsSaving)
+                                        {
+                                            <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+                                        }
+                                        else
+                                        {
+                                            <i class="bi @(ShouldDeleteCipher(cipherState) ? "bi-trash3" : "bi-check2")"></i>
+                                        }
+                                    </button>
+                                </div>
+                                @if (!string.IsNullOrWhiteSpace(cipherState.Error))
+                                {
+                                    <div class="oh-lg-cipher-error">@cipherState.Error</div>
+                                }
+                            </div>
+                        </CellDisplayTemplate>
+                    </DxGridDataColumn>
+                }
             }
 
             @if (Catalog)
@@ -574,6 +639,7 @@ else
 
     private LocationEditPopup locationPopup = null!;
     private List<LocationListDto> locations = [];
+    private List<LocationListDto> visibleRows = [];
     private HashSet<int> assignedLocationIds = [];
     private bool loading = true;
     private bool drozdFailed;   // flips true if /img/drozd/drozd-knocking.svg 404s
@@ -584,12 +650,97 @@ else
     private bool isSaving;
 
     // Toolbar filter state
-    private string? searchText;
-    private LocationKind? filterKind;
-    private string? filterRegion;
-    private bool filterOnlyWithStashes;
-    private bool filterOnlyWithQuests;
-    private bool filterOnlyUnassigned;
+    private string? searchText
+    {
+        get => searchTextValue;
+        set
+        {
+            if (searchTextValue == value) return;
+            searchTextValue = value;
+            RefreshVisibleRows();
+        }
+    }
+
+    private LocationKind? filterKind
+    {
+        get => filterKindValue;
+        set
+        {
+            if (filterKindValue == value) return;
+            filterKindValue = value;
+            RefreshVisibleRows();
+        }
+    }
+
+    private string? filterRegion
+    {
+        get => filterRegionValue;
+        set
+        {
+            if (filterRegionValue == value) return;
+            filterRegionValue = value;
+            RefreshVisibleRows();
+        }
+    }
+
+    private bool filterOnlyWithStashes
+    {
+        get => filterOnlyWithStashesValue;
+        set
+        {
+            if (filterOnlyWithStashesValue == value) return;
+            filterOnlyWithStashesValue = value;
+            RefreshVisibleRows();
+        }
+    }
+
+    private bool filterOnlyWithQuests
+    {
+        get => filterOnlyWithQuestsValue;
+        set
+        {
+            if (filterOnlyWithQuestsValue == value) return;
+            filterOnlyWithQuestsValue = value;
+            RefreshVisibleRows();
+        }
+    }
+
+    private bool filterOnlyWithoutGps
+    {
+        get => filterOnlyWithoutGpsValue;
+        set
+        {
+            if (filterOnlyWithoutGpsValue == value) return;
+            filterOnlyWithoutGpsValue = value;
+            RefreshVisibleRows();
+        }
+    }
+
+    private bool filterOnlyUnassigned
+    {
+        get => filterOnlyUnassignedValue;
+        set
+        {
+            if (filterOnlyUnassignedValue == value) return;
+            filterOnlyUnassignedValue = value;
+            RefreshVisibleRows();
+        }
+    }
+
+    private string? searchTextValue;
+    private LocationKind? filterKindValue;
+    private string? filterRegionValue;
+    private bool filterOnlyWithStashesValue;
+    private bool filterOnlyWithQuestsValue;
+    private bool filterOnlyWithoutGpsValue;
+    private bool filterOnlyUnassignedValue;
+
+    // Cipher grid state is loaded only after the user opts in with "Ukaž šifry".
+    private bool showCiphers;
+    private bool ciphersLoaded;
+    private bool ciphersLoading;
+    private string? cipherGridError;
+    private readonly Dictionary<CipherCellKey, CipherCellState> cipherStates = [];
 
     // Variant expansion
     private readonly HashSet<int> expandedParentIds = [];
@@ -627,61 +778,59 @@ else
                  .OrderBy(r => r)
                  .ToList();
 
-    // Flattened, filtered row set bound to the grid.
-    // Parent rows are always present; variant rows appear only when parent is expanded.
-    private List<LocationListDto> visibleRows
+    private void RefreshVisibleRows()
     {
-        get
+        bool Matches(LocationListDto l)
         {
-            bool Matches(LocationListDto l)
+            if (filterKind.HasValue && l.LocationKind != filterKind.Value) return false;
+            if (!string.IsNullOrWhiteSpace(filterRegion)
+                && !string.Equals(l.Region, filterRegion, StringComparison.OrdinalIgnoreCase)) return false;
+            if (filterOnlyWithoutGps && (l.IsLocated || l.ParentLocationId.HasValue)) return false;
+            // Catalog mode returns LocationListDto with empty Stashes/Quests
+            // arrays, so the "jen s poklady" / "jen s questy" toggles are
+            // per-hra-only. Guard them here in case the toggle is on when
+            // Catalog flips.
+            if (!Catalog && filterOnlyWithStashes && (l.Stashes is null || l.Stashes.Count == 0)) return false;
+            if (!Catalog && filterOnlyWithQuests
+                && (l.Quests is null || l.Quests.Count == 0)
+                && (l.LocationTreasureQuests is null || l.LocationTreasureQuests.Count == 0)) return false;
+            if (Catalog && filterOnlyUnassigned && assignedLocationIds.Contains(l.Id)) return false;
+            if (!string.IsNullOrWhiteSpace(searchText))
             {
-                if (filterKind.HasValue && l.LocationKind != filterKind.Value) return false;
-                if (!string.IsNullOrWhiteSpace(filterRegion)
-                    && !string.Equals(l.Region, filterRegion, StringComparison.OrdinalIgnoreCase)) return false;
-                // Catalog mode returns LocationListDto with empty Stashes/Quests
-                // arrays, so the "jen s poklady" / "jen s questy" toggles are
-                // per-hra-only. Guard them here in case the toggle is on when
-                // Catalog flips.
-                if (!Catalog && filterOnlyWithStashes && (l.Stashes is null || l.Stashes.Count == 0)) return false;
-                if (!Catalog && filterOnlyWithQuests
-                    && (l.Quests is null || l.Quests.Count == 0)
-                    && (l.LocationTreasureQuests is null || l.LocationTreasureQuests.Count == 0)) return false;
-                if (Catalog && filterOnlyUnassigned && assignedLocationIds.Contains(l.Id)) return false;
-                if (!string.IsNullOrWhiteSpace(searchText))
-                {
-                    var needle = searchText.Trim();
-                    var nameMatch = l.Name?.Contains(needle, StringComparison.OrdinalIgnoreCase) == true;
-                    var regionMatch = l.Region?.Contains(needle, StringComparison.OrdinalIgnoreCase) == true;
-                    var questMatch = (l.Quests ?? []).Any(q => q.Name.Contains(needle, StringComparison.OrdinalIgnoreCase));
-                    var tqMatch = (l.LocationTreasureQuests ?? []).Any(t => t.Title.Contains(needle, StringComparison.OrdinalIgnoreCase));
-                    if (!nameMatch && !regionMatch && !questMatch && !tqMatch) return false;
-                }
-                return true;
+                var needle = searchText.Trim();
+                var nameMatch = l.Name?.Contains(needle, StringComparison.OrdinalIgnoreCase) == true;
+                var regionMatch = l.Region?.Contains(needle, StringComparison.OrdinalIgnoreCase) == true;
+                var questMatch = (l.Quests ?? []).Any(q => q.Name.Contains(needle, StringComparison.OrdinalIgnoreCase));
+                var tqMatch = (l.LocationTreasureQuests ?? []).Any(t => t.Title.Contains(needle, StringComparison.OrdinalIgnoreCase));
+                if (!nameMatch && !regionMatch && !questMatch && !tqMatch) return false;
             }
-
-            var result = new List<LocationListDto>(locations.Count);
-            foreach (var l in locations.Where(l => !l.ParentLocationId.HasValue).OrderBy(l => l.Name))
-            {
-                if (!Matches(l)) continue;
-                result.Add(l);
-                if (expandedParentIds.Contains(l.Id))
-                {
-                    foreach (var v in locations
-                        .Where(x => x.ParentLocationId == l.Id)
-                        .OrderBy(x => x.Name))
-                    {
-                        if (Matches(v)) result.Add(v);
-                    }
-                }
-            }
-            return result;
+            return true;
         }
+
+        var result = new List<LocationListDto>(locations.Count);
+        foreach (var l in locations.Where(l => !l.ParentLocationId.HasValue).OrderBy(l => l.Name))
+        {
+            if (!Matches(l)) continue;
+            result.Add(l);
+            if (expandedParentIds.Contains(l.Id) && !filterOnlyWithoutGps)
+            {
+                foreach (var v in locations
+                    .Where(x => x.ParentLocationId == l.Id)
+                    .OrderBy(x => x.Name))
+                {
+                    if (Matches(v)) result.Add(v);
+                }
+            }
+        }
+
+        visibleRows = result;
     }
 
     private void ToggleExpand(int parentId)
     {
         if (!expandedParentIds.Add(parentId))
             expandedParentIds.Remove(parentId);
+        RefreshVisibleRows();
         StateHasChanged();
     }
 
@@ -946,13 +1095,142 @@ else
             .Where(l => l.ParentLocationId.HasValue)
             .GroupBy(l => l.ParentLocationId!.Value)
             .ToDictionary(g => g.Key, g => g.Count());
+        RefreshVisibleRows();
+        if (Catalog)
+        {
+            showCiphers = false;
+            ciphersLoaded = false;
+            cipherStates.Clear();
+        }
+        else if (showCiphers)
+        {
+            await LoadCiphersAsync(force: true);
+        }
         loading = false;
     }
+
+    private async Task ToggleCiphersAsync()
+    {
+        if (showCiphers)
+        {
+            showCiphers = false;
+            cipherGridError = null;
+            return;
+        }
+
+        showCiphers = true;
+        if (!ciphersLoaded)
+        {
+            await LoadCiphersAsync();
+        }
+    }
+
+    private async Task LoadCiphersAsync(bool force = false)
+    {
+        if (Catalog || (ciphersLoaded && !force)) return;
+
+        ciphersLoading = true;
+        cipherGridError = null;
+        try
+        {
+            var ciphers = await Api.GetListAsync<LocationCipherDto>($"/api/location-ciphers/{gameId}");
+            cipherStates.Clear();
+            foreach (var cipher in ciphers)
+            {
+                cipherStates[new CipherCellKey(cipher.LocationId, cipher.SkillKey)] =
+                    new CipherCellState(cipher.MessageRaw);
+            }
+            ciphersLoaded = true;
+        }
+        catch (Exception ex)
+        {
+            cipherGridError = ex.Message;
+            showCiphers = false;
+            ciphersLoaded = false;
+        }
+        finally
+        {
+            ciphersLoading = false;
+        }
+    }
+
+    private CipherCellState GetCipherState(int locationId, CipherColumn column)
+    {
+        var key = new CipherCellKey(locationId, column.SkillKey);
+        if (!cipherStates.TryGetValue(key, out var state))
+        {
+            state = new CipherCellState(null);
+            cipherStates[key] = state;
+        }
+        return state;
+    }
+
+    private static void OnCipherTextChanged(CipherCellState state, string? value)
+    {
+        state.MessageRaw = value ?? "";
+        state.Error = null;
+    }
+
+    private static bool CanSaveCipher(CipherCellState state) =>
+        state.IsDirty && !state.IsSaving;
+
+    private static bool ShouldDeleteCipher(CipherCellState state) =>
+        state.HasExisting && string.IsNullOrWhiteSpace(state.MessageRaw);
+
+    private static string GetCipherSaveTitle(CipherCellState state) =>
+        ShouldDeleteCipher(state) ? "Smazat šifru" : "Uložit šifru";
+
+    private async Task SaveCipherAsync(int locationId, CipherColumn column)
+    {
+        var state = GetCipherState(locationId, column);
+        if (!CanSaveCipher(state)) return;
+
+        state.IsSaving = true;
+        state.Error = null;
+        try
+        {
+            var message = NormalizeCipherInput(state.MessageRaw);
+            if (message.Length == 0)
+            {
+                if (!state.HasExisting) return;
+                var (ok, problem) = await Api.DeleteWithProblemAsync(
+                    $"/api/location-ciphers/{gameId}/{locationId}/{column.SkillSlug}");
+                if (!ok)
+                {
+                    state.Error = problem ?? "Šifru se nepodařilo smazat.";
+                    return;
+                }
+                state.SetSaved(null);
+                return;
+            }
+
+            var (putOk, putProblem) = await Api.PutWithProblemAsync(
+                $"/api/location-ciphers/{gameId}/{locationId}/{column.SkillSlug}",
+                new UpsertLocationCipherDto(message));
+            if (!putOk)
+            {
+                state.Error = putProblem ?? "Šifru se nepodařilo uložit.";
+                return;
+            }
+            state.SetSaved(message);
+        }
+        catch (Exception ex)
+        {
+            state.Error = ex.Message;
+        }
+        finally
+        {
+            state.IsSaving = false;
+        }
+    }
+
+    private static string NormalizeCipherInput(string? value) => value?.Trim() ?? "";
 
     private async Task AssignLocationAsync(int locationId)
     {
         await Api.PostAsync<GameLocationDto, object>("/api/locations/by-game", new GameLocationDto(gameId, locationId));
         assignedLocationIds.Add(locationId);
+        RefreshVisibleRows();
         StateHasChanged();
     }
 
@@ -993,4 +1271,56 @@ else
             StateHasChanged();
         }
     }
+
+    private sealed record CipherColumn(
+        CipherSkillKey SkillKey,
+        string SkillSlug,
+        string SkillName,
+        int MaxMessageLetters);
+
+    private readonly record struct CipherCellKey(int LocationId, CipherSkillKey SkillKey);
+
+    private sealed class CipherCellState
+    {
+        public CipherCellState(string? messageRaw)
+        {
+            OriginalMessageRaw = NormalizeCipherInput(messageRaw);
+            MessageRaw = OriginalMessageRaw;
+            if (OriginalMessageRaw.Length == 0)
+            {
+                OriginalMessageRaw = null;
+            }
+        }
+
+        public string? OriginalMessageRaw { get; private set; }
+        public string MessageRaw { get; set; }
+        public bool IsSaving { get; set; }
+        public string? Error { get; set; }
+        public bool HasExisting => OriginalMessageRaw is not null;
+        public bool IsDirty => !string.Equals(
+            NormalizeCipherInput(MessageRaw),
+            OriginalMessageRaw ?? "",
+            StringComparison.Ordinal);
+
+        public void SetSaved(string? messageRaw)
+        {
+            OriginalMessageRaw = NormalizeCipherInput(messageRaw);
+            MessageRaw = OriginalMessageRaw;
+            Error = null;
+            if (OriginalMessageRaw.Length == 0)
+            {
+                OriginalMessageRaw = null;
+                MessageRaw = "";
+            }
+        }
+    }
+
+    private static readonly IReadOnlyList<CipherColumn> CipherColumns =
+        CipherSkillKeyExtensions.All
+            .Select(skill => new CipherColumn(
+                skill,
+                skill.GetSlug(),
+                skill.GetDisplayName(),
+                skill.GetMaxMessageLetters()))
+            .ToList();
 }

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -738,6 +738,7 @@ else
     // Cipher grid state is loaded only after the user opts in with "Ukaž šifry".
     private bool showCiphers;
     private bool ciphersLoaded;
+    private int? ciphersLoadedForGameId;
     private bool ciphersLoading;
     private string? cipherGridError;
     private readonly Dictionary<CipherCellKey, CipherCellState> cipherStates = [];
@@ -1080,6 +1081,14 @@ else
     private async Task LoadDataAsync()
     {
         loading = true;
+        if (ciphersLoadedForGameId != gameId)
+        {
+            ciphersLoaded = false;
+            ciphersLoadedForGameId = null;
+            cipherGridError = null;
+            cipherStates.Clear();
+        }
+
         if (Catalog)
         {
             locations = await Api.GetListAsync<LocationListDto>("/api/locations");
@@ -1100,6 +1109,7 @@ else
         {
             showCiphers = false;
             ciphersLoaded = false;
+            ciphersLoadedForGameId = null;
             cipherStates.Clear();
         }
         else if (showCiphers)
@@ -1127,7 +1137,7 @@ else
 
     private async Task LoadCiphersAsync(bool force = false)
     {
-        if (Catalog || (ciphersLoaded && !force)) return;
+        if (Catalog || (ciphersLoaded && ciphersLoadedForGameId == gameId && !force)) return;
 
         ciphersLoading = true;
         cipherGridError = null;
@@ -1141,12 +1151,14 @@ else
                     new CipherCellState(cipher.MessageRaw);
             }
             ciphersLoaded = true;
+            ciphersLoadedForGameId = gameId;
         }
         catch (Exception ex)
         {
             cipherGridError = ex.Message;
             showCiphers = false;
             ciphersLoaded = false;
+            ciphersLoadedForGameId = null;
         }
         finally
         {
@@ -1275,8 +1287,7 @@ else
     private sealed record CipherColumn(
         CipherSkillKey SkillKey,
         string SkillSlug,
-        string SkillName,
-        int MaxMessageLetters);
+        string SkillName);
 
     private readonly record struct CipherCellKey(int LocationId, CipherSkillKey SkillKey);
 
@@ -1320,7 +1331,6 @@ else
             .Select(skill => new CipherColumn(
                 skill,
                 skill.GetSlug(),
-                skill.GetDisplayName(),
-                skill.GetMaxMessageLetters()))
+                skill.GetDisplayName()))
             .ToList();
 }

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -1581,11 +1581,9 @@
 .oh-lg-stash-cell.oh-lg-none{align-items:center !important}
 .oh-lg-stash-cell.oh-lg-none span{color:var(--oh-text-secondary);font-style:italic;font-size:.75rem}
 
-/* Location primary-image tile — sibling of .oh-lg-stash-tile for the
-   Obrázek column in /locations. Same aspect-ratio (5/7) so rows with a
-   location image line up in height with rows that only show stash tiles. */
+/* Location primary-image tile for the Obrázek column in /locations. */
 .oh-lg-loc-tile{
-  aspect-ratio:5/7;width:100%;max-width:100px;
+  aspect-ratio:1/1;width:100%;max-width:100px;
   border:1px solid #7a5a3d;border-radius:5px;
   box-shadow:0 1px 3px rgba(45,80,22,.18), inset 0 0 0 1px rgba(255,248,230,.15);
   transition:.18s;position:relative;overflow:hidden;min-width:0;
@@ -1596,6 +1594,18 @@
   position:absolute;inset:0;width:100%;height:100%;
   object-fit:cover;z-index:1;display:block;
 }
+
+.oh-lg-cipher-cell{display:flex;flex-direction:column;gap:4px;min-width:0}
+.oh-lg-cipher-editor{display:flex;align-items:center;gap:4px;min-width:0}
+.oh-lg-cipher-input{flex:1 1 auto;min-width:0}
+.oh-lg-cipher-save{
+  flex:0 0 30px;width:30px;height:30px;border:1px solid rgba(45,80,22,.28);
+  border-radius:5px;background:#fff8e6;color:var(--oh-primary);display:inline-flex;
+  align-items:center;justify-content:center;padding:0
+}
+.oh-lg-cipher-save:hover:not(:disabled){background:#f0e0b8}
+.oh-lg-cipher-save:disabled{opacity:.45;cursor:not-allowed}
+.oh-lg-cipher-error{font-size:.75rem;line-height:1.2;color:#9f1d1d}
 .oh-lg-loc-tile > .oh-lg-loc-tile-img-veil{
   position:absolute;inset:0;pointer-events:none;z-index:2;
   background:

--- a/tests/OvcinaHra.Api.Tests/Endpoints/LocationCipherEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/LocationCipherEndpointTests.cs
@@ -28,6 +28,38 @@ public class LocationCipherEndpointTests(PostgresFixture postgres) : Integration
     }
 
     [Fact]
+    public async Task GetByGame_ReturnsOnlyCiphersForRequestedGame()
+    {
+        var (game, location) = await CreateAssignedLocationAsync();
+        var (otherGame, otherLocation) = await CreateAssignedLocationAsync();
+        var firstResponse = await Client.PutAsJsonAsync(
+            $"/api/location-ciphers/{game.Id}/{location.Id}/hledani-magie",
+            new UpsertLocationCipherDto("Tady žije vlčí smečka"));
+        firstResponse.EnsureSuccessStatusCode();
+        var secondResponse = await Client.PutAsJsonAsync(
+            $"/api/location-ciphers/{game.Id}/{location.Id}/lezeni",
+            new UpsertLocationCipherDto("Vylez po skale"));
+        secondResponse.EnsureSuccessStatusCode();
+        var otherResponse = await Client.PutAsJsonAsync(
+            $"/api/location-ciphers/{otherGame.Id}/{otherLocation.Id}/prohledavani",
+            new UpsertLocationCipherDto("Cizi hra"));
+        otherResponse.EnsureSuccessStatusCode();
+
+        var ciphers = await Client.GetFromJsonAsync<List<LocationCipherDto>>(
+            $"/api/location-ciphers/{game.Id}");
+
+        Assert.NotNull(ciphers);
+        Assert.Equal(2, ciphers!.Count);
+        Assert.All(ciphers, c =>
+        {
+            Assert.Equal(game.Id, c.GameId);
+            Assert.Equal(location.Id, c.LocationId);
+        });
+        Assert.Contains(ciphers, c => c.SkillSlug == "hledani-magie");
+        Assert.Contains(ciphers, c => c.SkillSlug == "lezeni");
+    }
+
+    [Fact]
     public async Task Put_NormalizesMessage_AndReturnsPreviewOnGet()
     {
         var (game, location) = await CreateAssignedLocationAsync();
@@ -174,13 +206,14 @@ public class LocationCipherEndpointTests(PostgresFixture postgres) : Integration
 
     private async Task<(GameDetailDto Game, LocationDetailDto Location)> CreateAssignedLocationAsync()
     {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
         var gameResponse = await Client.PostAsJsonAsync("/api/games",
-            new CreateGameDto("Šifrová hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+            new CreateGameDto($"Šifrová hra {suffix}", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
         gameResponse.EnsureSuccessStatusCode();
         var game = (await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>())!;
 
         var locationResponse = await Client.PostAsJsonAsync("/api/locations",
-            new CreateLocationDto("Vlčí jeskyně", LocationKind.Wilderness, 49.5m, 17.1m));
+            new CreateLocationDto($"Vlčí jeskyně {suffix}", LocationKind.Wilderness, 49.5m, 17.1m));
         locationResponse.EnsureSuccessStatusCode();
         var location = (await locationResponse.Content.ReadFromJsonAsync<LocationDetailDto>())!;
 


### PR DESCRIPTION
## Summary
- hide location kind columns by default while keeping them available through the column chooser
- add Bez umístění and deferred Ukaž šifry grid toggles, with explicit cipher save/delete actions
- switch location thumbnails to 1:1 and add a game-level cipher batch endpoint for the grid

## Verification
- dotnet build OvcinaHra.slnx --no-restore
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build
- dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include src/OvcinaHra.Api/Endpoints/LocationCipherEndpoints.cs src/OvcinaHra.Client/Pages/Locations/LocationList.razor tests/OvcinaHra.Api.Tests/Endpoints/LocationCipherEndpointTests.cs

Full solution dotnet format still reports unrelated pre-existing whitespace in other files; left untouched.

Closes #329