### PR TITLE
Use DxPopup textbox for map text annotations

### DIFF
--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -1,4 +1,6 @@
 @implements IAsyncDisposable
+@using System.Globalization
+@using System.Text.Json
 @using OvcinaHra.Shared.Domain.Enums
 @inject ApiClient Api
 
@@ -99,6 +101,31 @@
             </div>
         </BodyContentTemplate>
     </DxPopup>
+
+    <DxPopup HeaderText="Text na mapě" Width="400px"
+             CloseOnEscape="true" ShowCloseButton="true"
+             Visible="@_textPopupVisible"
+             VisibleChanged="OnTextPopupVisibleChanged">
+        <BodyContentTemplate>
+            <div class="mb-3">
+                <label class="form-label" for="oh-map-text-popup-input">Popisek</label>
+                <DxTextBox Text="@_textPopupText"
+                           TextChanged="@((string v) => _textPopupText = v)"
+                           BindValueMode="BindValueMode.OnInput"
+                           InputId="oh-map-text-popup-input"
+                           NullText="Napište text..."
+                           CssClass="oh-map-text-popup-input"
+                           @onkeydown="HandleTextPopupKeyDownAsync" />
+            </div>
+            <div class="d-flex gap-2 justify-content-end">
+                <button type="button" class="btn btn-secondary" @onclick="CancelTextPopupAsync">Zrušit</button>
+                <button type="button" class="btn btn-primary" @onclick="SubmitTextPopupAsync"
+                        disabled="@string.IsNullOrWhiteSpace(_textPopupText)">
+                    Uložit
+                </button>
+            </div>
+        </BodyContentTemplate>
+    </DxPopup>
 </div>
 
 @code {
@@ -169,6 +196,10 @@
     private bool? _lastAppliedOverlayVisible;
     private bool? _lastAppliedOrganizerOverlayVisible;
     private MapOverlayAudience _activeAudience = MapOverlayAudience.Player;
+    private bool _textPopupVisible;
+    private bool _focusTextPopupAfterRender;
+    private string _textPopupText = "";
+    private OverlayCoord? _pendingTextCoord;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -212,6 +243,12 @@
                 || _lastAppliedOrganizerOverlayVisible != OrganizerOverlayVisible))
         {
             await RenderVisibleOverlaysAsync();
+        }
+
+        if (_focusTextPopupAfterRender)
+        {
+            _focusTextPopupAfterRender = false;
+            try { await JS.InvokeVoidAsync("ovcinaOverlay.focusTextPopup"); } catch { /* focus is best-effort */ }
         }
     }
 
@@ -470,6 +507,96 @@
         await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);
         await JS.InvokeVoidAsync("ovcinaOverlay.selectShape", _elementId, moved);
         StateHasChanged();
+    }
+
+    [JSInvokable]
+    public Task OnTextPlacementRequested(double lat, double lng)
+    {
+        _pendingTextCoord = new OverlayCoord(lat, lng);
+        _textPopupText = "";
+        _textPopupVisible = true;
+        _focusTextPopupAfterRender = true;
+        Console.WriteLine($"[map-text-popup] open coords={{\"lat\":{lat.ToString("F6", CultureInfo.InvariantCulture)},\"lng\":{lng.ToString("F6", CultureInfo.InvariantCulture)},\"audience\":\"{_activeAudience}\"}}");
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    private async Task SubmitTextPopupAsync()
+    {
+        var text = (_textPopupText ?? "").Trim();
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            Console.WriteLine("[map-text-popup] discard reason=empty");
+            ClearTextPopupState();
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        if (_pendingTextCoord is null)
+        {
+            Console.WriteLine("[map-text-popup] discard reason=missing-coordinates");
+            ClearTextPopupState();
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        Console.WriteLine($"[map-text-popup] submit text={JsonSerializer.Serialize(text)} length={text.Length}");
+        var shape = new TextShape(
+            Guid.NewGuid().ToString("N"),
+            _color,
+            _pendingTextCoord,
+            text,
+            _fontSize);
+        _stagedShapes.Add(shape);
+        _createdShapeIds.Add(shape.Id);
+        ClearTextPopupState();
+        await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private Task CancelTextPopupAsync()
+    {
+        Console.WriteLine("[map-text-popup] cancel");
+        ClearTextPopupState();
+        return Task.CompletedTask;
+    }
+
+    private Task OnTextPopupVisibleChanged(bool visible)
+    {
+        if (_textPopupVisible == visible)
+            return Task.CompletedTask;
+
+        if (!visible && _pendingTextCoord is not null)
+        {
+            Console.WriteLine("[map-text-popup] cancel");
+            ClearTextPopupState();
+        }
+        else
+        {
+            _textPopupVisible = visible;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task HandleTextPopupKeyDownAsync(KeyboardEventArgs args)
+    {
+        if (args.Key == "Enter")
+        {
+            await SubmitTextPopupAsync();
+        }
+        else if (args.Key == "Escape")
+        {
+            await CancelTextPopupAsync();
+        }
+    }
+
+    private void ClearTextPopupState()
+    {
+        _textPopupVisible = false;
+        _focusTextPopupAfterRender = false;
+        _textPopupText = "";
+        _pendingTextCoord = null;
     }
 
     // ---- Phase 3 — selection / edit / delete --------------------------

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -1,6 +1,5 @@
 @implements IAsyncDisposable
 @using System.Globalization
-@using System.Text.Json
 @using OvcinaHra.Shared.Domain.Enums
 @inject ApiClient Api
 
@@ -540,7 +539,7 @@
             return;
         }
 
-        Console.WriteLine($"[map-text-popup] submit text={JsonSerializer.Serialize(text)} length={text.Length}");
+        Console.WriteLine($"[map-text-popup] submit length={text.Length}");
         var shape = new TextShape(
             Guid.NewGuid().ToString("N"),
             _color,

--- a/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
@@ -704,7 +704,17 @@
                 mapDiag('text.request.no-dotnet', { mapId: inst.mapId });
                 return;
             }
-            inst.dotnetRef.invokeMethodAsync('OnTextPlacementRequested', e.lngLat.lat, e.lngLat.lng);
+            try {
+                inst.dotnetRef
+                    .invokeMethodAsync('OnTextPlacementRequested', e.lngLat.lat, e.lngLat.lng)
+                    .catch(function (err) {
+                        console.warn('Overlay text placement request failed:', err);
+                        mapDiag('text.request.failed', { mapId: inst.mapId });
+                    });
+            } catch (err) {
+                console.warn('Overlay text placement request failed:', err);
+                mapDiag('text.request.failed', { mapId: inst.mapId });
+            }
         });
     }
 

--- a/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
@@ -700,17 +700,11 @@
 
     function attachTextTool(map, inst) {
         onMap(map, inst, 'click', function (e) {
-            // Phase 1 uses window.prompt; Phase 3 replaces with an inline editor.
-            const text = window.prompt('Text:');
-            if (!text) return;
-            emitShape(inst, {
-                id: uuid(),
-                type: 'text',
-                color: currentStyle().color,
-                coord: { lat: e.lngLat.lat, lng: e.lngLat.lng },
-                text: text,
-                fontSize: currentStyle().fontSize || 14
-            });
+            if (!inst.dotnetRef) {
+                mapDiag('text.request.no-dotnet', { mapId: inst.mapId });
+                return;
+            }
+            inst.dotnetRef.invokeMethodAsync('OnTextPlacementRequested', e.lngLat.lat, e.lngLat.lng);
         });
     }
 
@@ -1187,6 +1181,16 @@
         return ICON_ASSETS.slice();
     }
 
+    function focusTextPopup() {
+        window.requestAnimationFrame(function () {
+            const input = document.getElementById('oh-map-text-popup-input')
+                || document.querySelector('.oh-map-text-popup-input input');
+            if (!input) return;
+            input.focus();
+            if (typeof input.select === 'function') input.select();
+        });
+    }
+
     window.ovcinaOverlay = {
         render: render,
         enterEditMode: enterEditMode,
@@ -1198,6 +1202,7 @@
         clearSelection: clearSelection,
         setVisibility: setVisibility,
         getIconAssets: getIconAssets,
+        focusTextPopup: focusTextPopup,
         // Exposed for unit-testability / future tools; not called by Blazor.
         _circleToPolygonRing: circleToPolygonRing,
         _normalizeShape: normalizeShape

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/MapTextPopupSmokeTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/MapTextPopupSmokeTests.cs
@@ -1,0 +1,41 @@
+namespace OvcinaHra.Api.Tests.ClientSmoke;
+
+public class MapTextPopupSmokeTests
+{
+    [Fact]
+    public void MapTextTool_UsesBlazorPopupInsteadOfBrowserPrompt()
+    {
+        var root = FindRepoRoot();
+        var mapView = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Components",
+            "MapView.razor"));
+        var overlayInterop = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "wwwroot",
+            "js",
+            "overlay-interop.js"));
+
+        Assert.DoesNotContain("prompt(", overlayInterop);
+        Assert.Contains("OnTextPlacementRequested", overlayInterop);
+        Assert.Contains("HeaderText=\"Text na mapě\"", mapView);
+        Assert.Contains("DxTextBox", mapView);
+        Assert.Contains("[map-text-popup] open", mapView);
+        Assert.Contains("[map-text-popup] submit", mapView);
+        Assert.Contains("[map-text-popup] cancel", mapView);
+        Assert.Contains("[map-text-popup] discard reason=empty", mapView);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "OvcinaHra.slnx")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not find repository root.");
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces browser `window.prompt()` in the map text annotation tool with a themed DxPopup textbox.
- Keeps existing click placement, style, staged shape, Player/Organizer audience, and overlay save logic intact.
- Adds `[map-text-popup]` diagnostics plus a client smoke test preventing prompt regression.

## Verification
- `dotnet build OvcinaHra.slnx --nologo -v:minimal`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter FullyQualifiedName~MapTextPopupSmokeTests --nologo -v:minimal`
- `dotnet test OvcinaHra.slnx --no-build --nologo -v:minimal`
- Headless local smoke: popup open/autofocus path, Enter submit with trim, cancel discard, empty Enter discard, organizer-layer save.

Closes #358