### PR TITLE
Fix treasure map inherited coordinates and filtered count pins

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -70,21 +70,27 @@ public static class LocationEndpoints
             db,
             rows.Select(r => new LocationCoordinateState(r.Id, r.Latitude, r.Longitude, r.ParentLocationId)));
 
-        var locations = rows.Select(r => new LocationListDto(
-            r.Id, r.Name, r.LocationKind,
-            r.Region,
-            r.Latitude,
-            r.Longitude,
-            r.ParentLocationId,
-            r.Description, r.Details, r.GamePotential, r.NpcInfo, r.SetupNotes,
-            Array.Empty<LocationStashDto>(),
-            Array.Empty<LocationQuestDto>(),
-            Array.Empty<LocationTreasureQuestDto>(),
-            ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
-            StampImagePath: r.StampImagePath,
-            StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"),
-            IsLocated: IsLocated(lookup, r.Id))).ToList();
+        var locations = rows.Select(r =>
+        {
+            var effective = GetEffectiveCoordinates(lookup, r.Id);
+            return new LocationListDto(
+                r.Id, r.Name, r.LocationKind,
+                r.Region,
+                r.Latitude,
+                r.Longitude,
+                r.ParentLocationId,
+                r.Description, r.Details, r.GamePotential, r.NpcInfo, r.SetupNotes,
+                Array.Empty<LocationStashDto>(),
+                Array.Empty<LocationQuestDto>(),
+                Array.Empty<LocationTreasureQuestDto>(),
+                ImagePath: r.ImagePath,
+                ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
+                StampImagePath: r.StampImagePath,
+                StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"),
+                IsLocated: effective.HasValue,
+                EffectiveLatitude: effective?.Latitude,
+                EffectiveLongitude: effective?.Longitude);
+        }).ToList();
 
         return TypedResults.Ok(locations);
     }
@@ -327,26 +333,32 @@ public static class LocationEndpoints
             db,
             rows.Select(r => new LocationCoordinateState(r.Id, r.Latitude, r.Longitude, r.ParentLocationId)));
 
-        var dtos = rows.Select(r => new LocationListDto(
-            r.Id, r.Name, r.LocationKind,
-            r.Region,
-            r.Latitude,
-            r.Longitude,
-            r.ParentLocationId,
-            r.Description, r.Details, r.GamePotential, r.NpcInfo, r.SetupNotes,
-            Stashes: r.Stashes.Select(s => new LocationStashDto(
-                s.SecretStashId,
-                s.StashName,
-                s.TreasureQuests,
-                ImagePath: s.StashImagePath,
-                ImageUrl: string.IsNullOrWhiteSpace(s.StashImagePath) ? null : ImageEndpoints.ThumbUrl(http, "secretstashes", s.SecretStashId, "medium"))).ToList(),
-            Quests: r.Quests,
-            LocationTreasureQuests: r.LocationTreasureQuests,
-            ImagePath: r.ImagePath,
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
-            StampImagePath: r.StampImagePath,
-            StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"),
-            IsLocated: IsLocated(lookup, r.Id))).ToList();
+        var dtos = rows.Select(r =>
+        {
+            var effective = GetEffectiveCoordinates(lookup, r.Id);
+            return new LocationListDto(
+                r.Id, r.Name, r.LocationKind,
+                r.Region,
+                r.Latitude,
+                r.Longitude,
+                r.ParentLocationId,
+                r.Description, r.Details, r.GamePotential, r.NpcInfo, r.SetupNotes,
+                Stashes: r.Stashes.Select(s => new LocationStashDto(
+                    s.SecretStashId,
+                    s.StashName,
+                    s.TreasureQuests,
+                    ImagePath: s.StashImagePath,
+                    ImageUrl: string.IsNullOrWhiteSpace(s.StashImagePath) ? null : ImageEndpoints.ThumbUrl(http, "secretstashes", s.SecretStashId, "medium"))).ToList(),
+                Quests: r.Quests,
+                LocationTreasureQuests: r.LocationTreasureQuests,
+                ImagePath: r.ImagePath,
+                ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
+                StampImagePath: r.StampImagePath,
+                StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"),
+                IsLocated: effective.HasValue,
+                EffectiveLatitude: effective?.Latitude,
+                EffectiveLongitude: effective?.Longitude);
+        }).ToList();
 
         return TypedResults.Ok(dtos);
     }
@@ -392,19 +404,25 @@ public static class LocationEndpoints
     internal static bool IsLocated(
         IReadOnlyDictionary<int, LocationCoordinateState> lookup,
         int? locationId,
+        int depth = 0) =>
+        GetEffectiveCoordinates(lookup, locationId, depth).HasValue;
+
+    internal static (decimal Latitude, decimal Longitude)? GetEffectiveCoordinates(
+        IReadOnlyDictionary<int, LocationCoordinateState> lookup,
+        int? locationId,
         int depth = 0)
     {
         if (locationId is null
             || depth > LocationInheritanceMaxDepth
             || !lookup.TryGetValue(locationId.Value, out var row))
         {
-            return false;
+            return null;
         }
 
         if (!row.ParentLocationId.HasValue && row.Latitude.HasValue && row.Longitude.HasValue)
-            return true;
+            return (row.Latitude.Value, row.Longitude.Value);
 
-        return IsLocated(lookup, row.ParentLocationId, depth + 1);
+        return GetEffectiveCoordinates(lookup, row.ParentLocationId, depth + 1);
     }
 
     private static async Task<Results<Created, Conflict>> AssignToGame(GameLocationDto dto, WorldDbContext db)

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -506,11 +506,11 @@
     public async Task UpdateMarkerPositionAsync(int id, double lat, double lon)
         => await JS.InvokeVoidAsync("ovcinaMap.updateMarkerPosition", id, lat, lon);
 
-    public async Task AddPieMarkerAsync(int id, double lat, double lon, int[] counts, int maxCount)
-        => await JS.InvokeVoidAsync("ovcinaMap.addPieMarker", id, lat, lon, counts, maxCount);
+    public async Task AddPieMarkerAsync(int id, double lat, double lon, int[] counts)
+        => await JS.InvokeVoidAsync("ovcinaMap.addPieMarker", id, lat, lon, counts);
 
-    public async Task UpdatePieMarkerCountsAsync(int id, int[] counts, int maxCount)
-        => await JS.InvokeVoidAsync("ovcinaMap.updatePieMarkerCounts", id, counts, maxCount);
+    public async Task UpdatePieMarkerCountsAsync(int id, int[] counts)
+        => await JS.InvokeVoidAsync("ovcinaMap.updatePieMarkerCounts", id, counts);
 
     public async Task RemovePieMarkerAsync(int id)
         => await JS.InvokeVoidAsync("ovcinaMap.removePieMarker", id);

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -97,7 +97,7 @@ else
                    Without this the map looks empty and the user can't tell
                    whether it's a bug or a data state (#211 reproduction). *@
                 @{
-                    var withGps = locations.Count(l => l.Latitude.HasValue && l.Longitude.HasValue);
+                    var withGps = locations.Count(l => l.IsLocated);
                     var missingGps = locations.Count - withGps;
                 }
                 @if (locations.Count == 0)
@@ -114,7 +114,7 @@ else
                     <div class="alert alert-info small mb-2 d-flex align-items-center gap-2">
                         <i class="bi bi-geo-alt"></i>
                         <span>
-                            Žádná z @locations.Count přiřazených lokací nemá nastavené GPS souřadnice.
+                            Žádná z @locations.Count přiřazených lokací nemá dostupné GPS souřadnice.
                             Otevři detail lokace a nastav je, aby se zobrazila na mapě —
                             nebo přepni na <button type="button" class="btn btn-link btn-sm p-0 align-baseline"
                                 @onclick='() => SetTreasuresViewAsync("cards")'>karty</button>.
@@ -127,7 +127,7 @@ else
                         <i class="bi bi-geo-alt"></i>
                         <span>
                             Mapa zobrazuje @withGps z @locations.Count lokací.
-                            @missingGps @(missingGps == 1 ? "lokace nemá" : missingGps < 5 ? "lokace nemají" : "lokací nemá") nastavené GPS —
+                            @missingGps @(missingGps == 1 ? "lokace nemá" : missingGps < 5 ? "lokace nemají" : "lokací nemá") dostupné GPS —
                             otevři jejich detail a nastav souřadnice, nebo přepni na
                             <button type="button" class="btn btn-link btn-sm p-0 align-baseline"
                                 @onclick='() => SetTreasuresViewAsync("cards")'>karty</button>.
@@ -719,6 +719,7 @@ else
     private MapView? mapView;
     private bool styleLoaded;
     private bool markersPlaced;
+    private sealed record LocatedTreasureLocation(LocationListDto Location, decimal Latitude, decimal Longitude);
 
     // ===== Overview =====
     private bool overviewVisible;
@@ -767,7 +768,6 @@ else
         new("early", "early",    GameTimePhase.Early,    "Rozvoj hry"),
         new("mid",   "midgame",  GameTimePhase.Midgame,  "Střed hry"),
         new("late",  "lategame", GameTimePhase.Lategame, "Závěr hry"),
-        new("end",   "endgame",  GameTimePhase.EndGame,  "Konec hry"),
     ];
 
     private static readonly List<EnumItem<GameTimePhase>> difficultyValues = Enum.GetValues<GameTimePhase>()
@@ -886,22 +886,28 @@ else
         // placed. Saved bbox stays as a fallback (and CZ countryside as a
         // last resort) so games without placements still render somewhere
         // sensible.
-        var placed = locations.Where(l => l.Latitude.HasValue && l.Longitude.HasValue).ToList();
+        var placed = locations
+            .Select(ToLocatedTreasureLocation)
+            .OfType<LocatedTreasureLocation>()
+            .ToList();
+        var cardsByLocationId = locationCards.ToDictionary(c => c.LocationId);
+
         await FitMapToLocationExtentOrFallbackAsync(placed);
-        foreach (var loc in placed)
+        foreach (var placedLocation in placed)
         {
-            var card = locationCards.FirstOrDefault(c => c.LocationId == loc.Id);
+            var loc = placedLocation.Location;
+            cardsByLocationId.TryGetValue(loc.Id, out var card);
             if (card is null || card.TotalItems == 0)
             {
                 await mapView.AddZeroMarkerAsync(loc.Id,
-                    (double)loc.Latitude!.Value, (double)loc.Longitude!.Value,
+                    (double)placedLocation.Latitude, (double)placedLocation.Longitude,
                     loc.Name, KindSlug(loc.LocationKind));
             }
             else
             {
                 var counts = new[] { card.StartCount, card.EarlyCount, card.MidgameCount, card.LategameCount };
                 await mapView.AddPieMarkerAsync(loc.Id,
-                    (double)loc.Latitude!.Value, (double)loc.Longitude!.Value,
+                    (double)placedLocation.Latitude, (double)placedLocation.Longitude,
                     counts, maxCount);
             }
         }
@@ -914,9 +920,20 @@ else
     private int? _cachedBoundsGameId;
     private (double SwLat, double SwLng, double NeLat, double NeLng)? _cachedBounds;
 
+    private static LocatedTreasureLocation? ToLocatedTreasureLocation(LocationListDto location)
+    {
+        if (location.EffectiveLatitude.HasValue && location.EffectiveLongitude.HasValue)
+            return new LocatedTreasureLocation(location, location.EffectiveLatitude.Value, location.EffectiveLongitude.Value);
+
+        if (!location.ParentLocationId.HasValue && location.Latitude.HasValue && location.Longitude.HasValue)
+            return new LocatedTreasureLocation(location, location.Latitude.Value, location.Longitude.Value);
+
+        return null;
+    }
+
     /// <summary>
     /// Issue #160: zoom the Treasures map tight on the smallest box that
-    /// contains every placed <see cref="LocationListDto"/> for the active
+    /// contains every placed map location for the active
     /// game. Three-tier fallback so the map renders cleanly even on
     /// freshly-created games:
     ///   1. ≥ 2 placed locations → fitBounds to their extent (40px padding
@@ -927,16 +944,16 @@ else
     ///      set, else the CZ-countryside default the BoundingBoxPicker uses.
     /// Saved-bbox fetch is best-effort: a 5xx must not break the page.
     /// </summary>
-    private async Task FitMapToLocationExtentOrFallbackAsync(IReadOnlyList<LocationListDto> placed)
+    private async Task FitMapToLocationExtentOrFallbackAsync(IReadOnlyList<LocatedTreasureLocation> placed)
     {
         if (mapView is null) return;
 
         if (placed.Count >= 2)
         {
-            var minLat = placed.Min(l => (double)l.Latitude!.Value);
-            var maxLat = placed.Max(l => (double)l.Latitude!.Value);
-            var minLng = placed.Min(l => (double)l.Longitude!.Value);
-            var maxLng = placed.Max(l => (double)l.Longitude!.Value);
+            var minLat = placed.Min(l => (double)l.Latitude);
+            var maxLat = placed.Max(l => (double)l.Latitude);
+            var minLng = placed.Min(l => (double)l.Longitude);
+            var maxLng = placed.Max(l => (double)l.Longitude);
             await mapView.FitBoundsAsync(minLat, minLng, maxLat, maxLng);
             return;
         }
@@ -944,7 +961,7 @@ else
         if (placed.Count == 1)
         {
             var only = placed[0];
-            await mapView.SetCenterAsync((double)only.Latitude!.Value, (double)only.Longitude!.Value, 14);
+            await mapView.SetCenterAsync((double)only.Latitude, (double)only.Longitude, 14);
             return;
         }
 

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -877,10 +877,6 @@ else
         if (mapView is null) return;
         await mapView.ClearPieMarkersAsync();
 
-        var maxCount = Math.Max(1, locationCards
-            .SelectMany(l => new[] { l.StartCount, l.EarlyCount, l.MidgameCount, l.LategameCount })
-            .DefaultIfEmpty(0).Max());
-
         // Issue #160 / #103: prefer the LOCATION-EXTENT bbox over the saved
         // game bbox so the map starts tight on what the organizer actually
         // placed. Saved bbox stays as a fallback (and CZ countryside as a
@@ -908,7 +904,7 @@ else
                 var counts = new[] { card.StartCount, card.EarlyCount, card.MidgameCount, card.LategameCount };
                 await mapView.AddPieMarkerAsync(loc.Id,
                     (double)placedLocation.Latitude, (double)placedLocation.Longitude,
-                    counts, maxCount);
+                    counts);
             }
         }
 

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2449,15 +2449,18 @@
 .oh-tp-map-toolbar-spacer{flex:1}
 .oh-tp-map-count{font-family:var(--oh-font-mono);color:var(--oh-text);font-size:.8125rem}
 
-/* Pie pins (SVG built in JS — only positioning + state CSS here) */
+/* Treasure count pins (SVG built in JS — only positioning + state CSS here) */
 .oh-tp-pin{cursor:pointer;transition:transform .15s ease,filter .15s ease}
-.oh-tp-pin-pie{width:64px;height:64px}
+.oh-tp-pin-pie{width:48px;height:48px}
 .oh-tp-pin-pie:hover{transform:scale(1.06);filter:drop-shadow(0 4px 8px rgba(40,25,5,.5));z-index:8}
-.oh-tp-pin-svg{display:block}
+.oh-tp-pin-pie.is-filter-zero{opacity:.5}
+.oh-tp-pin-pie.is-filter-zero:hover{opacity:.85}
+.oh-tp-pin-svg{display:block;width:48px;height:48px}
 .oh-tp-pin-backing{fill:rgba(245,237,227,.92);stroke:none}
 .oh-tp-pin-ring{fill:none;stroke:var(--oh-card-border,#8B6F47);stroke-width:2.5}
-.oh-tp-pin-inner{fill:rgba(255,248,240,.95);stroke:#6b5a3a;stroke-width:1}
-.oh-tp-pin-num{font:700 .75rem var(--oh-font-mono);fill:var(--oh-text,#2a2a2a);pointer-events:none;dominant-baseline:middle}
+.oh-tp-pin-inner{fill:rgba(255,248,240,.96);stroke:#6b5a3a;stroke-width:1}
+.oh-tp-pin-num{font:700 .9rem var(--oh-font-mono);fill:var(--oh-text,#2a2a2a);pointer-events:none;dominant-baseline:middle}
+.oh-tp-pin-num-wide{font-size:.68rem}
 .oh-tp-wedge{transition:opacity .2s}
 .oh-tp-wedge-start{fill:var(--oh-stage-start)}
 .oh-tp-wedge-early{fill:var(--oh-stage-early)}

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -545,11 +545,8 @@ window.ovcinaMiniMap = {
 
 // ----------------------------------------------------------------------
 // Pie-wedge markers for /treasures planning.
-// Fixed-quadrant layout — Start=NE, Early=SE, Mid=SW, Late=NW — with
-// per-stage wedge radius scaled by count / maxCount. Unfilled portion
-// shows a muted parchment disc beneath the coloured wedges. Pie markers
-// are tracked separately from ovcinaMap._markers so the /map and
-// /treasures pages never collide.
+// Count-badge treasure markers are tracked separately from ovcinaMap._markers
+// so the /map and /treasures pages never collide.
 // ----------------------------------------------------------------------
 window.ovcinaMap._pieMarkers = {};
 window.ovcinaMap._zeroMarkers = {};
@@ -602,13 +599,12 @@ window.ovcinaMap._wireDropTarget = function (element, locationId) {
     });
 };
 
-window.ovcinaMap.addPieMarker = function (id, lat, lon, counts, maxCount) {
+window.ovcinaMap.addPieMarker = function (id, lat, lon, counts) {
     if (!this._map) return;
     this.removePieMarker(id);
     var wrap = document.createElement('div');
     wrap.className = 'oh-tp-pin oh-tp-pin-pie';
     wrap.setAttribute('data-pie-id', id);
-    wrap.innerHTML = this._buildPieSvg(counts);
 
     var self = this;
     wrap.addEventListener('click', function (e) {
@@ -625,11 +621,10 @@ window.ovcinaMap.addPieMarker = function (id, lat, lon, counts, maxCount) {
     this._applyStageFilterToElement(wrap);
 };
 
-window.ovcinaMap.updatePieMarkerCounts = function (id, counts, maxCount) {
+window.ovcinaMap.updatePieMarkerCounts = function (id, counts) {
     var rec = this._pieMarkers[id];
     if (!rec) return;
     rec.counts = counts.slice();
-    rec.element.innerHTML = this._buildPieSvg(counts);
     this._applyStageFilterToElement(rec.element);
 };
 

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -555,34 +555,29 @@ window.ovcinaMap._pieMarkers = {};
 window.ovcinaMap._zeroMarkers = {};
 window.ovcinaMap._activePieStages = null; // Set<string> | null (null = all active)
 
-window.ovcinaMap._buildPieSvg = function (counts, maxCount) {
+window.ovcinaMap._filteredTreasureCount = function (counts) {
     var c0 = counts[0] | 0, c1 = counts[1] | 0, c2 = counts[2] | 0, c3 = counts[3] | 0;
-    var total = c0 + c1 + c2 + c3;
-    var cap = Math.max(1, maxCount || total);
-    var maxR = 28;
     var stages = ['start', 'early', 'mid', 'late'];
-    // Each wedge occupies a fixed 90° quadrant. Path uses a small arc.
-    // Paths below are parameterised by `r` (scaled radius per stage).
-    var paths = [
-        function (r) { return 'M0,0 L0,' + (-r) + ' A' + r + ',' + r + ' 0 0 1 ' + r + ',0 Z'; }, // NE / Start
-        function (r) { return 'M0,0 L' + r + ',0 A' + r + ',' + r + ' 0 0 1 0,' + r + ' Z'; }, // SE / Early
-        function (r) { return 'M0,0 L0,' + r + ' A' + r + ',' + r + ' 0 0 1 ' + (-r) + ',0 Z'; }, // SW / Mid
-        function (r) { return 'M0,0 L' + (-r) + ',0 A' + r + ',' + r + ' 0 0 1 0,' + (-r) + ' Z'; } // NW / Late
-    ];
-    var svg = '<svg width="64" height="64" viewBox="-32 -32 64 64" class="oh-tp-pin-svg">';
-    // Parchment backing disc (shows through in unfilled portions).
-    svg += '<circle class="oh-tp-pin-backing" r="' + maxR + '" cx="0" cy="0" />';
-    // Coloured wedges at scaled radius (skip zero-count stages).
     var cs = [c0, c1, c2, c3];
-    for (var i = 0; i < 4; i++) {
-        if (cs[i] <= 0) continue;
-        var r = Math.max(6, maxR * Math.min(1, cs[i] / cap));
-        svg += '<path class="oh-tp-wedge oh-tp-wedge-' + stages[i] + '" data-stage="' + stages[i] + '" d="' + paths[i](r.toFixed(2)) + '"/>';
+    if (!this._activePieStages) {
+        return c0 + c1 + c2 + c3;
     }
-    // Outer ring + inner numeral disc.
-    svg += '<circle class="oh-tp-pin-ring" r="' + (maxR + 1) + '" cx="0" cy="0" />';
-    svg += '<circle class="oh-tp-pin-inner" r="10" cx="0" cy="0" />';
-    svg += '<text class="oh-tp-pin-num" x="0" y="4" text-anchor="middle">' + total + '</text>';
+    var total = 0;
+    for (var i = 0; i < stages.length; i++) {
+        if (this._activePieStages.has(stages[i])) total += cs[i];
+    }
+    return total;
+};
+
+window.ovcinaMap._buildPieSvg = function (counts) {
+    var total = this._filteredTreasureCount(counts);
+    var label = total > 999 ? '999+' : String(total);
+    var labelClass = label.length > 2 ? ' oh-tp-pin-num-wide' : '';
+    var svg = '<svg width="48" height="48" viewBox="-24 -24 48 48" class="oh-tp-pin-svg">';
+    svg += '<circle class="oh-tp-pin-backing" r="21" cx="0" cy="0" />';
+    svg += '<circle class="oh-tp-pin-ring" r="22" cx="0" cy="0" />';
+    svg += '<circle class="oh-tp-pin-inner" r="15" cx="0" cy="0" />';
+    svg += '<text class="oh-tp-pin-num' + labelClass + '" x="0" y="4" text-anchor="middle">' + label + '</text>';
     svg += '</svg>';
     return svg;
 };
@@ -613,7 +608,7 @@ window.ovcinaMap.addPieMarker = function (id, lat, lon, counts, maxCount) {
     var wrap = document.createElement('div');
     wrap.className = 'oh-tp-pin oh-tp-pin-pie';
     wrap.setAttribute('data-pie-id', id);
-    wrap.innerHTML = this._buildPieSvg(counts, maxCount);
+    wrap.innerHTML = this._buildPieSvg(counts);
 
     var self = this;
     wrap.addEventListener('click', function (e) {
@@ -634,7 +629,7 @@ window.ovcinaMap.updatePieMarkerCounts = function (id, counts, maxCount) {
     var rec = this._pieMarkers[id];
     if (!rec) return;
     rec.counts = counts.slice();
-    rec.element.innerHTML = this._buildPieSvg(counts, maxCount);
+    rec.element.innerHTML = this._buildPieSvg(counts);
     this._applyStageFilterToElement(rec.element);
 };
 
@@ -706,11 +701,12 @@ window.ovcinaMap.clearPieMarkers = function () {
 })();
 
 window.ovcinaMap._applyStageFilterToElement = function (el) {
-    var active = this._activePieStages;
-    var wedges = el.querySelectorAll('[data-stage]');
-    for (var i = 0; i < wedges.length; i++) {
-        var s = wedges[i].getAttribute('data-stage');
-        wedges[i].style.opacity = (!active || active.has(s)) ? '1' : '0.15';
+    var id = el.getAttribute('data-pie-id');
+    var rec = id ? this._pieMarkers[id] : null;
+    if (rec) {
+        var total = this._filteredTreasureCount(rec.counts);
+        rec.element.innerHTML = this._buildPieSvg(rec.counts);
+        rec.element.classList.toggle('is-filter-zero', total === 0);
     }
 };
 

--- a/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
@@ -24,7 +24,9 @@ public record LocationListDto(
     string? ImageUrl = null,
     string? StampImagePath = null,
     string? StampImageUrl = null,
-    bool IsLocated = false)
+    bool IsLocated = false,
+    decimal? EffectiveLatitude = null,
+    decimal? EffectiveLongitude = null)
 {
     [JsonIgnore]
     public string LocationKindDisplay => LocationKind.GetDisplayName();

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ConsultEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ConsultEndpointTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -174,7 +175,7 @@ public class ConsultEndpointTests(PostgresFixture postgres)
 
     private sealed class CapturingLoggerProvider : ILoggerProvider
     {
-        public List<LogEntry> Entries { get; } = [];
+        public ConcurrentQueue<LogEntry> Entries { get; } = [];
 
         public ILogger CreateLogger(string categoryName)
             => new CapturingLogger(categoryName, Entries);
@@ -186,7 +187,7 @@ public class ConsultEndpointTests(PostgresFixture postgres)
 
     private sealed class CapturingLogger(
         string categoryName,
-        List<LogEntry> entries) : ILogger
+        ConcurrentQueue<LogEntry> entries) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state)
             where TState : notnull
@@ -202,7 +203,7 @@ public class ConsultEndpointTests(PostgresFixture postgres)
             Func<TState, Exception?, string> formatter)
         {
             var structuredState = state as IEnumerable<KeyValuePair<string, object?>>;
-            entries.Add(new LogEntry(
+            entries.Enqueue(new LogEntry(
                 logLevel,
                 categoryName,
                 formatter(state, exception),

--- a/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
@@ -173,8 +173,42 @@ public class LocationEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         Assert.Equal(parent.Id, child.ParentLocationId);
 
         var locations = (await Client.GetFromJsonAsync<List<LocationListDto>>("/api/locations"))!;
-        Assert.True(locations.Single(l => l.Id == parent.Id).IsLocated);
-        Assert.True(locations.Single(l => l.Id == child.Id).IsLocated);
+        var parentListRow = locations.Single(l => l.Id == parent.Id);
+        var childListRow = locations.Single(l => l.Id == child.Id);
+        Assert.True(parentListRow.IsLocated);
+        Assert.Equal(49.0m, parentListRow.EffectiveLatitude);
+        Assert.Equal(17.0m, parentListRow.EffectiveLongitude);
+        Assert.True(childListRow.IsLocated);
+        Assert.Equal(49.0m, childListRow.EffectiveLatitude);
+        Assert.Equal(17.0m, childListRow.EffectiveLongitude);
+    }
+
+    [Fact]
+    public async Task GetByGame_WithChildLocation_ReturnsInheritedCoordinates()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Inherited GPS Game", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var parentResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Inherited GPS Parent", LocationKind.PointOfInterest, 49.25m, 17.75m));
+        var parent = await parentResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        var childResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Inherited GPS Child", LocationKind.PointOfInterest, 50.0m, 18.0m,
+                ParentLocationId: parent!.Id));
+        var child = await childResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        await Client.PostAsJsonAsync("/api/locations/by-game", new GameLocationDto(game!.Id, child!.Id));
+
+        var gameLocations = (await Client.GetFromJsonAsync<List<LocationListDto>>(
+            $"/api/locations/by-game/{game.Id}"))!;
+        var row = Assert.Single(gameLocations);
+        Assert.Null(row.Latitude);
+        Assert.Null(row.Longitude);
+        Assert.True(row.IsLocated);
+        Assert.Equal(49.25m, row.EffectiveLatitude);
+        Assert.Equal(17.75m, row.EffectiveLongitude);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- refs #349
- expose effective inherited coordinates on `LocationListDto` and render treasure map pins at parent coordinates
- use `IsLocated` for treasure map GPS banners so inherited child/sibling locations do not spam missing-GPS warnings
- replace treasure pie pins with filtered count badges that remain visible as dim zero targets when the selected phase has no treasures
- remove EndGame from the treasure phase filter; character/player/person-ID ordering was left untouched per alignment
- stabilize the consult test log capture after API CI exposed a concurrent log enumeration race

## Verification
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter "FullyQualifiedName~ConsultEndpointTests"`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter "FullyQualifiedName~LocationEndpointTests"`
- `dotnet test OvcinaHra.slnx --no-build`
- `git diff --check` (only existing CRLF normalization warnings)

## Collision notes
- Did not touch `ExplorerMapExportService` or `MapDataService`.