### PR TITLE
feat(map): render parent pins as Hobbit child

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/MapEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/MapEndpoints.cs
@@ -46,6 +46,12 @@ public static class MapEndpoints
                 Lat = gl.Location.Coordinates!.Latitude,
                 Lon = gl.Location.Coordinates!.Longitude,
                 gl.Location.ImagePath,
+                HobbitChildName = db.Locations
+                    .Where(child => child.ParentLocationId == gl.LocationId
+                        && child.LocationKind == LocationKind.Hobbit)
+                    .OrderBy(child => child.Id)
+                    .Select(child => child.Name)
+                    .FirstOrDefault(),
             })
             .ToListAsync();
 
@@ -57,7 +63,9 @@ public static class MapEndpoints
             // null so the cockpit's kingdom-tint chip stays inert until
             // a follow-up adds the relationship.
             KingdomId: null, KingdomName: null,
-            ThumbnailUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath))).ToList();
+            ThumbnailUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath),
+            RenderKind: r.HobbitChildName is null ? null : LocationKind.Hobbit,
+            RenderName: r.HobbitChildName)).ToList();
 
         // Game-scoped stashes. Each pin sits at GameSecretStash.LocationId
         // (which has GPS via Location.Coordinates). Treasure count + highest

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -385,7 +385,7 @@
         // payload that PaintPinsAsync iterates, so chip totals always match
         // what the user sees on the map.
         _locationsByKind = _data?.Locations
-            .GroupBy(l => l.Kind)
+            .GroupBy(l => l.EffectiveKind)
             .ToDictionary(g => g.Key, g => g.Count());
 
         await PaintPinsAsync();
@@ -404,14 +404,14 @@
 
         if (_locationsVisible)
         {
-            foreach (var l in _data.Locations.OrderBy(l => l.Kind == LocationKind.Hobbit ? 1 : 0))
+            foreach (var l in _data.Locations.OrderBy(l => l.EffectiveKind == LocationKind.Hobbit ? 1 : 0))
             {
                 // Skip kinds the user has hidden via the legend chips. The
                 // counts in the rail still show the underlying total, but
                 // the pins drop out of the painted set.
-                if (_hiddenKinds.Contains(l.Kind)) continue;
+                if (_hiddenKinds.Contains(l.EffectiveKind)) continue;
                 await JS.InvokeVoidAsync("ovcinaMap.addLocationPin",
-                    l.Id, l.Lat, l.Lon, l.Name, l.Kind.ToString());
+                    l.Id, l.Lat, l.Lon, l.EffectiveName, l.EffectiveKind.ToString());
             }
         }
         if (_stashesVisible)

--- a/src/OvcinaHra.Client/Pages/Map/MapPrint.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPrint.razor
@@ -138,14 +138,14 @@
         if (_data is null) return;
 
         // Per-mode label: blind uses the location's stable DB id; labeled
-        // uses the actual name. The kind argument carries through unchanged
-        // so the per-kind tear-drop color and glyph still apply (the print
-        // sheet wants the icons too — they read as map symbols).
+        // uses the map-facing name. The kind argument carries the map-facing
+        // kind so parent pins with Hobbit child variants print like the
+        // on-screen map.
         foreach (var l in _data.Locations)
         {
-            var label = _mode == "blind" ? $"#{l.Id}" : l.Name;
+            var label = _mode == "blind" ? $"#{l.Id}" : l.EffectiveName;
             await JS.InvokeVoidAsync("ovcinaMap.addLocationPin",
-                l.Id, l.Lat, l.Lon, label, l.Kind.ToString());
+                l.Id, l.Lat, l.Lon, label, l.EffectiveKind.ToString());
         }
         // Stash pins intentionally omitted — print sheets focus on parent
         // locations; secret-stash detail belongs in the organizer's tablet.

--- a/src/OvcinaHra.Shared/Dtos/MapDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MapDtos.cs
@@ -30,10 +30,21 @@ public record MapLocationDto(
     LocationKind Kind,
     int? KingdomId,
     string? KingdomName,
-    string? ThumbnailUrl)
+    string? ThumbnailUrl,
+    LocationKind? RenderKind = null,
+    string? RenderName = null)
 {
     [JsonIgnore]
     public string KindDisplay => Kind.GetDisplayName();
+
+    [JsonIgnore]
+    public LocationKind EffectiveKind => RenderKind ?? Kind;
+
+    [JsonIgnore]
+    public string EffectiveName => string.IsNullOrWhiteSpace(RenderName) ? Name : RenderName;
+
+    [JsonIgnore]
+    public string EffectiveKindDisplay => EffectiveKind.GetDisplayName();
 }
 
 /// <summary>

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
@@ -118,6 +118,56 @@ public class MapEndpointsTests(PostgresFixture postgres)
     }
 
     [Fact]
+    public async Task Data_ParentWithHobbitChildUsesChildPresentation()
+    {
+        var game = await CreateGameAsync();
+        int parentId;
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var parent = new Location
+            {
+                Name = "Starý brod",
+                LocationKind = LocationKind.Wilderness,
+                Coordinates = new GpsCoordinates(49.5m, 17.1m),
+            };
+            db.Locations.Add(parent);
+            await db.SaveChangesAsync();
+            parentId = parent.Id;
+
+            db.Locations.AddRange(
+                new Location
+                {
+                    Name = "Dcera řeky",
+                    LocationKind = LocationKind.Hobbit,
+                    ParentLocationId = parent.Id,
+                },
+                new Location
+                {
+                    Name = "Druhý hobit",
+                    LocationKind = LocationKind.Hobbit,
+                    ParentLocationId = parent.Id,
+                });
+            db.GameLocations.Add(new GameLocation { GameId = game.Id, LocationId = parent.Id });
+            await db.SaveChangesAsync();
+        }
+
+        var data = await Client.GetFromJsonAsync<MapDataDto>(
+            $"/api/map/data?gameId={game.Id}");
+
+        Assert.NotNull(data);
+        var single = Assert.Single(data.Locations);
+        Assert.Equal(parentId, single.Id);
+        Assert.Equal("Starý brod", single.Name);
+        Assert.Equal(LocationKind.Wilderness, single.Kind);
+        Assert.Equal("Dcera řeky", single.RenderName);
+        Assert.Equal(LocationKind.Hobbit, single.RenderKind);
+        Assert.Equal("Dcera řeky", single.EffectiveName);
+        Assert.Equal(LocationKind.Hobbit, single.EffectiveKind);
+    }
+
+    [Fact]
     public async Task Peek_NonExistentLocation_Returns404()
     {
         var game = await CreateGameAsync();


### PR DESCRIPTION
## Summary
- Adds map presentation overrides so parent pins can render as a direct Hobbit child while keeping the parent location ID.
- Computes the first direct Hobbit child server-side in `/api/map/data` and uses it for pin name/kind only.
- Applies the effective pin name/kind to the interactive map and map print renderer.

## Phase 0 decisions
- Compute in the server map projection, not in the client renderer.
- Keep it in `/api/map/data`; no extra child fetch or client-side N+1.
- Override only pin presentation; detail title and click target remain the parent.
- Single-level only; first direct Hobbit child by `Location.Id` wins.
- Hobbit icon CSS was left untouched; wilderness color is out of scope.

## Verification
- `dotnet test tests\OvcinaHra.Api.Tests\OvcinaHra.Api.Tests.csproj --filter "FullyQualifiedName~MapEndpointsTests" --logger "console;verbosity=minimal"`
- `dotnet build OvcinaHra.slnx --no-restore --verbosity minimal`
- `dotnet test OvcinaHra.slnx --no-build --logger "console;verbosity=minimal"`
- `dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include ...`
- `git diff --check`

## Visual smoke after deploy
- Game 30 map: `Starý brod` should render as a purple Hobbit pin labeled `Dcera řeky`.
- Clicking that pin should still open the parent `Starý brod` peek/detail.
- The Hobbit layer toggle should hide/show that purple parent pin.

References #318.