### PR TITLE
fix(recipes): repaint edit popup after async load

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/RecipeEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/RecipeEndpoints.cs
@@ -112,153 +112,230 @@ public static class RecipeEndpoints
         return TypedResults.Ok(rows.Select(r => MapToListDto(http, r)).ToList());
     }
 
-    private static async Task<Results<Ok<RecipeDetailDto>, NotFound>> GetById(int id, WorldDbContext db, HttpContext http)
+    private static async Task<Results<Ok<RecipeDetailDto>, NotFound>> GetById(
+        int id,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
     {
-        var r = await db.CraftingRecipes
-            .Include(r => r.OutputItem)
-            .Include(r => r.Location)
-            .Include(r => r.Ingredients).ThenInclude(i => i.Item)
-            .Include(r => r.BuildingRequirements).ThenInclude(br => br.Building)
-            .Include(r => r.SkillRequirements).ThenInclude(sr => sr.GameSkill)
-            .FirstOrDefaultAsync(r => r.Id == id);
-        if (r is null) return TypedResults.NotFound();
+        var logger = loggerFactory.CreateLogger("RecipeEndpoints");
+        logger.LogInformation("[recipe-edit] get-by-id.entry RecipeId={RecipeId}", id);
+        try
+        {
+            logger.LogInformation("[recipe-edit] get-by-id.query.start RecipeId={RecipeId}", id);
+            var r = await db.CraftingRecipes
+                .Include(r => r.OutputItem)
+                .Include(r => r.Location)
+                .Include(r => r.Ingredients).ThenInclude(i => i.Item)
+                .Include(r => r.BuildingRequirements).ThenInclude(br => br.Building)
+                .Include(r => r.SkillRequirements).ThenInclude(sr => sr.GameSkill)
+                .FirstOrDefaultAsync(r => r.Id == id, ct);
+            logger.LogInformation(
+                "[recipe-edit] get-by-id.query.done RecipeId={RecipeId} Found={Found} GameId={GameId} OutputItemId={OutputItemId}",
+                id, r is not null, r?.GameId, r?.OutputItemId);
+            if (r is null) return TypedResults.NotFound();
 
-        // For catalog templates, count their per-game forks (drives Smazat-
-        // blocked check + UI badge). For per-game rows, ForksCount stays 0.
-        int forksCount = 0;
-        if (r.GameId is null)
-            forksCount = await db.CraftingRecipes.CountAsync(f => f.TemplateRecipeId == r.Id);
+            // For catalog templates, count their per-game forks (drives Smazat-
+            // blocked check + UI badge). For per-game rows, ForksCount stays 0.
+            int forksCount = 0;
+            if (r.GameId is null)
+            {
+                logger.LogInformation("[recipe-edit] get-by-id.forks-query.start RecipeId={RecipeId}", id);
+                forksCount = await db.CraftingRecipes.CountAsync(f => f.TemplateRecipeId == r.Id, ct);
+                logger.LogInformation("[recipe-edit] get-by-id.forks-query.done RecipeId={RecipeId} ForksCount={ForksCount}", id, forksCount);
+            }
 
-        return TypedResults.Ok(new RecipeDetailDto(
-            r.Id, r.Name,
-            Title: r.Name ?? r.OutputItem.Name,
-            r.OutputItem.ItemType, r.GameId, r.TemplateRecipeId,
-            r.OutputItemId, r.OutputItem.Name,
-            OutputItemThumbnailUrl: ThumbForItem(http, r.OutputItem),
-            OutputQuantity: 1,
-            r.LocationId, r.Location?.Name,
-            r.Ingredients.OrderBy(i => i.Item.Name).Select(i =>
-                new RecipeIngredientChipDto(i.ItemId, i.Item.Name, ThumbForItem(http, i.Item), i.Quantity)).ToList(),
-            r.BuildingRequirements.OrderBy(br => br.Building.Name).Select(br =>
-                new RecipeBuildingChipDto(br.BuildingId, br.Building.Name)).ToList(),
-            r.SkillRequirements.OrderBy(sr => sr.GameSkill.Name).Select(sr =>
-                new RecipeSkillChipDto(sr.GameSkillId, sr.GameSkill.Name)).ToList(),
-            r.IngredientNotes,
-            forksCount));
+            logger.LogInformation(
+                "[recipe-edit] get-by-id.project RecipeId={RecipeId} Ingredients={Ingredients} Buildings={Buildings} Skills={Skills}",
+                id, r.Ingredients.Count, r.BuildingRequirements.Count, r.SkillRequirements.Count);
+            return TypedResults.Ok(new RecipeDetailDto(
+                r.Id, r.Name,
+                Title: r.Name ?? r.OutputItem.Name,
+                r.OutputItem.ItemType, r.GameId, r.TemplateRecipeId,
+                r.OutputItemId, r.OutputItem.Name,
+                OutputItemThumbnailUrl: ThumbForItem(http, r.OutputItem),
+                OutputQuantity: 1,
+                r.LocationId, r.Location?.Name,
+                r.Ingredients.OrderBy(i => i.Item.Name).Select(i =>
+                    new RecipeIngredientChipDto(i.ItemId, i.Item.Name, ThumbForItem(http, i.Item), i.Quantity)).ToList(),
+                r.BuildingRequirements.OrderBy(br => br.Building.Name).Select(br =>
+                    new RecipeBuildingChipDto(br.BuildingId, br.Building.Name)).ToList(),
+                r.SkillRequirements.OrderBy(sr => sr.GameSkill.Name).Select(sr =>
+                    new RecipeSkillChipDto(sr.GameSkillId, sr.GameSkill.Name)).ToList(),
+                r.IngredientNotes,
+                forksCount));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "[recipe-edit] get-by-id.exception RecipeId={RecipeId}", id);
+            throw;
+        }
     }
 
     private static async Task<Results<Created<RecipeDetailDto>, BadRequest<ProblemDetails>, NotFound>> Create(
-        CreateRecipeDto dto, WorldDbContext db, HttpContext http, CancellationToken ct)
+        CreateRecipeDto dto,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
     {
-        var outputItem = await db.Items
-            .AsNoTracking()
-            .Where(i => i.Id == dto.OutputItemId)
-            .Select(i => new { i.Id, i.IsCraftable })
-            .SingleOrDefaultAsync(ct);
-        if (outputItem is null)
-            return TypedResults.BadRequest(new ProblemDetails
-            {
-                Title = "Vybraný výstupní předmět neexistuje.",
-                Detail = $"Předmět s ID {dto.OutputItemId} nebyl nalezen.",
-                Status = StatusCodes.Status400BadRequest
-            });
-        if (!outputItem.IsCraftable)
-            return TypedResults.BadRequest(new ProblemDetails
-            {
-                Title = "Vybraný výstupní předmět není vyráběný.",
-                Detail = "Recept lze vytvořit jen pro předmět s příznakem IsCraftable.",
-                Status = StatusCodes.Status400BadRequest
-            });
-
-        var recipe = new CraftingRecipe
+        var logger = loggerFactory.CreateLogger("RecipeEndpoints");
+        logger.LogInformation("[recipe-edit] create.entry OutputItemId={OutputItemId} GameId={GameId}", dto.OutputItemId, dto.GameId);
+        try
         {
-            Name = string.IsNullOrWhiteSpace(dto.Name) ? null : dto.Name.Trim(),
-            OutputItemId = dto.OutputItemId,
-            GameId = dto.GameId,
-            LocationId = dto.LocationId,
-            TemplateRecipeId = dto.TemplateRecipeId,
-            IngredientNotes = string.IsNullOrWhiteSpace(dto.IngredientNotes) ? null : dto.IngredientNotes.Trim()
-        };
-        db.CraftingRecipes.Add(recipe);
-        await db.SaveChangesAsync(ct);
+            logger.LogInformation("[recipe-edit] create.output-query.start OutputItemId={OutputItemId}", dto.OutputItemId);
+            var outputItem = await db.Items
+                .AsNoTracking()
+                .Where(i => i.Id == dto.OutputItemId)
+                .Select(i => new { i.Id, i.IsCraftable })
+                .SingleOrDefaultAsync(ct);
+            logger.LogInformation(
+                "[recipe-edit] create.output-query.done OutputItemId={OutputItemId} Found={Found} IsCraftable={IsCraftable}",
+                dto.OutputItemId, outputItem is not null, outputItem?.IsCraftable);
+            if (outputItem is null)
+                return TypedResults.BadRequest(new ProblemDetails
+                {
+                    Title = "Vybraný výstupní předmět neexistuje.",
+                    Detail = $"Předmět s ID {dto.OutputItemId} nebyl nalezen.",
+                    Status = StatusCodes.Status400BadRequest
+                });
+            if (!outputItem.IsCraftable)
+                return TypedResults.BadRequest(new ProblemDetails
+                {
+                    Title = "Vybraný výstupní předmět není vyráběný.",
+                    Detail = "Recept lze vytvořit jen pro předmět s příznakem IsCraftable.",
+                    Status = StatusCodes.Status400BadRequest
+                });
 
-        var detail = await GetById(recipe.Id, db, http);
-        return detail.Result switch
-        {
-            Ok<RecipeDetailDto> ok when ok.Value is not null => TypedResults.Created($"/api/recipes/{recipe.Id}", ok.Value),
-            _ => TypedResults.BadRequest(new ProblemDetails
+            var recipe = new CraftingRecipe
             {
-                Title = "Internal projection failed",
-                Status = StatusCodes.Status500InternalServerError
-            })
-        };
+                Name = string.IsNullOrWhiteSpace(dto.Name) ? null : dto.Name.Trim(),
+                OutputItemId = dto.OutputItemId,
+                GameId = dto.GameId,
+                LocationId = dto.LocationId,
+                TemplateRecipeId = dto.TemplateRecipeId,
+                IngredientNotes = string.IsNullOrWhiteSpace(dto.IngredientNotes) ? null : dto.IngredientNotes.Trim()
+            };
+            db.CraftingRecipes.Add(recipe);
+            logger.LogInformation("[recipe-edit] create.save.start OutputItemId={OutputItemId} GameId={GameId}", dto.OutputItemId, dto.GameId);
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation("[recipe-edit] create.save.done RecipeId={RecipeId}", recipe.Id);
+
+            var detail = await GetById(recipe.Id, db, http, loggerFactory, ct);
+            return detail.Result switch
+            {
+                Ok<RecipeDetailDto> ok when ok.Value is not null => TypedResults.Created($"/api/recipes/{recipe.Id}", ok.Value),
+                _ => TypedResults.BadRequest(new ProblemDetails
+                {
+                    Title = "Internal projection failed",
+                    Status = StatusCodes.Status500InternalServerError
+                })
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "[recipe-edit] create.exception OutputItemId={OutputItemId} GameId={GameId}", dto.OutputItemId, dto.GameId);
+            throw;
+        }
     }
 
     private static async Task<Results<NoContent, NotFound, BadRequest<ProblemDetails>>> Update(
-        int id, UpdateRecipeDto dto, WorldDbContext db, CancellationToken ct)
+        int id,
+        UpdateRecipeDto dto,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
     {
-        // Include SkillRequirements because we replace the set — same
-        // pattern as CraftingEndpoints.Update.
-        var recipe = await db.CraftingRecipes
-            .Include(r => r.SkillRequirements)
-            .SingleOrDefaultAsync(r => r.Id == id, ct);
-        if (recipe is null) return TypedResults.NotFound();
-
-        var outputItem = await db.Items
-            .AsNoTracking()
-            .Where(i => i.Id == dto.OutputItemId)
-            .Select(i => new { i.Id, i.IsCraftable })
-            .SingleOrDefaultAsync(ct);
-        if (outputItem is null)
-            return TypedResults.BadRequest(new ProblemDetails
-            {
-                Title = "Vybraný výstupní předmět neexistuje.",
-                Detail = $"Předmět s ID {dto.OutputItemId} nebyl nalezen.",
-                Status = StatusCodes.Status400BadRequest
-            });
-        if (!outputItem.IsCraftable)
-            return TypedResults.BadRequest(new ProblemDetails
-            {
-                Title = "Vybraný výstupní předmět není vyráběný.",
-                Detail = "Recept lze uložit jen pro předmět s příznakem IsCraftable.",
-                Status = StatusCodes.Status400BadRequest
-            });
-
-        var skillIds = dto.RequiredSkillIds?.Distinct().ToList() ?? [];
-        // Skills only validated against the per-game GameSkill set when the
-        // recipe IS per-game. Catalog templates (GameId == null) skip this
-        // check; the from-template fork endpoint re-validates when copying.
-        if (recipe.GameId is int gid && skillIds.Count > 0)
+        var logger = loggerFactory.CreateLogger("RecipeEndpoints");
+        logger.LogInformation(
+            "[recipe-edit] update.entry RecipeId={RecipeId} OutputItemId={OutputItemId} LocationId={LocationId} SkillCount={SkillCount}",
+            id, dto.OutputItemId, dto.LocationId, dto.RequiredSkillIds?.Count ?? 0);
+        try
         {
-            var existingSkills = await db.GameSkills
-                .Where(gs => gs.GameId == gid && skillIds.Contains(gs.Id))
-                .Select(gs => gs.Id)
-                .ToArrayAsync(ct);
-            var missing = skillIds.Except(existingSkills).ToArray();
-            if (missing.Length > 0)
+            // Include SkillRequirements because we replace the set — same
+            // pattern as CraftingEndpoints.Update.
+            logger.LogInformation("[recipe-edit] update.recipe-query.start RecipeId={RecipeId}", id);
+            var recipe = await db.CraftingRecipes
+                .Include(r => r.SkillRequirements)
+                .SingleOrDefaultAsync(r => r.Id == id, ct);
+            logger.LogInformation(
+                "[recipe-edit] update.recipe-query.done RecipeId={RecipeId} Found={Found} GameId={GameId}",
+                id, recipe is not null, recipe?.GameId);
+            if (recipe is null) return TypedResults.NotFound();
+
+            logger.LogInformation("[recipe-edit] update.output-query.start OutputItemId={OutputItemId}", dto.OutputItemId);
+            var outputItem = await db.Items
+                .AsNoTracking()
+                .Where(i => i.Id == dto.OutputItemId)
+                .Select(i => new { i.Id, i.IsCraftable })
+                .SingleOrDefaultAsync(ct);
+            logger.LogInformation(
+                "[recipe-edit] update.output-query.done OutputItemId={OutputItemId} Found={Found} IsCraftable={IsCraftable}",
+                dto.OutputItemId, outputItem is not null, outputItem?.IsCraftable);
+            if (outputItem is null)
                 return TypedResults.BadRequest(new ProblemDetails
                 {
-                    Title = "Dovednosti nejsou ve hře dostupné.",
-                    Detail = $"Dovednosti s ID [{string.Join(", ", missing)}] nejsou v této hře.",
+                    Title = "Vybraný výstupní předmět neexistuje.",
+                    Detail = $"Předmět s ID {dto.OutputItemId} nebyl nalezen.",
                     Status = StatusCodes.Status400BadRequest
                 });
+            if (!outputItem.IsCraftable)
+                return TypedResults.BadRequest(new ProblemDetails
+                {
+                    Title = "Vybraný výstupní předmět není vyráběný.",
+                    Detail = "Recept lze uložit jen pro předmět s příznakem IsCraftable.",
+                    Status = StatusCodes.Status400BadRequest
+                });
+
+            var skillIds = dto.RequiredSkillIds?.Distinct().ToList() ?? [];
+            // Skills only validated against the per-game GameSkill set when the
+            // recipe IS per-game. Catalog templates (GameId == null) skip this
+            // check; the from-template fork endpoint re-validates when copying.
+            if (recipe.GameId is int gid && skillIds.Count > 0)
+            {
+                logger.LogInformation("[recipe-edit] update.skill-query.start RecipeId={RecipeId} GameId={GameId} SkillCount={SkillCount}", id, gid, skillIds.Count);
+                var existingSkills = await db.GameSkills
+                    .Where(gs => gs.GameId == gid && skillIds.Contains(gs.Id))
+                    .Select(gs => gs.Id)
+                    .ToArrayAsync(ct);
+                logger.LogInformation("[recipe-edit] update.skill-query.done RecipeId={RecipeId} GameId={GameId} FoundSkillCount={FoundSkillCount}", id, gid, existingSkills.Length);
+                var missing = skillIds.Except(existingSkills).ToArray();
+                if (missing.Length > 0)
+                    return TypedResults.BadRequest(new ProblemDetails
+                    {
+                        Title = "Dovednosti nejsou ve hře dostupné.",
+                        Detail = $"Dovednosti s ID [{string.Join(", ", missing)}] nejsou v této hře.",
+                        Status = StatusCodes.Status400BadRequest
+                    });
+            }
+
+            recipe.Name = string.IsNullOrWhiteSpace(dto.Name) ? null : dto.Name.Trim();
+            recipe.OutputItemId = dto.OutputItemId;
+            recipe.LocationId = dto.LocationId;
+            recipe.IngredientNotes = string.IsNullOrWhiteSpace(dto.IngredientNotes) ? null : dto.IngredientNotes.Trim();
+
+            // Replace SkillRequirements as a set.
+            var currentIds = recipe.SkillRequirements.Select(r => r.GameSkillId).ToHashSet();
+            var desiredIds = skillIds.ToHashSet();
+            logger.LogInformation(
+                "[recipe-edit] update.state-mutating RecipeId={RecipeId} CurrentSkillCount={CurrentSkillCount} DesiredSkillCount={DesiredSkillCount}",
+                id, currentIds.Count, desiredIds.Count);
+            foreach (var req in recipe.SkillRequirements.Where(r => !desiredIds.Contains(r.GameSkillId)).ToList())
+                recipe.SkillRequirements.Remove(req);
+            foreach (var sid in desiredIds.Where(s => !currentIds.Contains(s)))
+                recipe.SkillRequirements.Add(new CraftingSkillRequirement { CraftingRecipeId = id, GameSkillId = sid });
+
+            logger.LogInformation("[recipe-edit] update.save.start RecipeId={RecipeId}", id);
+            await db.SaveChangesAsync(ct);
+            logger.LogInformation("[recipe-edit] update.save.done RecipeId={RecipeId}", id);
+            return TypedResults.NoContent();
         }
-
-        recipe.Name = string.IsNullOrWhiteSpace(dto.Name) ? null : dto.Name.Trim();
-        recipe.OutputItemId = dto.OutputItemId;
-        recipe.LocationId = dto.LocationId;
-        recipe.IngredientNotes = string.IsNullOrWhiteSpace(dto.IngredientNotes) ? null : dto.IngredientNotes.Trim();
-
-        // Replace SkillRequirements as a set.
-        var currentIds = recipe.SkillRequirements.Select(r => r.GameSkillId).ToHashSet();
-        var desiredIds = skillIds.ToHashSet();
-        foreach (var req in recipe.SkillRequirements.Where(r => !desiredIds.Contains(r.GameSkillId)).ToList())
-            recipe.SkillRequirements.Remove(req);
-        foreach (var sid in desiredIds.Where(s => !currentIds.Contains(s)))
-            recipe.SkillRequirements.Add(new CraftingSkillRequirement { CraftingRecipeId = id, GameSkillId = sid });
-
-        await db.SaveChangesAsync(ct);
-        return TypedResults.NoContent();
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "[recipe-edit] update.exception RecipeId={RecipeId}", id);
+            throw;
+        }
     }
 
     private static async Task<Results<NoContent, NotFound, Conflict<ProblemDetails>>> Delete(int id, WorldDbContext db, CancellationToken ct)
@@ -286,7 +363,7 @@ public static class RecipeEndpoints
     }
 
     private static async Task<Results<Created<RecipeDetailDto>, NotFound, BadRequest<ProblemDetails>>> CopyFromTemplate(
-        int gameId, int templateId, WorldDbContext db, HttpContext http, CancellationToken ct)
+        int gameId, int templateId, WorldDbContext db, HttpContext http, ILoggerFactory loggerFactory, CancellationToken ct)
     {
         var template = await db.CraftingRecipes
             .Include(r => r.Ingredients)
@@ -350,7 +427,7 @@ public static class RecipeEndpoints
 
         await db.SaveChangesAsync(ct);
 
-        var detail = await GetById(fork.Id, db, http);
+        var detail = await GetById(fork.Id, db, http, loggerFactory, ct);
         return detail.Result switch
         {
             Ok<RecipeDetailDto> ok when ok.Value is not null => TypedResults.Created($"/api/recipes/{fork.Id}", ok.Value),

--- a/src/OvcinaHra.Client/Components/RecipeEditPopup.razor
+++ b/src/OvcinaHra.Client/Components/RecipeEditPopup.razor
@@ -151,10 +151,21 @@
     {
         var prevVisible = Visible;
         var prevId = RecipeId;
+        Console.WriteLine($"[recipe-edit] {{\"event\":\"set-parameters.before\",\"prevVisible\":{JsonBool(prevVisible)},\"prevRecipeId\":{JsonInt(prevId)}}}");
         await base.SetParametersAsync(parameters);
+        Console.WriteLine($"[recipe-edit] {{\"event\":\"set-parameters.after\",\"visible\":{JsonBool(Visible)},\"recipeId\":{JsonInt(RecipeId)},\"shouldLoad\":{JsonBool(Visible && (!prevVisible || prevId != RecipeId))}}}");
         if (Visible && (!prevVisible || prevId != RecipeId))
         {
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"set-parameters.load-dispatch\",\"recipeId\":{JsonInt(RecipeId)}}}");
             await LoadAsync();
+        }
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (Visible)
+        {
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"after-render\",\"recipeId\":{JsonInt(RecipeId)},\"loading\":{JsonBool(loading)},\"detailId\":{JsonInt(detail?.Id)},\"outputItemId\":{JsonInt(editOutputItemId)},\"isSaving\":{JsonBool(isSaving)}}}");
         }
     }
 
@@ -167,20 +178,30 @@
 
     private async Task LoadAsync()
     {
-        if (RecipeId is null) return;
+        Console.WriteLine($"[recipe-edit] {{\"event\":\"load.entry\",\"visible\":{JsonBool(Visible)},\"recipeId\":{JsonInt(RecipeId)}}}");
+        if (RecipeId is null)
+        {
+            Console.WriteLine("[recipe-edit] {\"event\":\"load.skip\",\"reason\":\"recipeId-null\"}");
+            return;
+        }
         loading = true;
         error = null;
+        Console.WriteLine($"[recipe-edit] {{\"event\":\"state.loading\",\"recipeId\":{RecipeId.Value},\"loading\":true}}");
         try
         {
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"detail.request.start\",\"recipeId\":{RecipeId.Value},\"url\":\"/api/recipes/{RecipeId.Value}\"}}");
             detail = await Api.GetAsync<RecipeDetailDto>($"/api/recipes/{RecipeId.Value}");
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"detail.request.done\",\"recipeId\":{RecipeId.Value},\"found\":{JsonBool(detail is not null)},\"gameId\":{JsonInt(detail?.GameId)},\"outputItemId\":{JsonInt(detail?.OutputItemId)}}}");
             if (detail is null)
             {
                 error = "Recept nenalezen.";
+                Console.WriteLine($"[recipe-edit] {{\"event\":\"state.error\",\"recipeId\":{RecipeId.Value},\"message\":\"Recept nenalezen.\"}}");
                 return;
             }
             editName = detail.Name;
             editOutputItemId = detail.OutputItemId;
             editLocationId = detail.LocationId;
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"state.identity-set\",\"recipeId\":{detail.Id},\"outputItemId\":{JsonInt(editOutputItemId)},\"locationId\":{JsonInt(editLocationId)}}}");
             _ingredientRows = detail.Ingredients
                 .Select(i => new RecipeIngredientPicker.IngredientRow(i.ItemId, i.Name, i.Quantity))
                 .ToList();
@@ -188,13 +209,18 @@
                 .Select(b => new RecipeBuildingPicker.BuildingRow(b.BuildingId, b.Name))
                 .ToList();
             _skillIds = detail.Skills.Select(s => s.SkillId).ToList();
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"state.children-set\",\"recipeId\":{detail.Id},\"ingredients\":{_ingredientRows.Count},\"buildings\":{_buildingRows.Count},\"skills\":{_skillIds.Count}}}");
 
             // Picker source data — fetch in parallel to avoid serial waterfall.
-            var itemsTask = Api.GetListAsync<ItemListDto>("/api/items");
+            const string itemsUrl = "/api/items";
             var recipesUrl = detail.GameId is int recipeGameId ? $"/api/games/{recipeGameId}/recipes" : "/api/recipes";
-            var recipesTask = Api.GetListAsync<RecipeListDto>(recipesUrl);
-            var locationsTask = Api.GetListAsync<LocationListDto>("/api/locations");
-            var buildingsTask = Api.GetListAsync<BuildingListDto>("/api/buildings");
+            const string locationsUrl = "/api/locations";
+            const string buildingsUrl = "/api/buildings";
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"resources.dispatch\",\"recipeId\":{detail.Id},\"itemsUrl\":\"{itemsUrl}\",\"recipesUrl\":\"{recipesUrl}\",\"locationsUrl\":\"{locationsUrl}\",\"buildingsUrl\":\"{buildingsUrl}\"}}");
+            var itemsTask = TraceResourceAsync("items", itemsUrl, Api.GetListAsync<ItemListDto>(itemsUrl));
+            var recipesTask = TraceResourceAsync("recipes", recipesUrl, Api.GetListAsync<RecipeListDto>(recipesUrl));
+            var locationsTask = TraceResourceAsync("locations", locationsUrl, Api.GetListAsync<LocationListDto>(locationsUrl));
+            var buildingsTask = TraceResourceAsync("buildings", buildingsUrl, Api.GetListAsync<BuildingListDto>(buildingsUrl));
             await Task.WhenAll(itemsTask, recipesTask, locationsTask, buildingsTask);
             allItems = await itemsTask;
             usedOutputItemIdsInScope = (await recipesTask)
@@ -203,22 +229,36 @@
                 .ToHashSet();
             allLocations = await locationsTask;
             allBuildings = await buildingsTask;
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"state.sources-set\",\"recipeId\":{detail.Id},\"items\":{allItems.Count},\"usedOutputs\":{usedOutputItemIdsInScope.Count},\"locations\":{allLocations.Count},\"buildings\":{allBuildings.Count}}}");
 
             if (detail.GameId is int gid)
             {
-                gameSkills = await Api.GetListAsync<GameSkillDto>($"/api/games/{gid}/skills");
+                var skillsUrl = $"/api/games/{gid}/skills";
+                gameSkills = await TraceResourceAsync("skills", skillsUrl, Api.GetListAsync<GameSkillDto>(skillsUrl));
             }
             else
             {
                 gameSkills = [];
+                Console.WriteLine($"[recipe-edit] {{\"event\":\"state.skills-set\",\"recipeId\":{detail.Id},\"skills\":0,\"reason\":\"catalog-recipe\"}}");
             }
         }
-        catch (Exception ex) { error = ex.Message; }
-        finally { loading = false; }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"load.exception\",\"recipeId\":{JsonInt(RecipeId)},\"type\":\"{JsonEscape(ex.GetType().Name)}\",\"message\":\"{JsonEscape(ex.Message)}\"}}");
+        }
+        finally
+        {
+            loading = false;
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"state.loading\",\"recipeId\":{JsonInt(RecipeId)},\"loading\":false,\"hasError\":{JsonBool(error is not null)}}}");
+            await InvokeAsync(StateHasChanged);
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"state.render-requested\",\"recipeId\":{JsonInt(RecipeId)}}}");
+        }
     }
 
     private async Task SaveAsync()
     {
+        Console.WriteLine($"[recipe-edit] {{\"event\":\"save.click\",\"recipeId\":{JsonInt(detail?.Id)},\"outputItemId\":{JsonInt(editOutputItemId)},\"canSave\":{JsonBool(detail is not null && editOutputItemId is not null)}}}");
         if (detail is null || editOutputItemId is null) return;
         error = null;
         isSaving = true;
@@ -230,17 +270,28 @@
                 LocationId: editLocationId,
                 RequiredSkillIds: _skillIds,
                 IngredientNotes: detail.IngredientNotes);
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"save.request.start\",\"recipeId\":{detail.Id},\"outputItemId\":{dto.OutputItemId},\"locationId\":{JsonInt(dto.LocationId)},\"skillIds\":{dto.RequiredSkillIds?.Count ?? 0}}}");
             var (ok, problem) = await Api.PutWithProblemAsync($"/api/recipes/{detail.Id}", dto);
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"save.request.done\",\"recipeId\":{detail.Id},\"ok\":{JsonBool(ok)},\"problem\":\"{JsonEscape(problem)}\"}}");
             if (!ok)
             {
                 error = problem ?? "Uložení se nezdařilo.";
+                Console.WriteLine($"[recipe-edit] {{\"event\":\"state.error\",\"recipeId\":{detail.Id},\"message\":\"{JsonEscape(error)}\"}}");
                 return;
             }
             await OnSaved.InvokeAsync();
             await VisibleChanged.InvokeAsync(false);
         }
-        catch (Exception ex) { error = ex.Message; }
-        finally { isSaving = false; }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"save.exception\",\"recipeId\":{JsonInt(detail?.Id)},\"type\":\"{JsonEscape(ex.GetType().Name)}\",\"message\":\"{JsonEscape(ex.Message)}\"}}");
+        }
+        finally
+        {
+            isSaving = false;
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"state.saving\",\"recipeId\":{JsonInt(detail?.Id)},\"saving\":false,\"hasError\":{JsonBool(error is not null)}}}");
+        }
     }
 
     private async Task Cancel() => await VisibleChanged.InvokeAsync(false);
@@ -356,6 +407,7 @@
     private async Task ReloadDetailAsync()
     {
         if (RecipeId is null) return;
+        Console.WriteLine($"[recipe-edit] {{\"event\":\"reload-detail.start\",\"recipeId\":{RecipeId.Value}}}");
         detail = await Api.GetAsync<RecipeDetailDto>($"/api/recipes/{RecipeId.Value}");
         if (detail is not null)
         {
@@ -366,7 +418,37 @@
                 .Select(b => new RecipeBuildingPicker.BuildingRow(b.BuildingId, b.Name))
                 .ToList();
             _skillIds = detail.Skills.Select(s => s.SkillId).ToList();
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"reload-detail.done\",\"recipeId\":{detail.Id},\"ingredients\":{_ingredientRows.Count},\"buildings\":{_buildingRows.Count},\"skills\":{_skillIds.Count}}}");
+        }
+        else
+        {
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"reload-detail.done\",\"recipeId\":{RecipeId.Value},\"found\":false}}");
         }
         StateHasChanged();
     }
+
+    private static async Task<List<T>> TraceResourceAsync<T>(string name, string url, Task<List<T>> task)
+    {
+        Console.WriteLine($"[recipe-edit] {{\"event\":\"resource.request.start\",\"name\":\"{JsonEscape(name)}\",\"url\":\"{JsonEscape(url)}\"}}");
+        try
+        {
+            var result = await task;
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"resource.request.done\",\"name\":\"{JsonEscape(name)}\",\"url\":\"{JsonEscape(url)}\",\"count\":{result.Count}}}");
+            return result;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[recipe-edit] {{\"event\":\"resource.request.exception\",\"name\":\"{JsonEscape(name)}\",\"url\":\"{JsonEscape(url)}\",\"type\":\"{JsonEscape(ex.GetType().Name)}\",\"message\":\"{JsonEscape(ex.Message)}\"}}");
+            throw;
+        }
+    }
+
+    private static string JsonBool(bool value) => value ? "true" : "false";
+    private static string JsonInt(int? value) => value?.ToString() ?? "null";
+    private static string JsonEscape(string? value) => value?
+        .Replace("\\", "\\\\", StringComparison.Ordinal)
+        .Replace("\"", "\\\"", StringComparison.Ordinal)
+        .Replace("\r", "\\r", StringComparison.Ordinal)
+        .Replace("\n", "\\n", StringComparison.Ordinal)
+        ?? "";
 }


### PR DESCRIPTION
## Summary
- closes #364
- keep permanent `[recipe-edit]` markers across the recipe edit client load/save chain and server `GetById`/`Create`/`Update`
- fix the edit popup state lock by requesting a render after `LoadAsync` clears `loading`

## Diagnosis
- last firing marker before the fix: `[recipe-edit] state.loading loading=false hasError=false`
- first missing UI transition: popup body repaint from `Načítám…` into the editable form
- regression source: #352 touched `RecipeEditPopup` and added the parallel `/api/games/{gid}/recipes` fetch in the popup load path

## Verification
- `gh pr diff 352 --repo timurlain/ovcinahra | grep -A5 RecipeEditPopup`
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test OvcinaHra.slnx --no-build` — 549 API tests + 8 E2E tests passed
- `git diff --check origin/main..HEAD`
- visual smoke: edit popup opens and renders the form; footer `Uložit` is enabled; editing the recipe name saves with `[recipe-edit] save.request.done ok=true`; popup closes; reopening shows the saved name