### PR TITLE
feat(treasures): improve allocation entry flow

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
@@ -10,6 +11,8 @@ namespace OvcinaHra.Api.Endpoints;
 
 public static class TreasurePlanningEndpoints
 {
+    private static readonly JsonSerializerOptions TreasureAllocLogJsonOptions = new(JsonSerializerDefaults.Web);
+
     public static RouteGroupBuilder MapTreasurePlanningEndpoints(this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/treasure-planning").WithTags("TreasurePlanning");
@@ -229,22 +232,25 @@ public static class TreasurePlanningEndpoints
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
         var poolCount = dto.TreasureItemIds?.Count ?? 0;
         var unlimitedCount = dto.UnlimitedItems?.Count ?? 0;
-        logger.LogInformation(
-            "[treasure-alloc] {{\"event\":\"assign-entry\",\"gameId\":{GameId},\"locationId\":{LocationId},\"secretStashId\":{SecretStashId},\"poolCount\":{PoolCount},\"unlimitedCount\":{UnlimitedCount}}}",
+        LogTreasureAlloc(logger, LogLevel.Information, "assign-entry", new
+        {
             dto.GameId,
             dto.LocationId,
             dto.SecretStashId,
             poolCount,
-            unlimitedCount);
+            unlimitedCount
+        });
 
         // Validate XOR
         if ((dto.LocationId is null) == (dto.SecretStashId is null))
         {
-            logger.LogWarning(
-                "[treasure-alloc] {{\"event\":\"assign-validation-rejected\",\"reason\":\"location-stash-xor\",\"gameId\":{GameId},\"locationId\":{LocationId},\"secretStashId\":{SecretStashId}}}",
+            LogTreasureAlloc(logger, LogLevel.Warning, "assign-validation-rejected", new
+            {
+                reason = "location-stash-xor",
                 dto.GameId,
                 dto.LocationId,
-                dto.SecretStashId);
+                dto.SecretStashId
+            });
             return TypedResults.ValidationProblem(new Dictionary<string, string[]>
             {
                 ["LocationId"] = ["Musí být vyplněna buď lokace, nebo tajná skrýš (ne obojí)."]
@@ -260,11 +266,13 @@ public static class TreasurePlanningEndpoints
                 LocationId = dto.LocationId, SecretStashId = dto.SecretStashId, GameId = dto.GameId
             };
             db.TreasureQuests.Add(quest);
-            logger.LogInformation(
-                "[treasure-alloc] {{\"event\":\"assign-before-save\",\"phase\":\"create-quest\",\"gameId\":{GameId},\"locationId\":{LocationId},\"secretStashId\":{SecretStashId}}}",
+            LogTreasureAlloc(logger, LogLevel.Information, "assign-before-save", new
+            {
+                phase = "create-quest",
                 dto.GameId,
                 dto.LocationId,
-                dto.SecretStashId);
+                dto.SecretStashId
+            });
             await db.SaveChangesAsync(); // get the ID
 
             // Assign pool items
@@ -289,12 +297,14 @@ public static class TreasurePlanningEndpoints
                 }
             }
 
-            logger.LogInformation(
-                "[treasure-alloc] {{\"event\":\"assign-before-save\",\"phase\":\"attach-items\",\"questId\":{QuestId},\"gameId\":{GameId},\"poolCount\":{PoolCount},\"unlimitedCount\":{UnlimitedCount}}}",
-                quest.Id,
+            LogTreasureAlloc(logger, LogLevel.Information, "assign-before-save", new
+            {
+                phase = "attach-items",
+                questId = quest.Id,
                 dto.GameId,
                 poolCount,
-                unlimitedCount);
+                unlimitedCount
+            });
             await db.SaveChangesAsync();
 
             // Reload with includes for response
@@ -304,11 +314,12 @@ public static class TreasurePlanningEndpoints
                 .Include(t => t.TreasureItems).ThenInclude(ti => ti.Item)
                 .FirstAsync(t => t.Id == quest.Id);
 
-            logger.LogInformation(
-                "[treasure-alloc] {{\"event\":\"assign-success\",\"questId\":{QuestId},\"gameId\":{GameId},\"itemCount\":{ItemCount}}}",
-                quest.Id,
+            LogTreasureAlloc(logger, LogLevel.Information, "assign-success", new
+            {
+                questId = quest.Id,
                 dto.GameId,
-                loaded.TreasureItems.Sum(ti => ti.Count));
+                itemCount = loaded.TreasureItems.Sum(ti => ti.Count)
+            });
 
             return TypedResults.Created($"/api/treasure-quests/{quest.Id}",
                 new TreasureQuestDetailDto(
@@ -318,16 +329,28 @@ public static class TreasurePlanningEndpoints
         }
         catch (Exception ex)
         {
-            logger.LogError(
-                ex,
-                "[treasure-alloc] {{\"event\":\"assign-catch\",\"gameId\":{GameId},\"locationId\":{LocationId},\"secretStashId\":{SecretStashId},\"poolCount\":{PoolCount},\"unlimitedCount\":{UnlimitedCount}}}",
+            LogTreasureAlloc(logger, LogLevel.Error, "assign-catch", new
+            {
                 dto.GameId,
                 dto.LocationId,
                 dto.SecretStashId,
                 poolCount,
-                unlimitedCount);
+                unlimitedCount
+            }, ex);
             throw;
         }
+    }
+
+    private static void LogTreasureAlloc(ILogger logger, LogLevel level, string eventName, object payload, Exception? exception = null)
+    {
+        var json = JsonSerializer.Serialize(new { Event = eventName, Payload = payload }, TreasureAllocLogJsonOptions);
+        if (exception is null)
+        {
+            logger.Log(level, "[treasure-alloc] {Payload}", json);
+            return;
+        }
+
+        logger.Log(level, exception, "[treasure-alloc] {Payload}", json);
     }
 
     // ── Issue #160: bulk refill ───────────────────────────────────────────

--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -221,62 +221,113 @@ public static class TreasurePlanningEndpoints
             CountByDifficulty(GameTimePhase.Lategame)));
     }
 
-    private static async Task<Results<Created<TreasureQuestDetailDto>, ValidationProblem>> AssignTreasure(AssignTreasureDto dto, WorldDbContext db)
+    private static async Task<Results<Created<TreasureQuestDetailDto>, ValidationProblem>> AssignTreasure(
+        AssignTreasureDto dto,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory)
     {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
+        var poolCount = dto.TreasureItemIds?.Count ?? 0;
+        var unlimitedCount = dto.UnlimitedItems?.Count ?? 0;
+        logger.LogInformation(
+            "[treasure-alloc] {{\"event\":\"assign-entry\",\"gameId\":{GameId},\"locationId\":{LocationId},\"secretStashId\":{SecretStashId},\"poolCount\":{PoolCount},\"unlimitedCount\":{UnlimitedCount}}}",
+            dto.GameId,
+            dto.LocationId,
+            dto.SecretStashId,
+            poolCount,
+            unlimitedCount);
+
         // Validate XOR
         if ((dto.LocationId is null) == (dto.SecretStashId is null))
         {
+            logger.LogWarning(
+                "[treasure-alloc] {{\"event\":\"assign-validation-rejected\",\"reason\":\"location-stash-xor\",\"gameId\":{GameId},\"locationId\":{LocationId},\"secretStashId\":{SecretStashId}}}",
+                dto.GameId,
+                dto.LocationId,
+                dto.SecretStashId);
             return TypedResults.ValidationProblem(new Dictionary<string, string[]>
             {
                 ["LocationId"] = ["Musí být vyplněna buď lokace, nebo tajná skrýš (ne obojí)."]
             });
         }
 
-        // Create the quest
-        var quest = new TreasureQuest
+        try
         {
-            Title = dto.Title, Clue = dto.Clue, Difficulty = dto.Difficulty,
-            LocationId = dto.LocationId, SecretStashId = dto.SecretStashId, GameId = dto.GameId
-        };
-        db.TreasureQuests.Add(quest);
-        await db.SaveChangesAsync(); // get the ID
-
-        // Assign pool items
-        if (dto.TreasureItemIds is { Count: > 0 })
-        {
-            var poolItems = await db.TreasureItems
-                .Where(ti => dto.TreasureItemIds.Contains(ti.Id) && ti.TreasureQuestId == null && ti.GameId == dto.GameId)
-                .ToListAsync();
-            foreach (var item in poolItems)
-                item.TreasureQuestId = quest.Id;
-        }
-
-        // Add unlimited items directly
-        if (dto.UnlimitedItems is { Count: > 0 })
-        {
-            foreach (var ui in dto.UnlimitedItems)
+            // Create the quest
+            var quest = new TreasureQuest
             {
-                db.TreasureItems.Add(new TreasureItem
-                {
-                    ItemId = ui.ItemId, GameId = dto.GameId, Count = ui.Count, TreasureQuestId = quest.Id
-                });
+                Title = dto.Title, Clue = dto.Clue, Difficulty = dto.Difficulty,
+                LocationId = dto.LocationId, SecretStashId = dto.SecretStashId, GameId = dto.GameId
+            };
+            db.TreasureQuests.Add(quest);
+            logger.LogInformation(
+                "[treasure-alloc] {{\"event\":\"assign-before-save\",\"phase\":\"create-quest\",\"gameId\":{GameId},\"locationId\":{LocationId},\"secretStashId\":{SecretStashId}}}",
+                dto.GameId,
+                dto.LocationId,
+                dto.SecretStashId);
+            await db.SaveChangesAsync(); // get the ID
+
+            // Assign pool items
+            if (dto.TreasureItemIds is { Count: > 0 })
+            {
+                var poolItems = await db.TreasureItems
+                    .Where(ti => dto.TreasureItemIds.Contains(ti.Id) && ti.TreasureQuestId == null && ti.GameId == dto.GameId)
+                    .ToListAsync();
+                foreach (var item in poolItems)
+                    item.TreasureQuestId = quest.Id;
             }
+
+            // Add unlimited items directly
+            if (dto.UnlimitedItems is { Count: > 0 })
+            {
+                foreach (var ui in dto.UnlimitedItems)
+                {
+                    db.TreasureItems.Add(new TreasureItem
+                    {
+                        ItemId = ui.ItemId, GameId = dto.GameId, Count = ui.Count, TreasureQuestId = quest.Id
+                    });
+                }
+            }
+
+            logger.LogInformation(
+                "[treasure-alloc] {{\"event\":\"assign-before-save\",\"phase\":\"attach-items\",\"questId\":{QuestId},\"gameId\":{GameId},\"poolCount\":{PoolCount},\"unlimitedCount\":{UnlimitedCount}}}",
+                quest.Id,
+                dto.GameId,
+                poolCount,
+                unlimitedCount);
+            await db.SaveChangesAsync();
+
+            // Reload with includes for response
+            var loaded = await db.TreasureQuests
+                .Include(t => t.Location)
+                .Include(t => t.SecretStash)
+                .Include(t => t.TreasureItems).ThenInclude(ti => ti.Item)
+                .FirstAsync(t => t.Id == quest.Id);
+
+            logger.LogInformation(
+                "[treasure-alloc] {{\"event\":\"assign-success\",\"questId\":{QuestId},\"gameId\":{GameId},\"itemCount\":{ItemCount}}}",
+                quest.Id,
+                dto.GameId,
+                loaded.TreasureItems.Sum(ti => ti.Count));
+
+            return TypedResults.Created($"/api/treasure-quests/{quest.Id}",
+                new TreasureQuestDetailDto(
+                    loaded.Id, loaded.Title, loaded.Clue, loaded.Difficulty,
+                    loaded.LocationId, loaded.Location?.Name, loaded.SecretStashId, loaded.SecretStash?.Name, loaded.GameId,
+                    loaded.TreasureItems.Select(ti => new TreasureItemDto(ti.Id, ti.ItemId, ti.Item.Name, ti.Count, ti.TreasureQuestId)).ToList()));
         }
-
-        await db.SaveChangesAsync();
-
-        // Reload with includes for response
-        var loaded = await db.TreasureQuests
-            .Include(t => t.Location)
-            .Include(t => t.SecretStash)
-            .Include(t => t.TreasureItems).ThenInclude(ti => ti.Item)
-            .FirstAsync(t => t.Id == quest.Id);
-
-        return TypedResults.Created($"/api/treasure-quests/{quest.Id}",
-            new TreasureQuestDetailDto(
-                loaded.Id, loaded.Title, loaded.Clue, loaded.Difficulty,
-                loaded.LocationId, loaded.Location?.Name, loaded.SecretStashId, loaded.SecretStash?.Name, loaded.GameId,
-                loaded.TreasureItems.Select(ti => new TreasureItemDto(ti.Id, ti.ItemId, ti.Item.Name, ti.Count, ti.TreasureQuestId)).ToList()));
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "[treasure-alloc] {{\"event\":\"assign-catch\",\"gameId\":{GameId},\"locationId\":{LocationId},\"secretStashId\":{SecretStashId},\"poolCount\":{PoolCount},\"unlimitedCount\":{UnlimitedCount}}}",
+                dto.GameId,
+                dto.LocationId,
+                dto.SecretStashId,
+                poolCount,
+                unlimitedCount);
+            throw;
+        }
     }
 
     // ── Issue #160: bulk refill ───────────────────────────────────────────

--- a/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
+++ b/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
@@ -44,6 +44,14 @@
                             @bind-Value="@stashId"
                             TextFieldName="Name" ValueFieldName="Id"
                             NullText="Vyberte skrýš…" />
+                <div class="oh-tp-stash-summary compact">
+                    @foreach (var stash in Stashes.OrderBy(s => s.Name))
+                    {
+                        <span class="oh-tp-stash-chip">
+                            <i class="bi bi-archive"></i>@stash.Name <strong>@stash.ItemCount</strong>
+                        </span>
+                    }
+                </div>
             </div>
         }
     </div>

--- a/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
+++ b/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
@@ -1,0 +1,83 @@
+@using OvcinaHra.Shared.Dtos
+@using OvcinaHra.Shared.Extensions
+@inject IJSRuntime JS
+@implements IAsyncDisposable
+
+<button @ref="elementRef"
+        type="button"
+        class="@CssClass"
+        @key="Location.LocationId"
+        @onclick="HandleClick">
+    <div class="oh-tp-card-hdr">
+        <span class="oh-tp-card-kind">@Location.LocationKind.GetDisplayName()</span>
+        <span class="oh-tp-card-count">@Location.TotalItems pokladů</span>
+    </div>
+    <div class="oh-tp-card-name">
+        @Location.LocationName <span class="oh-tp-card-name-count">(@Location.TotalItems)</span>
+    </div>
+    @if (Location.StashCount > 0)
+    {
+        <div class="oh-tp-card-stash">
+            <i class="bi bi-archive"></i> @Location.StashCount / @Location.MaxStashes skrýší
+            @if (Location.Stashes.Sum(s => s.ItemCount) > 0)
+            {
+                <span>· @Location.Stashes.Sum(s => s.ItemCount) ve skrýších</span>
+            }
+        </div>
+    }
+    @if (HasSelectedPool)
+    {
+        <div class="oh-tp-card-cta">
+            <i class="bi bi-plus-circle"></i> Přidat vybrané sem
+        </div>
+    }
+</button>
+
+@code {
+    [Parameter, EditorRequired] public TreasurePlanningLocationDto Location { get; set; } = default!;
+    [Parameter] public bool IsFocused { get; set; }
+    [Parameter] public bool HasSelectedPool { get; set; }
+    [Parameter] public EventCallback<int> OnClick { get; set; }
+    [Parameter] public EventCallback<PiePayloadEventArgs> OnDrop { get; set; }
+
+    private ElementReference elementRef;
+    private DotNetObjectReference<TreasureLocationTargetCard>? dropRef;
+    private int wiredLocationId;
+
+    private string CssClass =>
+        $"oh-tp-card {(IsFocused ? "is-focused" : "")} {(HasSelectedPool ? "has-pending" : "")}".Trim();
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (dropRef is null)
+        {
+            dropRef = DotNetObjectReference.Create(this);
+        }
+
+        if (wiredLocationId != Location.LocationId)
+        {
+            wiredLocationId = Location.LocationId;
+            await JS.InvokeVoidAsync("ovcinaDnd.setDropTarget", elementRef, Location.LocationId, dropRef);
+        }
+    }
+
+    private Task HandleClick() => OnClick.InvokeAsync(Location.LocationId);
+
+    [JSInvokable]
+    public Task OnTreasurePoolDropped(int locationId, string payload) =>
+        OnDrop.InvokeAsync(new PiePayloadEventArgs(locationId, payload));
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("ovcinaDnd.clearDropTarget", elementRef);
+        }
+        catch
+        {
+            // Browser teardown can race component disposal in Blazor WASM.
+        }
+
+        dropRef?.Dispose();
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -187,7 +187,7 @@ else
                     @* Cards view: groups by Region, click a card → focus/assign flow *@
                     var filtered = GetFilteredLocationCards().ToList();
                     var grouped = filtered
-                        .GroupBy(GetRegionLabel)
+                        .GroupBy(GetRegionLabel, StringComparer.CurrentCultureIgnoreCase)
                         .OrderBy(g => GetRegionSortKey(g.Key))
                         .ToList();
                     if (grouped.Count == 0)
@@ -867,7 +867,8 @@ else
         // Prune selection of items that left the pool.
         var poolIds = poolItems.Select(p => p.Id).ToHashSet();
         selectedPool.RemoveAll(s => !poolIds.Contains(s.Id));
-        if (treasuresRegionFilter is not null && !GetRegionOptions(locationCards).Contains(treasuresRegionFilter))
+        if (treasuresRegionFilter is not null
+            && !GetRegionOptions(locationCards).Contains(treasuresRegionFilter, StringComparer.CurrentCultureIgnoreCase))
             treasuresRegionFilter = null;
 
         loading = false;
@@ -930,7 +931,7 @@ else
         if (treasuresKindFilter.HasValue)
             filtered = filtered.Where(l => l.LocationKind == treasuresKindFilter.Value);
         if (!string.IsNullOrWhiteSpace(treasuresRegionFilter))
-            filtered = filtered.Where(l => GetRegionLabel(l) == treasuresRegionFilter);
+            filtered = filtered.Where(l => string.Equals(GetRegionLabel(l), treasuresRegionFilter, StringComparison.CurrentCultureIgnoreCase));
         return filtered;
     }
 

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -1,5 +1,6 @@
 @page "/treasures"
 @attribute [Authorize]
+@using System.Text.Json
 @using OvcinaHra.Client.Components
 @using OvcinaHra.Shared.Dtos
 @using OvcinaHra.Shared.Domain.Enums
@@ -157,13 +158,26 @@ else
                             <span class="text-muted small">Typ:</span>
                             <button type="button"
                                     class="oh-tp-kind-pill @(treasuresKindFilter is null ? "on" : "")"
-                                    @onclick="() => treasuresKindFilter = null">vše</button>
+                                    @onclick="() => SetTreasuresKindFilter(null)">vše</button>
                             @foreach (var kind in locationCards.Select(l => l.LocationKind).Distinct().OrderBy(k => k.GetDisplayName()))
                             {
                                 var k = kind;
                                 <button type="button"
                                         class="oh-tp-kind-pill @(treasuresKindFilter == k ? "on" : "")"
-                                        @onclick="() => treasuresKindFilter = k">@k.GetDisplayName()</button>
+                                        @onclick="() => SetTreasuresKindFilter(k)">@k.GetDisplayName()</button>
+                            }
+                        </div>
+                        <div class="oh-tp-kind-filter">
+                            <span class="text-muted small">Region:</span>
+                            <button type="button"
+                                    class="oh-tp-kind-pill @(treasuresRegionFilter is null ? "on" : "")"
+                                    @onclick="() => SetTreasuresRegionFilter(null)">vše</button>
+                            @foreach (var region in GetRegionOptions(locationCards))
+                            {
+                                var r = region;
+                                <button type="button"
+                                        class="oh-tp-kind-pill @(treasuresRegionFilter == r ? "on" : "")"
+                                        @onclick="() => SetTreasuresRegionFilter(r)">@r</button>
                             }
                         </div>
                     }
@@ -171,12 +185,10 @@ else
                 @if (treasuresView == "cards")
                 {
                     @* Cards view: groups by Region, click a card → focus/assign flow *@
-                    var filtered = treasuresKindFilter.HasValue
-                        ? locationCards.Where(l => l.LocationKind == treasuresKindFilter.Value).ToList()
-                        : locationCards.ToList();
+                    var filtered = GetFilteredLocationCards().ToList();
                     var grouped = filtered
-                        .GroupBy(l => string.IsNullOrWhiteSpace(l.Region) ? "(bez regionu)" : l.Region!)
-                        .OrderBy(g => g.Key)
+                        .GroupBy(GetRegionLabel)
+                        .OrderBy(g => GetRegionSortKey(g.Key))
                         .ToList();
                     if (grouped.Count == 0)
                     {
@@ -193,25 +205,11 @@ else
                                         @foreach (var loc in grp.OrderBy(l => l.LocationName))
                                         {
                                             var isFocused = focusedLocationId == loc.LocationId;
-                                            <button type="button"
-                                                    class="oh-tp-card @(isFocused ? "is-focused" : "")"
-                                                    @key="loc.LocationId"
-                                                    @onclick="() => HandlePieClick(loc.LocationId)">
-                                                <div class="oh-tp-card-hdr">
-                                                    <span class="oh-tp-card-kind">@loc.LocationKind.GetDisplayName()</span>
-                                                    @if (loc.TotalItems > 0)
-                                                    {
-                                                        <span class="oh-tp-card-count">@loc.TotalItems pokladů</span>
-                                                    }
-                                                </div>
-                                                <div class="oh-tp-card-name">@loc.LocationName</div>
-                                                @if (loc.StashCount > 0)
-                                                {
-                                                    <div class="oh-tp-card-stash">
-                                                        <i class="bi bi-archive"></i> @loc.StashCount / @loc.MaxStashes skrýší
-                                                    </div>
-                                                }
-                                            </button>
+                                            <TreasureLocationTargetCard Location="loc"
+                                                                        IsFocused="isFocused"
+                                                                        HasSelectedPool="@(selectedPool.Count > 0)"
+                                                                        OnClick="HandleLocationTargetClick"
+                                                                        OnDrop="HandlePieDrop" />
                                         }
                                     </div>
                                 </div>
@@ -261,7 +259,7 @@ else
                         {
                             <div class="oh-tp-drag-hint">
                                 <i class="bi bi-arrow-left-right"></i>
-                                Přetáhni vybrané kachličky na špendlík na mapě, nebo klikni na lokaci pro přidání.
+                                Přetáhni vybrané kachličky na špendlík nebo kartu lokace, případně klikni na lokaci pro přidání.
                             </div>
                         }
                         @if (poolItems.Count == 0)
@@ -292,28 +290,54 @@ else
                     @* --- Location focus --- *@
                     var loc = locationCards.FirstOrDefault(l => l.LocationId == focusedLocationId);
                     <div class="oh-tp-assign-hdr">
-                        <h5>@(loc?.LocationName ?? "Lokace")</h5>
+                        <h5>
+                            @(loc?.LocationName ?? "Lokace")
+                            @if (loc is not null)
+                            {
+                                <span class="oh-tp-location-total">(@loc.TotalItems)</span>
+                            }
+                        </h5>
                         <button class="oh-tp-close" @onclick="CloseFocus" title="Zavřít">
                             <i class="bi bi-x-lg"></i>
                         </button>
                     </div>
                     <div class="oh-tp-assign-tabs">
                         <button class="oh-tp-assign-tab @(focusTab == "prehled" ? "active" : "")"
-                                @onclick='() => focusTab = "prehled"'>Přehled</button>
+                                @onclick='() => SetFocusTab("prehled", "tab")'>Přehled</button>
                         <button class="oh-tp-assign-tab @(focusTab == "pridat" ? "active" : "")"
-                                @onclick='() => focusTab = "pridat"'>Přidat poklad</button>
+                                @onclick='() => SetFocusTab("pridat", "tab")'>Přidat poklad</button>
                     </div>
                     <div class="oh-tp-assign-body">
                         @if (focusTab == "prehled" && loc is not null)
                         {
                             <div class="oh-tp-focus-summary">
                                 <div class="oh-tp-focus-stats">
+                                    <span><i class="bi bi-box-seam"></i> Celkem @loc.TotalItems</span>
                                     <span><span class="sw" style="background:var(--oh-stage-start)"></span>Start @loc.StartCount</span>
                                     <span><span class="sw" style="background:var(--oh-stage-early)"></span>Rozvoj @loc.EarlyCount</span>
                                     <span><span class="sw" style="background:var(--oh-stage-midgame)"></span>Střed @loc.MidgameCount</span>
                                     <span><span class="sw" style="background:var(--oh-stage-lategame)"></span>Závěr @loc.LategameCount</span>
                                 </div>
+                                @if (selectedPool.Count > 0)
+                                {
+                                    <button type="button"
+                                            class="btn btn-sm btn-primary"
+                                            @onclick='() => StartAddToFocusedLocation("focus-cta")'>
+                                        <i class="bi bi-plus-circle me-1"></i>Přiřadit vybrané sem
+                                    </button>
+                                }
                             </div>
+                            @if (loc.Stashes.Count > 0)
+                            {
+                                <div class="oh-tp-stash-summary">
+                                    @foreach (var stash in loc.Stashes.OrderBy(s => s.Name))
+                                    {
+                                        <span class="oh-tp-stash-chip">
+                                            <i class="bi bi-archive"></i>@stash.Name <strong>@stash.ItemCount</strong>
+                                        </span>
+                                    }
+                                </div>
+                            }
 
                             var locQuests = allQuests.Where(q => q.LocationId == focusedLocationId).ToList();
                             var stashIds = loc.Stashes.Select(s => s.Id).ToHashSet();
@@ -362,7 +386,7 @@ else
                                                 Unlimited="@unlimitedItems"
                                                 InitialDifficulty="@lastUsedDifficulty"
                                                 OnSave="HandleAssignSaveAsync"
-                                                OnCancel='() => focusTab = "prehled"' />
+                                                OnCancel='() => SetFocusTab("prehled", "cancel")' />
                         }
                     </div>
                 }
@@ -659,6 +683,9 @@ else
 }
 
 @code {
+    private static readonly JsonSerializerOptions TreasureAllocLogJsonOptions = new(JsonSerializerDefaults.Web);
+    private const string NoRegionLabel = "Bez regionu";
+
     // ===== Data =====
     private List<TreasurePoolItemDto> poolItems = [];
     private List<TreasurePlanningLocationDto> locationCards = [];
@@ -678,6 +705,14 @@ else
         var existing = selectedPool.FirstOrDefault(s => s.Id == p.Id);
         if (existing is not null) selectedPool.Remove(existing);
         else selectedPool.Add(p);
+        LogTreasureAlloc("click-treasure", new
+        {
+            poolItemId = p.Id,
+            p.ItemId,
+            selected = existing is null,
+            selectedCount = selectedPool.Count,
+            focusedLocationId
+        });
     }
 
     // ===== Stage filter =====
@@ -700,6 +735,12 @@ else
         if (mapView is not null) await mapView.SetStageFilterAsync(activeStages);
     }
 
+    private static void LogTreasureAlloc(string eventName, object payload)
+    {
+        var json = JsonSerializer.Serialize(new { Event = eventName, Payload = payload }, TreasureAllocLogJsonOptions);
+        Console.WriteLine($"[treasure-alloc] {json}");
+    }
+
     // ===== Focus state =====
     private int? focusedLocationId;
     private string focusTab = "prehled";
@@ -710,6 +751,7 @@ else
     private const string TreasuresViewKey = "oh-tp-view";
     private string treasuresView = "map";
     private OvcinaHra.Shared.Domain.Enums.LocationKind? treasuresKindFilter;
+    private string? treasuresRegionFilter;
     private GameTimePhase lastUsedDifficulty = GameTimePhase.Start;
 
     // ===== Game context =====
@@ -794,6 +836,7 @@ else
         markersPlaced = false;
         focusedLocationId = null;
         selectedPool.Clear();
+        treasuresRegionFilter = null;
         await LoadAllAsync();
         await PlaceMarkersIfReadyAsync();
         StateHasChanged();
@@ -824,6 +867,8 @@ else
         // Prune selection of items that left the pool.
         var poolIds = poolItems.Select(p => p.Id).ToHashSet();
         selectedPool.RemoveAll(s => !poolIds.Contains(s.Id));
+        if (treasuresRegionFilter is not null && !GetRegionOptions(locationCards).Contains(treasuresRegionFilter))
+            treasuresRegionFilter = null;
 
         loading = false;
     }
@@ -854,9 +899,53 @@ else
     {
         if (treasuresView == next) return;
         treasuresView = next;
+        LogTreasureAlloc("view-change", new { view = next, gameId });
         try { await JS.InvokeVoidAsync("localStorage.setItem", TreasuresViewKey, next); }
         catch { /* non-fatal */ }
     }
+
+    private void SetTreasuresKindFilter(OvcinaHra.Shared.Domain.Enums.LocationKind? next)
+    {
+        treasuresKindFilter = next;
+        LogTreasureAlloc("kind-filter-change", new
+        {
+            kind = next?.ToString(),
+            gameId
+        });
+    }
+
+    private void SetTreasuresRegionFilter(string? next)
+    {
+        treasuresRegionFilter = next;
+        LogTreasureAlloc("region-filter-change", new
+        {
+            region = next,
+            gameId
+        });
+    }
+
+    private IEnumerable<TreasurePlanningLocationDto> GetFilteredLocationCards()
+    {
+        IEnumerable<TreasurePlanningLocationDto> filtered = locationCards;
+        if (treasuresKindFilter.HasValue)
+            filtered = filtered.Where(l => l.LocationKind == treasuresKindFilter.Value);
+        if (!string.IsNullOrWhiteSpace(treasuresRegionFilter))
+            filtered = filtered.Where(l => GetRegionLabel(l) == treasuresRegionFilter);
+        return filtered;
+    }
+
+    private static string GetRegionLabel(TreasurePlanningLocationDto location) =>
+        string.IsNullOrWhiteSpace(location.Region) ? NoRegionLabel : location.Region.Trim();
+
+    private static string GetRegionSortKey(string region) =>
+        region == NoRegionLabel ? "\uFFFF" : region;
+
+    private static List<string> GetRegionOptions(IEnumerable<TreasurePlanningLocationDto> locations) =>
+        locations
+            .Select(GetRegionLabel)
+            .Distinct(StringComparer.CurrentCultureIgnoreCase)
+            .OrderBy(GetRegionSortKey)
+            .ToList();
 
     private async Task PlaceMarkersIfReadyAsync()
     {
@@ -1004,12 +1093,44 @@ else
     };
 
     // ===== Handlers from MapView =====
-    private Task HandlePieClick(int locationId)
+    private Task HandlePieClick(int locationId) => HandleLocationTargetClick(locationId);
+
+    private Task HandleLocationTargetClick(int locationId)
     {
         focusedLocationId = locationId;
-        focusTab = "prehled";
+        focusTab = selectedPool.Count > 0 ? "pridat" : "prehled";
+        LogTreasureAlloc("click-to-allocate", new
+        {
+            locationId,
+            selectedCount = selectedPool.Count,
+            targetTab = focusTab,
+            view = treasuresView
+        });
         StateHasChanged();
         return Task.CompletedTask;
+    }
+
+    private void SetFocusTab(string tab, string source)
+    {
+        focusTab = tab;
+        LogTreasureAlloc("focus-tab-change", new
+        {
+            tab,
+            source,
+            focusedLocationId,
+            selectedCount = selectedPool.Count
+        });
+    }
+
+    private void StartAddToFocusedLocation(string source)
+    {
+        focusTab = "pridat";
+        LogTreasureAlloc("button-allocate", new
+        {
+            source,
+            focusedLocationId,
+            selectedCount = selectedPool.Count
+        });
     }
 
     private async Task HandlePieDrop(PiePayloadEventArgs args)
@@ -1017,23 +1138,46 @@ else
         // Payload: { PoolItemId, ItemId, ItemName, Count }
         try
         {
-            using var doc = System.Text.Json.JsonDocument.Parse(args.Payload);
+            LogTreasureAlloc("drop-received", new
+            {
+                args.LocationId,
+                args.Payload
+            });
+            using var doc = JsonDocument.Parse(args.Payload);
             var poolItemId = doc.RootElement.GetProperty("PoolItemId").GetInt32();
             var picked = poolItems.FirstOrDefault(p => p.Id == poolItemId);
-            if (picked is null) return;
+            if (picked is null)
+            {
+                LogTreasureAlloc("drop-rejected", new
+                {
+                    reason = "pool-item-not-found",
+                    poolItemId,
+                    args.LocationId
+                });
+                return;
+            }
 
             // Ensure the dragged item is selected; keep any prior selection intact
             // so the user can batch-drop multiple onto the same pin.
-            if (!IsSelected(picked)) selectedPool.Add(picked);
+            if (!IsSelected(picked))
+            {
+                selectedPool.Add(picked);
+            }
 
             focusedLocationId = args.LocationId;
             focusTab = "pridat";
+            LogTreasureAlloc("drop-applied", new
+            {
+                args.LocationId,
+                poolItemId,
+                selectedCount = selectedPool.Count
+            });
             StateHasChanged();
             await Task.CompletedTask;
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Pie drop payload error: {ex.Message}");
+            Console.Error.WriteLine($"[treasure-alloc] {JsonSerializer.Serialize(new { Event = "drop-error", ex.Message }, TreasureAllocLogJsonOptions)}");
         }
     }
 
@@ -1047,13 +1191,34 @@ else
     // ===== Save assignment =====
     private async Task HandleAssignSaveAsync(AssignTreasureDto dto)
     {
-        await Api.PostAsync<AssignTreasureDto, TreasureQuestDetailDto>("/api/treasure-planning/assign", dto);
+        LogTreasureAlloc("assign-save-entry", new
+        {
+            dto.GameId,
+            dto.LocationId,
+            dto.SecretStashId,
+            poolCount = dto.TreasureItemIds?.Count ?? 0,
+            unlimitedCount = dto.UnlimitedItems?.Count ?? 0
+        });
+        var result = await Api.PostWithProblemAsync<AssignTreasureDto, TreasureQuestDetailDto>("/api/treasure-planning/assign", dto);
+        if (!result.Ok)
+        {
+            LogTreasureAlloc("assign-save-rejected", new { result.ProblemDetail });
+            throw new InvalidOperationException(result.ProblemDetail ?? "Přiřazení pokladu se nepodařilo.");
+        }
+
         lastUsedDifficulty = dto.Difficulty;
         selectedPool.Clear();
         markersPlaced = false;
         await LoadAllAsync();
         await PlaceMarkersIfReadyAsync();
         focusTab = "prehled";
+        LogTreasureAlloc("assign-save-success", new
+        {
+            questId = result.Value?.Id,
+            dto.GameId,
+            dto.LocationId,
+            dto.SecretStashId
+        });
         StateHasChanged();
     }
 

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3241,11 +3241,20 @@
     transition:.12s ease;display:flex;flex-direction:column;gap:.25rem}
 .oh-tp-card:hover{background:#F2EBD8;border-color:#2D5016}
 .oh-tp-card.is-focused{border-color:#2D5016;box-shadow:0 0 0 2px rgba(45,80,22,.18)}
+.oh-tp-card.has-pending{border-style:dashed}
+.oh-tp-card.oh-tp-card-dragtarget{border-color:#2D5016;background:var(--oh-primary-surface,#E8F0E4);box-shadow:0 0 0 3px rgba(45,80,22,.18)}
 .oh-tp-card-hdr{display:flex;justify-content:space-between;align-items:center;gap:.4rem;font-size:.75rem;color:var(--oh-text-secondary,#666)}
 .oh-tp-card-kind{text-transform:capitalize;font-family:'JetBrains Mono',monospace}
-.oh-tp-card-count{background:#2D5016;color:#fff;border-radius:999px;padding:.05rem .4rem;font-size:.7rem}
+.oh-tp-card-count{background:#2D5016;color:#fff;border-radius:999px;padding:.05rem .4rem;font-size:.7rem;white-space:nowrap}
 .oh-tp-card-name{font-weight:600;color:var(--oh-text,#2a2a2a);font-size:.95rem}
+.oh-tp-card-name-count{color:var(--oh-text-secondary,#666);font-family:'JetBrains Mono',monospace;font-size:.82rem}
 .oh-tp-card-stash{font-size:.75rem;color:var(--oh-text-secondary,#666);display:flex;align-items:center;gap:.3rem}
+.oh-tp-card-cta{margin-top:.2rem;display:inline-flex;align-items:center;gap:.3rem;color:#2D5016;font-weight:600;font-size:.78rem}
+.oh-tp-location-total{font-family:'JetBrains Mono',monospace;font-size:.85rem;color:var(--oh-text-secondary,#666);margin-left:.35rem}
+.oh-tp-stash-summary{display:flex;flex-wrap:wrap;gap:.35rem;margin:.45rem 0 .7rem}
+.oh-tp-stash-summary.compact{margin:.35rem 0 0}
+.oh-tp-stash-chip{display:inline-flex;align-items:center;gap:.3rem;border:1px solid var(--oh-border,#D9CFB6);border-radius:999px;background:var(--oh-surface,#FAF6EC);padding:.18rem .55rem;font-size:.76rem;color:var(--oh-text-secondary,#666)}
+.oh-tp-stash-chip strong{font-family:'JetBrains Mono',monospace;color:var(--oh-text,#2a2a2a)}
 
 /* ======================================================================
    Issue #158 — Home cockpit (Příprava + Hra běží + Drozd welcome)

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -581,10 +581,20 @@ window.ovcinaMap._buildPieSvg = function (counts) {
 
 window.ovcinaMap._wireDropTarget = function (element, locationId) {
     var self = this;
+    var lastDragOverLog = 0;
     element.addEventListener('dragover', function (e) {
         e.preventDefault();
         if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
         element.classList.add('oh-tp-pin-dragtarget');
+        var now = Date.now();
+        if (now - lastDragOverLog > 750) {
+            lastDragOverLog = now;
+            console.log('[treasure-alloc] ' + JSON.stringify({
+                event: 'drag-over',
+                target: 'map-pin',
+                locationId: locationId
+            }));
+        }
     });
     element.addEventListener('dragleave', function () {
         element.classList.remove('oh-tp-pin-dragtarget');
@@ -594,6 +604,12 @@ window.ovcinaMap._wireDropTarget = function (element, locationId) {
         element.classList.remove('oh-tp-pin-dragtarget');
         var payload = e.dataTransfer && e.dataTransfer.getData('application/x-oh-pool-item');
         if (self._dotnetRef && payload) {
+            console.log('[treasure-alloc] ' + JSON.stringify({
+                event: 'drop',
+                target: 'map-pin',
+                locationId: locationId,
+                payload: window.ovcinaDnd ? window.ovcinaDnd.parsePayload(payload) : payload
+            }));
             self._dotnetRef.invokeMethodAsync('OnPieMarkerDropped', locationId, payload);
         }
     });
@@ -720,6 +736,15 @@ window.ovcinaMap.setStageFilter = function (stages) {
 // ----------------------------------------------------------------------
 window.ovcinaDnd = {
     _wired: new WeakMap(),
+    _dropTargets: new WeakMap(),
+
+    parsePayload: function (payload) {
+        try {
+            return JSON.parse(payload);
+        } catch (e) {
+            return payload;
+        }
+    },
 
     setDraggable: function (element, payload) {
         if (!element) return;
@@ -737,6 +762,7 @@ window.ovcinaDnd = {
                 e.dataTransfer.setData('application/x-oh-pool-item', p);
                 e.dataTransfer.effectAllowed = 'move';
             }
+            console.log('[treasure-alloc] ' + JSON.stringify({ event: 'drag-start', payload: self.parsePayload(p) }));
             element.classList.add('oh-tp-pool-tile-dragging');
         });
         element.addEventListener('dragend', function () {
@@ -748,6 +774,64 @@ window.ovcinaDnd = {
         if (!element) return;
         this._wired.delete(element);
         element.removeAttribute('draggable');
+    },
+
+    setDropTarget: function (element, locationId, dotnetRef) {
+        if (!element) return;
+        var existing = this._dropTargets.get(element);
+        if (existing) {
+            existing.locationId = locationId;
+            existing.dotnetRef = dotnetRef;
+            return;
+        }
+
+        var record = {
+            locationId: locationId,
+            dotnetRef: dotnetRef,
+            lastDragOverLog: 0
+        };
+        this._dropTargets.set(element, record);
+
+        var self = this;
+        element.addEventListener('dragover', function (e) {
+            e.preventDefault();
+            if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+            element.classList.add('oh-tp-card-dragtarget');
+
+            var now = Date.now();
+            if (now - record.lastDragOverLog > 750) {
+                record.lastDragOverLog = now;
+                console.log('[treasure-alloc] ' + JSON.stringify({
+                    event: 'drag-over',
+                    target: 'location-card',
+                    locationId: record.locationId
+                }));
+            }
+        });
+        element.addEventListener('dragleave', function () {
+            element.classList.remove('oh-tp-card-dragtarget');
+        });
+        element.addEventListener('drop', function (e) {
+            e.preventDefault();
+            element.classList.remove('oh-tp-card-dragtarget');
+            var payload = e.dataTransfer && e.dataTransfer.getData('application/x-oh-pool-item');
+            if (!payload) return;
+            console.log('[treasure-alloc] ' + JSON.stringify({
+                event: 'drop',
+                target: 'location-card',
+                locationId: record.locationId,
+                payload: self.parsePayload(payload)
+            }));
+            if (record.dotnetRef) {
+                record.dotnetRef.invokeMethodAsync('OnTreasurePoolDropped', record.locationId, payload);
+            }
+        });
+    },
+
+    clearDropTarget: function (element) {
+        if (!element) return;
+        this._dropTargets.delete(element);
+        element.classList.remove('oh-tp-card-dragtarget');
     },
 
     // Generic DOM helper used by pages that want a smooth scroll to a known


### PR DESCRIPTION
﻿## Summary
- Adds reusable location target cards for drag/drop from the treasure pool and click-to-allocate fallback inside /treasures.
- Surfaces location and stash treasure counts more clearly, with region filtering/grouping using existing Location.Region and Bez regionu sorted last.
- Adds permanent [treasure-alloc] diagnostics on client drag/click/drop/save paths and server assignment entry/validation/save/catch paths.

refs #349

## Verification
- dotnet build OvcinaHra.slnx
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter "FullyQualifiedName~TreasurePlanning"

## Self-audit
- Uses existing Api.PostWithProblemAsync for assignment validation surfacing.
- No csproj version or service-worker changes.
- No schema/migration changes.
