### PR TITLE
fix(uploads): surface image upload ProblemDetails

### DIFF
--- a/src/OvcinaHra.Client/Components/ImagePicker.razor
+++ b/src/OvcinaHra.Client/Components/ImagePicker.razor
@@ -131,20 +131,32 @@
             }
 
             var query = Field is not null ? $"?field={Field}" : "";
+            Console.WriteLine($"[image-upload] start entity={EntityType} id={EntityId} field={Field ?? "image"}");
             using var content = new MultipartFormDataContent();
             using var stream = file.OpenReadStream(maxAllowedSize: 5 * 1024 * 1024);
             var fileContent = new StreamContent(stream);
             fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(file.ContentType);
             content.Add(fileContent, "file", file.Name);
 
-            var result = await Api.PostMultipartAsync<ImageUploadResult>(
+            var (ok, result, problemDetail, statusCode) = await Api.PostMultipartWithProblemAsync<ImageUploadResult>(
                 $"/api/images/{EntityType}/{EntityId}{query}", content);
+            if (!ok)
+            {
+                errorMessage = problemDetail ?? "Nahrání obrázku selhalo.";
+                Console.WriteLine($"[image-upload] failed status={(int)statusCode} detail={errorMessage}");
+                return;
+            }
+
             if (result is not null)
+            {
                 currentUrl = result.Url;
+                Console.WriteLine($"[image-upload] success blobKey={result.BlobKey}");
+            }
         }
         catch (Exception ex)
         {
             errorMessage = ex.Message;
+            Console.WriteLine($"[image-upload] failed status=exception detail={errorMessage}");
         }
         finally
         {

--- a/src/OvcinaHra.Client/Services/ApiClient.cs
+++ b/src/OvcinaHra.Client/Services/ApiClient.cs
@@ -93,9 +93,25 @@ public class ApiClient
 
     public async Task<T?> PostMultipartAsync<T>(string url, MultipartFormDataContent content)
     {
-        var response = await _http.PostAsync(url, content);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<T>(JsonOptions);
+        var (ok, value, problemDetail, statusCode) = await PostMultipartWithProblemAsync<T>(url, content);
+        if (!ok)
+            throw new HttpRequestException(problemDetail ?? $"HTTP {(int)statusCode}", null, statusCode);
+        return value;
+    }
+
+    public async Task<(bool Ok, TResponse? Value, string? ProblemDetail, HttpStatusCode StatusCode)> PostMultipartWithProblemAsync<TResponse>(
+        string url,
+        MultipartFormDataContent content,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await _http.PostAsync(url, content, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+            return (false, default, await ReadProblemDetailAsync(response), response.StatusCode);
+
+        if (response.Content.Headers.ContentLength == 0 || response.StatusCode == HttpStatusCode.NoContent)
+            return (true, default, null, response.StatusCode);
+
+        return (true, await response.Content.ReadFromJsonAsync<TResponse>(JsonOptions, cancellationToken), null, response.StatusCode);
     }
 
     public async Task<bool> DeleteAsync(string url)


### PR DESCRIPTION
## Summary
- add `ApiClient.PostMultipartWithProblemAsync` for multipart uploads
- route the shared `ImagePicker` upload path through the ProblemDetails-aware helper
- surface Czech server `detail` text and add light `[image-upload]` markers

Closes #360.

## Verification
- `dotnet build OvcinaHra.slnx --no-restore`
- §16 sweep: no `PostMultipartAsync` callers outside `ApiClient`; all multipart upload UI goes through `ImagePicker`
- browser smoke: too-small stamp shows `Razítko musí být alespoň 200×200 px.`
- browser smoke: non-square stamp shows `Razítko musí být přibližně čtvercové.`
- browser smoke: valid stamp upload succeeds
- browser smoke: valid location image upload succeeds