### PR TITLE
Overlay location dots on bounding-box authoring map

### DIFF
--- a/src/OvcinaHra.Client/Components/BoundingBoxPicker.razor
+++ b/src/OvcinaHra.Client/Components/BoundingBoxPicker.razor
@@ -1,6 +1,7 @@
 @implements IAsyncDisposable
 @inject IJSRuntime JS
 @inject IConfiguration Config
+@inject ApiClient Api
 
 <div class="oh-bbox-picker">
     <div class="oh-bbox-picker-map" id="@_mapId"></div>
@@ -54,9 +55,19 @@
 
     [Parameter] public BboxValue Value { get; set; } = BboxValue.Empty;
     [Parameter] public EventCallback<BboxValue> ValueChanged { get; set; }
+    [Parameter] public int? GameId { get; set; }
 
     private readonly string _mapId = $"oh-bbox-{Guid.NewGuid():N}";
     private bool _mapReady;
+    private int? _locationDotsLoadedForGameId;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_mapReady && GameId != _locationDotsLoadedForGameId)
+        {
+            await LoadLocationDotsAsync();
+        }
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -72,6 +83,7 @@
 
         await JS.InvokeVoidAsync("ovcinaBboxMap.init", _mapId, apiKey, centerLat, centerLon, zoom);
         _mapReady = true;
+        await LoadLocationDotsAsync();
 
         if (Value.IsComplete)
         {
@@ -146,6 +158,71 @@
         }
         Value = next;
         await ValueChanged.InvokeAsync(next);
+    }
+
+    private async Task LoadLocationDotsAsync()
+    {
+        if (!_mapReady) return;
+
+        if (GameId is not int gameId)
+        {
+            await JS.InvokeVoidAsync("ovcinaBboxMap.setLocationDots", _mapId, Array.Empty<LocationDotJs>());
+            _locationDotsLoadedForGameId = null;
+            Console.WriteLine("[bbox-author] dots loaded count=0");
+            return;
+        }
+
+        try
+        {
+            var data = await Api.GetAsync<MapDataDto>($"/api/map/data?gameId={gameId}");
+            var dots = data?.Locations
+                .Select(LocationDotJs.From)
+                .ToArray() ?? [];
+            await JS.InvokeVoidAsync("ovcinaBboxMap.setLocationDots", _mapId, dots);
+            _locationDotsLoadedForGameId = gameId;
+            Console.WriteLine($"[bbox-author] dots loaded count={dots.Length}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[bbox-author] dots load failed: {ex.GetType().Name}: {ex.Message}");
+            await JS.InvokeVoidAsync("ovcinaBboxMap.setLocationDots", _mapId, Array.Empty<LocationDotJs>());
+            _locationDotsLoadedForGameId = gameId;
+            Console.WriteLine("[bbox-author] dots loaded count=0");
+        }
+    }
+
+    private sealed record LocationDotJs(
+        [property: System.Text.Json.Serialization.JsonPropertyName("lat")] double Lat,
+        [property: System.Text.Json.Serialization.JsonPropertyName("lon")] double Lon,
+        [property: System.Text.Json.Serialization.JsonPropertyName("kind")] string Kind,
+        [property: System.Text.Json.Serialization.JsonPropertyName("color")] string Color,
+        [property: System.Text.Json.Serialization.JsonPropertyName("strokeColor")] string StrokeColor)
+    {
+        public static LocationDotJs From(MapLocationDto location)
+        {
+            var kind = location.EffectiveKind;
+            return new LocationDotJs(
+                location.Lat,
+                location.Lon,
+                kind.ToString().ToLowerInvariant(),
+                KindColorFor(kind),
+                StrokeColorFor(kind));
+        }
+
+        private static string KindColorFor(LocationKind kind) => kind switch
+        {
+            LocationKind.Town => "#6D6D6D",
+            LocationKind.Village => "#FF0000",
+            LocationKind.Magical => "#EAF626",
+            LocationKind.Hobbit => "#9400D4",
+            LocationKind.Wilderness => "#FFFFFF",
+            LocationKind.Dungeon => "#000000",
+            LocationKind.PointOfInterest => "#FF6600",
+            _ => "#2D5016"
+        };
+
+        private static string StrokeColorFor(LocationKind kind)
+            => kind == LocationKind.Wilderness ? "#2A2A2A" : "#FFFFFF";
     }
 
     public async ValueTask DisposeAsync()

--- a/src/OvcinaHra.Client/Pages/Games/GameList.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameList.razor
@@ -57,7 +57,7 @@ else
             <DxFormLayout CssClass="mt-3">
                 <DxFormLayoutGroup Caption="Oblast hry na mapě" ColSpanMd="12">
                     <DxFormLayoutItem ColSpanMd="12">
-                        <BoundingBoxPicker Value="@bboxValue" ValueChanged="OnBboxChanged" />
+                        <BoundingBoxPicker GameId="@editingId.Value" Value="@bboxValue" ValueChanged="OnBboxChanged" />
                     </DxFormLayoutItem>
                 </DxFormLayoutGroup>
             </DxFormLayout>

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -855,6 +855,8 @@ window.ovcinaBboxMap = {
     _sourceId: 'oh-bbox-overlay',
     _fillLayerId: 'oh-bbox-overlay-fill',
     _lineLayerId: 'oh-bbox-overlay-line',
+    _dotSourceId: 'oh-bbox-location-dots',
+    _dotLayerId: 'oh-bbox-location-dots-layer',
 
     _styleFor: function (apiKey) {
         if (apiKey && apiKey.length > 5) {
@@ -928,6 +930,70 @@ window.ovcinaBboxMap = {
         });
     },
 
+    _locationDotsFeatureCollection: function (dots) {
+        var features = (dots || [])
+            .filter(function (dot) {
+                return dot && Number.isFinite(dot.lat) && Number.isFinite(dot.lon);
+            })
+            .map(function (dot) {
+                return {
+                    type: 'Feature',
+                    geometry: { type: 'Point', coordinates: [dot.lon, dot.lat] },
+                    properties: {
+                        kind: dot.kind || 'wilderness',
+                        color: dot.color || '#2D5016',
+                        strokeColor: dot.strokeColor || '#FFFFFF'
+                    }
+                };
+            });
+        return { type: 'FeatureCollection', features: features };
+    },
+
+    _addOrUpdateLocationDots: function (map, dots) {
+        var self = window.ovcinaBboxMap;
+        var featureCollection = self._locationDotsFeatureCollection(dots);
+        var src = map.getSource(self._dotSourceId);
+        if (src) {
+            src.setData(featureCollection);
+            return;
+        }
+
+        map.addSource(self._dotSourceId, { type: 'geojson', data: featureCollection });
+        map.addLayer({
+            id: self._dotLayerId,
+            type: 'circle',
+            source: self._dotSourceId,
+            paint: {
+                'circle-radius': 3,
+                'circle-color': ['get', 'color'],
+                'circle-stroke-color': ['get', 'strokeColor'],
+                'circle-stroke-width': 1
+            }
+        }, map.getLayer(self._fillLayerId) ? self._fillLayerId : undefined);
+    },
+
+    _whenStyleReady: function (inst, apply) {
+        var map = inst.map;
+        if (inst.styleReady || map.isStyleLoaded()) {
+            inst.styleReady = true;
+            apply();
+            return;
+        }
+
+        var applied = false;
+        var once = function () {
+            if (applied) return;
+            applied = true;
+            inst.styleReady = true;
+            apply();
+        };
+        map.once('load', once);
+        map.once('styledata', function () {
+            var style = map.getStyle && map.getStyle();
+            if (style && Array.isArray(style.layers)) once();
+        });
+    },
+
     _removeOverlay: function (map) {
         var self = window.ovcinaBboxMap;
         if (map.getLayer(self._lineLayerId)) map.removeLayer(self._lineLayerId);
@@ -949,7 +1015,13 @@ window.ovcinaBboxMap = {
         map.addControl(new maplibregl.NavigationControl(), 'top-right');
         map.addControl(new maplibregl.ScaleControl(), 'bottom-left');
         map.on('error', function (e) { console.warn('Bbox map tile error:', e.error && e.error.message || e); });
-        this._instances[elementId] = { map: map, hasOverlay: false };
+        var inst = { map: map, hasOverlay: false, styleReady: false };
+        map.on('load', function () { inst.styleReady = true; });
+        map.on('styledata', function () {
+            var style = map.getStyle && map.getStyle();
+            if (style && Array.isArray(style.layers)) inst.styleReady = true;
+        });
+        this._instances[elementId] = inst;
     },
 
     getBounds: function (elementId) {
@@ -969,7 +1041,7 @@ window.ovcinaBboxMap = {
         if (!inst) return;
         var map = inst.map;
         var apply = function () { window.ovcinaBboxMap._addOrUpdateOverlay(map, swLat, swLng, neLat, neLng); };
-        if (map.isStyleLoaded()) apply(); else map.once('styledata', apply);
+        window.ovcinaBboxMap._whenStyleReady(inst, apply);
         inst.hasOverlay = true;
     },
 
@@ -978,6 +1050,21 @@ window.ovcinaBboxMap = {
         if (!inst) return;
         window.ovcinaBboxMap._removeOverlay(inst.map);
         inst.hasOverlay = false;
+    },
+
+    setLocationDots: function (elementId, dots) {
+        var inst = this._instances[elementId];
+        if (!inst) {
+            console.warn('[bbox-author] passthrough ok=false');
+            return;
+        }
+
+        var map = inst.map;
+        var apply = function () {
+            window.ovcinaBboxMap._addOrUpdateLocationDots(map, dots || []);
+            console.log('[bbox-author] passthrough ok=true');
+        };
+        window.ovcinaBboxMap._whenStyleReady(inst, apply);
     },
 
     fitToBounds: function (elementId, swLat, swLng, neLat, neLng, paddingPx) {


### PR DESCRIPTION
## Summary
- Adds game-scoped location dots to the bounding-box picker using the existing `/api/map/data` payload and `EffectiveKind`/Hobbit override.
- Renders unclickable 6px MapLibre circle dots below the bbox rectangle layer, with kind colors and wilderness contrast stroke.
- Adds `[bbox-author]` diagnostics for dot counts and pointer passthrough.

## Verification
- `dotnet build OvcinaHra.slnx --nologo -v:minimal`
- `dotnet test OvcinaHra.slnx --no-build --nologo -v:minimal`
- Headless smoke against local dev API/client: seeded game + Town/Village/Hobbit-propagated parent, verified 3 dots, `#9400D4` Hobbit color, and bbox overlay after `Použít aktuální pohled`.

Closes #355