### PR TITLE
chore(client): route auth and skill calls through ApiClient

### DIFF
--- a/src/OvcinaHra.Client/Auth/JwtAuthStateProvider.cs
+++ b/src/OvcinaHra.Client/Auth/JwtAuthStateProvider.cs
@@ -1,8 +1,8 @@
-using System.Net.Http.Json;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
+using OvcinaHra.Client.Services;
 
 namespace OvcinaHra.Client.Auth;
 
@@ -13,12 +13,14 @@ public class JwtAuthStateProvider : AuthenticationStateProvider
 
     private readonly IJSRuntime _js;
     private readonly HttpClient _http;
+    private readonly ApiClient _api;
     private readonly IServiceProvider _services;
 
-    public JwtAuthStateProvider(IJSRuntime js, HttpClient http, IServiceProvider services)
+    public JwtAuthStateProvider(IJSRuntime js, HttpClient http, ApiClient api, IServiceProvider services)
     {
         _js = js;
         _http = http;
+        _api = api;
         _services = services;
     }
 
@@ -38,10 +40,9 @@ public class JwtAuthStateProvider : AuthenticationStateProvider
         // Validate by calling the API — works with both dev JWTs and OIDC encrypted tokens.
         try
         {
-            var response = await _http.GetAsync("/api/auth/me");
-            if (response.IsSuccessStatusCode)
+            var (ok, statusCode, me) = await _api.GetWithStatusAsync<MeResponse>("/api/auth/me");
+            if (ok)
             {
-                var me = await response.Content.ReadFromJsonAsync<MeResponse>();
                 if (me is not null)
                 {
                     var claims = new List<Claim>
@@ -69,7 +70,7 @@ public class JwtAuthStateProvider : AuthenticationStateProvider
             else
             {
                 AuthLog.Event("authstate.me_failed",
-                    ("status", (int)response.StatusCode),
+                    ("status", (int)statusCode),
                     ("action", "clear"));
             }
         }

--- a/src/OvcinaHra.Client/Pages/AuthCallback.razor
+++ b/src/OvcinaHra.Client/Pages/AuthCallback.razor
@@ -1,7 +1,7 @@
 @page "/auth-callback"
 @attribute [AllowAnonymous]
 @inject IJSRuntime JS
-@inject HttpClient Http
+@inject ApiClient Api
 @inject JwtAuthStateProvider AuthProvider
 @inject TokenRefreshService RefreshService
 @inject NavigationManager Nav
@@ -72,13 +72,12 @@
         try
         {
             var redirectUri = $"{Nav.BaseUri}auth-callback";
-            var response = await Http.PostAsJsonAsync("/api/auth/oidc-exchange",
+            var (ok, token, _) = await Api.PostWithProblemAsync<object, OvcinaHra.Client.Auth.OidcExchangeResponse>(
+                "/api/auth/oidc-exchange",
                 new { Code, RedirectUri = redirectUri, CodeVerifier = codeVerifier });
 
-            if (response.IsSuccessStatusCode)
+            if (ok)
             {
-                var token = await response.Content.ReadFromJsonAsync<OvcinaHra.Client.Auth.OidcExchangeResponse>();
-
                 if (token?.Token is not null)
                 {
                     if (!string.IsNullOrEmpty(token.RefreshToken))

--- a/src/OvcinaHra.Client/Pages/Login.razor
+++ b/src/OvcinaHra.Client/Pages/Login.razor
@@ -1,5 +1,5 @@
 @page "/login"
-@inject HttpClient Http
+@inject ApiClient Api
 @inject JwtAuthStateProvider AuthProvider
 @inject TokenRefreshService RefreshService
 @inject NavigationManager Nav
@@ -207,12 +207,12 @@
 
         try
         {
-            var response = await Http.PostAsJsonAsync("/api/auth/dev-token",
+            var (ok, token, _) = await Api.PostWithProblemAsync<object, OvcinaHra.Client.Auth.TokenResponse>(
+                "/api/auth/dev-token",
                 new { Name = name, Email = email });
 
-            if (response.IsSuccessStatusCode)
+            if (ok)
             {
-                var token = await response.Content.ReadFromJsonAsync<OvcinaHra.Client.Auth.TokenResponse>();
                 if (token is not null)
                 {
                     await AuthProvider.SetTokenAsync(token.Token);

--- a/src/OvcinaHra.Client/Services/ApiClient.cs
+++ b/src/OvcinaHra.Client/Services/ApiClient.cs
@@ -22,9 +22,9 @@ public class ApiClient
 
     public sealed record FileDownload(byte[] Bytes, string ContentType, string FileName);
 
-    public async Task<List<T>> GetListAsync<T>(string url)
+    public async Task<List<T>> GetListAsync<T>(string url, CancellationToken cancellationToken = default)
     {
-        return await _http.GetFromJsonAsync<List<T>>(url, JsonOptions) ?? [];
+        return await _http.GetFromJsonAsync<List<T>>(url, JsonOptions, cancellationToken) ?? [];
     }
 
     public async Task<T?> GetAsync<T>(string url, CancellationToken cancellationToken = default)
@@ -36,33 +36,50 @@ public class ApiClient
         return await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken);
     }
 
-    public async Task<TResponse?> PostAsync<TRequest, TResponse>(string url, TRequest data)
+    public async Task<(bool Ok, HttpStatusCode StatusCode, T? Value)> GetWithStatusAsync<T>(
+        string url,
+        CancellationToken cancellationToken = default)
     {
-        var response = await _http.PostAsJsonAsync(url, data, JsonOptions);
+        using var response = await _http.GetAsync(url, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+            return (false, response.StatusCode, default);
+
+        if (response.Content.Headers.ContentLength == 0 || response.StatusCode == HttpStatusCode.NoContent)
+            return (true, response.StatusCode, default);
+
+        return (true, response.StatusCode, await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken));
+    }
+
+    public async Task<TResponse?> PostAsync<TRequest, TResponse>(
+        string url,
+        TRequest data,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await _http.PostAsJsonAsync(url, data, JsonOptions, cancellationToken);
         response.EnsureSuccessStatusCode();
         if (response.Content.Headers.ContentLength == 0 || response.StatusCode == System.Net.HttpStatusCode.NoContent)
             return default;
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
         if (string.IsNullOrEmpty(content))
             return default;
         return JsonSerializer.Deserialize<TResponse>(content, JsonOptions);
     }
 
-    public async Task PostAsync<TRequest>(string url, TRequest data)
+    public async Task PostAsync<TRequest>(string url, TRequest data, CancellationToken cancellationToken = default)
     {
-        var response = await _http.PostAsJsonAsync(url, data, JsonOptions);
+        var response = await _http.PostAsJsonAsync(url, data, JsonOptions, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task PostAsync(string url)
+    public async Task PostAsync(string url, CancellationToken cancellationToken = default)
     {
-        var response = await _http.PostAsync(url, null);
+        var response = await _http.PostAsync(url, null, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task PutAsync<TRequest>(string url, TRequest data)
+    public async Task PutAsync<TRequest>(string url, TRequest data, CancellationToken cancellationToken = default)
     {
-        var response = await _http.PutAsJsonAsync(url, data, JsonOptions);
+        var response = await _http.PutAsJsonAsync(url, data, JsonOptions, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
 
@@ -85,6 +102,12 @@ public class ApiClient
     {
         var response = await _http.DeleteAsync(url);
         return response.IsSuccessStatusCode;
+    }
+
+    public async Task DeleteRequiredAsync(string url, CancellationToken cancellationToken = default)
+    {
+        var response = await _http.DeleteAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
     }
 
     public async Task<(bool Ok, FileDownload? File, string? ProblemDetail)> DownloadWithProblemAsync(string url)

--- a/src/OvcinaHra.Client/Services/SkillService.cs
+++ b/src/OvcinaHra.Client/Services/SkillService.cs
@@ -1,6 +1,3 @@
-using System.Net.Http.Json;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Client.Services;
@@ -13,78 +10,57 @@ namespace OvcinaHra.Client.Services;
 public class SkillService
 {
     private readonly ApiClient _api;
-    private readonly HttpClient _http;
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        Converters = { new JsonStringEnumConverter() }
-    };
-
-    public SkillService(ApiClient api, HttpClient http)
+    public SkillService(ApiClient api)
     {
         _api = api;
-        _http = http;
     }
 
     // ---- /api/skills ----
 
     public async Task<IReadOnlyList<SkillDto>> GetAllAsync(CancellationToken ct = default)
     {
-        var list = await _api.GetListAsync<SkillDto>("/api/skills");
+        var list = await _api.GetListAsync<SkillDto>("/api/skills", ct);
         return list;
     }
 
     public Task<SkillDto?> GetByIdAsync(int id, CancellationToken ct = default)
-        => _api.GetAsync<SkillDto>($"/api/skills/{id}");
+        => _api.GetAsync<SkillDto>($"/api/skills/{id}", ct);
 
     public async Task<SkillDto> CreateAsync(CreateSkillRequest req, CancellationToken ct = default)
     {
-        var response = await _http.PostAsJsonAsync("/api/skills", req, JsonOptions, ct);
-        response.EnsureSuccessStatusCode();
-        var created = await response.Content.ReadFromJsonAsync<SkillDto>(JsonOptions, ct);
+        var created = await _api.PostAsync<CreateSkillRequest, SkillDto>("/api/skills", req, ct);
         return created
             ?? throw new InvalidOperationException("Server returned empty body for created skill.");
     }
 
     public Task UpdateAsync(int id, UpdateSkillRequest req, CancellationToken ct = default)
-        => _api.PutAsync($"/api/skills/{id}", req);
+        => _api.PutAsync($"/api/skills/{id}", req, ct);
 
-    public async Task DeleteAsync(int id, CancellationToken ct = default)
-    {
-        var response = await _http.DeleteAsync($"/api/skills/{id}", ct);
-        response.EnsureSuccessStatusCode();
-    }
+    public Task DeleteAsync(int id, CancellationToken ct = default)
+        => _api.DeleteRequiredAsync($"/api/skills/{id}", ct);
 
     // ---- /api/games/{gameId}/skills ----
 
     public async Task<IReadOnlyList<GameSkillDto>> GetGameSkillsAsync(int gameId, CancellationToken ct = default)
     {
-        var list = await _api.GetListAsync<GameSkillDto>($"/api/games/{gameId}/skills");
+        var list = await _api.GetListAsync<GameSkillDto>($"/api/games/{gameId}/skills", ct);
         return list;
     }
 
     public Task<GameSkillDto?> GetGameSkillAsync(int gameId, int gameSkillId, CancellationToken ct = default)
-        => _api.GetAsync<GameSkillDto>($"/api/games/{gameId}/skills/{gameSkillId}");
+        => _api.GetAsync<GameSkillDto>($"/api/games/{gameId}/skills/{gameSkillId}", ct);
 
     public async Task<GameSkillDto> CreateGameSkillAsync(int gameId, CreateGameSkillRequest req, CancellationToken ct = default)
     {
-        var response = await _http.PostAsJsonAsync($"/api/games/{gameId}/skills", req, JsonOptions, ct);
-        response.EnsureSuccessStatusCode();
-        var created = await response.Content.ReadFromJsonAsync<GameSkillDto>(JsonOptions, ct);
+        var created = await _api.PostAsync<CreateGameSkillRequest, GameSkillDto>($"/api/games/{gameId}/skills", req, ct);
         return created
             ?? throw new InvalidOperationException("Server returned empty body for created game skill.");
     }
 
-    public async Task UpdateGameSkillAsync(int gameId, int gameSkillId, UpdateGameSkillRequest req, CancellationToken ct = default)
-    {
-        var response = await _http.PutAsJsonAsync($"/api/games/{gameId}/skills/{gameSkillId}", req, JsonOptions, ct);
-        response.EnsureSuccessStatusCode();
-    }
+    public Task UpdateGameSkillAsync(int gameId, int gameSkillId, UpdateGameSkillRequest req, CancellationToken ct = default)
+        => _api.PutAsync($"/api/games/{gameId}/skills/{gameSkillId}", req, ct);
 
-    public async Task RemoveGameSkillAsync(int gameId, int gameSkillId, CancellationToken ct = default)
-    {
-        var response = await _http.DeleteAsync($"/api/games/{gameId}/skills/{gameSkillId}", ct);
-        response.EnsureSuccessStatusCode();
-    }
+    public Task RemoveGameSkillAsync(int gameId, int gameSkillId, CancellationToken ct = default)
+        => _api.DeleteRequiredAsync($"/api/games/{gameId}/skills/{gameSkillId}", ct);
 }


### PR DESCRIPTION
## Summary
- Routed `SkillService` through `ApiClient` instead of direct `HttpClient` + `ReadFromJsonAsync` / `EnsureSuccessStatusCode`.
- Routed login/OIDC exchange and `/api/auth/me` validation through `ApiClient` helper methods.
- Added cancellation-aware `ApiClient` overloads and a status-preserving GET helper for auth checks.

## §16 sweep notes
- Requested narrow grep now finds `GetAsync`, `EnsureSuccessStatusCode`, and HTTP response `JsonSerializer.Deserialize` only in `ApiClient` internals.
- Remaining `JsonSerializer.Deserialize` hits outside `ApiClient` are local/JS state parsing (`MapPage`, `MapView`, `OvcinaGrid`) and not HTTP response handling.
- `TokenRefreshService` remains an intentional OAuth refresh exception: it handles token-refresh-specific status/body semantics and has no raw `GetAsync` or `EnsureSuccessStatusCode` hit.

## Verification
- `dotnet restore OvcinaHra.slnx`
- `dotnet build OvcinaHra.slnx --no-restore` (0 warnings, 0 errors)
- `dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include ...`
- `dotnet test OvcinaHra.slnx --no-build --filter "FullyQualifiedName!~E2E"` (504 passed)
- `rg -n "\.GetAsync\(|JsonSerializer\.Deserialize|EnsureSuccessStatusCode" src/OvcinaHra.Client --glob "!**/bin/**" --glob "!**/obj/**"`