### PR TITLE
Add organizer and kingdom map exports

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/GameMapOverlayConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/GameMapOverlayConfiguration.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class GameMapOverlayConfiguration : IEntityTypeConfiguration<GameMapOverlay>
+{
+    public void Configure(EntityTypeBuilder<GameMapOverlay> builder)
+    {
+        builder.HasKey(e => new { e.GameId, e.Audience });
+
+        builder.Property(e => e.Audience)
+            .HasConversion<string>()
+            .HasMaxLength(20);
+
+        builder.Property(e => e.OverlayJson)
+            .IsRequired();
+
+        builder.HasOne(e => e.Game)
+            .WithMany(e => e.MapOverlays)
+            .HasForeignKey(e => e.GameId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -6,6 +6,7 @@ namespace OvcinaHra.Api.Data;
 public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContext(options)
 {
     public DbSet<Game> Games => Set<Game>();
+    public DbSet<GameMapOverlay> GameMapOverlays => Set<GameMapOverlay>();
     public DbSet<Location> Locations => Set<Location>();
     public DbSet<GameLocation> GameLocations => Set<GameLocation>();
     public DbSet<Tag> Tags => Set<Tag>();

--- a/src/OvcinaHra.Api/Endpoints/ExportEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ExportEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using OvcinaHra.Api.Services;
@@ -13,22 +14,107 @@ public static class ExportEndpoints
 
         group.MapGet("/{gameId:int}/exports/explorer-map.pdf", DownloadExplorerMapPdf);
         group.MapGet("/{gameId:int}/exports/magic-book.pdf", DownloadMagicBookPdf);
+        group.MapGet("/{gameId:int}/exports/organizer-map.pdf", DownloadOrganizerMapPdf);
+        group.MapGet("/{gameId:int}/exports/kingdom-map.pdf", DownloadKingdomMapPdf);
 
         return group;
     }
 
-    private static async Task<Results<FileContentHttpResult, NotFound, BadRequest<ProblemDetails>>> DownloadExplorerMapPdf(
+    private static Task<IResult> DownloadExplorerMapPdf(
         int gameId,
         string? style,
         IExplorerMapExportService exporter,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct) =>
+        DownloadMapPdf(
+            gameId,
+            style,
+            MapExportKind.Explorer,
+            MapExportPageFormat.A4Portrait,
+            organizerOnly: false,
+            exporter,
+            null,
+            loggerFactory,
+            ct);
+
+    private static Task<IResult> DownloadOrganizerMapPdf(
+        int gameId,
+        string? style,
+        IExplorerMapExportService exporter,
+        HttpContext http,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct) =>
+        DownloadMapPdf(
+            gameId,
+            style,
+            MapExportKind.Organizer,
+            MapExportPageFormat.A4Portrait,
+            organizerOnly: true,
+            exporter,
+            http,
+            loggerFactory,
+            ct);
+
+    private static Task<IResult> DownloadKingdomMapPdf(
+        int gameId,
+        string? style,
+        IExplorerMapExportService exporter,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct) =>
+        DownloadMapPdf(
+            gameId,
+            style,
+            MapExportKind.Kingdom,
+            MapExportPageFormat.A3Portrait,
+            organizerOnly: false,
+            exporter,
+            null,
+            loggerFactory,
+            ct);
+
+    private static async Task<IResult> DownloadMapPdf(
+        int gameId,
+        string? style,
+        MapExportKind kind,
+        MapExportPageFormat pageFormat,
+        bool organizerOnly,
+        IExplorerMapExportService exporter,
+        HttpContext? http,
+        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.ExportEndpoints");
+        logger.LogInformation(
+            "[map-export-pr3] export endpoint entry gameId={GameId} kind={Kind} pageFormat={PageFormat} styleRaw={StyleRaw}",
+            gameId,
+            kind,
+            pageFormat,
+            style);
+
         if (!TryParseStyle(style, out var parsedStyle))
             return TypedResults.BadRequest(ValidationProblem("Neznámý podklad mapy."));
 
+        if (organizerOnly && (http?.User is null || !IsOrganizer(http.User)))
+        {
+            logger.LogWarning(
+                "[map-export-pr3] export auth-gate denial gameId={GameId} kind={Kind}",
+                gameId,
+                kind);
+            return TypedResults.Problem(
+                title: "Přístup odepřen",
+                detail: "Pouze organizátoři mohou stáhnout tuto mapu.",
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
         try
         {
-            var pdf = await exporter.RenderExplorerMapAsync(gameId, parsedStyle, ct);
+            var pdf = await exporter.RenderMapAsync(gameId, parsedStyle, kind, pageFormat, ct);
+            logger.LogInformation(
+                "[map-export-pr3] export endpoint exit gameId={GameId} kind={Kind} status=file fileName={FileName} bytes={ByteCount}",
+                gameId,
+                kind,
+                pdf.FileName,
+                pdf.Bytes.Length);
             return TypedResults.File(
                 pdf.Bytes,
                 contentType: "application/pdf",
@@ -36,6 +122,10 @@ public static class ExportEndpoints
         }
         catch (KeyNotFoundException)
         {
+            logger.LogInformation(
+                "[map-export-pr3] export endpoint exit gameId={GameId} kind={Kind} status=not-found",
+                gameId,
+                kind);
             return TypedResults.NotFound();
         }
         catch (MapExportProblemException ex)
@@ -65,6 +155,15 @@ public static class ExportEndpoints
         {
             return TypedResults.BadRequest(ValidationProblem(ex.Title, ex.Detail));
         }
+    }
+
+    private static bool IsOrganizer(ClaimsPrincipal user)
+    {
+        var roles = user.FindAll(ClaimTypes.Role)
+            .Concat(user.FindAll("role"))
+            .Select(c => c.Value);
+
+        return roles.Any(role => role is "Organizer" or "Organizator" or "Organizátor" or "Admin");
     }
 
     private static bool TryParseStyle(string? value, out MapExportBasemapStyle style)

--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -9,6 +9,7 @@ using Npgsql;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Endpoints;
@@ -346,14 +347,51 @@ public static class GameEndpoints
     /// </summary>
     private static readonly JsonSerializerOptions OverlayJsonOptions = new() { WriteIndented = false };
 
-    private static async Task<Results<Ok<MapOverlayDto>, NoContent, NotFound>> GetOverlay(int id, WorldDbContext db)
+    private static async Task<IResult> GetOverlay(
+        int id,
+        string? audience,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
     {
-        var game = await db.Games.FindAsync(id);
-        if (game is null)
-            return TypedResults.NotFound();
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.GameEndpoints");
+        logger.LogInformation(
+            "[map-export-pr3] overlay get entry gameId={GameId} audienceRaw={AudienceRaw}",
+            id,
+            audience);
 
-        if (string.IsNullOrWhiteSpace(game.OverlayJson))
+        if (!await db.Games.AnyAsync(g => g.Id == id, ct))
+        {
+            logger.LogInformation("[map-export-pr3] overlay get exit gameId={GameId} status=not-found", id);
+            return TypedResults.NotFound();
+        }
+
+        if (!TryParseOverlayAudience(audience, out var parsedAudience))
+            return InvalidOverlayAudienceProblem();
+
+        if (parsedAudience == MapOverlayAudience.Organizer && !IsOrganizer(http.User))
+        {
+            logger.LogWarning(
+                "[map-export-pr3] overlay auth-gate denial gameId={GameId} audience={Audience}",
+                id,
+                parsedAudience);
+            return OverlayAuthorizationProblem();
+        }
+
+        var overlayJson = await db.GameMapOverlays
+            .AsNoTracking()
+            .Where(o => o.GameId == id && o.Audience == parsedAudience)
+            .Select(o => o.OverlayJson)
+            .FirstOrDefaultAsync(ct);
+        if (string.IsNullOrWhiteSpace(overlayJson))
+        {
+            logger.LogInformation(
+                "[map-export-pr3] overlay get exit gameId={GameId} audience={Audience} status=no-content",
+                id,
+                parsedAudience);
             return TypedResults.NoContent();
+        }
 
         // Best-effort deserialize: if a stored overlay is corrupt (e.g. schema
         // drift from a future shape type, or a hand-edited row), treat as
@@ -363,22 +401,68 @@ public static class GameEndpoints
         // both must be caught here.
         try
         {
-            var dto = JsonSerializer.Deserialize<MapOverlayDto>(game.OverlayJson, OverlayJsonOptions);
-            return dto is null ? TypedResults.NoContent() : TypedResults.Ok(dto);
+            var dto = JsonSerializer.Deserialize<MapOverlayDto>(overlayJson, OverlayJsonOptions);
+            if (dto is null)
+            {
+                logger.LogInformation(
+                    "[map-export-pr3] overlay get exit gameId={GameId} audience={Audience} status=no-content",
+                    id,
+                    parsedAudience);
+                return TypedResults.NoContent();
+            }
+
+            logger.LogInformation(
+                "[map-export-pr3] overlay get exit gameId={GameId} audience={Audience} status=ok shapes={ShapeCount}",
+                id,
+                parsedAudience,
+                dto.Shapes.Count);
+            return TypedResults.Ok(dto);
         }
         catch (Exception ex) when (ex is JsonException or NotSupportedException)
         {
+            logger.LogWarning(
+                ex,
+                "[map-export-pr3] overlay get exit gameId={GameId} audience={Audience} status=corrupt",
+                id,
+                parsedAudience);
             return TypedResults.NoContent();
         }
     }
 
-    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> UpdateOverlay(
-        int id, MapOverlayDto dto, WorldDbContext db)
+    private static async Task<IResult> UpdateOverlay(
+        int id,
+        string? audience,
+        MapOverlayDto dto,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
     {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.GameEndpoints");
+        logger.LogInformation(
+            "[map-export-pr3] overlay put entry gameId={GameId} audienceRaw={AudienceRaw} shapes={ShapeCount}",
+            id,
+            audience,
+            dto.Shapes.Count);
+
         // § _review-instincts #1: resource lookup BEFORE validation.
-        var game = await db.Games.FindAsync(id);
-        if (game is null)
+        if (!await db.Games.AnyAsync(g => g.Id == id, ct))
+        {
+            logger.LogInformation("[map-export-pr3] overlay put exit gameId={GameId} status=not-found", id);
             return TypedResults.NotFound();
+        }
+
+        if (!TryParseOverlayAudience(audience, out var parsedAudience))
+            return InvalidOverlayAudienceProblem();
+
+        if (parsedAudience == MapOverlayAudience.Organizer && !IsOrganizer(http.User))
+        {
+            logger.LogWarning(
+                "[map-export-pr3] overlay auth-gate denial gameId={GameId} audience={Audience}",
+                id,
+                parsedAudience);
+            return OverlayAuthorizationProblem();
+        }
 
         var serialized = JsonSerializer.Serialize(dto, OverlayJsonOptions);
         var byteCount = Encoding.UTF8.GetByteCount(serialized);
@@ -407,9 +491,62 @@ public static class GameEndpoints
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
-        game.OverlayJson = serialized;
-        await db.SaveChangesAsync();
+        var overlay = await db.GameMapOverlays
+            .SingleOrDefaultAsync(o => o.GameId == id && o.Audience == parsedAudience, ct);
+        if (overlay is null)
+        {
+            db.GameMapOverlays.Add(new GameMapOverlay
+            {
+                GameId = id,
+                Audience = parsedAudience,
+                OverlayJson = serialized
+            });
+        }
+        else
+        {
+            overlay.OverlayJson = serialized;
+        }
+
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation(
+            "[map-export-pr3] overlay put exit gameId={GameId} audience={Audience} status=no-content bytes={ByteCount}",
+            id,
+            parsedAudience,
+            byteCount);
         return TypedResults.NoContent();
+    }
+
+    private static bool TryParseOverlayAudience(string? value, out MapOverlayAudience audience)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            audience = MapOverlayAudience.Player;
+            return true;
+        }
+
+        return Enum.TryParse(value, ignoreCase: true, out audience)
+            && Enum.IsDefined(audience);
+    }
+
+    private static IResult InvalidOverlayAudienceProblem() =>
+        TypedResults.Problem(
+            title: "Neznámá vrstva překryvu",
+            detail: "Překryv může být jen pro hráče nebo pro organizátory.",
+            statusCode: StatusCodes.Status400BadRequest);
+
+    private static IResult OverlayAuthorizationProblem() =>
+        TypedResults.Problem(
+            title: "Přístup odepřen",
+            detail: "Pouze organizátoři mohou pracovat s organizátorským překryvem.",
+            statusCode: StatusCodes.Status403Forbidden);
+
+    private static bool IsOrganizer(ClaimsPrincipal user)
+    {
+        var roles = user.FindAll(ClaimTypes.Role)
+            .Concat(user.FindAll("role"))
+            .Select(c => c.Value);
+
+        return roles.Any(role => role is "Organizer" or "Organizator" or "Organizátor" or "Admin");
     }
 
     private static async Task<Results<Ok<List<GameStampDto>>, NotFound>> GetGameStamps(

--- a/src/OvcinaHra.Api/Migrations/20260428181819_AddGameMapOverlays.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260428181819_AddGameMapOverlays.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428181819_AddGameMapOverlays")]
+    partial class AddGameMapOverlays
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260428181819_AddGameMapOverlays.cs
+++ b/src/OvcinaHra.Api/Migrations/20260428181819_AddGameMapOverlays.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameMapOverlays : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GameMapOverlays",
+                columns: table => new
+                {
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    Audience = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    OverlayJson = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameMapOverlays", x => new { x.GameId, x.Audience });
+                    table.ForeignKey(
+                        name: "FK_GameMapOverlays_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.Sql("""
+                DO $$ BEGIN RAISE NOTICE '[map-export-pr3] before GameMapOverlays backfill'; END $$;
+                """);
+
+            migrationBuilder.Sql("""
+                INSERT INTO "GameMapOverlays" ("GameId", "Audience", "OverlayJson")
+                SELECT "Id", 'Player', "OverlayJson"
+                FROM "Games"
+                WHERE "OverlayJson" IS NOT NULL AND btrim("OverlayJson") <> '';
+                """);
+
+            migrationBuilder.Sql("""
+                DO $$ BEGIN RAISE NOTICE '[map-export-pr3] after GameMapOverlays backfill'; END $$;
+                """);
+
+            migrationBuilder.DropColumn(
+                name: "OverlayJson",
+                table: "Games");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OverlayJson",
+                table: "Games",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.Sql("""
+                UPDATE "Games" AS g
+                SET "OverlayJson" = o."OverlayJson"
+                FROM "GameMapOverlays" AS o
+                WHERE o."GameId" = g."Id" AND o."Audience" = 'Player';
+                """);
+
+            migrationBuilder.DropTable(
+                name: "GameMapOverlays");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Properties/AssemblyInfo.cs
+++ b/src/OvcinaHra.Api/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OvcinaHra.Api.Tests")]

--- a/src/OvcinaHra.Api/Services/ExplorerMapExportService.cs
+++ b/src/OvcinaHra.Api/Services/ExplorerMapExportService.cs
@@ -8,7 +8,9 @@ using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Services.Pdf;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
+using SixLabors.Fonts;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
@@ -17,13 +19,17 @@ namespace OvcinaHra.Api.Services;
 
 public interface IExplorerMapExportService
 {
-    Task<ExplorerMapExportFile> RenderExplorerMapAsync(
+    Task<ExplorerMapExportFile> RenderMapAsync(
         int gameId,
         MapExportBasemapStyle style,
+        MapExportKind kind,
+        MapExportPageFormat pageFormat,
         CancellationToken ct = default);
 }
 
 public sealed record ExplorerMapExportFile(byte[] Bytes, string FileName);
+
+internal sealed record MapExportMapArea(double X, double Y, double Width, double Height);
 
 public sealed class MapExportProblemException : Exception
 {
@@ -48,21 +54,36 @@ public sealed class ExplorerMapExportService(
     WorldDbContext db,
     IMapDataService mapData,
     IMapTileClient tileClient,
+    IWebHostEnvironment environment,
     ILogger<ExplorerMapExportService> logger) : IExplorerMapExportService
 {
     private const double A4Width = 595.276;
     private const double A4Height = 841.89;
-    private const double PageMargin = 24;
+    private const double A3Width = 841.89;
+    private const double A3Height = 1190.551;
+    private const double PageMargin = 12;
     private const double PixelScale = 2.5;
+    private const double LabelRasterScale = 3;
+    private const int LabelMaxCharsPerLine = 14;
+    private const int LabelMaxLines = 3;
     private const int TileFetchConcurrency = 6;
 
     private static readonly JsonSerializerOptions OverlayJsonOptions = new() { WriteIndented = false };
 
-    public async Task<ExplorerMapExportFile> RenderExplorerMapAsync(
+    public async Task<ExplorerMapExportFile> RenderMapAsync(
         int gameId,
         MapExportBasemapStyle style,
+        MapExportKind kind,
+        MapExportPageFormat pageFormat,
         CancellationToken ct = default)
     {
+        logger.LogInformation(
+            "[map-export-pr3] map export entry gameId={GameId} kind={Kind} pageFormat={PageFormat} style={Style}",
+            gameId,
+            kind,
+            pageFormat,
+            style);
+
         var game = await db.Games
             .AsNoTracking()
             .Where(g => g.Id == gameId)
@@ -74,8 +95,7 @@ public sealed class ExplorerMapExportService(
                 g.BoundingBoxSwLat,
                 g.BoundingBoxSwLng,
                 g.BoundingBoxNeLat,
-                g.BoundingBoxNeLng,
-                g.OverlayJson
+                g.BoundingBoxNeLng
             })
             .FirstOrDefaultAsync(ct);
         if (game is null)
@@ -104,29 +124,71 @@ public sealed class ExplorerMapExportService(
             .ThenBy(l => l.Id)
             .ToList();
 
-        var layout = ExportLayout.For(A4Width, A4Height, bounds.AspectRatio);
+        var page = PageGeometry.For(pageFormat);
+        var layout = ExportLayout.For(page.Width, page.Height, bounds.AspectRatio);
         var mapImage = await RenderBasemapAsync(style, bounds, layout, ct);
-        var overlay = DeserializeOverlay(game.OverlayJson);
+        var overlays = await LoadOverlaysAsync(gameId, kind, ct);
+        var labelOverlay = RenderPinLabelOverlay(page, layout, bounds, locations, ct);
 
-        var canvas = new PdfCanvas(A4Height);
-        canvas.FillRectangle(0, 0, A4Width, A4Height, "#ffffff");
+        var canvas = new PdfCanvas(page.Height);
+        canvas.FillRectangle(0, 0, page.Width, page.Height, "#ffffff");
         canvas.FillRectangle(layout.MapX, layout.MapY, layout.MapWidth, layout.MapHeight, "#f8f5ed");
         canvas.BeginClip(layout.MapX, layout.MapY, layout.MapWidth, layout.MapHeight);
         if (mapImage is not null)
             canvas.DrawImage("Im1", layout.MapX, layout.MapY, layout.MapWidth, layout.MapHeight);
-        RenderOverlay(canvas, layout, bounds, overlay);
+        foreach (var overlay in overlays)
+            RenderOverlay(canvas, layout, bounds, overlay);
         RenderPins(canvas, layout, bounds, locations);
+        if (labelOverlay is not null)
+            canvas.DrawImage("Labels", 0, 0, page.Width, page.Height);
         canvas.EndClip();
         canvas.StrokeRectangle(layout.MapX, layout.MapY, layout.MapWidth, layout.MapHeight, 0.8, "#6f6658");
 
-        var pdf = SimpleImagePdfWriter.Build(
-            A4Width,
-            A4Height,
-            canvas.Content.ToString(),
-            mapImage);
+        var images = new Dictionary<string, PdfImage>();
+        if (mapImage is not null)
+            images["Im1"] = mapImage;
+        if (labelOverlay is not null)
+            images["Labels"] = labelOverlay;
 
-        var fileName = $"{Slugify(game.Name)}-postavy-{DateTime.Today:yyyy-MM-dd}.pdf";
+        var pdf = SimpleImagePdfWriter.Build([
+            new PdfImagePage(page.Width, page.Height, canvas.Content.ToString(), images)
+        ]);
+
+        var fileName = BuildFileName(game.Name, kind);
+        logger.LogInformation(
+            "[map-export-pr3] map export exit gameId={GameId} kind={Kind} pageFormat={PageFormat} fileName={FileName} bytes={ByteCount} overlays={OverlayCount}",
+            gameId,
+            kind,
+            pageFormat,
+            fileName,
+            pdf.Length,
+            overlays.Count);
         return new ExplorerMapExportFile(pdf, fileName);
+    }
+
+    private async Task<IReadOnlyList<MapOverlayDto>> LoadOverlaysAsync(
+        int gameId,
+        MapExportKind kind,
+        CancellationToken ct)
+    {
+        var audiences = kind switch
+        {
+            MapExportKind.Organizer => new[] { MapOverlayAudience.Player, MapOverlayAudience.Organizer },
+            _ => [MapOverlayAudience.Player]
+        };
+
+        var rows = await db.GameMapOverlays
+            .AsNoTracking()
+            .Where(o => o.GameId == gameId && audiences.Contains(o.Audience))
+            .OrderBy(o => o.Audience == MapOverlayAudience.Player ? 0 : 1)
+            .Select(o => o.OverlayJson)
+            .ToListAsync(ct);
+
+        return rows
+            .Select(DeserializeOverlay)
+            .Where(o => o is not null)
+            .Select(o => o!)
+            .ToList();
     }
 
     private async Task<PdfImage?> RenderBasemapAsync(
@@ -206,12 +268,182 @@ public sealed class ExplorerMapExportService(
         await using var stream = new MemoryStream();
         await stitched.SaveAsJpegAsync(stream, new JpegEncoder { Quality = 88 }, ct);
         logger.LogInformation(
-            "Rendered explorer map basemap style={Style} zoom={Zoom} tiles={TileCount}",
+            "[map-export-pr3] rendered map basemap style={Style} zoom={Zoom} tiles={TileCount}",
             style,
             zoom,
             (maxTileX - minTileX + 1) * (maxTileY - minTileY + 1));
         return new PdfImage(width, height, stream.ToArray());
     }
+
+    private PdfImage? RenderPinLabelOverlay(
+        PageGeometry page,
+        ExportLayout layout,
+        MapBounds bounds,
+        IReadOnlyList<MapLocationDto> locations,
+        CancellationToken ct)
+    {
+        var labelLocations = locations
+            .Where(l => l.EffectiveKind is LocationKind.Town or LocationKind.Village)
+            .ToList();
+        if (labelLocations.Count == 0)
+            return null;
+
+        var width = (int)Math.Ceiling(page.Width * LabelRasterScale);
+        var height = (int)Math.Ceiling(page.Height * LabelRasterScale);
+        using var image = new Image<Rgba32>(width, height, Color.Transparent);
+        var font = LoadLabelFont(10.5f * (float)LabelRasterScale);
+        var ink = Color.ParseHex("#fff8e8");
+        var outline = Color.ParseHex("#17120d");
+
+        image.Mutate(ctx =>
+        {
+            foreach (var location in labelLocations)
+            {
+                var point = layout.Project(bounds, location.Lat, location.Lon);
+                DrawPinLabel(ctx, point, location.EffectiveName, font, ink, outline);
+            }
+        });
+
+        var rgb = new byte[width * height * 3];
+        var alpha = new byte[width * height];
+        image.ProcessPixelRows(accessor =>
+        {
+            for (var y = 0; y < accessor.Height; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+                for (var x = 0; x < row.Length; x++)
+                {
+                    var pixel = row[x];
+                    var i = y * width + x;
+                    rgb[i * 3] = pixel.R;
+                    rgb[i * 3 + 1] = pixel.G;
+                    rgb[i * 3 + 2] = pixel.B;
+                    alpha[i] = pixel.A;
+                }
+            }
+        });
+
+        ct.ThrowIfCancellationRequested();
+        return SimpleImagePdfWriter.BuildRgbaImage(width, height, rgb, alpha);
+    }
+
+    private Font LoadLabelFont(float size)
+    {
+        var fonts = new FontCollection();
+        var fontPath = Path.Combine(environment.ContentRootPath, "Fonts", "Kalam", "Kalam-Regular.ttf");
+        var family = fonts.Add(fontPath);
+        return family.CreateFont(size);
+    }
+
+    private static void DrawPinLabel(
+        IImageProcessingContext ctx,
+        PdfPoint pinTip,
+        string text,
+        Font font,
+        Color ink,
+        Color outline)
+    {
+        var lines = WrapPinLabel(text);
+        var lineHeight = font.Size * 0.92f;
+        var totalHeight = lines.Count * lineHeight;
+        var centerX = (float)(pinTip.X * LabelRasterScale);
+        var y = (float)((pinTip.Y + 5) * LabelRasterScale);
+        if (lines.Count > 1)
+            y -= totalHeight * 0.12f;
+
+        for (var i = 0; i < lines.Count; i++)
+        {
+            var line = lines[i];
+            var width = ApproxKalamWidth(line, font.Size);
+            var x = centerX - width / 2f;
+            var baseline = y + i * lineHeight;
+            DrawOutlinedText(ctx, line, font, ink, outline, new PointF(x, baseline));
+        }
+    }
+
+    private static void DrawOutlinedText(
+        IImageProcessingContext ctx,
+        string text,
+        Font font,
+        Color ink,
+        Color outline,
+        PointF point)
+    {
+        var offset = (float)LabelRasterScale;
+        foreach (var (dx, dy) in new[] { (-offset, 0f), (offset, 0f), (0f, -offset), (0f, offset) })
+            ctx.DrawText(text, font, outline, new PointF(point.X + dx, point.Y + dy));
+        ctx.DrawText(text, font, ink, point);
+    }
+
+    internal static IReadOnlyList<string> WrapPinLabelForTesting(string text) => WrapPinLabel(text);
+
+    internal static MapExportMapArea CalculateMapAreaForTesting(MapExportPageFormat format, double aspectRatio)
+    {
+        var page = PageGeometry.For(format);
+        var layout = ExportLayout.For(page.Width, page.Height, aspectRatio);
+        return new MapExportMapArea(layout.MapX, layout.MapY, layout.MapWidth, layout.MapHeight);
+    }
+
+    private static IReadOnlyList<string> WrapPinLabel(string text)
+    {
+        var normalized = text.Trim();
+        if (normalized.Length <= LabelMaxCharsPerLine)
+            return [normalized];
+
+        var tokens = SplitLabelTokens(normalized);
+        var lines = new List<string>();
+        var current = string.Empty;
+
+        foreach (var token in tokens)
+        {
+            if (current.Length == 0)
+            {
+                current = token;
+                continue;
+            }
+
+            if (current.Length + 1 + token.Length <= LabelMaxCharsPerLine)
+            {
+                current += token.StartsWith("-", StringComparison.Ordinal) ? token : " " + token;
+                continue;
+            }
+
+            lines.Add(current.Trim());
+            current = token.TrimStart();
+            if (lines.Count == LabelMaxLines - 1)
+                break;
+        }
+
+        if (lines.Count < LabelMaxLines && !string.IsNullOrWhiteSpace(current))
+            lines.Add(current.Trim());
+
+        return lines.Count == 0 ? [normalized] : lines;
+    }
+
+    private static List<string> SplitLabelTokens(string text)
+    {
+        var tokens = new List<string>();
+        foreach (var word in text.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (word.Length <= LabelMaxCharsPerLine || !word.Contains('-'))
+            {
+                tokens.Add(word);
+                continue;
+            }
+
+            var parts = word.Split('-', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            for (var i = 0; i < parts.Length; i++)
+            {
+                var part = parts[i];
+                tokens.Add(i < parts.Length - 1 ? part + "-" : part);
+            }
+        }
+
+        return tokens;
+    }
+
+    private static float ApproxKalamWidth(string text, float fontSize) =>
+        text.Sum(ch => char.IsWhiteSpace(ch) ? 0.28f : 0.54f) * fontSize;
 
     private static int ChooseZoom(MapBounds bounds, int targetWidth, int targetHeight)
     {
@@ -298,17 +530,6 @@ public sealed class ExplorerMapExportService(
             var kind = location.EffectiveKind;
             var showName = kind is LocationKind.Town or LocationKind.Village;
             DrawPin(canvas, point.X, point.Y, kind, showName ? null : location.Id.ToString(CultureInfo.InvariantCulture));
-
-            if (showName)
-            {
-                canvas.DrawLabel(
-                    NormalizePdfText(location.EffectiveName, 34),
-                    point.X + 10,
-                    point.Y - 17,
-                    8.5,
-                    "#1f1a12",
-                    "#ffffff");
-            }
         }
     }
 
@@ -376,6 +597,19 @@ public sealed class ExplorerMapExportService(
         return string.IsNullOrWhiteSpace(result) ? "ovcina" : result;
     }
 
+    private static string BuildFileName(string gameName, MapExportKind kind)
+    {
+        var suffix = kind switch
+        {
+            MapExportKind.Explorer => "postavy",
+            MapExportKind.Organizer => "organizatori",
+            MapExportKind.Kingdom => "kralovstvi-A3",
+            _ => "mapa"
+        };
+
+        return $"{Slugify(gameName)}-{suffix}-{DateTime.Today:yyyy-MM-dd}.pdf";
+    }
+
     private static string NormalizePdfText(string value, int maxLength)
     {
         var decomposed = value.Normalize(NormalizationForm.FormD);
@@ -440,6 +674,16 @@ public sealed class ExplorerMapExportService(
 
         public bool Contains(double lat, double lon) =>
             lat >= South && lat <= North && lon >= West && lon <= East;
+    }
+
+    private sealed record PageGeometry(double Width, double Height)
+    {
+        public static PageGeometry For(MapExportPageFormat format) => format switch
+        {
+            MapExportPageFormat.A4Portrait => new PageGeometry(A4Width, A4Height),
+            MapExportPageFormat.A3Portrait => new PageGeometry(A3Width, A3Height),
+            _ => new PageGeometry(A4Width, A4Height)
+        };
     }
 
     private sealed record ExportLayout(double MapX, double MapY, double MapWidth, double MapHeight)

--- a/src/OvcinaHra.Api/Services/Pdf/SimpleImagePdfWriter.cs
+++ b/src/OvcinaHra.Api/Services/Pdf/SimpleImagePdfWriter.cs
@@ -1,9 +1,21 @@
 using System.Globalization;
+using System.IO.Compression;
 using System.Text;
 
 namespace OvcinaHra.Api.Services.Pdf;
 
-public sealed record PdfImage(int Width, int Height, byte[] JpegBytes);
+public sealed record PdfImage(
+    int Width,
+    int Height,
+    byte[] JpegBytes,
+    PdfImageEncoding Encoding = PdfImageEncoding.Jpeg,
+    byte[]? AlphaBytes = null);
+
+public enum PdfImageEncoding
+{
+    Jpeg,
+    RgbFlate
+}
 
 public sealed record PdfImagePage(
     double Width,
@@ -42,8 +54,15 @@ public static class SimpleImagePdfWriter
             var imageObjectNumbers = new Dictionary<string, int>();
             foreach (var (name, image) in page.Images)
             {
+                int? alphaObjectNumber = null;
+                if (image.AlphaBytes is not null)
+                {
+                    alphaObjectNumber = objects.Count + 1;
+                    objects.Add(BuildAlphaMaskObject(image));
+                }
+
                 imageObjectNumbers[name] = objects.Count + 1;
-                objects.Add(BuildImageObject(image));
+                objects.Add(BuildImageObject(image, alphaObjectNumber));
             }
 
             var pageObjectNumber = objects.Count + 1;
@@ -77,11 +96,30 @@ public static class SimpleImagePdfWriter
         return $"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {Pt(page.Width)} {Pt(page.Height)}] {resources} /Contents {contentObjectNumber} 0 R >>";
     }
 
-    private static byte[] BuildImageObject(PdfImage image)
+    public static PdfImage BuildRgbaImage(int width, int height, byte[] rgbBytes, byte[] alphaBytes) =>
+        new(width, height, Compress(rgbBytes), PdfImageEncoding.RgbFlate, Compress(alphaBytes));
+
+    private static byte[] BuildImageObject(PdfImage image, int? alphaObjectNumber)
     {
-        var header = Ascii($"<< /Type /XObject /Subtype /Image /Width {image.Width} /Height {image.Height} /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length {image.JpegBytes.Length} >>\nstream\n");
+        if (image.Encoding == PdfImageEncoding.RgbFlate)
+        {
+            var smask = alphaObjectNumber is null ? "" : $" /SMask {alphaObjectNumber.Value} 0 R";
+            var header = Ascii($"<< /Type /XObject /Subtype /Image /Width {image.Width} /Height {image.Height} /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /FlateDecode /Length {image.JpegBytes.Length}{smask} >>\nstream\n");
+            var footer = Ascii("\nendstream");
+            return Concat(header, image.JpegBytes, footer);
+        }
+
+        var jpegHeader = Ascii($"<< /Type /XObject /Subtype /Image /Width {image.Width} /Height {image.Height} /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length {image.JpegBytes.Length} >>\nstream\n");
+        var jpegFooter = Ascii("\nendstream");
+        return Concat(jpegHeader, image.JpegBytes, jpegFooter);
+    }
+
+    private static byte[] BuildAlphaMaskObject(PdfImage image)
+    {
+        var alpha = image.AlphaBytes ?? [];
+        var header = Ascii($"<< /Type /XObject /Subtype /Image /Width {image.Width} /Height {image.Height} /ColorSpace /DeviceGray /BitsPerComponent 8 /Filter /FlateDecode /Length {alpha.Length} >>\nstream\n");
         var footer = Ascii("\nendstream");
-        return Concat(header, image.JpegBytes, footer);
+        return Concat(header, alpha, footer);
     }
 
     private static byte[] BuildStreamObject(byte[] stream)
@@ -131,4 +169,14 @@ public static class SimpleImagePdfWriter
     private static void WriteAscii(Stream stream, string value) => stream.Write(Ascii(value));
     private static byte[] Ascii(string value) => Encoding.ASCII.GetBytes(value);
     private static string Pt(double value) => value.ToString("0.###", CultureInfo.InvariantCulture);
+
+    private static byte[] Compress(byte[] bytes)
+    {
+        using var output = new MemoryStream();
+        using (var zlib = new ZLibStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
+        {
+            zlib.Write(bytes);
+        }
+        return output.ToArray();
+    }
 }

--- a/src/OvcinaHra.Client/Components/MapLayerRail.razor
+++ b/src/OvcinaHra.Client/Components/MapLayerRail.razor
@@ -51,8 +51,18 @@
         <input type="checkbox" checked="@OverlaysVisible"
                @onchange="@(e => OnOverlayVisibilityChange.InvokeAsync((bool)e.Value!))" />
         <span class="oh-map-layer-dot oh-map-layer-overlay"></span>
-        <span class="oh-map-layer-lbl">Překryv</span>
+        <span class="oh-map-layer-lbl">Překryv hráčů</span>
     </label>
+
+    @if (OrganizerOverlayEnabled)
+    {
+        <label class="oh-map-layer-row">
+            <input type="checkbox" checked="@OrganizerOverlayVisible"
+                   @onchange="@(e => OnOrganizerOverlayVisibilityChange.InvokeAsync((bool)e.Value!))" />
+            <span class="oh-map-layer-dot oh-map-layer-organizer-overlay"></span>
+            <span class="oh-map-layer-lbl">Překryv organizátorů</span>
+        </label>
+    }
 
     <p class="oh-map-layer-hint text-muted small fst-italic">
         Setkání questů přibydou, jakmile budou mít body na mapě.
@@ -71,10 +81,13 @@
     [Parameter] public bool LocationsVisible { get; set; } = true;
     [Parameter] public bool StashesVisible { get; set; } = true;
     [Parameter] public bool OverlaysVisible { get; set; } = true;
+    [Parameter] public bool OrganizerOverlayEnabled { get; set; }
+    [Parameter] public bool OrganizerOverlayVisible { get; set; } = true;
     [Parameter] public int LocationsCount { get; set; }
     [Parameter] public int StashesCount { get; set; }
     [Parameter] public EventCallback<(string Layer, bool Visible)> OnVisibilityChange { get; set; }
     [Parameter] public EventCallback<bool> OnOverlayVisibilityChange { get; set; }
+    [Parameter] public EventCallback<bool> OnOrganizerOverlayVisibilityChange { get; set; }
     [Parameter] public IReadOnlyDictionary<LocationKind, int>? LocationsByKind { get; set; }
     [Parameter] public HashSet<LocationKind> HiddenKinds { get; set; } = new();
     [Parameter] public EventCallback<LocationKind> OnKindToggle { get; set; }

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -1,4 +1,5 @@
 @implements IAsyncDisposable
+@using OvcinaHra.Shared.Domain.Enums
 @inject ApiClient Api
 
 <div class="oh-map-host-wrap" style="position:relative;width:100%;height:@Height;">
@@ -22,6 +23,22 @@
 
     @if (GameId.HasValue && _editMode)
     {
+        @if (OrganizerOverlayEnabled)
+        {
+            <div class="oh-map-overlay-audience" role="group" aria-label="Vrstva překryvu">
+                <button type="button"
+                        class="btn btn-sm @(_activeAudience == MapOverlayAudience.Player ? "btn-primary" : "btn-outline-primary")"
+                        @onclick="@(() => ChangeAudienceAsync(MapOverlayAudience.Player))">
+                    Hráčská vrstva
+                </button>
+                <button type="button"
+                        class="btn btn-sm @(_activeAudience == MapOverlayAudience.Organizer ? "btn-primary" : "btn-outline-primary")"
+                        @onclick="@(() => ChangeAudienceAsync(MapOverlayAudience.Organizer))">
+                    Organizátorská vrstva
+                </button>
+            </div>
+        }
+
         <MapOverlayToolbar Tool="@_tool" ToolChanged="ChangeToolAsync"
                            Color="@_color" ColorChanged="OnColorChanged"
                            UseFill="@_useFill" UseFillChanged="OnUseFillChanged"
@@ -121,11 +138,18 @@
     /// </summary>
     [Parameter] public bool OverlayVisible { get; set; } = true;
 
+    /// <summary>Organizer-only layer is loaded and editable only for organizer users.</summary>
+    [Parameter] public bool OrganizerOverlayEnabled { get; set; }
+
+    /// <summary>Controls the organizer overlay layer independently from the player overlay.</summary>
+    [Parameter] public bool OrganizerOverlayVisible { get; set; } = true;
+
     private readonly string _elementId = $"map-{Guid.NewGuid():N}";
     private DotNetObjectReference<MapView>? _dotnetRef;
 
     // ---- Overlay editor state ------------------------------------------
-    private List<MapOverlayShape> _committedShapes = new();   // last-saved baseline
+    private List<MapOverlayShape> _committedPlayerShapes = new();     // last-saved player baseline
+    private List<MapOverlayShape> _committedOrganizerShapes = new();  // last-saved organizer baseline
     private List<MapOverlayShape> _stagedShapes = new();      // working copy
     private readonly List<string> _createdShapeIds = new();   // undo stack for this edit session
     private bool _editMode;
@@ -141,8 +165,10 @@
     private bool _deleteConfirmVisible;
     private bool _clearAllConfirmVisible;
     private string? _overlayError;
-    private int? _loadedOverlayForGameId;
+    private string? _loadedOverlayKey;
     private bool? _lastAppliedOverlayVisible;
+    private bool? _lastAppliedOrganizerOverlayVisible;
+    private MapOverlayAudience _activeAudience = MapOverlayAudience.Player;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -158,64 +184,120 @@
             await JS.InvokeVoidAsync("ovcinaMap.init", _elementId, _dotnetRef, CenterLat, CenterLon, Zoom, apiKey, glyphsUrl);
         }
 
-        // Load overlay once per game. Repeat on GameId change. Wrapped in
+        // Load overlay once per game/audience availability. Repeat on GameId
+        // or organizer-role change. Wrapped in
         // try/catch per _review-instincts §11 — a dead overlay fetch mustn't
         // break the rest of the map page. Marker is set only after a
         // successful load so transient failures can retry on the next render.
-        if (GameId.HasValue && _loadedOverlayForGameId != GameId)
+        var overlayKey = GetOverlayLoadKey();
+        if (GameId.HasValue && _loadedOverlayKey != overlayKey)
         {
             try
             {
-                List<MapOverlayShape> shapes;
-                try
-                {
-                    var dto = await Api.GetAsync<MapOverlayDto>($"/api/games/{GameId.Value}/overlay");
-                    shapes = dto?.Shapes ?? new List<MapOverlayShape>();
-                }
-                catch (Exception ex) when (ex is System.Text.Json.JsonException or NotSupportedException)
-                {
-                    // 204 NoContent → empty body can't parse as JSON → JsonException.
-                    // Unknown polymorphic discriminator (server returned a shape
-                    // type a stale client doesn't know yet) → NotSupportedException.
-                    // Either way: treat as no overlay so the editor can still
-                    // open and the user can re-save. Preview layers initialise
-                    // below regardless.
-                    shapes = new List<MapOverlayShape>();
-                }
-                _committedShapes = shapes;
-                _stagedShapes = new List<MapOverlayShape>(shapes);
-                await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _committedShapes);
-                await SetOverlayVisibilityAsync(OverlayVisible);
-                _loadedOverlayForGameId = GameId;
+                _committedPlayerShapes = await LoadOverlayShapesAsync(MapOverlayAudience.Player);
+                _committedOrganizerShapes = OrganizerOverlayEnabled
+                    ? await LoadOverlayShapesAsync(MapOverlayAudience.Organizer)
+                    : [];
+                if (!OrganizerOverlayEnabled)
+                    _activeAudience = MapOverlayAudience.Player;
+                _stagedShapes = new List<MapOverlayShape>(GetCommittedShapes(_activeAudience));
+                await RenderVisibleOverlaysAsync();
+                _loadedOverlayKey = overlayKey;
             }
-            catch { /* network / JS failure — leave _loadedOverlayForGameId unset so a retry is possible */ }
+            catch { /* network / JS failure — leave _loadedOverlayKey unset so a retry is possible */ }
         }
 
-        if (GameId.HasValue && _lastAppliedOverlayVisible != OverlayVisible)
+        if (GameId.HasValue
+            && (_lastAppliedOverlayVisible != OverlayVisible
+                || _lastAppliedOrganizerOverlayVisible != OrganizerOverlayVisible))
         {
-            await SetOverlayVisibilityAsync(OverlayVisible);
+            await RenderVisibleOverlaysAsync();
         }
     }
 
     public async Task SetOverlayVisibilityAsync(bool visible)
     {
+        await RenderVisibleOverlaysAsync(playerVisibleOverride: visible);
+    }
+
+    public async Task SetOrganizerOverlayVisibilityAsync(bool visible)
+    {
+        await RenderVisibleOverlaysAsync(organizerVisibleOverride: visible);
+    }
+
+    private string? GetOverlayLoadKey() =>
+        GameId.HasValue ? $"{GameId.Value}:{OrganizerOverlayEnabled}" : null;
+
+    private async Task<List<MapOverlayShape>> LoadOverlayShapesAsync(MapOverlayAudience audience)
+    {
         try
         {
-            await JS.InvokeVoidAsync("ovcinaOverlay.setVisibility", _elementId, visible);
-            _lastAppliedOverlayVisible = visible;
+            var dto = await Api.GetAsync<MapOverlayDto>(
+                $"/api/games/{GameId!.Value}/overlay?audience={AudienceQueryValue(audience)}");
+            return dto?.Shapes ?? [];
+        }
+        catch (Exception ex) when (ex is System.Text.Json.JsonException or NotSupportedException)
+        {
+            // 204 NoContent → empty body can't parse as JSON → JsonException.
+            // Unknown polymorphic discriminator (server returned a shape type a
+            // stale client doesn't know yet) → NotSupportedException. Either way:
+            // treat as no overlay so the editor can still open and re-save.
+            return [];
+        }
+    }
+
+    private async Task RenderVisibleOverlaysAsync(
+        bool? playerVisibleOverride = null,
+        bool? organizerVisibleOverride = null)
+    {
+        if (!GameId.HasValue || _editMode)
+            return;
+
+        var playerVisible = playerVisibleOverride ?? OverlayVisible;
+        var organizerVisible = OrganizerOverlayEnabled && (organizerVisibleOverride ?? OrganizerOverlayVisible);
+        var shapes = new List<MapOverlayShape>();
+        if (playerVisible)
+            shapes.AddRange(_committedPlayerShapes);
+        if (organizerVisible)
+            shapes.AddRange(_committedOrganizerShapes);
+
+        try
+        {
+            await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, shapes);
+            await JS.InvokeVoidAsync("ovcinaOverlay.setVisibility", _elementId, playerVisible || organizerVisible);
+            _lastAppliedOverlayVisible = playerVisible;
+            _lastAppliedOrganizerOverlayVisible = organizerVisibleOverride ?? OrganizerOverlayVisible;
         }
         catch { /* map / JS may not be ready yet; next render reapplies */ }
     }
+
+    private List<MapOverlayShape> GetCommittedShapes(MapOverlayAudience audience) =>
+        audience == MapOverlayAudience.Organizer ? _committedOrganizerShapes : _committedPlayerShapes;
+
+    private void SetCommittedShapes(MapOverlayAudience audience, List<MapOverlayShape> shapes)
+    {
+        if (audience == MapOverlayAudience.Organizer)
+            _committedOrganizerShapes = new List<MapOverlayShape>(shapes);
+        else
+            _committedPlayerShapes = new List<MapOverlayShape>(shapes);
+    }
+
+    private static string AudienceQueryValue(MapOverlayAudience audience) =>
+        audience == MapOverlayAudience.Organizer ? "organizer" : "player";
 
     // ---- Overlay editor handlers --------------------------------------
 
     private async Task EnterEditModeAsync()
     {
+        if (!OrganizerOverlayEnabled)
+            _activeAudience = MapOverlayAudience.Player;
+
         _editMode = true;
-        _stagedShapes = new List<MapOverlayShape>(_committedShapes);
+        _stagedShapes = new List<MapOverlayShape>(GetCommittedShapes(_activeAudience));
         _createdShapeIds.Clear();
         _overlayError = null;
         await PushStyleToJsAsync();
+        await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);
         await JS.InvokeVoidAsync("ovcinaOverlay.enterEditMode", _elementId, _tool, _dotnetRef);
     }
 
@@ -226,22 +308,24 @@
         _deleteConfirmVisible = false;
         _clearAllConfirmVisible = false;
         _createdShapeIds.Clear();
-        _stagedShapes = new List<MapOverlayShape>(_committedShapes);
+        _stagedShapes = new List<MapOverlayShape>(GetCommittedShapes(_activeAudience));
         await JS.InvokeVoidAsync("ovcinaOverlay.clearSelection", _elementId);
         await JS.InvokeVoidAsync("ovcinaOverlay.exitEditMode", _elementId);
-        await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _committedShapes);
+        await RenderVisibleOverlaysAsync();
     }
 
     private async Task SaveOverlayAsync()
     {
         var dto = new MapOverlayDto(_stagedShapes);
-        var (ok, problem) = await Api.PutWithProblemAsync($"/api/games/{GameId!.Value}/overlay", dto);
+        var (ok, problem) = await Api.PutWithProblemAsync(
+            $"/api/games/{GameId!.Value}/overlay?audience={AudienceQueryValue(_activeAudience)}",
+            dto);
         if (!ok)
         {
             _overlayError = problem ?? "Uložení překryvu selhalo.";
             return;
         }
-        _committedShapes = new List<MapOverlayShape>(_stagedShapes);
+        SetCommittedShapes(_activeAudience, _stagedShapes);
         _editMode = false;
         _selectedShape = null;
         _deleteConfirmVisible = false;
@@ -249,7 +333,23 @@
         _createdShapeIds.Clear();
         await JS.InvokeVoidAsync("ovcinaOverlay.clearSelection", _elementId);
         await JS.InvokeVoidAsync("ovcinaOverlay.exitEditMode", _elementId);
-        await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _committedShapes);
+        await RenderVisibleOverlaysAsync();
+    }
+
+    private async Task ChangeAudienceAsync(MapOverlayAudience audience)
+    {
+        if (!OrganizerOverlayEnabled && audience == MapOverlayAudience.Organizer)
+            return;
+
+        Console.WriteLine($"[map-export-pr3] overlay audience toggle audience={audience}");
+        _activeAudience = audience;
+        _selectedShape = null;
+        _createdShapeIds.Clear();
+        _overlayError = null;
+        _stagedShapes = new List<MapOverlayShape>(GetCommittedShapes(audience));
+        await JS.InvokeVoidAsync("ovcinaOverlay.clearSelection", _elementId);
+        await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);
+        await PushStyleToJsAsync();
     }
 
     private async Task ChangeToolAsync(string tool)
@@ -562,15 +662,21 @@
         // honour the in-memory staged list (with unsaved edits) and re-apply
         // the active selection highlight — committed-only would silently
         // discard the user's work.
-        if (GameId.HasValue && _loadedOverlayForGameId == GameId)
+        if (GameId.HasValue && _loadedOverlayKey == GetOverlayLoadKey())
         {
-            var shapes = _editMode ? _stagedShapes : _committedShapes;
             try
             {
-                await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, shapes);
-                if (_editMode && _selectedShape is not null)
+                if (_editMode)
                 {
-                    await JS.InvokeVoidAsync("ovcinaOverlay.selectShape", _elementId, _selectedShape);
+                    await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);
+                    if (_selectedShape is not null)
+                    {
+                        await JS.InvokeVoidAsync("ovcinaOverlay.selectShape", _elementId, _selectedShape);
+                    }
+                }
+                else
+                {
+                    await RenderVisibleOverlaysAsync();
                 }
             }
             catch { /* best-effort */ }

--- a/src/OvcinaHra.Client/Pages/Exports/Exports.razor
+++ b/src/OvcinaHra.Client/Pages/Exports/Exports.razor
@@ -36,6 +36,30 @@
         </button>
         <button type="button"
                 class="oh-exports-card oh-exports-card-button"
+                title="Mapa s organizátorskou vrstvou."
+                @onclick='() => OpenMapExport("Export pro organizátory (A4)", "organizer-map.pdf", "organizer")'>
+            <div class="oh-exports-card-icon">
+                <i class="bi bi-map"></i>
+            </div>
+            <div class="oh-exports-card-body">
+                <h3>Export pro organizátory (A4)</h3>
+                <p>Mapa A4 s hráčským i organizátorským překryvem.</p>
+            </div>
+        </button>
+        <button type="button"
+                class="oh-exports-card oh-exports-card-button"
+                title="Velká slepá mapa pro vyvěšení v městě."
+                @onclick='() => OpenMapExport("Export pro království (A3)", "kingdom-map.pdf", "kingdom")'>
+            <div class="oh-exports-card-icon">
+                <i class="bi bi-buildings-fill"></i>
+            </div>
+            <div class="oh-exports-card-body">
+                <h3>Export pro království (A3)</h3>
+                <p>Velká A3 mapa s hráčskou vrstvou pro vyvěšení.</p>
+            </div>
+        </button>
+        <button type="button"
+                class="oh-exports-card oh-exports-card-button"
                 title="Vyexportuje knihu kouzel do A4 PDF, které po rozstřižení dá dvě A6 knížečky."
                 disabled="@isMagicBookDownloading"
                 @onclick="DownloadMagicBookAsync">
@@ -70,7 +94,7 @@
     <div class="oh-exports-modal-backdrop" @onclick="CloseCharacterExport">
         <section class="oh-exports-modal" @onclick:stopPropagation="true">
             <header>
-                <h2>Export pro postavy</h2>
+                <h2>@activeMapExportTitle</h2>
                 <button type="button" class="oh-exports-modal-close" @onclick="CloseCharacterExport" aria-label="Zavřít">
                     <i class="bi bi-x-lg"></i>
                 </button>
@@ -80,7 +104,7 @@
                 {
                     <label class="oh-exports-style-option">
                         <input type="radio"
-                               name="character-export-style"
+                               name="map-export-style"
                                checked="@(selectedBasemap == option.Value)"
                                @onchange="@(() => selectedBasemap = option.Value)" />
                         <span>
@@ -274,10 +298,19 @@
     private bool isDownloading;
     private bool isMagicBookDownloading;
     private string selectedBasemap = TouristBasemap;
+    private string activeMapExportTitle = "Export pro postavy";
+    private string activeMapExportEndpoint = "explorer-map.pdf";
+    private string activeMapExportKind = "explorer";
     private string? downloadError;
 
-    private void OpenCharacterExport()
+    private void OpenCharacterExport() =>
+        OpenMapExport("Export pro postavy", "explorer-map.pdf", "explorer");
+
+    private void OpenMapExport(string title, string endpoint, string kind)
     {
+        activeMapExportTitle = title;
+        activeMapExportEndpoint = endpoint;
+        activeMapExportKind = kind;
         selectedBasemap = TouristBasemap;
         downloadError = null;
         showCharacterExport = true;
@@ -304,7 +337,8 @@
         downloadError = null;
         try
         {
-            var url = $"/api/games/{gameId}/exports/explorer-map.pdf?style={Uri.EscapeDataString(selectedBasemap)}";
+            Console.WriteLine($"[map-export-pr3] map export download init kind={activeMapExportKind} style={selectedBasemap}");
+            var url = $"/api/games/{gameId}/exports/{activeMapExportEndpoint}?style={Uri.EscapeDataString(selectedBasemap)}";
             var (ok, file, problem) = await Api.DownloadWithProblemAsync(url);
             if (!ok || file is null)
             {

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -4,8 +4,11 @@
 @inject GameContextService GameContext
 @inject IJSRuntime JS
 @inject NavigationManager Nav
+@inject AuthenticationStateProvider AuthStateProvider
 @implements IDisposable
+@using System.Security.Claims
 @using System.Web
+@using Microsoft.AspNetCore.Components.Authorization
 @using OvcinaHra.Shared.Dtos
 @using OvcinaHra.Shared.Domain.Enums
 
@@ -39,12 +42,15 @@
                     <MapLayerRail LocationsVisible="@_locationsVisible"
                                    StashesVisible="@_stashesVisible"
                                    OverlaysVisible="@_overlaysVisible"
+                                   OrganizerOverlayEnabled="@_isOrganizer"
+                                   OrganizerOverlayVisible="@_organizerOverlayVisible"
                                    LocationsCount="@(_data?.Locations.Count ?? 0)"
                                    StashesCount="@(_data?.Stashes.Count ?? 0)"
                                    LocationsByKind="@_locationsByKind"
                                    HiddenKinds="@_hiddenKinds"
                                    OnVisibilityChange="OnLayerVisibilityChange"
                                    OnOverlayVisibilityChange="OnOverlayVisibilityChange"
+                                   OnOrganizerOverlayVisibilityChange="OnOrganizerOverlayVisibilityChange"
                                    OnKindToggle="OnKindToggle" />
 
                     <div class="oh-map-canvas">
@@ -62,6 +68,8 @@
                                  Height="calc(100vh - 200px)"
                                  GameId="@GameContext.SelectedGameId"
                                  OverlayVisible="@_overlaysVisible"
+                                 OrganizerOverlayEnabled="@_isOrganizer"
+                                 OrganizerOverlayVisible="@_organizerOverlayVisible"
                                  OnStyleLoaded="OnMapReadyAsync"
                                  OnMapPagePinClick="OnPinClickedAsync"
                                  OnMapPagePinDrag="OnPinDraggedAsync"
@@ -210,6 +218,8 @@
     private bool _locationsVisible = true;
     private bool _stashesVisible = true;
     private bool _overlaysVisible = true;
+    private bool _organizerOverlayVisible = true;
+    private bool _isOrganizer;
     // Per-LocationKind hide set. Empty (default) = all kinds visible.
     // Persists alongside the layer-visibility flags.
     private HashSet<LocationKind> _hiddenKinds = new();
@@ -268,6 +278,8 @@
     protected override async Task OnInitializedAsync()
     {
         Console.WriteLine("[map-diag] OnInitializedAsync entry");
+        var auth = await AuthStateProvider.GetAuthenticationStateAsync();
+        _isOrganizer = IsOrganizer(auth.User);
         await GameContext.InitializeAsync();
         Console.WriteLine($"[map-diag] After InitializeAsync — SelectedGameId={GameContext.SelectedGameId?.ToString() ?? "null"}");
         GameContext.OnGameChanged += HandleGameChanged;
@@ -343,6 +355,7 @@
             _locationsVisible = saved.Locations;
             _stashesVisible = saved.Stashes;
             _overlaysVisible = saved.Overlays ?? true;
+            _organizerOverlayVisible = _isOrganizer && (saved.OrganizerOverlays ?? true);
             if (saved.HiddenKinds is { Count: > 0 })
             {
                 _hiddenKinds = saved.HiddenKinds.ToHashSet();
@@ -356,7 +369,7 @@
         try
         {
             var json = System.Text.Json.JsonSerializer.Serialize(
-                new LayerState(_locationsVisible, _stashesVisible, _hiddenKinds.ToList(), _overlaysVisible));
+                new LayerState(_locationsVisible, _stashesVisible, _hiddenKinds.ToList(), _overlaysVisible, _organizerOverlayVisible));
             await JS.InvokeVoidAsync("localStorage.setItem", LayerStateKey, json);
         }
         catch { /* same fallback */ }
@@ -441,6 +454,18 @@
         if (_mapView is not null)
         {
             await _mapView.SetOverlayVisibilityAsync(visible);
+        }
+        await PersistLayerStateAsync();
+        PushUrl();
+    }
+
+    private async Task OnOrganizerOverlayVisibilityChange(bool visible)
+    {
+        Console.WriteLine($"[map-export-pr3] organizer overlay visibility changed visible={visible}");
+        _organizerOverlayVisible = visible;
+        if (_mapView is not null)
+        {
+            await _mapView.SetOrganizerOverlayVisibilityAsync(visible);
         }
         await PersistLayerStateAsync();
         PushUrl();
@@ -670,6 +695,7 @@
             _locationsVisible = set.Contains("loc");
             _stashesVisible = set.Contains("stash");
             _overlaysVisible = set.Contains("overlay");
+            _organizerOverlayVisible = _isOrganizer && set.Contains("organizer-overlay");
             _urlLayersHydratedFromQuery = true;
         }
 
@@ -719,12 +745,14 @@
         var pairs = new List<string>();
 
         // Layers — emit only when not the default (all visible).
-        if (!(_locationsVisible && _stashesVisible && _overlaysVisible))
+        var organizerOverlayAtDefault = !_isOrganizer || _organizerOverlayVisible;
+        if (!(_locationsVisible && _stashesVisible && _overlaysVisible && organizerOverlayAtDefault))
         {
-            var parts = new List<string>(3);
+            var parts = new List<string>(4);
             if (_locationsVisible) parts.Add("loc");
             if (_stashesVisible) parts.Add("stash");
             if (_overlaysVisible) parts.Add("overlay");
+            if (_isOrganizer && _organizerOverlayVisible) parts.Add("organizer-overlay");
             // Empty string is meaningful (all optional layers off); always emit the key.
             pairs.Add($"layers={Uri.EscapeDataString(string.Join(',', parts))}");
         }
@@ -752,7 +780,17 @@
         bool Locations,
         bool Stashes,
         List<LocationKind>? HiddenKinds = null,
-        bool? Overlays = null);
+        bool? Overlays = null,
+        bool? OrganizerOverlays = null);
+
+    private static bool IsOrganizer(ClaimsPrincipal user)
+    {
+        var roles = user.FindAll(ClaimTypes.Role)
+            .Concat(user.FindAll("role"))
+            .Select(c => c.Value);
+
+        return roles.Any(role => role is "Organizer" or "Organizator" or "Organizátor" or "Admin");
+    }
 
     public void Dispose() => GameContext.OnGameChanged -= HandleGameChanged;
 }

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2614,6 +2614,10 @@
 .oh-mo-stroke-val{font-family:var(--oh-font-mono,Menlo,monospace);color:var(--oh-text,#2a2a2a);
     font-size:.75rem;min-width:30px;text-align:right}
 .oh-map-overlay-edit-btn{position:absolute;top:12px;left:12px;right:auto;z-index:19}
+.oh-map-overlay-audience{position:absolute;top:12px;left:12px;right:auto;z-index:21;
+    display:flex;gap:6px;padding:6px;background:rgba(250,246,236,.94);
+    border:1px solid var(--oh-border,#d8d2be);border-radius:6px;
+    box-shadow:0 2px 8px rgba(0,0,0,.16)}
 .oh-map-overlay-error{position:absolute;top:72px;left:50%;transform:translateX(-50%);z-index:21;
     display:flex;align-items:center;gap:8px;max-width:min(520px,calc(100% - 24px));
     margin:0;padding:8px 12px;font-size:.875rem}
@@ -3660,6 +3664,7 @@
 .oh-map-layer-dot{width:10px;height:10px;border-radius:50%;flex-shrink:0;background:#2D5016}
 .oh-map-layer-stash{background:#C19A3A}
 .oh-map-layer-overlay{background:#7048a8}
+.oh-map-layer-organizer-overlay{background:#b26223}
 .oh-map-layer-lbl{flex:1}
 .oh-map-layer-num{font-variant-numeric:tabular-nums}
 .oh-map-layer-hint{margin-top:8px;line-height:1.3}

--- a/src/OvcinaHra.Shared/Domain/Entities/Game.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Game.cs
@@ -27,13 +27,7 @@ public class Game
     public decimal? BoundingBoxNeLat { get; set; }
     public decimal? BoundingBoxNeLng { get; set; }
 
-    /// <summary>
-    /// Vector overlay drawn on top of the map — freeform text, freehand,
-    /// lines, shapes. Persisted as a JSON string of <c>MapOverlayDto</c>.
-    /// Null = no overlay drawn yet. See issue #96.
-    /// </summary>
-    public string? OverlayJson { get; set; }
-
+    public ICollection<GameMapOverlay> MapOverlays { get; set; } = [];
     public ICollection<GameLocation> GameLocations { get; set; } = [];
     public ICollection<GameItem> GameItems { get; set; } = [];
     public ICollection<GameSecretStash> GameSecretStashes { get; set; } = [];

--- a/src/OvcinaHra.Shared/Domain/Entities/GameMapOverlay.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameMapOverlay.cs
@@ -1,0 +1,12 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class GameMapOverlay
+{
+    public int GameId { get; set; }
+    public MapOverlayAudience Audience { get; set; }
+    public required string OverlayJson { get; set; }
+
+    public Game Game { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Domain/Enums/MapOverlayAudience.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/MapOverlayAudience.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Domain.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum MapOverlayAudience
+{
+    Player,
+    Organizer
+}

--- a/src/OvcinaHra.Shared/Dtos/MapExportDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MapExportDtos.cs
@@ -11,3 +11,18 @@ public enum MapExportBasemapStyle
     Osm,
     Blank
 }
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum MapExportKind
+{
+    Explorer,
+    Organizer,
+    Kingdom
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum MapExportPageFormat
+{
+    A4Portrait,
+    A3Portrait
+}

--- a/src/OvcinaHra.Shared/Dtos/MapOverlayDto.cs
+++ b/src/OvcinaHra.Shared/Dtos/MapOverlayDto.cs
@@ -4,7 +4,7 @@ namespace OvcinaHra.Shared.Dtos;
 
 /// <summary>
 /// Vector overlay drawn on top of a game's map — issue #96. Persisted as a
-/// JSON string on <c>Game.OverlayJson</c>. Phase 1+2 ships 6 primitives
+/// JSON string on <c>GameMapOverlay.OverlayJson</c>. Phase 1+2 ships 6 primitives
 /// (text, freehand, polyline, rectangle, circle, polygon); icons + arrows
 /// are deferred to Phase 3.
 /// </summary>

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ExportEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ExportEndpointTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using Microsoft.AspNetCore.Mvc;
@@ -105,7 +106,7 @@ public class ExportEndpointTests(PostgresFixture postgres)
     }
 
     [Fact]
-    public async Task ExplorerMap_BlankExport_UsesTownVillageNamesAndIdsForOtherKinds()
+    public async Task ExplorerMap_BlankExport_UsesLabelOverlayAndIdsForOtherKinds()
     {
         var game = await CreateGameAsync();
         const int wildernessId = 12345;
@@ -163,11 +164,112 @@ public class ExportEndpointTests(PostgresFixture postgres)
         var bytes = await response.Content.ReadAsByteArrayAsync();
         Assert.StartsWith("%PDF-1.4", Encoding.ASCII.GetString(bytes, 0, 8));
         var pdfText = Encoding.ASCII.GetString(bytes);
-        Assert.Contains("Town Alpha", pdfText);
-        Assert.Contains("Village Beta", pdfText);
+        Assert.Contains("/SMask", pdfText);
         Assert.Contains($"({wildernessId})", pdfText);
         Assert.DoesNotContain("Hidden Wild", pdfText);
         Assert.DoesNotContain("Outside Town", pdfText);
+    }
+
+    [Fact]
+    public async Task ExplorerMap_PinLabelOverlay_PreservesCzechGlyphPath()
+    {
+        var lines = ExplorerMapExportService.WrapPinLabelForTesting("Vořařská osada");
+
+        Assert.Contains("ř", string.Concat(lines));
+        Assert.Contains("á", string.Concat(lines));
+    }
+
+    [Fact]
+    public void ExplorerMap_ReducedMargin_ExpandsMapArea()
+    {
+        var area = ExplorerMapExportService.CalculateMapAreaForTesting(
+            MapExportPageFormat.A4Portrait,
+            aspectRatio: 2.0);
+
+        Assert.Equal(12, area.X, precision: 3);
+        Assert.True(area.Width > 570);
+    }
+
+    [Fact]
+    public void ExplorerMap_LongPinLabel_WrapsAcrossMultipleLines()
+    {
+        var lines = ExplorerMapExportService.WrapPinLabelForTesting("Caras Amarth - Karaskov");
+
+        Assert.True(lines.Count >= 2);
+        Assert.All(lines, line => Assert.True(line.Length <= 14));
+    }
+
+    [Fact]
+    public async Task OrganizerMap_NonOrganizer_ReturnsCzechForbiddenProblem()
+    {
+        using var client = Factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            TestJwt.CreateToken(Factory.Services, "Player"));
+
+        var response = await client.GetAsync("/api/games/30/exports/organizer-map.pdf?style=blank");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Přístup odepřen", problem.Title);
+        Assert.Equal("Pouze organizátoři mohou stáhnout tuto mapu.", problem.Detail);
+    }
+
+    [Fact]
+    public async Task KingdomMap_BlankExport_UsesA3MediaBox()
+    {
+        var game = await CreateGameAsync();
+        await SetGameBoundsAsync(game.Id);
+
+        var response = await Client.GetAsync($"/api/games/{game.Id}/exports/kingdom-map.pdf?style=blank");
+
+        response.EnsureSuccessStatusCode();
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        var pdfText = Encoding.ASCII.GetString(bytes);
+        Assert.Contains("/MediaBox [0 0 841.89 1190.551]", pdfText);
+        Assert.Contains("edition-30-kralovstvi-A3-", response.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
+        WriteMapSmokeArtifact("kingdom-smoke.pdf", bytes);
+    }
+
+    [Fact]
+    public async Task OrganizerMap_IncludesOrganizerOverlayButExplorerDoesNot()
+    {
+        var game = await CreateGameAsync();
+        await SetGameBoundsAsync(game.Id);
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            db.GameMapOverlays.AddRange(
+                new GameMapOverlay
+                {
+                    GameId = game.Id,
+                    Audience = MapOverlayAudience.Player,
+                    OverlayJson = """{"Shapes":[{"type":"text","Id":"p","Color":"#242F3D","Coord":{"Lat":49.5,"Lng":17.5},"Text":"PlayerOverlay","FontSize":14}]}"""
+                },
+                new GameMapOverlay
+                {
+                    GameId = game.Id,
+                    Audience = MapOverlayAudience.Organizer,
+                    OverlayJson = """{"Shapes":[{"type":"text","Id":"o","Color":"#242F3D","Coord":{"Lat":49.55,"Lng":17.55},"Text":"OrganizerOverlay","FontSize":14}]}"""
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var organizer = await Client.GetAsync($"/api/games/{game.Id}/exports/organizer-map.pdf?style=blank");
+        organizer.EnsureSuccessStatusCode();
+        var organizerBytes = await organizer.Content.ReadAsByteArrayAsync();
+        var organizerText = Encoding.ASCII.GetString(organizerBytes);
+        Assert.Contains("PlayerOverlay", organizerText);
+        Assert.Contains("OrganizerOverlay", organizerText);
+        WriteMapSmokeArtifact("organizer-smoke.pdf", organizerBytes);
+
+        var explorer = await Client.GetAsync($"/api/games/{game.Id}/exports/explorer-map.pdf?style=blank");
+        explorer.EnsureSuccessStatusCode();
+        var explorerText = Encoding.ASCII.GetString(await explorer.Content.ReadAsByteArrayAsync());
+        Assert.Contains("PlayerOverlay", explorerText);
+        Assert.DoesNotContain("OrganizerOverlay", explorerText);
     }
 
     [Fact]
@@ -242,13 +344,27 @@ public class ExportEndpointTests(PostgresFixture postgres)
 
     private sealed class MissingMapyKeyExporter : IExplorerMapExportService
     {
-        public Task<ExplorerMapExportFile> RenderExplorerMapAsync(
+        public Task<ExplorerMapExportFile> RenderMapAsync(
             int gameId,
             MapExportBasemapStyle style,
+            MapExportKind kind,
+            MapExportPageFormat pageFormat,
             CancellationToken ct = default) =>
             throw new MapExportProblemException(
                 "Mapy.cz API klíč není nastaven.",
                 "Kontaktujte správce systému.");
+    }
+
+    private async Task SetGameBoundsAsync(int gameId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var entity = await db.Games.SingleAsync(g => g.Id == gameId);
+        entity.BoundingBoxSwLat = 49.0m;
+        entity.BoundingBoxSwLng = 17.0m;
+        entity.BoundingBoxNeLat = 50.0m;
+        entity.BoundingBoxNeLng = 18.0m;
+        await db.SaveChangesAsync();
     }
 
     private static Spell CreateSpell(string name, int level) => new()
@@ -294,5 +410,22 @@ public class ExportEndpointTests(PostgresFixture postgres)
         var tmp = Path.Combine(directory.FullName, ".tmp");
         Directory.CreateDirectory(tmp);
         File.WriteAllBytes(Path.Combine(tmp, "magic-book-A4.pdf"), bytes);
+    }
+
+    private static void WriteMapSmokeArtifact(string fileName, byte[] bytes)
+    {
+        if (Environment.GetEnvironmentVariable("OVCINA_WRITE_MAP_EXPORT_SMOKE") != "1")
+            return;
+
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "OvcinaHra.slnx")))
+            directory = directory.Parent;
+
+        if (directory is null)
+            return;
+
+        var tmp = Path.Combine(directory.FullName, ".tmp");
+        Directory.CreateDirectory(tmp);
+        File.WriteAllBytes(Path.Combine(tmp, fileName), bytes);
     }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/GameEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/GameEndpointTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Services;
@@ -201,6 +203,14 @@ public class GameEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
         var putResponse = await Client.PutAsJsonAsync($"/api/games/{game.Id}/overlay", dto);
         Assert.Equal(HttpStatusCode.NoContent, putResponse.StatusCode);
 
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var stored = await db.GameMapOverlays.SingleAsync(o =>
+                o.GameId == game.Id && o.Audience == MapOverlayAudience.Player);
+            Assert.Contains("\"t1\"", stored.OverlayJson);
+        }
+
         var getResponse = await Client.GetAsync($"/api/games/{game.Id}/overlay");
         Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
 
@@ -304,6 +314,44 @@ public class GameEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
 
         var getResponse = await Client.GetAsync("/api/games/999999/overlay");
         Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task Overlay_OrganizerAudience_IsSeparateFromPlayer()
+    {
+        var game = await CreateGameAsync("Overlay-Audiences");
+        var player = new MapOverlayDto([new TextShape("p", "#242F3D", new OverlayCoord(49.5, 17.1), "Hráčská")]);
+        var organizer = new MapOverlayDto([new TextShape("o", "#242F3D", new OverlayCoord(49.6, 17.2), "Organizátorská")]);
+
+        var playerPut = await Client.PutAsJsonAsync($"/api/games/{game.Id}/overlay", player);
+        var organizerPut = await Client.PutAsJsonAsync($"/api/games/{game.Id}/overlay?audience=organizer", organizer);
+
+        Assert.Equal(HttpStatusCode.NoContent, playerPut.StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, organizerPut.StatusCode);
+
+        var playerGet = await Client.GetFromJsonAsync<MapOverlayDto>($"/api/games/{game.Id}/overlay?audience=player");
+        var organizerGet = await Client.GetFromJsonAsync<MapOverlayDto>($"/api/games/{game.Id}/overlay?audience=organizer");
+        Assert.Equal("Hráčská", Assert.IsType<TextShape>(Assert.Single(playerGet!.Shapes)).Text);
+        Assert.Equal("Organizátorská", Assert.IsType<TextShape>(Assert.Single(organizerGet!.Shapes)).Text);
+    }
+
+    [Fact]
+    public async Task Overlay_OrganizerAudience_NonOrganizerGetsForbidden()
+    {
+        var game = await CreateGameAsync("Overlay-Forbidden");
+        using var client = Factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            TestJwt.CreateToken(Factory.Services, "Player"));
+
+        var response = await client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/overlay?audience=organizer",
+            new MapOverlayDto([]));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Pouze organizátoři mohou pracovat s organizátorským překryvem.", problem.Detail);
     }
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Fixtures/TestJwt.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/TestJwt.cs
@@ -1,0 +1,34 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace OvcinaHra.Api.Tests.Fixtures;
+
+internal static class TestJwt
+{
+    public static string CreateToken(IServiceProvider services, params string[] roles)
+    {
+        var config = services.GetRequiredService<IConfiguration>();
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, "test-non-organizer"),
+            new(ClaimTypes.NameIdentifier, "test-non-organizer"),
+            new(ClaimTypes.Email, "player@example.test"),
+            new("name", "Test Player")
+        };
+        claims.AddRange(roles.Select(role => new Claim(ClaimTypes.Role, role)));
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(config["Jwt:Key"]!));
+        var token = new JwtSecurityToken(
+            issuer: config["Jwt:Issuer"],
+            audience: config["Jwt:Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256));
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GameMapOverlays` with Player/Organizer audiences and migrates existing `Games.OverlayJson` into Player overlay rows.
- Adds Organizer A4 and Kingdom A3 map export endpoints/UI, sharing the existing map export renderer via export kind + page format parameters.
- Adds organizer overlay editing/toggles in MapView/MapLayerRail, plus organizer-only export authorization.
- Updates map PDF labels: tighter 12pt margins, transparent Kalam label overlay with outline, and wrapped town/village labels.

## Smoke Artifacts
- `.tmp/organizer-smoke.pdf`
- `.tmp/kingdom-smoke.pdf`

## Verification
- `dotnet build OvcinaHra.slnx --verbosity minimal`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter "FullyQualifiedName~ExportEndpointTests|FullyQualifiedName~GameEndpointTests" --verbosity minimal`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --verbosity minimal`

## Visual Test Notes
After deploy, please test in `/map` and `/exports`:
- On `/map`, as an organizer, confirm the rail shows separate `Překryv hráčů` and `Překryv organizátorů` toggles.
- Click `Upravit překryv`, switch between `Hráčská vrstva` and `Organizátorská vrstva`, draw a small shape in each, save, and confirm each rail toggle hides only its layer.
- In `/exports`, download `Export pro organizátory (A4)` and confirm both overlay layers appear.
- Download `Export pro království (A3)` and confirm it is A3, uses the player layer only, has tighter margins, and town/village labels keep Czech diacritics and wrap without a white pill.

Closes #318