### PR TITLE
Filter used outputs in recipe popup

### DIFF
--- a/src/OvcinaHra.Client/Components/RecipeEditPopup.razor
+++ b/src/OvcinaHra.Client/Components/RecipeEditPopup.razor
@@ -29,13 +29,13 @@
         {
             <DxFormLayout>
                 <DxFormLayoutGroup Caption="Identita" ColSpanMd="12">
-                    <DxFormLayoutItem Caption="Výstupní předmět" ColSpanMd="8">
+                    <DxFormLayoutItem Caption="Výstupní předmět" ColSpanMd="12">
                         <DxComboBox Data="@craftableItems" @bind-Value="@editOutputItemId"
                                     TextFieldName="Name" ValueFieldName="Id"
                                     NullText="(vyberte vyráběný předmět)"
                                     SearchMode="ListSearchMode.AutoSearch" />
                     </DxFormLayoutItem>
-                    <DxFormLayoutItem Caption="Kategorie" ColSpanMd="4">
+                    <DxFormLayoutItem Caption="Kategorie" ColSpanMd="12">
                         <DxTextBox Text="@SelectedEditCategoryDisplay" ReadOnly="true" />
                     </DxFormLayoutItem>
                     <DxFormLayoutItem Caption="Název" ColSpanMd="8">
@@ -130,6 +130,7 @@
     private int? editLocationId;
 
     private List<ItemListDto> allItems = [];
+    private List<RecipeListDto> allRecipes = [];
     private List<LocationListDto> allLocations = [];
     private List<BuildingListDto> allBuildings = [];
     private List<GameSkillDto> gameSkills = [];
@@ -138,7 +139,14 @@
     private IReadOnlyList<RecipeBuildingPicker.BuildingRow> _buildingRows = [];
     private List<int> _skillIds = [];
 
-    private List<ItemListDto> craftableItems => allItems.Where(i => i.IsCraftable).ToList();
+    private List<ItemListDto> craftableItems => allItems
+        .Where(i => i.IsCraftable
+            && (i.Id == detail?.OutputItemId
+                || !allRecipes.Any(r =>
+                    r.Id != detail?.Id
+                    && r.GameId == detail?.GameId
+                    && r.OutputItemId == i.Id)))
+        .ToList();
     private string SelectedEditCategoryDisplay => allItems
         .FirstOrDefault(i => i.Id == editOutputItemId)?.ItemTypeDisplay ?? "Podle výstupu";
 
@@ -186,10 +194,12 @@
 
             // Picker source data — fetch in parallel to avoid serial waterfall.
             var itemsTask = Api.GetListAsync<ItemListDto>("/api/items");
+            var recipesTask = Api.GetListAsync<RecipeListDto>("/api/recipes");
             var locationsTask = Api.GetListAsync<LocationListDto>("/api/locations");
             var buildingsTask = Api.GetListAsync<BuildingListDto>("/api/buildings");
-            await Task.WhenAll(itemsTask, locationsTask, buildingsTask);
+            await Task.WhenAll(itemsTask, recipesTask, locationsTask, buildingsTask);
             allItems = await itemsTask;
+            allRecipes = await recipesTask;
             allLocations = await locationsTask;
             allBuildings = await buildingsTask;
 

--- a/src/OvcinaHra.Client/Components/RecipeEditPopup.razor
+++ b/src/OvcinaHra.Client/Components/RecipeEditPopup.razor
@@ -130,10 +130,10 @@
     private int? editLocationId;
 
     private List<ItemListDto> allItems = [];
-    private List<RecipeListDto> allRecipes = [];
     private List<LocationListDto> allLocations = [];
     private List<BuildingListDto> allBuildings = [];
     private List<GameSkillDto> gameSkills = [];
+    private HashSet<int> usedOutputItemIdsInScope = [];
 
     private IReadOnlyList<RecipeIngredientPicker.IngredientRow> _ingredientRows = [];
     private IReadOnlyList<RecipeBuildingPicker.BuildingRow> _buildingRows = [];
@@ -142,10 +142,7 @@
     private List<ItemListDto> craftableItems => allItems
         .Where(i => i.IsCraftable
             && (i.Id == detail?.OutputItemId
-                || !allRecipes.Any(r =>
-                    r.Id != detail?.Id
-                    && r.GameId == detail?.GameId
-                    && r.OutputItemId == i.Id)))
+                || !usedOutputItemIdsInScope.Contains(i.Id)))
         .ToList();
     private string SelectedEditCategoryDisplay => allItems
         .FirstOrDefault(i => i.Id == editOutputItemId)?.ItemTypeDisplay ?? "Podle výstupu";
@@ -194,12 +191,16 @@
 
             // Picker source data — fetch in parallel to avoid serial waterfall.
             var itemsTask = Api.GetListAsync<ItemListDto>("/api/items");
-            var recipesTask = Api.GetListAsync<RecipeListDto>("/api/recipes");
+            var recipesUrl = detail.GameId is int recipeGameId ? $"/api/games/{recipeGameId}/recipes" : "/api/recipes";
+            var recipesTask = Api.GetListAsync<RecipeListDto>(recipesUrl);
             var locationsTask = Api.GetListAsync<LocationListDto>("/api/locations");
             var buildingsTask = Api.GetListAsync<BuildingListDto>("/api/buildings");
             await Task.WhenAll(itemsTask, recipesTask, locationsTask, buildingsTask);
             allItems = await itemsTask;
-            allRecipes = await recipesTask;
+            usedOutputItemIdsInScope = (await recipesTask)
+                .Where(r => r.Id != detail.Id && r.GameId == detail.GameId)
+                .Select(r => r.OutputItemId)
+                .ToHashSet();
             allLocations = await locationsTask;
             allBuildings = await buildingsTask;
 

--- a/src/OvcinaHra.Client/Pages/Recipes/RecipeList.razor
+++ b/src/OvcinaHra.Client/Pages/Recipes/RecipeList.razor
@@ -101,9 +101,10 @@ else
     private string? createError;
     private string? createName;
     private int? createOutputItemId;
+    private HashSet<int> catalogRecipeOutputItemIds = [];
 
     private List<ItemListDto> availableCreateOutputItems => allItems
-        .Where(i => i.IsCraftable && !recipes.Any(r => r.GameId is null && r.OutputItemId == i.Id))
+        .Where(i => i.IsCraftable && !catalogRecipeOutputItemIds.Contains(i.Id))
         .ToList();
     private IEnumerable<ItemType> categoryPills => recipes
         .Select(r => r.Category)
@@ -133,6 +134,10 @@ else
             await Task.WhenAll(recipesTask, itemsTask);
             recipes = await recipesTask;
             allItems = await itemsTask;
+            catalogRecipeOutputItemIds = recipes
+                .Where(r => r.GameId is null)
+                .Select(r => r.OutputItemId)
+                .ToHashSet();
         }
         finally { loading = false; }
     }

--- a/src/OvcinaHra.Client/Pages/Recipes/RecipeList.razor
+++ b/src/OvcinaHra.Client/Pages/Recipes/RecipeList.razor
@@ -57,16 +57,16 @@ else
 }
 
 @* Minimal create modal. Output first; category is derived from selected item. *@
-<DxPopup AllowResize="true" @bind-Visible="@isCreateVisible" HeaderText="Nový recept (šablona)" Width="560px">
+<DxPopup AllowResize="true" @bind-Visible="@isCreateVisible" HeaderText="Nový recept (šablona)" Width="480px">
     <BodyContentTemplate Context="cCtx">
         <DxFormLayout>
-            <DxFormLayoutItem Caption="Výstupní předmět" ColSpanMd="8">
-                <DxComboBox Data="@craftableItems" @bind-Value="@createOutputItemId"
+            <DxFormLayoutItem Caption="Výstupní předmět" ColSpanMd="12">
+                <DxComboBox Data="@availableCreateOutputItems" @bind-Value="@createOutputItemId"
                             TextFieldName="Name" ValueFieldName="Id"
                             NullText="(vyberte vyráběný předmět)"
                             SearchMode="ListSearchMode.AutoSearch" />
             </DxFormLayoutItem>
-            <DxFormLayoutItem Caption="Kategorie" ColSpanMd="4">
+            <DxFormLayoutItem Caption="Kategorie" ColSpanMd="12">
                 <DxTextBox Text="@SelectedCreateCategoryDisplay" ReadOnly="true" />
             </DxFormLayoutItem>
             <DxFormLayoutItem Caption="Název (volitelně)" ColSpanMd="12">
@@ -102,7 +102,9 @@ else
     private string? createName;
     private int? createOutputItemId;
 
-    private List<ItemListDto> craftableItems => allItems.Where(i => i.IsCraftable).ToList();
+    private List<ItemListDto> availableCreateOutputItems => allItems
+        .Where(i => i.IsCraftable && !recipes.Any(r => r.GameId is null && r.OutputItemId == i.Id))
+        .ToList();
     private IEnumerable<ItemType> categoryPills => recipes
         .Select(r => r.Category)
         .Distinct()


### PR DESCRIPTION
## Summary
- closes #350
- filter Nový recept output item options to craftable items without an existing catalog recipe
- keep the current output item visible in edit mode while hiding outputs used by other recipes in the same GameId scope
- stack output item and derived category fields in a single column and narrow the create popup

## Verification
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter "FullyQualifiedName~RecipePhase1Tests"`
- `dotnet test OvcinaHra.slnx --no-build`
- `git diff --check` (only existing CRLF normalization warnings)