### PR TITLE
fix(map): restore overlay drawing interactions

### DIFF
--- a/src/OvcinaHra.Client/Components/MapOverlayToolbar.razor
+++ b/src/OvcinaHra.Client/Components/MapOverlayToolbar.razor
@@ -95,7 +95,7 @@
     <div class="oh-mo-actions" role="group" aria-label="Akce">
         <button type="button" class="btn btn-outline-secondary btn-sm" title="Vrátit poslední nově přidaný tvar"
                 disabled="@(!CanUndo)"
-                @onclick="OnUndo">
+                @onclick="UndoClickedAsync">
             <i class="bi bi-arrow-counterclockwise"></i> Zpět
         </button>
         <button type="button" class="btn btn-outline-danger btn-sm" title="Smazat všechny tvary překryvu"
@@ -195,7 +195,18 @@
     [Parameter] public EventCallback OnUndo { get; set; }
     [Parameter] public EventCallback OnClearAll { get; set; }
 
-    private Task SelectToolAsync(string key) => ToolChanged.InvokeAsync(key);
+    private Task SelectToolAsync(string key)
+    {
+        Console.WriteLine($"[map-diag] MapOverlayToolbar.SelectTool key={key}");
+        return ToolChanged.InvokeAsync(key);
+    }
+
+    private Task UndoClickedAsync()
+    {
+        Console.WriteLine($"[map-diag] MapOverlayToolbar.UndoClicked canUndo={CanUndo}");
+        return OnUndo.InvokeAsync();
+    }
+
     private Task SetColorAsync(string hex) => ColorChanged.InvokeAsync(hex);
     private Task SetIconAssetAsync(string key) => IconAssetChanged.InvokeAsync(key);
 

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -296,6 +296,7 @@
         _stagedShapes = new List<MapOverlayShape>(GetCommittedShapes(_activeAudience));
         _createdShapeIds.Clear();
         _overlayError = null;
+        Console.WriteLine($"[map-diag] MapView.EnterEditMode gameId={GameId?.ToString() ?? "null"} tool={_tool} audience={_activeAudience} committed={_stagedShapes.Count}");
         await PushStyleToJsAsync();
         await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);
         await JS.InvokeVoidAsync("ovcinaOverlay.enterEditMode", _elementId, _tool, _dotnetRef);
@@ -354,6 +355,7 @@
 
     private async Task ChangeToolAsync(string tool)
     {
+        Console.WriteLine($"[map-diag] MapView.ChangeTool from={_tool} to={tool} editMode={_editMode}");
         _tool = tool;
         if (_editMode)
         {
@@ -427,14 +429,23 @@
     [JSInvokable]
     public async Task OnShapeComplete(string shapeJson)
     {
+        Console.WriteLine($"[map-diag] MapView.OnShapeComplete entry length={shapeJson?.Length ?? 0}");
+        if (string.IsNullOrWhiteSpace(shapeJson))
+        {
+            Console.WriteLine("[map-diag] MapView.OnShapeComplete ignored-empty-payload");
+            return;
+        }
         try
         {
             var shape = System.Text.Json.JsonSerializer.Deserialize<MapOverlayShape>(
                 shapeJson,
                 new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
             if (shape is null) return;
+            Console.WriteLine($"[map-diag] MapView.OnShapeComplete parsed id={shape.Id} type={shape.GetType().Name}");
             _stagedShapes.Add(shape);
             _createdShapeIds.Add(shape.Id);
+            Console.WriteLine($"[map-diag] MapView.OnShapeComplete staged={_stagedShapes.Count} created={_createdShapeIds.Count}");
+            await InvokeAsync(StateHasChanged);
             await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);
         }
         catch (Exception ex) when (ex is System.Text.Json.JsonException
@@ -525,14 +536,19 @@
 
     private async Task UndoLastCreatedShapeAsync()
     {
+        Console.WriteLine($"[map-diag] MapView.UndoLastCreated entry created={_createdShapeIds.Count} staged={_stagedShapes.Count}");
         while (_createdShapeIds.Count > 0)
         {
             var lastIndex = _createdShapeIds.Count - 1;
             var id = _createdShapeIds[lastIndex];
             _createdShapeIds.RemoveAt(lastIndex);
+            Console.WriteLine($"[map-diag] MapView.UndoLastCreated pop id={id}");
 
             if (_stagedShapes.RemoveAll(s => s.Id == id) == 0)
+            {
+                Console.WriteLine($"[map-diag] MapView.UndoLastCreated missing-staged id={id}");
                 continue;
+            }
 
             if (_selectedShape?.Id == id)
             {
@@ -541,9 +557,11 @@
             }
 
             await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);
+            Console.WriteLine($"[map-diag] MapView.UndoLastCreated rendered staged={_stagedShapes.Count} created={_createdShapeIds.Count}");
             StateHasChanged();
             return;
         }
+        Console.WriteLine("[map-diag] MapView.UndoLastCreated exit-empty");
     }
 
     private Task RequestClearAllAsync()
@@ -629,7 +647,10 @@
 
     [JSInvokable]
     public async Task OnMapClicked(double lat, double lng, bool ctrlKey = false, bool shiftKey = false)
-        => await OnMapClick.InvokeAsync(new OvcinaMapClickEventArgs(lat, lng, ctrlKey, shiftKey));
+    {
+        Console.WriteLine($"[map-diag] MapView.OnMapClicked lat={lat} lng={lng} ctrl={ctrlKey} shift={shiftKey}");
+        await OnMapClick.InvokeAsync(new OvcinaMapClickEventArgs(lat, lng, ctrlKey, shiftKey));
+    }
 
     [JSInvokable]
     public async Task OnPieMarkerClicked(int id)

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -545,23 +545,36 @@
     /// </summary>
     private async Task OnMapClickAsync(OvcinaMapClickEventArgs e)
     {
-        if (!e.CtrlKey) return;
-        if (GameContext.SelectedGameId is not int gid) return;
+        Console.WriteLine($"[map-diag] MapPage.OnMapClick entry lat={e.Latitude} lng={e.Longitude} ctrl={e.CtrlKey} shift={e.ShiftKey} gameId={GameContext.SelectedGameId?.ToString() ?? "null"}");
+        if (!e.CtrlKey)
+        {
+            Console.WriteLine("[map-diag] MapPage.OnMapClick ignored-no-ctrl");
+            return;
+        }
+        if (GameContext.SelectedGameId is not int gid)
+        {
+            Console.WriteLine("[map-diag] MapPage.OnMapClick ignored-no-game");
+            return;
+        }
         _placeMode = e.ShiftKey ? "move" : "place";
         _placeLat = e.Latitude;
         _placeLng = e.Longitude;
         _placeError = null;
         _placeSearch = "";
         _placeSaving = false;
+        Console.WriteLine($"[map-diag] MapPage.OnMapClick placement-start mode={_placeMode} gameId={gid}");
         // Fetch the per-game location list. Filter depends on mode:
         // place mode = only ungeocoded parents; move mode = all parents.
         var all = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gid}");
+        Console.WriteLine($"[map-diag] MapPage.OnMapClick candidates-fetched count={all.Count}");
         _placeCandidates = all
             .Where(l => l.ParentLocationId is null
                 && (_placeMode == "move" || l.Latitude is null || l.Longitude is null))
             .OrderBy(l => l.Name)
             .ToList();
+        Console.WriteLine($"[map-diag] MapPage.OnMapClick candidates-filtered mode={_placeMode} count={_placeCandidates.Count}");
         _placeVisible = true;
+        Console.WriteLine("[map-diag] MapPage.OnMapClick popup-visible");
         await InvokeAsync(StateHasChanged);
     }
 

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -52,6 +52,12 @@ window.ovcinaMap = {
         catch (e) { return false; }
     },
 
+    _mapDiag: function (event, data) {
+        try {
+            console.log('[map-diag] map.' + event + ' ' + JSON.stringify(data || {}));
+        } catch (e) { }
+    },
+
     init: function (elementId, dotnetRef, centerLat, centerLon, zoom, mapyCzApiKey, glyphsUrl) {
         if (this._pinDiag()) {
             console.log('[pin-diag] init() — elementId=' + elementId + ', existingMap=' + (this._map ? 'YES' : 'no') + ', center=[' + centerLon + ',' + centerLat + '], zoom=' + zoom);
@@ -81,13 +87,22 @@ window.ovcinaMap = {
         });
 
         this._map.on('click', (e) => {
+            var orig = e.originalEvent;
+            var ctrl = !!(orig && (orig.ctrlKey || orig.metaKey));
+            var shift = !!(orig && orig.shiftKey);
+            this._mapDiag('click', {
+                elementId: this._elementId,
+                lat: e.lngLat.lat,
+                lng: e.lngLat.lng,
+                ctrl: ctrl,
+                shift: shift,
+                hasDotNetRef: !!this._dotnetRef
+            });
             if (this._dotnetRef) {
                 // Forward Ctrl/Meta + Shift state — /map uses
                 //   Ctrl+Click       → place ungeocoded location
                 //   Ctrl+Shift+Click → move existing location (any)
-                var orig = e.originalEvent;
-                var ctrl = !!(orig && (orig.ctrlKey || orig.metaKey));
-                var shift = !!(orig && orig.shiftKey);
+                this._mapDiag('click.invoke-dotnet', { ctrl: ctrl, shift: shift });
                 this._dotnetRef.invokeMethodAsync('OnMapClicked', e.lngLat.lat, e.lngLat.lng, ctrl, shift);
             }
         });
@@ -140,12 +155,25 @@ window.ovcinaMap = {
         // rest of the time. Listeners cleared in dispose().
         var mapContainer = this._map.getContainer();
         var keyDown = function (e) {
-            if (e.key === 'Control' || e.key === 'Meta') mapContainer.classList.add('oh-map-ctrl-held');
+            if (e.key === 'Control' || e.key === 'Meta') {
+                mapContainer.classList.add('oh-map-ctrl-held');
+                window.ovcinaMap._mapDiag('modifier.down', { key: e.key, ctrl: e.ctrlKey || e.metaKey, shift: e.shiftKey });
+            } else if (e.key === 'Shift') {
+                window.ovcinaMap._mapDiag('modifier.down', { key: e.key, ctrl: e.ctrlKey || e.metaKey, shift: e.shiftKey });
+            }
         };
         var keyUp = function (e) {
-            if (e.key === 'Control' || e.key === 'Meta') mapContainer.classList.remove('oh-map-ctrl-held');
+            if (e.key === 'Control' || e.key === 'Meta') {
+                mapContainer.classList.remove('oh-map-ctrl-held');
+                window.ovcinaMap._mapDiag('modifier.up', { key: e.key, ctrl: e.ctrlKey || e.metaKey, shift: e.shiftKey });
+            } else if (e.key === 'Shift') {
+                window.ovcinaMap._mapDiag('modifier.up', { key: e.key, ctrl: e.ctrlKey || e.metaKey, shift: e.shiftKey });
+            }
         };
-        var blur = function () { mapContainer.classList.remove('oh-map-ctrl-held'); };
+        var blur = function () {
+            mapContainer.classList.remove('oh-map-ctrl-held');
+            window.ovcinaMap._mapDiag('modifier.blur', {});
+        };
         document.addEventListener('keydown', keyDown);
         document.addEventListener('keyup', keyUp);
         window.addEventListener('blur', blur);

--- a/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
@@ -36,6 +36,12 @@
     // Singleton state, keyed by mapId so future multi-map callers don't collide.
     const instances = {};
 
+    function mapDiag(event, data) {
+        try {
+            console.log('[map-diag] overlay.' + event + ' ' + JSON.stringify(data || {}));
+        } catch (e) { }
+    }
+
     function getMap(mapId) {
         // Phase 1+2: MapView only boots the global `ovcinaMap`. If we ever host
         // overlays on a second MapLibre instance, widen this lookup to a
@@ -436,12 +442,16 @@
 
     function render(mapId, shapes) {
         const map = getMap(mapId);
-        if (!map) return;
+        if (!map) {
+            mapDiag('render.no-map', { mapId: mapId });
+            return;
+        }
         const inst = ensureInstance(mapId);
         const normalizedShapes = (shapes || [])
             .map(normalizeShape)
             .filter(s => s !== null);
         inst.shapes = normalizedShapes;
+        mapDiag('render', { mapId: mapId, shapeCount: normalizedShapes.length });
 
         const paint = () => {
             ensureLayers(map, SRC_SAVED, LYR_FILLS, LYR_STROKES, LYR_TEXT, LYR_ICONS);
@@ -464,7 +474,20 @@
 
     function enterEditMode(mapId, tool, dotnetRef) {
         const map = getMap(mapId);
-        if (!map) return;
+        if (!map) {
+            mapDiag('enter-edit.no-map', { mapId: mapId, tool: tool });
+            return;
+        }
+        const inst = ensureInstance(mapId);
+        inst.tool = tool;
+        inst.dotnetRef = dotnetRef;
+        inst.editMode = true;
+        mapDiag('enter-edit', {
+            mapId: mapId,
+            tool: tool,
+            shapeCount: inst.shapes ? inst.shapes.length : 0,
+            hasDotNetRef: !!dotnetRef
+        });
         // If the editor is invoked before `render()` has been called (e.g.
         // game has no saved overlay yet) the source+layer pair is missing and
         // preview updates would no-op — make sure both exist before wiring
@@ -474,10 +497,6 @@
             ensureLayers(map, SRC_PREVIEW, LYR_PREVIEW_FILLS, LYR_PREVIEW_STROKES, LYR_PREVIEW_TEXT, LYR_PREVIEW_ICONS);
             ensureSelectionLayers(map);
             ensureIconsLoaded(map).then(function () { try { map.triggerRepaint(); } catch (e) { } });
-            const inst = ensureInstance(mapId);
-            inst.tool = tool;
-            inst.dotnetRef = dotnetRef;
-            inst.editMode = true;
             map.getCanvas().style.cursor = tool === 'select' ? '' : 'crosshair';
             // Suspend MapLibre handlers that compete with click-to-draw: drag-pan
             // would steal mousedown+mousemove from freehand/rectangle/circle and
@@ -496,20 +515,32 @@
             // to finish" doesn't also zoom the viewport.
             if (map.doubleClickZoom && map.doubleClickZoom.disable) map.doubleClickZoom.disable();
             renderTextMarkers(map, inst, inst.shapes || []);
+            detachHandlers(map, inst);
             attachHandlers(map, inst);
         };
-        if (map.isStyleLoaded()) setup(); else map.once('styledata', setup);
+        if (map.isStyleLoaded()) setup();
+        else {
+            mapDiag('enter-edit.defer-style', { mapId: mapId, tool: tool });
+            map.once('styledata', setup);
+        }
     }
 
     function switchTool(mapId, tool) {
         const inst = instances[mapId];
-        if (!inst) return;
+        if (!inst) {
+            mapDiag('switch-tool.no-instance', { mapId: mapId, tool: tool });
+            return;
+        }
         const map = getMap(mapId);
-        if (!map) return;
+        if (!map) {
+            mapDiag('switch-tool.no-map', { mapId: mapId, tool: tool });
+            return;
+        }
         detachHandlers(map, inst);
         resetInProgress(inst);
         teardownPreview(map);
         inst.tool = tool;
+        mapDiag('switch-tool', { mapId: mapId, tool: tool });
         // Cursor: drawing tools get crosshair, select gets default (handler swaps
         // to pointer on hover-over-shape). Idle (null) also gets default.
         try { map.getCanvas().style.cursor = (tool && tool !== 'select') ? 'crosshair' : ''; } catch (e) { }
@@ -634,7 +665,10 @@
     }
 
     function emitShape(inst, shape) {
-        if (!inst.dotnetRef) return;
+        if (!inst.dotnetRef) {
+            mapDiag('shape.emit.no-dotnet', { mapId: inst.mapId, type: shape && shape.type, id: shape && shape.id });
+            return;
+        }
         try {
             // System.Text.Json's [JsonPolymorphic] requires the discriminator
             // ("type") to be the FIRST JSON property — otherwise it throws
@@ -643,6 +677,7 @@
             // chokepoint reorders so `type` lands first regardless. DO NOT
             // remove without also reordering every emitShape() call site.
             const orderedShape = { type: shape.type, ...shape };
+            mapDiag('shape.emit', { mapId: inst.mapId, type: orderedShape.type, id: orderedShape.id });
             inst.dotnetRef.invokeMethodAsync('OnShapeComplete', JSON.stringify(orderedShape));
         } catch (e) {
             console.warn('Overlay shape emit failed:', e);
@@ -686,6 +721,7 @@
         const onDown = function (e) {
             drawing = true;
             inst.tempPoints = [{ lat: e.lngLat.lat, lng: e.lngLat.lng }];
+            mapDiag('freehand.down', { mapId: inst.mapId, lat: e.lngLat.lat, lng: e.lngLat.lng });
             if (map.dragPan && map.dragPan.disable) map.dragPan.disable();
         };
         const onMove = function (e) {
@@ -695,11 +731,15 @@
                 type: 'freehand', color: currentStyle().color,
                 strokeWidth: currentStyle().strokeWidth, points: inst.tempPoints
             });
+            if (inst.tempPoints.length <= 5 || inst.tempPoints.length % 10 === 0) {
+                mapDiag('freehand.move', { mapId: inst.mapId, pointCount: inst.tempPoints.length });
+            }
         };
         const onUp = function () {
             if (!drawing) return;
             drawing = false;
             if (map.dragPan && map.dragPan.enable) map.dragPan.enable();
+            mapDiag('freehand.up', { mapId: inst.mapId, pointCount: inst.tempPoints.length });
             if (inst.tempPoints.length >= 2) {
                 emitShape(inst, {
                     id: uuid(),
@@ -1034,9 +1074,22 @@
     // ---- Preview rendering ------------------------------------------------
 
     function updatePreview(map, shape) {
-        const feature = shapeToFeature(shape);
-        if (!feature) { teardownPreview(map); return; }
+        // Preview shapes are transient and intentionally never persisted.
+        // Give them an ephemeral id so normalizeShape can render during drag
+        // without weakening the saved-shape id contract.
+        const previewShape = shape
+            ? { ...shape, id: pick(shape, 'id', null) || '__preview-' + (pick(shape, 'type', 'shape') || 'shape') }
+            : shape;
+        const feature = shapeToFeature(previewShape);
+        if (!feature) {
+            mapDiag('preview.empty', { type: shape && shape.type });
+            teardownPreview(map);
+            return;
+        }
         setSourceData(map, SRC_PREVIEW, [feature]);
+        if (shape && shape.type === 'freehand') {
+            mapDiag('preview.update', { type: shape.type, pointCount: shape.points ? shape.points.length : 0 });
+        }
     }
 
     // ---- Style config set by the toolbar ----------------------------------


### PR DESCRIPTION
## Summary
- keep permanent `[map-diag]` markers around overlay drawing, undo, and Ctrl+Shift map-click routing
- restore freehand live preview by giving transient preview shapes an ephemeral id before normalization
- register overlay edit-mode DotNet ref before style-load deferral so draw completion reaches `OnShapeComplete`
- rerender after `OnShapeComplete` updates `_createdShapeIds` so undo enables immediately

Refs #343.

## Verification
- `node --check src/OvcinaHra.Client/wwwroot/js/overlay-interop.js`
- `node --check src/OvcinaHra.Client/wwwroot/js/map-interop.js`
- `dotnet build OvcinaHra.slnx --no-restore`
- browser smoke: freehand preview visible before mouse-up; shape emits to `OnShapeComplete`; undo enables; undo removes staged shape

## Notes
- Ctrl+Shift click was not changed. Local markers still show the full route to `popup-visible`; prod follow-up can use the now-live markers if the user still reproduces a missing transition after deploy.