### PR TITLE
chore(ui): welcome copy and version in header

### DIFF
--- a/src/OvcinaHra.Client/Components/DrozdWelcome.razor
+++ b/src/OvcinaHra.Client/Components/DrozdWelcome.razor
@@ -30,7 +30,7 @@
             <div class="oh-home-drozd-greet">
                 <h2>Dobrý den, @(UserName ?? "organizátore")!</h2>
                 <p>Drozd vás vítá ve vašem světě. Klikněte kdekoli, ať se pustíme do práce.</p>
-                <button class="btn btn-primary" type="button" @onclick="Dismiss">Pochopeno</button>
+                <button class="btn btn-primary" type="button" @onclick="Dismiss">Tak dobře</button>
             </div>
         </div>
     </div>

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -5,7 +5,9 @@
 @implements IDisposable
 
 <div class="sb-brand">
-    <i class="bi bi-feather"></i><span>OvčinaHra</span>
+    <i class="bi bi-feather"></i>
+    <span class="sb-brand-title">Ovčina</span>
+    <span class="oh-brand-version">v @AppVersion</span>
     <button title="Navigační menu" class="sb-brand-toggler" @onclick="ToggleNavMenu" aria-label="Navigační menu">
         <i class="bi bi-list"></i>
     </button>
@@ -222,7 +224,7 @@
         </button>
         @if (!Collapsed)
         {
-            <span>© 2026 Ovčina v@(AppVersion)</span>
+            <span>© 2026 Ovčina</span>
         }
     </div>
 </div>

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor.css
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor.css
@@ -25,6 +25,19 @@
         opacity: 0.92;
     }
 
+.sb-brand-title {
+    white-space: nowrap;
+}
+
+.oh-brand-version {
+    color: rgba(255, 255, 255, 0.62);
+    font-family: var(--oh-font-mono);
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+}
+
 .sb-brand-toggler {
     margin-left: auto;
     background-color: rgba(255, 255, 255, 0.15);

--- a/src/OvcinaHra.Client/Pages/Exports/Exports.razor
+++ b/src/OvcinaHra.Client/Pages/Exports/Exports.razor
@@ -2,7 +2,7 @@
 @attribute [Authorize]
 @using Microsoft.AspNetCore.Authorization
 
-<PageTitle>Exporty | OvčinaHra</PageTitle>
+<PageTitle>Exporty | Ovčina</PageTitle>
 
 <div class="oh-exports-page">
     <h1>Exporty</h1>

--- a/src/OvcinaHra.Client/Pages/Exports/LocationsPreparation.razor
+++ b/src/OvcinaHra.Client/Pages/Exports/LocationsPreparation.razor
@@ -6,7 +6,7 @@
 @inject GameContextService GameContext
 @implements IDisposable
 
-<PageTitle>Příprava lokací — Export | OvčinaHra</PageTitle>
+<PageTitle>Příprava lokací — Export | Ovčina</PageTitle>
 
 <div class="oh-exp-lp-page">
     <div class="oh-exp-lp-toolbar oh-no-print">
@@ -21,7 +21,7 @@
 
     <div class="oh-exp-lp-print-header oh-print-only">
         <h1>Příprava lokací</h1>
-        <p>OvčinaHra · @DateTime.Now.ToString("d. MMMM yyyy", System.Globalization.CultureInfo.GetCultureInfo("cs-CZ"))</p>
+        <p>Ovčina · @DateTime.Now.ToString("d. MMMM yyyy", System.Globalization.CultureInfo.GetCultureInfo("cs-CZ"))</p>
     </div>
 
     @if (loading)

--- a/src/OvcinaHra.Client/Pages/Login.razor
+++ b/src/OvcinaHra.Client/Pages/Login.razor
@@ -62,7 +62,7 @@
                        or a local auto-redirect failure. Show a manual retry button. *@
                     <div class="card mb-4">
                         <div class="card-header text-center">
-                            <h4 class="mb-0">OvčinaHra — Přihlášení</h4>
+                            <h4 class="mb-0">Ovčina — Přihlášení</h4>
                         </div>
                         <div class="card-body d-flex flex-column align-items-center">
                             @if (autoRedirectError is not null)


### PR DESCRIPTION
## Summary
- Replace the Drozd welcome acknowledgement button text with `Tak dobře`.
- Move the app version from the nav footer to the sidebar brand header as `Ovčina v 0.16.9`.
- Keep the footer copyright text without the version.

## Decisions
- #336 text: `Tak dobře` per orchestrator confirmation.
- #337 layout: brand label changed from `OvčinaHra` to `Ovčina`, version rendered next to the brand, footer kept as copyright-only.

## Verification
- `dotnet build OvcinaHra.slnx` (0 warnings, 0 errors)
- `dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include ...`
- `git diff --check`

Closes #336
Closes #337