### PR TITLE
feat(tags): create on the fly from tag picker

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TagEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TagEndpoints.cs
@@ -51,25 +51,13 @@ public static class TagEndpoints
         return TypedResults.Ok(new TagDto(tag.Id, tag.Name, tag.Kind));
     }
 
-    // Issue #234 — name now flows through Trim + non-empty + max-length +
-    // dup-check guards that surface Czech ProblemDetails verbatim instead of
-    // hiding behind EnsureSuccessStatusCode. The client passes the user's
-    // typed name through unchanged (PostAsJsonAsync, JSON body) so any char
-    // — `+`, `&`, `:`, `'`, space — round-trips end-to-end.
-    private static async Task<Results<Created<TagDto>, ProblemHttpResult>> Create(CreateTagDto dto, WorldDbContext db)
+    // Issue #234/#331 — name flows through Trim + validation that surfaces
+    // Czech ProblemDetails verbatim. Create is idempotent by case-insensitive
+    // (Kind, Name): existing tag wins and keeps its canonical display casing.
+    private static async Task<Results<Created<TagDto>, Ok<TagDto>, ProblemHttpResult>> Create(CreateTagDto dto, WorldDbContext db)
     {
-        var name = dto.Name?.Trim() ?? "";
-        if (string.IsNullOrEmpty(name))
-            return TypedResults.Problem(
-                title: "Uložení selhalo",
-                detail: "Název tagu nesmí být prázdný.",
-                statusCode: StatusCodes.Status400BadRequest);
-
-        if (name.Length > NameMaxLength)
-            return TypedResults.Problem(
-                title: "Uložení selhalo",
-                detail: $"Název tagu nesmí přesáhnout {NameMaxLength} znaků.",
-                statusCode: StatusCodes.Status400BadRequest);
+        if (ValidateName(dto.Name, out var name) is { } problem)
+            return problem;
 
         if (!Enum.IsDefined(dto.Kind))
             return TypedResults.Problem(
@@ -77,15 +65,9 @@ public static class TagEndpoints
                 detail: "Neplatný druh tagu.",
                 statusCode: StatusCodes.Status400BadRequest);
 
-        // EF translates Trim() to Postgres TRIM() so legacy rows that already
-        // have whitespace padding still collide on the dup-check.
-        var collision = await db.Tags
-            .AnyAsync(t => t.Kind == dto.Kind && t.Name.Trim() == name);
-        if (collision)
-            return TypedResults.Problem(
-                title: "Uložení selhalo",
-                detail: $"Tag s názvem „{name}“ už v této kategorii existuje.",
-                statusCode: StatusCodes.Status400BadRequest);
+        var existing = await FindByNameIgnoringCaseAsync(db, dto.Kind, name);
+        if (existing is not null)
+            return TypedResults.Ok(ToDto(existing));
 
         var tag = new Tag { Name = name, Kind = dto.Kind };
         db.Tags.Add(tag);
@@ -95,11 +77,10 @@ public static class TagEndpoints
         }
         catch (DbUpdateException ex) when (IsUniqueViolation(ex))
         {
-            // Concurrency race: AnyAsync above passed but a parallel request
-            // beat us to the (Kind, Name) UNIQUE index. Surface the same Czech
-            // ProblemDetails as the explicit dup-check so the client never
-            // sees a 500 for what is conceptually a duplicate-name conflict.
-            // Per Copilot review on PR #282 — same pattern as GameEndpoints.
+            var existingAfterRace = await FindByNameIgnoringCaseAsync(db, dto.Kind, name);
+            if (existingAfterRace is not null)
+                return TypedResults.Ok(ToDto(existingAfterRace));
+
             return TypedResults.Problem(
                 title: "Uložení selhalo",
                 detail: $"Tag s názvem „{name}“ už v této kategorii existuje.",
@@ -117,22 +98,11 @@ public static class TagEndpoints
         if (tag is null)
             return TypedResults.NotFound();
 
-        var name = dto.Name?.Trim() ?? "";
-        if (string.IsNullOrEmpty(name))
-            return TypedResults.Problem(
-                title: "Uložení selhalo",
-                detail: "Název tagu nesmí být prázdný.",
-                statusCode: StatusCodes.Status400BadRequest);
+        if (ValidateName(dto.Name, out var name) is { } problem)
+            return problem;
 
-        if (name.Length > NameMaxLength)
-            return TypedResults.Problem(
-                title: "Uložení selhalo",
-                detail: $"Název tagu nesmí přesáhnout {NameMaxLength} znaků.",
-                statusCode: StatusCodes.Status400BadRequest);
-
-        var collision = await db.Tags
-            .AnyAsync(t => t.Id != id && t.Kind == tag.Kind && t.Name.Trim() == name);
-        if (collision)
+        var collision = await FindByNameIgnoringCaseAsync(db, tag.Kind, name, exceptId: id);
+        if (collision is not null)
             return TypedResults.Problem(
                 title: "Uložení selhalo",
                 detail: $"Tag s názvem „{name}“ už v této kategorii existuje.",
@@ -161,6 +131,45 @@ public static class TagEndpoints
     private static bool IsUniqueViolation(DbUpdateException ex) =>
         ex.InnerException is PostgresException pg
         && pg.SqlState == PostgresErrorCodes.UniqueViolation;
+
+    private static ProblemHttpResult? ValidateName(string? rawName, out string name)
+    {
+        name = rawName?.Trim() ?? "";
+        if (string.IsNullOrEmpty(name))
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: "Název tagu nesmí být prázdný.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        if (name.Length > NameMaxLength)
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: $"Název tagu nesmí přesáhnout {NameMaxLength} znaků.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        if (name.Any(char.IsControl))
+            return TypedResults.Problem(
+                title: "Uložení selhalo",
+                detail: "Název tagu nesmí obsahovat řídicí znaky.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        return null;
+    }
+
+    private static async Task<Tag?> FindByNameIgnoringCaseAsync(
+        WorldDbContext db,
+        TagKind kind,
+        string name,
+        int? exceptId = null)
+    {
+        var normalized = name.ToLower();
+        return await db.Tags.FirstOrDefaultAsync(t =>
+            t.Kind == kind
+            && (!exceptId.HasValue || t.Id != exceptId.Value)
+            && t.Name.Trim().ToLower() == normalized);
+    }
+
+    private static TagDto ToDto(Tag tag) => new(tag.Id, tag.Name, tag.Kind);
 
     private static async Task<Results<NoContent, NotFound>> Delete(int id, WorldDbContext db)
     {

--- a/src/OvcinaHra.Client/Components/TagChipPicker.razor
+++ b/src/OvcinaHra.Client/Components/TagChipPicker.razor
@@ -15,16 +15,24 @@
 
     @if (showAdd)
     {
-        <DxComboBox Data="@unselectedTags"
-                    @bind-Value="@pendingAddId"
-                    TextFieldName="Name"
-                    ValueFieldName="Id"
-                    NullText="(vyberte tag)"
-                    SearchMode="ListSearchMode.AutoSearch"
-                    SizeMode="SizeMode.Small" />
+        <input class="form-control form-control-sm"
+               style="max-width: 220px"
+               list="@DataListId"
+               placeholder="Název tagu"
+               disabled="@isAdding"
+               @bind="typedTagText"
+               @bind:event="oninput"
+               @onkeyup="HandleKeyUpAsync" />
+        <datalist id="@DataListId">
+            @foreach (var tag in unselectedTags)
+            {
+                <option value="@tag.Name"></option>
+            }
+        </datalist>
         <button type="button" class="btn btn-sm btn-primary"
-                disabled="@(pendingAddId is null)" @onclick="AddAsync">Přidat</button>
-        <button type="button" class="btn btn-sm btn-link" @onclick="() => showAdd = false">Zrušit</button>
+                disabled="@(isAdding || string.IsNullOrWhiteSpace(typedTagText))"
+                @onclick="AddTypedAsync">Přidat</button>
+        <button type="button" class="btn btn-sm btn-link" disabled="@isAdding" @onclick="CancelAdd">Zrušit</button>
     }
     else
     {
@@ -40,7 +48,9 @@
 }
 
 @code {
-    [Parameter, EditorRequired] public int MonsterId { get; set; }
+    [Parameter, EditorRequired] public TagChipPickerTarget Target { get; set; }
+    [Parameter, EditorRequired] public int EntityId { get; set; }
+    [Parameter, EditorRequired] public TagKind Kind { get; set; }
     [Parameter] public List<TagDto> InitialTags { get; set; } = [];
     [Parameter] public EventCallback Changed { get; set; }
 
@@ -48,9 +58,14 @@
     private List<TagDto> allTags = [];
     private List<TagDto> unselectedTags = [];
     private bool showAdd;
-    private int? pendingAddId;
+    private bool isAdding;
+    private string typedTagText = "";
     private string? error;
-    private int _lastMonsterId;
+    private int _lastEntityId;
+    private TagKind _lastKind;
+    private TagChipPickerTarget _lastTarget;
+
+    private string DataListId => $"tag-picker-{Target}-{EntityId}-{Kind}";
 
     protected override async Task OnInitializedAsync()
     {
@@ -59,7 +74,7 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (_lastMonsterId != MonsterId)
+        if (_lastEntityId != EntityId || _lastKind != Kind || _lastTarget != Target)
         {
             await SyncFromParamsAsync();
         }
@@ -67,12 +82,13 @@
 
     private async Task SyncFromParamsAsync()
     {
-        _lastMonsterId = MonsterId;
+        _lastEntityId = EntityId;
+        _lastKind = Kind;
+        _lastTarget = Target;
         selectedTags = [..InitialTags];
-        if (allTags.Count == 0)
-        {
-            allTags = await Api.GetListAsync<TagDto>("/api/tags");
-        }
+        allTags = (await Api.GetListAsync<TagDto>("/api/tags"))
+            .Where(t => t.Kind == Kind)
+            .ToList();
         Recompute();
     }
 
@@ -87,29 +103,100 @@
 
     private void OpenAdd()
     {
-        pendingAddId = null;
+        typedTagText = "";
         error = null;
         showAdd = true;
     }
 
-    private async Task AddAsync()
+    private void CancelAdd()
     {
-        if (pendingAddId is null) return;
+        typedTagText = "";
         error = null;
+        showAdd = false;
+    }
+
+    private async Task HandleKeyUpAsync(KeyboardEventArgs args)
+    {
+        if (args.Key == "Enter")
+            await AddTypedAsync();
+    }
+
+    private async Task AddTypedAsync()
+    {
+        if (isAdding) return;
+
+        var names = ParseTagNames(typedTagText);
+        if (names.Count == 0)
+        {
+            error = "Zadejte název tagu.";
+            return;
+        }
+
+        if (names.Any(n => n.Any(char.IsControl)))
+        {
+            error = "Název tagu nesmí obsahovat řídicí znaky.";
+            return;
+        }
+
+        error = null;
+        isAdding = true;
+        var changed = false;
+        var completed = false;
         try
         {
-            await Api.PostAsync($"/api/monsters/{MonsterId}/tags/{pendingAddId}");
-            var newTag = allTags.FirstOrDefault(t => t.Id == pendingAddId);
-            if (newTag is not null)
+            foreach (var name in names)
             {
-                selectedTags.Add(newTag);
-                Recompute();
+                var tag = await CreateOrGetTagAsync(name);
+                if (tag is null) return;
+
+                RememberTag(tag);
+                if (selectedTags.Any(t => t.Id == tag.Id))
+                    continue;
+
+                await Api.PostAsync(LinkUrl(tag.Id));
+                selectedTags.Add(tag);
+                changed = true;
             }
-            pendingAddId = null;
-            showAdd = false;
-            if (Changed.HasDelegate) await Changed.InvokeAsync();
+
+            completed = true;
         }
-        catch (Exception ex) { error = ex.Message; }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            isAdding = false;
+            if (completed)
+            {
+                typedTagText = "";
+                showAdd = false;
+            }
+            Recompute();
+            if (changed && Changed.HasDelegate)
+                await Changed.InvokeAsync();
+        }
+    }
+
+    private async Task<TagDto?> CreateOrGetTagAsync(string name)
+    {
+        var (ok, tag, problem) = await Api.PostWithProblemAsync<CreateTagDto, TagDto>(
+            "/api/tags",
+            new CreateTagDto(name, Kind));
+        if (ok && tag is not null)
+            return tag;
+
+        error = problem ?? "Vytvoření tagu se nezdařilo.";
+        return null;
+    }
+
+    private void RememberTag(TagDto tag)
+    {
+        var index = allTags.FindIndex(t => t.Id == tag.Id);
+        if (index >= 0)
+            allTags[index] = tag;
+        else
+            allTags.Add(tag);
     }
 
     private async Task RemoveAsync(TagDto tag)
@@ -117,7 +204,7 @@
         error = null;
         try
         {
-            var ok = await Api.DeleteAsync($"/api/monsters/{MonsterId}/tags/{tag.Id}");
+            var ok = await Api.DeleteAsync(UnlinkUrl(tag.Id));
             if (!ok)
             {
                 error = $"Odebrání tagu „{tag.Name}\u201c selhalo.";
@@ -128,5 +215,28 @@
             if (Changed.HasDelegate) await Changed.InvokeAsync();
         }
         catch (Exception ex) { error = ex.Message; }
+    }
+
+    private string LinkUrl(int tagId) => Target switch
+    {
+        TagChipPickerTarget.Monster => $"/api/monsters/{EntityId}/tags/{tagId}",
+        TagChipPickerTarget.Quest => $"/api/quests/{EntityId}/tags/{tagId}",
+        _ => throw new InvalidOperationException($"Unsupported tag target {Target}.")
+    };
+
+    private string UnlinkUrl(int tagId) => LinkUrl(tagId);
+
+    private static List<string> ParseTagNames(string raw)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var names = new List<string>();
+        foreach (var part in raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (part.Length == 0 || !seen.Add(part))
+                continue;
+            names.Add(part);
+        }
+
+        return names;
     }
 }

--- a/src/OvcinaHra.Client/Components/TagChipPickerTarget.cs
+++ b/src/OvcinaHra.Client/Components/TagChipPickerTarget.cs
@@ -1,0 +1,7 @@
+namespace OvcinaHra.Client.Components;
+
+public enum TagChipPickerTarget
+{
+    Monster,
+    Quest
+}

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterDetail.razor
@@ -237,7 +237,11 @@ else
                 </DxFormLayoutGroup>
                 <DxFormLayoutGroup Caption="Tagy" ColSpanMd="12">
                     <DxFormLayoutItem ColSpanMd="12">
-                        <TagChipPicker MonsterId="monster.Id" InitialTags="monster.Tags" Changed="OnTagsChangedAsync" />
+                        <TagChipPicker Target="TagChipPickerTarget.Monster"
+                                       EntityId="monster.Id"
+                                       Kind="TagKind.Monster"
+                                       InitialTags="monster.Tags"
+                                       Changed="OnTagsChangedAsync" />
                     </DxFormLayoutItem>
                 </DxFormLayoutGroup>
                 <DxFormLayoutGroup Caption="Poznámky" ColSpanMd="12">

--- a/src/OvcinaHra.Client/Pages/Quests/QuestDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestDetail.razor
@@ -257,37 +257,11 @@ else
             @* Tags multi-select — quest tags only (TagKind == Quest) *@
             <div class="oh-qst-edit-tags mt-3">
                 <h6><i class="bi bi-tags"></i> Tagy</h6>
-                @if (quest.Tags.Count > 0)
-                {
-                    <div class="d-flex flex-wrap gap-1 mb-2">
-                        @foreach (var tag in quest.Tags)
-                        {
-                            <span class="oh-qst-tag-chip">
-                                @tag.Name
-                                <button type="button" class="oh-qst-tag-chip-x"
-                                        @onclick="() => RemoveTagAsync(tag)" @onclick:stopPropagation="true"
-                                        title="Odebrat">
-                                    <i class="bi bi-x"></i>
-                                </button>
-                            </span>
-                        }
-                    </div>
-                }
-                else
-                {
-                    <p class="text-muted small mb-2">Žádné tagy.</p>
-                }
-                <div class="d-flex gap-2 align-items-end">
-                    <div style="flex:1">
-                        <DxComboBox Data="@allQuestTags" @bind-Value="@newTagId"
-                                    TextFieldName="Name" ValueFieldName="Id"
-                                    NullText="(vyberte tag)" SearchMode="ListSearchMode.AutoSearch" />
-                    </div>
-                    <button class="btn btn-sm btn-outline-primary" type="button"
-                            disabled="@(newTagId is null)" @onclick="AddTagAsync">
-                        <i class="bi bi-plus"></i> Přidat tag
-                    </button>
-                </div>
+                <TagChipPicker Target="TagChipPickerTarget.Quest"
+                               EntityId="quest.Id"
+                               Kind="TagKind.Quest"
+                               InitialTags="quest.Tags"
+                               Changed="@(async () => await LoadAsync())" />
             </div>
 
             @if (saveError is not null)
@@ -506,10 +480,6 @@ else
     private bool isDeleteVisible;
     private string? deleteError;
 
-    // Tags
-    private List<TagDto> allQuestTags = [];
-    private int? newTagId;
-
     // Locations
     private List<LocationListDto> gameLocations = [];
     private int? newLocationId;
@@ -593,7 +563,6 @@ else
         availableTimeSlots = [];
         try
         {
-            var tagsTask = Api.GetListAsync<TagDto>("/api/tags");
             var gameId = quest.GameId ?? GameContext.SelectedGameId;
             var locationsTask = gameId is int gid
                 ? Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gid}")
@@ -601,8 +570,7 @@ else
             var slotsTask = gameId is int slotGameId
                 ? Api.GetListAsync<GameTimeSlotDto>($"/api/timeline/slots/by-game/{slotGameId}")
                 : Task.FromResult(new List<GameTimeSlotDto>());
-            await Task.WhenAll(tagsTask, locationsTask, slotsTask);
-            allQuestTags = (await tagsTask).Where(t => t.Kind == TagKind.Quest).ToList();
+            await Task.WhenAll(locationsTask, slotsTask);
             gameLocations = await locationsTask;
             availableTimeSlots = BuildTimeSlotOptions(await slotsTask, editModel.TimeSlot);
             editModel.SelectedTimeSlotOptionId = ResolveTimeSlotOptionId(editModel.TimeSlot);
@@ -751,29 +719,6 @@ else
         }
         catch (Exception ex) { error = ex.Message; }
         finally { isCopying = false; }
-    }
-
-    private async Task AddTagAsync()
-    {
-        if (quest is null || newTagId is null) return;
-        try
-        {
-            await Api.PostAsync($"/api/quests/{quest.Id}/tags/{newTagId}");
-            newTagId = null;
-            await LoadAsync();
-        }
-        catch (Exception ex) { saveError = ex.Message; }
-    }
-
-    private async Task RemoveTagAsync(TagDto tag)
-    {
-        if (quest is null) return;
-        try
-        {
-            await Api.DeleteAsync($"/api/quests/{quest.Id}/tags/{tag.Id}");
-            await LoadAsync();
-        }
-        catch (Exception ex) { saveError = ex.Message; }
     }
 
     private async Task AddLocationAsync()

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TagEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TagEndpointTests.cs
@@ -45,20 +45,38 @@ public class TagEndpointTests(PostgresFixture postgres) : IntegrationTestBase(po
     }
 
     [Fact]
-    public async Task Create_DuplicateNameWithinKind_Returns400WithCzechProblemDetails()
+    public async Task Create_DuplicateNameWithinKind_ReturnsExistingTagIgnoringCase()
     {
-        var initialResponse = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("Plus+Tag", TagKind.Monster));
+        var initialResponse = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("big", TagKind.Monster));
         // Assert the Arrange step succeeded — without this, a regression in
-        // baseline Create would still pass the test for the wrong reason
-        // (both calls return 400). Per Copilot review on PR #282.
+        // baseline Create would still pass the test for the wrong reason.
         Assert.Equal(HttpStatusCode.Created, initialResponse.StatusCode);
+        var initial = await initialResponse.Content.ReadFromJsonAsync<TagDto>();
 
-        var response = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("Plus+Tag", TagKind.Monster));
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
-        Assert.NotNull(problem);
-        Assert.Equal("Uložení selhalo", problem!.Title);
-        Assert.Contains("už", problem.Detail, StringComparison.OrdinalIgnoreCase);
+        var response = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("BiG", TagKind.Monster));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var existing = await response.Content.ReadFromJsonAsync<TagDto>();
+        Assert.Equal(initial!.Id, existing!.Id);
+        Assert.Equal("big", existing.Name);
+
+        var monsterTags = await Client.GetFromJsonAsync<List<TagDto>>("/api/tags?kind=Monster");
+        Assert.Single(monsterTags!);
+    }
+
+    [Fact]
+    public async Task Create_SameNameDifferentKind_CreatesSeparateTag()
+    {
+        var monsterResponse = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("Shared", TagKind.Monster));
+        Assert.Equal(HttpStatusCode.Created, monsterResponse.StatusCode);
+
+        var questResponse = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("shared", TagKind.Quest));
+        Assert.Equal(HttpStatusCode.Created, questResponse.StatusCode);
+
+        var monsterTag = await monsterResponse.Content.ReadFromJsonAsync<TagDto>();
+        var questTag = await questResponse.Content.ReadFromJsonAsync<TagDto>();
+        Assert.NotEqual(monsterTag!.Id, questTag!.Id);
+        Assert.Equal(TagKind.Monster, monsterTag.Kind);
+        Assert.Equal(TagKind.Quest, questTag.Kind);
     }
 
     [Fact]
@@ -69,6 +87,16 @@ public class TagEndpointTests(PostgresFixture postgres) : IntegrationTestBase(po
         var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.NotNull(problem);
         Assert.Contains("prázd", problem!.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Create_ControlCharacter_Returns400()
+    {
+        var response = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("Bad\u0001Tag", TagKind.Monster));
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Contains("řídicí", problem!.Detail, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -93,6 +121,22 @@ public class TagEndpointTests(PostgresFixture postgres) : IntegrationTestBase(po
 
         var fetched = await Client.GetFromJsonAsync<TagDto>($"/api/tags/{created.Id}");
         Assert.Equal("Foo+Bar", fetched!.Name);
+    }
+
+    [Fact]
+    public async Task Update_DuplicateNameWithinKind_Returns400IgnoringCase()
+    {
+        var firstResponse = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("big", TagKind.Monster));
+        Assert.Equal(HttpStatusCode.Created, firstResponse.StatusCode);
+        var secondResponse = await Client.PostAsJsonAsync("/api/tags", new CreateTagDto("small", TagKind.Monster));
+        Assert.Equal(HttpStatusCode.Created, secondResponse.StatusCode);
+        var second = await secondResponse.Content.ReadFromJsonAsync<TagDto>();
+
+        var response = await Client.PutAsJsonAsync($"/api/tags/{second!.Id}", new UpdateTagDto("BiG"));
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Contains("už", problem!.Detail, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Makes `POST /api/tags` create-or-return-existing by case-insensitive `(Kind, Name)`, with existing tag casing preserved.
- Adds validation for empty/control-character tag names and keeps punctuation/internal spaces allowed.
- Refactors `TagChipPicker` into a shared monster/quest picker that supports typed Enter and comma-split create/link while preserving the `Přidat tag` browse flow.
- Replaces the quest-specific tag picker with the shared component.

## Phase-0 decisions applied
- Monster + quest assignment use the shared picker.
- Existing tags win on casing; typed `BiG` links existing `big`.
- Input trims edges, preserves internal spaces, splits comma-pasted names, waits for server response before rendering chips.
- `/tags` catalog remains intact and benefits from idempotent create behavior.

## Verification
- `dotnet build OvcinaHra.slnx --no-restore` (0 warnings, 0 errors)
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter "FullyQualifiedName~TagEndpointTests"` (16 passed)
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter "FullyQualifiedName~QuestPhase1Tests"` (7 passed)
- `dotnet test OvcinaHra.slnx --no-build --filter "FullyQualifiedName!~E2E"` (518 passed)
- `dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include ...`
- `git diff --check`

Closes #331