### PR TITLE
Alias registrace Novy Arnor kingdom

### DIFF
--- a/src/OvcinaHra.Api/Services/RegistraceImportService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceImportService.cs
@@ -142,10 +142,18 @@ public class RegistraceImportService(
 
         var records = await FetchCharactersAsync(externalGameId, ct);
 
-        // Kingdom-name → id lookup, loaded once per import. Names from registrace
-        // are matched case-insensitively against the Kingdom lookup table.
-        var kingdomByName = await db.Kingdoms
-            .ToDictionaryAsync(k => k.Name, k => k.Id, StringComparer.OrdinalIgnoreCase, ct);
+        // Kingdom-name → id lookup, loaded once per import. Registrace and the
+        // local lookup can spell the same kingdom with different separators or
+        // diacritics, so normalize and alias known variants before matching.
+        var kingdomRows = await db.Kingdoms
+            .Select(k => new { k.Id, k.Name })
+            .ToListAsync(ct);
+        var kingdomByName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kingdom in kingdomRows)
+        {
+            foreach (var key in GetKingdomLookupKeys(kingdom.Name))
+                kingdomByName.TryAdd(key, kingdom.Id);
+        }
 
         foreach (var record in records)
         {
@@ -209,10 +217,13 @@ public class RegistraceImportService(
                         .WhenTrue(pc, ref playerClass);
 
                 int? kingdomId = null;
-                if (!string.IsNullOrWhiteSpace(record.KingdomName)
-                    && kingdomByName.TryGetValue(record.KingdomName, out var kid))
+                foreach (var key in GetKingdomLookupKeys(record.KingdomName))
                 {
-                    kingdomId = kid;
+                    if (kingdomByName.TryGetValue(key, out var kid))
+                    {
+                        kingdomId = kid;
+                        break;
+                    }
                 }
 
                 if (assignment is null)
@@ -369,8 +380,21 @@ public class RegistraceImportService(
             "aradhryand" => Race.Elf,
             "azanulinbar-dum" or "azanulinbar dum" => Race.Dwarf,
             "esgaroth" => Race.Human,
-            "novy arnor" => null,
+            "novy arnor" or "novy-arnor" => null,
             _ => null
+        };
+    }
+
+    public static IReadOnlyList<string> GetKingdomLookupKeys(string? kingdomName)
+    {
+        var normalized = NormalizeKingdomName(kingdomName);
+        if (normalized.Length == 0) return [];
+
+        return normalized switch
+        {
+            "novy arnor" => [normalized, "novy-arnor"],
+            "novy-arnor" => [normalized, "novy arnor"],
+            _ => [normalized]
         };
     }
 

--- a/src/OvcinaHra.Api/Services/RegistraceImportService.cs
+++ b/src/OvcinaHra.Api/Services/RegistraceImportService.cs
@@ -149,10 +149,30 @@ public class RegistraceImportService(
             .Select(k => new { k.Id, k.Name })
             .ToListAsync(ct);
         var kingdomByName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var ambiguousKingdomKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var kingdom in kingdomRows)
         {
             foreach (var key in GetKingdomLookupKeys(kingdom.Name))
-                kingdomByName.TryAdd(key, kingdom.Id);
+            {
+                if (ambiguousKingdomKeys.Contains(key))
+                    continue;
+
+                if (kingdomByName.TryGetValue(key, out var existingKingdomId))
+                {
+                    if (existingKingdomId != kingdom.Id)
+                    {
+                        kingdomByName.Remove(key);
+                        ambiguousKingdomKeys.Add(key);
+                        errors.Add(
+                            $"Ambiguous kingdom lookup key '{key}' maps to multiple kingdoms "
+                            + $"(Ids {existingKingdomId} and {kingdom.Id}).");
+                    }
+
+                    continue;
+                }
+
+                kingdomByName[key] = kingdom.Id;
+            }
         }
 
         foreach (var record in records)

--- a/tests/OvcinaHra.Api.Tests/Services/RegistraceImportServiceTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Services/RegistraceImportServiceTests.cs
@@ -13,11 +13,23 @@ public class RegistraceImportServiceTests
     [InlineData("Esgaroth", Race.Human)]
     [InlineData("Nový Arnor", null)]
     [InlineData("Novy Arnor", null)]
+    [InlineData("Novy-Arnor", null)]
     [InlineData(null, null)]
     public void InferRaceFromKingdomName_UsesCanonicalKingdomMapping(
         string? kingdomName,
         Race? expected)
     {
         Assert.Equal(expected, RegistraceImportService.InferRaceFromKingdomName(kingdomName));
+    }
+
+    [Theory]
+    [InlineData("Nový Arnor", "novy arnor", "novy-arnor")]
+    [InlineData("Novy-Arnor", "novy-arnor", "novy arnor")]
+    public void GetKingdomLookupKeys_AliasesRegistraceNovyArnor(
+        string kingdomName,
+        string first,
+        string second)
+    {
+        Assert.Equal([first, second], RegistraceImportService.GetKingdomLookupKeys(kingdomName));
     }
 }


### PR DESCRIPTION
## Summary
- aliases registrace Novy-Arnor to the local Nový Arnor kingdom lookup row
- keeps Nový Arnor race blank while resolving the assignment kingdom
- covers kingdom alias behavior in focused import tests

## Tests
- dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include src/OvcinaHra.Api/Services/RegistraceImportService.cs tests/OvcinaHra.Api.Tests/Services/RegistraceImportServiceTests.cs
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter RegistraceImportServiceTests