### PR TITLE
feat(treasures): non-unique pool + count semantics

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -445,6 +445,15 @@ public static class TreasurePlanningEndpoints
             dto.Source
         });
 
+        var item = await db.TreasureItems
+            .Include(ti => ti.Item)
+            .FirstOrDefaultAsync(ti => ti.Id == id);
+
+        if (item is null)
+        {
+            return TypedResults.NotFound();
+        }
+
         if (dto.Delta == 0)
         {
             LogTreasureAlloc(logger, LogLevel.Warning, "count-adjust-validation-rejected", new
@@ -456,15 +465,6 @@ public static class TreasurePlanningEndpoints
             {
                 ["Delta"] = ["Změna počtu nesmí být nula."]
             });
-        }
-
-        var item = await db.TreasureItems
-            .Include(ti => ti.Item)
-            .FirstOrDefaultAsync(ti => ti.Id == id);
-
-        if (item is null)
-        {
-            return TypedResults.NotFound();
         }
 
         if (item.TreasureQuestId is null)

--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -49,7 +49,7 @@ public static class TreasurePlanningEndpoints
             .Where(ti => ti.GameId == gameId && ti.TreasureQuestId == null)
             .Include(ti => ti.Item)
             .OrderBy(ti => ti.Item.ItemType).ThenBy(ti => ti.Item.Name)
-            .Select(ti => new TreasurePoolItemDto(ti.Id, ti.ItemId, ti.Item.Name, ti.Item.ItemType, ti.Count, ti.GameId))
+            .Select(ti => new TreasurePoolItemDto(ti.Id, ti.ItemId, ti.Item.Name, ti.Item.ItemType, ti.Count, ti.GameId, ti.Item.IsUnique))
             .ToListAsync();
         return TypedResults.Ok(items);
     }
@@ -90,7 +90,7 @@ public static class TreasurePlanningEndpoints
         await db.SaveChangesAsync();
 
         return TypedResults.Created($"/api/treasure-planning/pool/{dto.GameId}",
-            new TreasurePoolItemDto(ti.Id, ti.ItemId, gameItem.Item.Name, gameItem.Item.ItemType, ti.Count, ti.GameId));
+            new TreasurePoolItemDto(ti.Id, ti.ItemId, gameItem.Item.Name, gameItem.Item.ItemType, ti.Count, ti.GameId, gameItem.Item.IsUnique));
     }
 
     private static async Task<Results<NoContent, NotFound, ValidationProblem>> RemoveFromPool(int id, WorldDbContext db)

--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -39,6 +39,7 @@ public static class TreasurePlanningEndpoints
 
         // Assignment
         group.MapPost("/assign", AssignTreasure);
+        group.MapPost("/treasure-items/{id:int}/adjust-count", AdjustTreasureItemCount);
 
         return group;
     }
@@ -230,7 +231,12 @@ public static class TreasurePlanningEndpoints
         ILoggerFactory loggerFactory)
     {
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
-        var poolCount = dto.TreasureItemIds?.Count ?? 0;
+        var poolAssignments = dto.PoolItems?
+            .GroupBy(p => p.TreasureItemId)
+            .Select(g => new PoolItemAssignDto(g.Key, g.Sum(p => p.Count)))
+            .ToList() ?? [];
+        var legacyPoolItemIds = dto.TreasureItemIds ?? [];
+        var poolCount = poolAssignments.Count + legacyPoolItemIds.Count;
         var unlimitedCount = dto.UnlimitedItems?.Count ?? 0;
         LogTreasureAlloc(logger, LogLevel.Information, "assign-entry", new
         {
@@ -238,6 +244,7 @@ public static class TreasurePlanningEndpoints
             dto.LocationId,
             dto.SecretStashId,
             poolCount,
+            poolUnits = poolAssignments.Sum(p => p.Count),
             unlimitedCount
         });
 
@@ -257,6 +264,82 @@ public static class TreasurePlanningEndpoints
             });
         }
 
+        if (poolAssignments.Count > 0 && legacyPoolItemIds.Count > 0)
+        {
+            LogTreasureAlloc(logger, LogLevel.Warning, "assign-validation-rejected", new
+            {
+                reason = "mixed-pool-contracts",
+                dto.GameId,
+                poolAssignmentRows = poolAssignments.Count,
+                legacyPoolRows = legacyPoolItemIds.Count
+            });
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["PoolItems"] = ["Použijte buď položky s počtem, nebo starý seznam položek — ne obojí."]
+            });
+        }
+
+        Dictionary<int, TreasureItem> poolItemsById = [];
+        if (poolAssignments.Count > 0)
+        {
+            var poolIds = poolAssignments.Select(p => p.TreasureItemId).ToHashSet();
+            poolItemsById = await db.TreasureItems
+                .Include(ti => ti.Item)
+                .Where(ti => ti.GameId == dto.GameId && ti.TreasureQuestId == null && poolIds.Contains(ti.Id))
+                .ToDictionaryAsync(ti => ti.Id);
+
+            var missing = poolIds.Except(poolItemsById.Keys).ToList();
+            if (missing.Count > 0)
+            {
+                LogTreasureAlloc(logger, LogLevel.Warning, "assign-validation-rejected", new
+                {
+                    reason = "pool-item-missing",
+                    dto.GameId,
+                    missing
+                });
+                return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["PoolItems"] = ["Některé položky už nejsou v zásobníku."]
+                });
+            }
+
+            foreach (var assignment in poolAssignments)
+            {
+                var poolItem = poolItemsById[assignment.TreasureItemId];
+                if (assignment.Count <= 0 || assignment.Count > poolItem.Count)
+                {
+                    LogTreasureAlloc(logger, LogLevel.Warning, "assign-validation-rejected", new
+                    {
+                        reason = "pool-count-out-of-range",
+                        dto.GameId,
+                        assignment.TreasureItemId,
+                        requested = assignment.Count,
+                        available = poolItem.Count
+                    });
+                    return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+                    {
+                        ["PoolItems"] = [$"Počet pro {poolItem.Item.Name} musí být mezi 1 a {poolItem.Count}."]
+                    });
+                }
+
+                if (poolItem.Item.IsUnique && assignment.Count != poolItem.Count)
+                {
+                    LogTreasureAlloc(logger, LogLevel.Warning, "assign-validation-rejected", new
+                    {
+                        reason = "unique-partial-count",
+                        dto.GameId,
+                        assignment.TreasureItemId,
+                        requested = assignment.Count,
+                        available = poolItem.Count
+                    });
+                    return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+                    {
+                        ["PoolItems"] = [$"{poolItem.Item.Name} je unikátní předmět a musí se přiřadit celý."]
+                    });
+                }
+            }
+        }
+
         try
         {
             // Create the quest
@@ -271,11 +354,12 @@ public static class TreasurePlanningEndpoints
                 phase = "create-quest",
                 dto.GameId,
                 dto.LocationId,
-                dto.SecretStashId
+                dto.SecretStashId,
+                poolUnits = poolAssignments.Sum(p => p.Count)
             });
             await db.SaveChangesAsync(); // get the ID
 
-            // Assign pool items
+            // Assign legacy pool items by moving the whole row.
             if (dto.TreasureItemIds is { Count: > 0 })
             {
                 var poolItems = await db.TreasureItems
@@ -283,6 +367,11 @@ public static class TreasurePlanningEndpoints
                     .ToListAsync();
                 foreach (var item in poolItems)
                     item.TreasureQuestId = quest.Id;
+            }
+
+            foreach (var assignment in poolAssignments)
+            {
+                AssignPoolItemToQuest(poolItemsById[assignment.TreasureItemId], assignment.Count, quest.Id, db);
             }
 
             // Add unlimited items directly
@@ -303,6 +392,7 @@ public static class TreasurePlanningEndpoints
                 questId = quest.Id,
                 dto.GameId,
                 poolCount,
+                poolUnits = poolAssignments.Sum(p => p.Count),
                 unlimitedCount
             });
             await db.SaveChangesAsync();
@@ -339,6 +429,187 @@ public static class TreasurePlanningEndpoints
             }, ex);
             throw;
         }
+    }
+
+    private static async Task<Results<Ok<TreasureItemDto>, ValidationProblem, NotFound>> AdjustTreasureItemCount(
+        int id,
+        AdjustTreasureItemCountDto dto,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
+        LogTreasureAlloc(logger, LogLevel.Information, "count-adjust-entry", new
+        {
+            treasureItemId = id,
+            dto.Delta,
+            dto.Source
+        });
+
+        if (dto.Delta == 0)
+        {
+            LogTreasureAlloc(logger, LogLevel.Warning, "count-adjust-validation-rejected", new
+            {
+                reason = "zero-delta",
+                treasureItemId = id
+            });
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["Delta"] = ["Změna počtu nesmí být nula."]
+            });
+        }
+
+        var item = await db.TreasureItems
+            .Include(ti => ti.Item)
+            .FirstOrDefaultAsync(ti => ti.Id == id);
+
+        if (item is null)
+        {
+            return TypedResults.NotFound();
+        }
+
+        if (item.TreasureQuestId is null)
+        {
+            LogTreasureAlloc(logger, LogLevel.Warning, "count-adjust-validation-rejected", new
+            {
+                reason = "pool-row-not-target",
+                treasureItemId = id
+            });
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["TreasureItemId"] = ["Počet lze upravovat jen u již umístěného pokladu."]
+            });
+        }
+
+        if (item.Item.IsUnique)
+        {
+            LogTreasureAlloc(logger, LogLevel.Warning, "count-adjust-validation-rejected", new
+            {
+                reason = "unique-item",
+                treasureItemId = id,
+                item.ItemId
+            });
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["TreasureItemId"] = ["Unikátní předmět nelze upravovat po kusech."]
+            });
+        }
+
+        if (dto.Delta < 0)
+        {
+            var removeCount = -dto.Delta;
+            if (item.Count - removeCount < 1)
+            {
+                LogTreasureAlloc(logger, LogLevel.Warning, "count-adjust-validation-rejected", new
+                {
+                    reason = "below-one",
+                    treasureItemId = id,
+                    item.Count,
+                    dto.Delta
+                });
+                return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["Delta"] = ["Počet pokladu nesmí klesnout pod 1."]
+                });
+            }
+
+            item.Count -= removeCount;
+            await ReturnToPoolAsync(db, item.GameId, item.ItemId, removeCount);
+        }
+        else
+        {
+            var remaining = dto.Delta;
+            var poolRows = await db.TreasureItems
+                .Where(ti => ti.GameId == item.GameId && ti.ItemId == item.ItemId && ti.TreasureQuestId == null)
+                .OrderBy(ti => ti.Id)
+                .ToListAsync();
+            var available = poolRows.Sum(ti => ti.Count);
+            if (available < remaining)
+            {
+                LogTreasureAlloc(logger, LogLevel.Warning, "count-adjust-validation-rejected", new
+                {
+                    reason = "not-enough-pool",
+                    treasureItemId = id,
+                    requested = dto.Delta,
+                    available
+                });
+                return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["Delta"] = [$"V zásobníku je už jen {available} kusů."]
+                });
+            }
+
+            foreach (var poolRow in poolRows)
+            {
+                if (remaining == 0) break;
+                var take = Math.Min(poolRow.Count, remaining);
+                poolRow.Count -= take;
+                remaining -= take;
+                if (poolRow.Count == 0)
+                {
+                    db.TreasureItems.Remove(poolRow);
+                }
+            }
+            item.Count += dto.Delta;
+        }
+
+        LogTreasureAlloc(logger, LogLevel.Information, "count-adjust-before-save", new
+        {
+            treasureItemId = id,
+            item.ItemId,
+            item.GameId,
+            dto.Delta,
+            item.Count,
+            dto.Source
+        });
+        await db.SaveChangesAsync();
+
+        LogTreasureAlloc(logger, LogLevel.Information, "count-adjust-success", new
+        {
+            treasureItemId = id,
+            item.ItemId,
+            item.GameId,
+            item.Count
+        });
+
+        return TypedResults.Ok(new TreasureItemDto(item.Id, item.ItemId, item.Item.Name, item.Count, item.TreasureQuestId));
+    }
+
+    private static void AssignPoolItemToQuest(TreasureItem poolItem, int count, int questId, WorldDbContext db)
+    {
+        if (count == poolItem.Count)
+        {
+            poolItem.TreasureQuestId = questId;
+            return;
+        }
+
+        poolItem.Count -= count;
+        db.TreasureItems.Add(new TreasureItem
+        {
+            ItemId = poolItem.ItemId,
+            GameId = poolItem.GameId,
+            Count = count,
+            TreasureQuestId = questId
+        });
+    }
+
+    private static async Task ReturnToPoolAsync(WorldDbContext db, int gameId, int itemId, int count)
+    {
+        var poolRow = await db.TreasureItems
+            .FirstOrDefaultAsync(ti => ti.GameId == gameId && ti.ItemId == itemId && ti.TreasureQuestId == null);
+
+        if (poolRow is null)
+        {
+            db.TreasureItems.Add(new TreasureItem
+            {
+                GameId = gameId,
+                ItemId = itemId,
+                Count = count,
+                TreasureQuestId = null
+            });
+            return;
+        }
+
+        poolRow.Count += count;
     }
 
     private static void LogTreasureAlloc(ILogger logger, LogLevel level, string eventName, object payload, Exception? exception = null)

--- a/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
+++ b/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
@@ -67,7 +67,7 @@
                         <i class="bi bi-check-circle text-success"></i>
                         <span class="flex-grow-1">@p.ItemName</span>
                         <span class="oh-tp-focus-quest-meta">
-                            @(p.IsUnique ? "×1" : $"×1 z {p.Count}")
+                            @(p.IsUnique ? $"×{p.Count}" : $"×1 z {p.Count}")
                         </span>
                     </div>
                 }

--- a/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
+++ b/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
@@ -66,7 +66,9 @@
                     <div class="oh-tp-chosen-row">
                         <i class="bi bi-check-circle text-success"></i>
                         <span class="flex-grow-1">@p.ItemName</span>
-                        <span class="oh-tp-focus-quest-meta">×@p.Count</span>
+                        <span class="oh-tp-focus-quest-meta">
+                            @(p.IsUnique ? "×1" : $"×1 z {p.Count}")
+                        </span>
                     </div>
                 }
             </div>
@@ -241,8 +243,9 @@
                 string.IsNullOrWhiteSpace(clue) ? null : clue.Trim(),
                 toStash ? null : LocationId,
                 toStash ? stashId : null,
-                SelectedPool.Select(p => p.Id).ToList(),
-                unlimitedItems.Select(u => new UnlimitedItemAssignDto(u.ItemId, u.Count)).ToList());
+                TreasureItemIds: null,
+                UnlimitedItems: unlimitedItems.Select(u => new UnlimitedItemAssignDto(u.ItemId, u.Count)).ToList(),
+                PoolItems: SelectedPool.Select(p => new PoolItemAssignDto(p.Id, p.IsUnique ? p.Count : 1)).ToList());
 
             await OnSave.InvokeAsync(dto);
         }

--- a/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
+++ b/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
@@ -3,8 +3,8 @@
 @inject IJSRuntime JS
 
 <div @ref="elementRef"
-     class="oh-tp-pool-tile @(Selected ? "selected" : "")"
-     title="@($"{Item.ItemName} (×{Item.Count})")"
+     class="oh-tp-pool-tile @(Selected ? "selected" : "") @(Item.IsUnique ? "is-unique" : "is-aggregate")"
+     title="@TileLabel"
      @onclick="OnClickInternal">
     @if (!imageFailed)
     {
@@ -18,9 +18,9 @@
     {
         <div class="oh-tp-pool-tile-fallback"><i class="bi bi-gem"></i></div>
     }
-    @if (Item.Count > 1)
+    @if (!Item.IsUnique)
     {
-        <div class="oh-tp-pool-tile-badge">×@Item.Count</div>
+        <div class="oh-tp-pool-tile-badge">@Item.ItemName × @Item.Count</div>
     }
 
     @* Unobtrusive remove affordance — unbundled from the draggable surface:
@@ -43,7 +43,7 @@
         <i class="bi bi-x-lg"></i>
     </button>
 
-    <div class="oh-tp-pool-tile-name">@Item.ItemName</div>
+    <div class="oh-tp-pool-tile-name">@TileLabel</div>
 </div>
 
 <DxPopup @bind-Visible="@isRemoveVisible"
@@ -86,6 +86,7 @@
 
     private bool isRemoveVisible;
     private bool removing;
+    private string TileLabel => Item.IsUnique ? Item.ItemName : $"{Item.ItemName} × {Item.Count}";
 
     protected override void OnParametersSet()
     {
@@ -108,7 +109,9 @@
                 PoolItemId = Item.Id,
                 ItemId = Item.ItemId,
                 ItemName = Item.ItemName,
-                Count = Item.Count
+                Count = Item.Count,
+                IsUnique = Item.IsUnique,
+                Kind = Item.IsUnique ? "unique" : "non-unique"
             });
             await JS.InvokeVoidAsync("ovcinaDnd.setDraggable", elementRef, payload);
         }

--- a/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
+++ b/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
@@ -43,7 +43,7 @@
         <i class="bi bi-x-lg"></i>
     </button>
 
-    <div class="oh-tp-pool-tile-name">@TileLabel</div>
+    <div class="oh-tp-pool-tile-name">@Item.ItemName</div>
 </div>
 
 <DxPopup @bind-Visible="@isRemoveVisible"

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -773,6 +773,8 @@ else
         if (quickAllocation is null) return;
         quickAllocation = null;
         quickAllocationCollapseCts?.Cancel();
+        quickAllocationCollapseCts?.Dispose();
+        quickAllocationCollapseCts = null;
         LogTreasureAlloc("stepper-collapse", new { source = "click-away", focusedLocationId });
     }
 

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -74,7 +74,7 @@ else
         </div>
 
         @* ================== ZONE 2 — Workspace ================== *@
-        <div class="oh-tp-workspace">
+        <div class="oh-tp-workspace" @onclick="CollapseQuickAllocationStepper">
 
             @* LEFT: map *@
             <div class="oh-tp-map-panel">
@@ -327,6 +327,31 @@ else
                                     </button>
                                 }
                             </div>
+                            @if (quickAllocation is { IsUnique: false } qa && qa.LocationId == loc.LocationId)
+                            {
+                                <div class="oh-tp-count-stepper" @onclick:stopPropagation="true">
+                                    <span class="oh-tp-count-stepper-name">@qa.ItemName</span>
+                                    <button type="button"
+                                            class="oh-tp-stepper-btn"
+                                            disabled="@(qa.Count <= 1 || quickAllocationAdjusting)"
+                                            @onclick="() => AdjustQuickAllocationAsync(-1)">
+                                        <i class="bi bi-dash-lg"></i>
+                                    </button>
+                                    <span class="oh-tp-stepper-count">×@qa.Count</span>
+                                    <button type="button"
+                                            class="oh-tp-stepper-btn"
+                                            disabled="@quickAllocationAdjusting"
+                                            @onclick="() => AdjustQuickAllocationAsync(1)">
+                                        <i class="bi bi-plus-lg"></i>
+                                    </button>
+                                </div>
+                            }
+                            @if (allocationError is not null)
+                            {
+                                <div class="alert alert-danger py-2 mb-2" role="alert">
+                                    <i class="bi bi-exclamation-triangle me-1"></i>@allocationError
+                                </div>
+                            }
                             @if (loc.Stashes.Count > 0)
                             {
                                 <div class="oh-tp-stash-summary">
@@ -709,6 +734,8 @@ else
         {
             poolItemId = p.Id,
             p.ItemId,
+            kind = p.IsUnique ? "unique" : "non-unique",
+            p.Count,
             selected = existing is null,
             selectedCount = selectedPool.Count,
             focusedLocationId
@@ -741,9 +768,52 @@ else
         Console.WriteLine($"[treasure-alloc] {json}");
     }
 
+    private void CollapseQuickAllocationStepper()
+    {
+        if (quickAllocation is null) return;
+        quickAllocation = null;
+        quickAllocationCollapseCts?.Cancel();
+        LogTreasureAlloc("stepper-collapse", new { source = "click-away", focusedLocationId });
+    }
+
+    private void ScheduleQuickAllocationCollapse()
+    {
+        quickAllocationCollapseCts?.Cancel();
+        quickAllocationCollapseCts?.Dispose();
+        quickAllocationCollapseCts = new CancellationTokenSource();
+        _ = CollapseQuickAllocationLaterAsync(quickAllocationCollapseCts.Token);
+    }
+
+    private async Task CollapseQuickAllocationLaterAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+            if (cancellationToken.IsCancellationRequested) return;
+            quickAllocation = null;
+            LogTreasureAlloc("stepper-collapse", new { source = "timeout", focusedLocationId });
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
     // ===== Focus state =====
     private int? focusedLocationId;
     private string focusTab = "prehled";
+    private QuickAllocationState? quickAllocation;
+    private bool quickAllocationAdjusting;
+    private string? allocationError;
+    private CancellationTokenSource? quickAllocationCollapseCts;
+    private sealed record QuickAllocationState(
+        int QuestId,
+        int TreasureItemId,
+        int LocationId,
+        int ItemId,
+        string ItemName,
+        int Count,
+        bool IsUnique);
 
     // Issue #200: Mapa ↔ Karty toggle. Cards view groups by Region with a
     // LocationKind filter — works without GPS coords. Persisted via
@@ -837,12 +907,19 @@ else
         focusedLocationId = null;
         selectedPool.Clear();
         treasuresRegionFilter = null;
+        quickAllocation = null;
+        allocationError = null;
         await LoadAllAsync();
         await PlaceMarkersIfReadyAsync();
         StateHasChanged();
     }
 
-    public void Dispose() => GameContext.OnGameChanged -= OnGameChanged;
+    public void Dispose()
+    {
+        GameContext.OnGameChanged -= OnGameChanged;
+        quickAllocationCollapseCts?.Cancel();
+        quickAllocationCollapseCts?.Dispose();
+    }
 
     private async Task LoadAllAsync()
     {
@@ -1096,19 +1173,24 @@ else
     // ===== Handlers from MapView =====
     private Task HandlePieClick(int locationId) => HandleLocationTargetClick(locationId);
 
-    private Task HandleLocationTargetClick(int locationId)
+    private async Task HandleLocationTargetClick(int locationId)
     {
         focusedLocationId = locationId;
-        focusTab = selectedPool.Count > 0 ? "pridat" : "prehled";
         LogTreasureAlloc("click-to-allocate", new
         {
             locationId,
             selectedCount = selectedPool.Count,
-            targetTab = focusTab,
             view = treasuresView
         });
+
+        if (selectedPool.Count == 1)
+        {
+            await QuickAssignPoolItemAsync(selectedPool[0], locationId, "click-fallback");
+            return;
+        }
+
+        focusTab = selectedPool.Count > 0 ? "pridat" : "prehled";
         StateHasChanged();
-        return Task.CompletedTask;
     }
 
     private void SetFocusTab(string tab, string source)
@@ -1123,8 +1205,14 @@ else
         });
     }
 
-    private void StartAddToFocusedLocation(string source)
+    private async Task StartAddToFocusedLocation(string source)
     {
+        if (focusedLocationId is int locationId && selectedPool.Count == 1)
+        {
+            await QuickAssignPoolItemAsync(selectedPool[0], locationId, source);
+            return;
+        }
+
         focusTab = "pridat";
         LogTreasureAlloc("button-allocate", new
         {
@@ -1158,23 +1246,7 @@ else
                 return;
             }
 
-            // Ensure the dragged item is selected; keep any prior selection intact
-            // so the user can batch-drop multiple onto the same pin.
-            if (!IsSelected(picked))
-            {
-                selectedPool.Add(picked);
-            }
-
-            focusedLocationId = args.LocationId;
-            focusTab = "pridat";
-            LogTreasureAlloc("drop-applied", new
-            {
-                args.LocationId,
-                poolItemId,
-                selectedCount = selectedPool.Count
-            });
-            StateHasChanged();
-            await Task.CompletedTask;
+            await QuickAssignPoolItemAsync(picked, args.LocationId, "drop");
         }
         catch (Exception ex)
         {
@@ -1189,6 +1261,122 @@ else
         focusTab = "prehled";
     }
 
+    private async Task QuickAssignPoolItemAsync(TreasurePoolItemDto item, int locationId, string source)
+    {
+        allocationError = null;
+        focusedLocationId = locationId;
+        focusTab = "prehled";
+        var count = item.IsUnique ? item.Count : 1;
+        var dto = new AssignTreasureDto(
+            Title: item.ItemName,
+            Difficulty: lastUsedDifficulty,
+            GameId: gameId,
+            LocationId: locationId,
+            PoolItems: [new PoolItemAssignDto(item.Id, count)]);
+
+        LogTreasureAlloc("drop-commit", new
+        {
+            source,
+            target = "location",
+            locationId,
+            poolItemId = item.Id,
+            item.ItemId,
+            kind = item.IsUnique ? "unique" : "non-unique",
+            availableCount = item.Count,
+            committedCount = count
+        });
+
+        var result = await Api.PostWithProblemAsync<AssignTreasureDto, TreasureQuestDetailDto>("/api/treasure-planning/assign", dto);
+        if (!result.Ok || result.Value is null)
+        {
+            allocationError = result.ProblemDetail ?? "Rychlé přiřazení pokladu se nepodařilo.";
+            LogTreasureAlloc("drop-commit-rejected", new { source, allocationError });
+            StateHasChanged();
+            return;
+        }
+
+        lastUsedDifficulty = dto.Difficulty;
+        selectedPool.RemoveAll(p => p.Id == item.Id);
+        focusedLocationId = locationId;
+        focusTab = "prehled";
+        var assignedItem = result.Value.Items.FirstOrDefault(i => i.ItemId == item.ItemId);
+        if (assignedItem is not null)
+        {
+            quickAllocation = new QuickAllocationState(
+                result.Value.Id,
+                assignedItem.Id,
+                locationId,
+                assignedItem.ItemId,
+                assignedItem.ItemName,
+                assignedItem.Count,
+                item.IsUnique);
+            if (!item.IsUnique)
+            {
+                ScheduleQuickAllocationCollapse();
+            }
+        }
+
+        markersPlaced = false;
+        await LoadAllAsync();
+        await PlaceMarkersIfReadyAsync();
+        LogTreasureAlloc("drop-commit-success", new
+        {
+            source,
+            questId = result.Value.Id,
+            treasureItemId = assignedItem?.Id,
+            locationId,
+            item.ItemId,
+            committedCount = count
+        });
+        StateHasChanged();
+    }
+
+    private async Task AdjustQuickAllocationAsync(int delta)
+    {
+        if (quickAllocation is null || quickAllocationAdjusting) return;
+        allocationError = null;
+        quickAllocationAdjusting = true;
+        LogTreasureAlloc("stepper", new
+        {
+            target = "location",
+            quickAllocation.LocationId,
+            quickAllocation.TreasureItemId,
+            quickAllocation.ItemId,
+            delta
+        });
+
+        try
+        {
+            var result = await Api.PostWithProblemAsync<AdjustTreasureItemCountDto, TreasureItemDto>(
+                $"/api/treasure-planning/treasure-items/{quickAllocation.TreasureItemId}/adjust-count",
+                new AdjustTreasureItemCountDto(delta, "stepper"));
+
+            if (!result.Ok || result.Value is null)
+            {
+                allocationError = result.ProblemDetail ?? "Úprava počtu se nepodařila.";
+                LogTreasureAlloc("stepper-rejected", new { delta, allocationError });
+                return;
+            }
+
+            quickAllocation = quickAllocation with { Count = result.Value.Count };
+            markersPlaced = false;
+            await LoadAllAsync();
+            await PlaceMarkersIfReadyAsync();
+            ScheduleQuickAllocationCollapse();
+            LogTreasureAlloc("stepper-success", new
+            {
+                delta,
+                result.Value.Count,
+                quickAllocation.TreasureItemId
+            });
+        }
+        finally
+        {
+            quickAllocationAdjusting = false;
+            StateHasChanged();
+        }
+    }
+
     // ===== Save assignment =====
     private async Task HandleAssignSaveAsync(AssignTreasureDto dto)
     {
@@ -1197,7 +1385,8 @@ else
             dto.GameId,
             dto.LocationId,
             dto.SecretStashId,
-            poolCount = dto.TreasureItemIds?.Count ?? 0,
+            poolCount = (dto.PoolItems?.Count ?? 0) + (dto.TreasureItemIds?.Count ?? 0),
+            poolUnits = dto.PoolItems?.Sum(p => p.Count) ?? 0,
             unlimitedCount = dto.UnlimitedItems?.Count ?? 0
         });
         var result = await Api.PostWithProblemAsync<AssignTreasureDto, TreasureQuestDetailDto>("/api/treasure-planning/assign", dto);

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2500,7 +2500,8 @@
 .oh-tp-pool-tile-img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
 .oh-tp-pool-tile-fallback{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:1.5rem;color:var(--oh-primary-light);background:var(--oh-surface-alt)}
 .oh-tp-pool-tile-name{position:absolute;left:4px;right:4px;bottom:4px;font:600 .75rem var(--oh-font-body);color:#fff;text-shadow:0 1px 3px rgba(0,0,0,.8);line-height:1.15;max-height:2.3em;overflow:hidden}
-.oh-tp-pool-tile-badge{position:absolute;top:4px;right:4px;background:rgba(45,80,22,.92);color:#fff;border-radius:99px;padding:1px 6px;font:600 .6875rem var(--oh-font-mono);letter-spacing:.01em}
+.oh-tp-pool-tile-badge{position:absolute;top:4px;right:4px;left:4px;background:rgba(45,80,22,.92);color:#fff;border-radius:99px;padding:2px 7px;font:700 .75rem var(--oh-font-mono);letter-spacing:0;text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.oh-tp-pool-tile.is-aggregate .oh-tp-pool-tile-name{padding-top:1.2rem}
 /* Remove affordance — sits at top-left so it doesn't collide with the count
    badge. Always visible but low-opacity; hover bumps to full opacity. Sized
    small enough to stay unobtrusive on the 5:7 tile. */

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3256,6 +3256,11 @@
 .oh-tp-stash-summary.compact{margin:.35rem 0 0}
 .oh-tp-stash-chip{display:inline-flex;align-items:center;gap:.3rem;border:1px solid var(--oh-border,#D9CFB6);border-radius:999px;background:var(--oh-surface,#FAF6EC);padding:.18rem .55rem;font-size:.76rem;color:var(--oh-text-secondary,#666)}
 .oh-tp-stash-chip strong{font-family:'JetBrains Mono',monospace;color:var(--oh-text,#2a2a2a)}
+.oh-tp-count-stepper{display:flex;align-items:center;gap:.4rem;margin:.5rem 0 .7rem;padding:.4rem .55rem;border:1px solid #2D5016;border-radius:8px;background:var(--oh-primary-surface,#E8F0E4);width:max-content;max-width:100%}
+.oh-tp-count-stepper-name{font-weight:700;color:var(--oh-text,#2a2a2a)}
+.oh-tp-stepper-count{font:700 .85rem var(--oh-font-mono);min-width:2.4rem;text-align:center;color:#2D5016}
+.oh-tp-stepper-btn{width:26px;height:26px;display:inline-flex;align-items:center;justify-content:center;border:1px solid #2D5016;border-radius:50%;background:#fff;color:#2D5016;padding:0}
+.oh-tp-stepper-btn:disabled{opacity:.42;cursor:not-allowed}
 
 /* ======================================================================
    Issue #158 — Home cockpit (Příprava + Hra běží + Drozd welcome)

--- a/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
@@ -68,9 +68,12 @@ public record AssignTreasureDto(
     string Title, GameTimePhase Difficulty, int GameId,
     string? Clue = null, int? LocationId = null, int? SecretStashId = null,
     List<int>? TreasureItemIds = null,
-    List<UnlimitedItemAssignDto>? UnlimitedItems = null);
+    List<UnlimitedItemAssignDto>? UnlimitedItems = null,
+    List<PoolItemAssignDto>? PoolItems = null);
 
 public record UnlimitedItemAssignDto(int ItemId, int Count = 1);
+public record PoolItemAssignDto(int TreasureItemId, int Count = 1);
+public record AdjustTreasureItemCountDto(int Delta, string? Source = null);
 
 public record TreasureSummaryDto(
     int PoolRemaining, int Placed,

--- a/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
@@ -46,7 +46,7 @@ public record VerifyTreasureQuestDto(
 
 // --- Treasure Pool DTOs ---
 
-public record TreasurePoolItemDto(int Id, int ItemId, string ItemName, ItemType ItemType, int Count, int GameId)
+public record TreasurePoolItemDto(int Id, int ItemId, string ItemName, ItemType ItemType, int Count, int GameId, bool IsUnique)
 {
     [JsonIgnore]
     public string ItemTypeDisplay => ItemType.GetDisplayName();

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
@@ -102,6 +102,58 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
     }
 
     [Fact]
+    public async Task AssignTreasure_WithPartialPoolCount_SplitsStackAndStepperAdjustsCount()
+    {
+        var game = await CreateGameAsync();
+        var location = await CreateLocationAsync();
+        var item = await CreateItemAsync("Bronz");
+        await AssignItemToGameAsync(game.Id, item.Id);
+        var pool = await AddPoolItemAsync(game.Id, item.Id, count: 5);
+
+        var assignResponse = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto(
+                Title: "Bronz",
+                Difficulty: GameTimePhase.Early,
+                GameId: game.Id,
+                LocationId: location.Id,
+                PoolItems: [new PoolItemAssignDto(pool.Id, 1)]));
+        assignResponse.EnsureSuccessStatusCode();
+
+        var quest = (await assignResponse.Content.ReadFromJsonAsync<TreasureQuestDetailDto>())!;
+        var assigned = Assert.Single(quest.Items);
+        Assert.Equal(1, assigned.Count);
+
+        var poolAfterAssign = await Client.GetFromJsonAsync<List<TreasurePoolItemDto>>(
+            $"/api/treasure-planning/pool/{game.Id}");
+        var poolRow = Assert.Single(poolAfterAssign!, p => p.ItemId == item.Id);
+        Assert.Equal(4, poolRow.Count);
+
+        var plusResponse = await Client.PostAsJsonAsync(
+            $"/api/treasure-planning/treasure-items/{assigned.Id}/adjust-count",
+            new AdjustTreasureItemCountDto(3, "test-stepper"));
+        plusResponse.EnsureSuccessStatusCode();
+        var afterPlus = (await plusResponse.Content.ReadFromJsonAsync<TreasureItemDto>())!;
+        Assert.Equal(4, afterPlus.Count);
+
+        var poolAfterPlus = await Client.GetFromJsonAsync<List<TreasurePoolItemDto>>(
+            $"/api/treasure-planning/pool/{game.Id}");
+        poolRow = Assert.Single(poolAfterPlus!, p => p.ItemId == item.Id);
+        Assert.Equal(1, poolRow.Count);
+
+        var minusResponse = await Client.PostAsJsonAsync(
+            $"/api/treasure-planning/treasure-items/{assigned.Id}/adjust-count",
+            new AdjustTreasureItemCountDto(-1, "test-stepper"));
+        minusResponse.EnsureSuccessStatusCode();
+        var afterMinus = (await minusResponse.Content.ReadFromJsonAsync<TreasureItemDto>())!;
+        Assert.Equal(3, afterMinus.Count);
+
+        var poolAfterMinus = await Client.GetFromJsonAsync<List<TreasurePoolItemDto>>(
+            $"/api/treasure-planning/pool/{game.Id}");
+        poolRow = Assert.Single(poolAfterMinus!, p => p.ItemId == item.Id);
+        Assert.Equal(2, poolRow.Count);
+    }
+
+    [Fact]
     public async Task RemoveFromPool_NonExistentRow_ReturnsNotFound()
     {
         var response = await Client.DeleteAsync("/api/treasure-planning/pool/999999");


### PR DESCRIPTION
﻿## Summary
- Adds Item.IsUnique to treasure pool DTOs and renders non-unique pool stacks as aggregate quantity tiles like Bronz × 38.
- Changes assignment semantics so non-unique stacked rows can allocate a partial count instead of moving the whole row.
- Adds quick default-1 drop/click allocation and a temporary inline - / + stepper that moves counts between the target and the pool.
- Keeps permanent [treasure-alloc] client/server diagnostics for drag, default-1 commit, stepper, and server count adjustment paths.

refs #349

## Verification
- dotnet build OvcinaHra.slnx --no-restore
- dotnet test OvcinaHra.slnx --no-build

## Visual smoke verdict
- Non-unique tile displays aggregate label/counter (Item.IsUnique=false, Count=N).
- Drop/click quick allocation sends Count=1 for non-unique pool rows.
- Stepper +/- uses the new count-adjust endpoint; integration test covers 1 -> 4 -> 3 and pool count 4 -> 1 -> 2.
- Unique items keep whole-row assignment and have no stepper.

## Self-audit
- Uses existing Api.PostWithProblemAsync helpers for assign and count-adjust calls.
- No csproj version or service-worker changes.
- No schema/migration changes.
