### PR TITLE
feat(treasures): composite stash inline UI (closes #349)

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -238,11 +238,13 @@ public static class TreasurePlanningEndpoints
         var legacyPoolItemIds = dto.TreasureItemIds ?? [];
         var poolCount = poolAssignments.Count + legacyPoolItemIds.Count;
         var unlimitedCount = dto.UnlimitedItems?.Count ?? 0;
+        var isComposite = poolAssignments.Count > 1 || poolAssignments.Sum(p => p.Count) > 1;
         LogTreasureAlloc(logger, LogLevel.Information, "assign-entry", new
         {
             dto.GameId,
             dto.LocationId,
             dto.SecretStashId,
+            kind = isComposite ? "composite" : "single",
             poolCount,
             poolUnits = poolAssignments.Sum(p => p.Count),
             unlimitedCount
@@ -371,7 +373,30 @@ public static class TreasurePlanningEndpoints
 
             foreach (var assignment in poolAssignments)
             {
-                AssignPoolItemToQuest(poolItemsById[assignment.TreasureItemId], assignment.Count, quest.Id, db);
+                var poolItem = poolItemsById[assignment.TreasureItemId];
+                LogTreasureAlloc(logger, LogLevel.Information, "assign-item-before", new
+                {
+                    kind = isComposite ? "composite" : "single",
+                    questId = quest.Id,
+                    poolItemId = poolItem.Id,
+                    poolItem.ItemId,
+                    requestedCount = assignment.Count,
+                    availableCount = poolItem.Count,
+                    dto.LocationId,
+                    dto.SecretStashId
+                });
+                AssignPoolItemToQuest(poolItem, assignment.Count, quest.Id, db);
+                LogTreasureAlloc(logger, LogLevel.Information, "assign-item-after", new
+                {
+                    kind = isComposite ? "composite" : "single",
+                    questId = quest.Id,
+                    poolItemId = poolItem.Id,
+                    poolItem.ItemId,
+                    assignedCount = assignment.Count,
+                    remainingPoolCount = poolItem.TreasureQuestId is null ? poolItem.Count : 0,
+                    dto.LocationId,
+                    dto.SecretStashId
+                });
             }
 
             // Add unlimited items directly

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -298,6 +298,7 @@ else
                                     <button type="button"
                                             class="btn btn-sm btn-outline-primary"
                                             @onclick="AddCompositeBundleItem"
+                                            aria-label="Přidat do balíčku"
                                             disabled="@(!CanAddCompositeBundleItem)">
                                         <i class="bi bi-plus-circle"></i>
                                     </button>
@@ -341,16 +342,18 @@ else
                         }
                         @if (HasCompositeBundle)
                         {
-                            <div @ref="compositeBundleElement"
-                                 class="oh-tp-composite-tile @(selectedCompositeBundle ? "selected" : "")"
-                                 @onclick="ToggleCompositeBundleSelection">
+                            <button @ref="compositeBundleElement"
+                                    type="button"
+                                    class="oh-tp-composite-tile @(selectedCompositeBundle ? "selected" : "")"
+                                    aria-pressed="@selectedCompositeBundle"
+                                    @onclick="ToggleCompositeBundleSelection">
                                 <div class="oh-tp-composite-icon"><i class="bi bi-collection"></i></div>
                                 <div class="oh-tp-composite-body">
                                     <strong>@EffectiveCompositeBundleTitle</strong>
                                     <span>@CompositeBundleSummary</span>
                                 </div>
                                 <div class="oh-tp-composite-count">×@CompositeBundleUnitCount</div>
-                            </div>
+                            </button>
                         }
                         @if (HasPendingAllocation)
                         {

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -207,7 +207,7 @@ else
                                             var isFocused = focusedLocationId == loc.LocationId;
                                             <TreasureLocationTargetCard Location="loc"
                                                                         IsFocused="isFocused"
-                                                                        HasSelectedPool="@(selectedPool.Count > 0)"
+                                                                        HasSelectedPool="@HasPendingAllocation"
                                                                         OnClick="HandleLocationTargetClick"
                                                                         OnDrop="HandlePieDrop" />
                                         }
@@ -246,16 +246,113 @@ else
                     @* --- Default: pool grid --- *@
                     <div class="oh-tp-assign-hdr">
                         <h5>Zásobník (@poolItems.Count)</h5>
-                        <span class="oh-tp-focus-quest-meta">@selectedPool.Count vybráno</span>
+                        <span class="oh-tp-focus-quest-meta">@PendingAllocationLabel</span>
+                        <button type="button"
+                                class="btn btn-sm btn-outline-primary"
+                                @onclick="OpenCompositeBundleComposer">
+                            <i class="bi bi-collection me-1"></i>Vytvořit balíček
+                        </button>
                     </div>
                     <div class="oh-tp-assign-body" id="oh-tp-pool-anchor">
+                        @{
+                            var visiblePoolItems = GetVisiblePoolItems().ToList();
+                        }
                         @if (poolRemoveError is not null)
                         {
                             <div class="alert alert-danger py-2 mb-2" role="alert">
                                 <i class="bi bi-exclamation-triangle me-1"></i>@poolRemoveError
                             </div>
                         }
-                        @if (selectedPool.Count > 0)
+                        @if (isCompositeBundleComposerOpen)
+                        {
+                            <div class="oh-tp-bundle-composer">
+                                <div class="oh-tp-bundle-head">
+                                    <div>
+                                        <strong><i class="bi bi-collection me-1"></i>Vytvořit balíček</strong>
+                                        <span>Počty se teď odečítají jen v prohlížeči. Server se mění až při přiřazení na lokaci.</span>
+                                    </div>
+                                    @if (HasCompositeBundle)
+                                    {
+                                        <button type="button" class="btn btn-sm btn-outline-danger" @onclick="CancelCompositeBundle">
+                                            Zrušit balíček
+                                        </button>
+                                    }
+                                </div>
+                                <div class="oh-tp-bundle-title">
+                                    <label class="oh-tp-form-label">Název</label>
+                                    <DxTextBox @bind-Text="@compositeBundleTitle"
+                                               NullText="@BuildCompositeBundleAutoTitle()" />
+                                </div>
+                                <div class="oh-tp-bundle-add">
+                                    <DxComboBox Data="@GetCompositeBundleChoices()"
+                                                @bind-Value="@compositeBundlePoolItemId"
+                                                TextFieldName="Label"
+                                                ValueFieldName="PoolItemId"
+                                                NullText="Přidat položku ze zásobníku…"
+                                                ListRenderMode="ListRenderMode.Virtual"
+                                                style="flex:1" />
+                                    <DxSpinEdit @bind-Value="@compositeBundleAddCount"
+                                                MinValue="1"
+                                                MaxValue="@CompositeBundleAddMax"
+                                                style="width:84px" />
+                                    <button type="button"
+                                            class="btn btn-sm btn-outline-primary"
+                                            @onclick="AddCompositeBundleItem"
+                                            disabled="@(!CanAddCompositeBundleItem)">
+                                        <i class="bi bi-plus-circle"></i>
+                                    </button>
+                                </div>
+                                @if (HasCompositeBundle)
+                                {
+                                    <div class="oh-tp-bundle-lines">
+                                        @foreach (var line in GetCompositeBundleDisplayLines())
+                                        {
+                                            <div class="oh-tp-bundle-line" @key="line.ItemId">
+                                                <span class="oh-tp-bundle-line-name">@line.ItemName</span>
+                                                <button type="button"
+                                                        class="oh-tp-stepper-btn"
+                                                        @onclick="() => ChangeCompositeBundleItemCount(line.ItemId, -1)">
+                                                    <i class="bi bi-dash-lg"></i>
+                                                </button>
+                                                <span class="oh-tp-stepper-count">×@line.Count</span>
+                                                <button type="button"
+                                                        class="oh-tp-stepper-btn"
+                                                        disabled="@(!CanIncreaseCompositeBundleItem(line.ItemId))"
+                                                        @onclick="() => ChangeCompositeBundleItemCount(line.ItemId, 1)">
+                                                    <i class="bi bi-plus-lg"></i>
+                                                </button>
+                                                <button type="button"
+                                                        class="remove"
+                                                        aria-label="Odebrat"
+                                                        @onclick="() => RemoveCompositeBundleItem(line.ItemId)">
+                                                    <i class="bi bi-x-circle"></i>
+                                                </button>
+                                            </div>
+                                        }
+                                    </div>
+                                }
+                                @if (compositeBundleError is not null)
+                                {
+                                    <div class="alert alert-danger py-2 mt-2 mb-0" role="alert">
+                                        <i class="bi bi-exclamation-triangle me-1"></i>@compositeBundleError
+                                    </div>
+                                }
+                            </div>
+                        }
+                        @if (HasCompositeBundle)
+                        {
+                            <div @ref="compositeBundleElement"
+                                 class="oh-tp-composite-tile @(selectedCompositeBundle ? "selected" : "")"
+                                 @onclick="ToggleCompositeBundleSelection">
+                                <div class="oh-tp-composite-icon"><i class="bi bi-collection"></i></div>
+                                <div class="oh-tp-composite-body">
+                                    <strong>@EffectiveCompositeBundleTitle</strong>
+                                    <span>@CompositeBundleSummary</span>
+                                </div>
+                                <div class="oh-tp-composite-count">×@CompositeBundleUnitCount</div>
+                            </div>
+                        }
+                        @if (HasPendingAllocation)
                         {
                             <div class="oh-tp-drag-hint">
                                 <i class="bi bi-arrow-left-right"></i>
@@ -270,10 +367,17 @@ else
                                 <button class="btn btn-sm btn-outline-primary" @onclick="OpenAddToPoolModal">Přidat předmět</button>
                             </div>
                         }
+                        else if (visiblePoolItems.Count == 0)
+                        {
+                            <div class="oh-tp-empty compact">
+                                <i class="bi bi-collection"></i>
+                                <p>Všechny položky ze zásobníku jsou teď v rozpracovaném balíčku.</p>
+                            </div>
+                        }
                         else
                         {
                             <div class="oh-tp-pool-grid">
-                                @foreach (var p in poolItems)
+                                @foreach (var p in visiblePoolItems)
                                 {
                                     <TreasurePoolTile @key="p.Id"
                                                       Item="p"
@@ -318,7 +422,7 @@ else
                                     <span><span class="sw" style="background:var(--oh-stage-midgame)"></span>Střed @loc.MidgameCount</span>
                                     <span><span class="sw" style="background:var(--oh-stage-lategame)"></span>Závěr @loc.LategameCount</span>
                                 </div>
-                                @if (selectedPool.Count > 0)
+                                @if (HasPendingAllocation)
                                 {
                                     <button type="button"
                                             class="btn btn-sm btn-primary"
@@ -723,13 +827,21 @@ else
 
     // ===== Pool selection =====
     private readonly List<TreasurePoolItemDto> selectedPool = [];
+    private bool HasPendingAllocation => selectedPool.Count > 0 || selectedCompositeBundle;
+    private string PendingAllocationLabel => selectedCompositeBundle
+        ? "balíček vybrán"
+        : $"{selectedPool.Count} vybráno";
     private bool IsSelected(TreasurePoolItemDto p) => selectedPool.Any(s => s.Id == p.Id);
 
     private void TogglePoolSelection(TreasurePoolItemDto p)
     {
         var existing = selectedPool.FirstOrDefault(s => s.Id == p.Id);
         if (existing is not null) selectedPool.Remove(existing);
-        else selectedPool.Add(p);
+        else
+        {
+            selectedCompositeBundle = false;
+            selectedPool.Add(p);
+        }
         LogTreasureAlloc("click-treasure", new
         {
             poolItemId = p.Id,
@@ -741,6 +853,316 @@ else
             focusedLocationId
         });
     }
+
+    // ===== Transient composite bundle =====
+    private ElementReference compositeBundleElement;
+    private bool isCompositeBundleComposerOpen;
+    private bool selectedCompositeBundle;
+    private int? compositeBundlePoolItemId;
+    private int compositeBundleAddCount = 1;
+    private string compositeBundleTitle = "";
+    private string lastCompositeBundleAutoTitle = "";
+    private string? compositeBundleError;
+    private string compositeBundleClientId = NewCompositeBundleClientId();
+    private string? wiredCompositeBundlePayload;
+    private readonly List<CompositeBundleLine> compositeBundleItems = [];
+
+    private sealed record CompositeBundleLine(int PoolItemId, int ItemId, string ItemName, bool IsUnique, int Count);
+    private sealed record CompositeBundleDisplayLine(int ItemId, string ItemName, int Count);
+    private sealed record CompositeBundleChoice(int PoolItemId, int ItemId, string ItemName, string Label, int Available, bool IsUnique);
+
+    private bool HasCompositeBundle => compositeBundleItems.Count > 0;
+    private int CompositeBundleUnitCount => compositeBundleItems.Sum(i => i.Count);
+    private string EffectiveCompositeBundleTitle =>
+        string.IsNullOrWhiteSpace(compositeBundleTitle) ? BuildCompositeBundleAutoTitle() : compositeBundleTitle.Trim();
+    private string CompositeBundleSummary => string.Join(" + ", GetCompositeBundleDisplayLines().Select(i => $"{i.ItemName} × {i.Count}"));
+    private int CompositeBundleAddMax => compositeBundlePoolItemId is int id
+        ? Math.Max(1, GetCompositeBundleAvailableCount(id))
+        : 1;
+    private bool CanAddCompositeBundleItem => compositeBundlePoolItemId is int id && GetCompositeBundleAvailableCount(id) > 0;
+
+    private static string NewCompositeBundleClientId() => Guid.NewGuid().ToString("N");
+
+    private IEnumerable<TreasurePoolItemDto> GetVisiblePoolItems()
+    {
+        foreach (var item in poolItems)
+        {
+            var available = item.Count - GetCompositeBundleReservedCount(item.Id);
+            if (available > 0)
+            {
+                yield return item with { Count = available };
+            }
+        }
+    }
+
+    private IEnumerable<CompositeBundleChoice> GetCompositeBundleChoices() =>
+        poolItems
+            .Select(p =>
+            {
+                var available = p.Count - GetCompositeBundleReservedCount(p.Id);
+                var label = p.IsUnique ? p.ItemName : $"{p.ItemName} (zbývá {available})";
+                return new CompositeBundleChoice(p.Id, p.ItemId, p.ItemName, label, available, p.IsUnique);
+            })
+            .Where(c => c.Available > 0)
+            .OrderBy(c => c.ItemName);
+
+    private IEnumerable<CompositeBundleDisplayLine> GetCompositeBundleDisplayLines() =>
+        compositeBundleItems
+            .GroupBy(i => new { i.ItemId, i.ItemName })
+            .OrderBy(g => g.Key.ItemName)
+            .Select(g => new CompositeBundleDisplayLine(g.Key.ItemId, g.Key.ItemName, g.Sum(i => i.Count)));
+
+    private int GetCompositeBundleReservedCount(int poolItemId) =>
+        compositeBundleItems.Where(i => i.PoolItemId == poolItemId).Sum(i => i.Count);
+
+    private int GetCompositeBundleAvailableCount(int poolItemId)
+    {
+        var poolItem = poolItems.FirstOrDefault(p => p.Id == poolItemId);
+        return poolItem is null ? 0 : Math.Max(0, poolItem.Count - GetCompositeBundleReservedCount(poolItemId));
+    }
+
+    private string BuildCompositeBundleAutoTitle()
+    {
+        var summary = CompositeBundleSummary;
+        return string.IsNullOrWhiteSpace(summary) ? "Balíček" : $"Balíček: {summary}";
+    }
+
+    private void RefreshCompositeBundleTitle()
+    {
+        var next = BuildCompositeBundleAutoTitle();
+        if (string.IsNullOrWhiteSpace(compositeBundleTitle) || compositeBundleTitle == lastCompositeBundleAutoTitle)
+        {
+            compositeBundleTitle = next;
+        }
+        lastCompositeBundleAutoTitle = next;
+    }
+
+    private void OpenCompositeBundleComposer()
+    {
+        isCompositeBundleComposerOpen = true;
+        selectedPool.Clear();
+        LogTreasureAlloc("composite-open", new
+        {
+            kind = "composite",
+            clientBundleId = compositeBundleClientId,
+            itemRows = compositeBundleItems.Count,
+            units = CompositeBundleUnitCount
+        });
+    }
+
+    private void AddCompositeBundleItem()
+    {
+        compositeBundleError = null;
+        if (compositeBundlePoolItemId is not int poolItemId) return;
+        var poolItem = poolItems.FirstOrDefault(p => p.Id == poolItemId);
+        if (poolItem is null) return;
+        var available = GetCompositeBundleAvailableCount(poolItemId);
+        if (available <= 0) return;
+        var count = Math.Clamp(compositeBundleAddCount, 1, available);
+        if (poolItem.IsUnique) count = 1;
+        var existing = compositeBundleItems.FirstOrDefault(i => i.PoolItemId == poolItemId);
+        if (existing is not null)
+        {
+            compositeBundleItems.Remove(existing);
+            compositeBundleItems.Add(existing with { Count = existing.Count + count });
+        }
+        else
+        {
+            compositeBundleItems.Add(new CompositeBundleLine(poolItem.Id, poolItem.ItemId, poolItem.ItemName, poolItem.IsUnique, count));
+        }
+        selectedPool.Clear();
+        selectedCompositeBundle = true;
+        compositeBundlePoolItemId = null;
+        compositeBundleAddCount = 1;
+        RefreshCompositeBundleTitle();
+        wiredCompositeBundlePayload = null;
+        LogTreasureAlloc("composite-add", new
+        {
+            kind = "composite",
+            clientBundleId = compositeBundleClientId,
+            poolItemId,
+            poolItem.ItemId,
+            count,
+            reserved = GetCompositeBundleReservedCount(poolItemId)
+        });
+    }
+
+    private bool CanIncreaseCompositeBundleItem(int itemId) =>
+        poolItems.Any(p => p.ItemId == itemId && GetCompositeBundleAvailableCount(p.Id) > 0);
+
+    private void ChangeCompositeBundleItemCount(int itemId, int delta)
+    {
+        compositeBundleError = null;
+        if (delta < 0)
+        {
+            var line = compositeBundleItems.LastOrDefault(i => i.ItemId == itemId);
+            if (line is null) return;
+            compositeBundleItems.Remove(line);
+            if (line.Count > 1)
+            {
+                compositeBundleItems.Add(line with { Count = line.Count - 1 });
+            }
+        }
+        else
+        {
+            var poolItem = poolItems.FirstOrDefault(p => p.ItemId == itemId && GetCompositeBundleAvailableCount(p.Id) > 0);
+            if (poolItem is null) return;
+            var existing = compositeBundleItems.FirstOrDefault(i => i.PoolItemId == poolItem.Id);
+            if (existing is not null)
+            {
+                compositeBundleItems.Remove(existing);
+                compositeBundleItems.Add(existing with { Count = existing.Count + 1 });
+            }
+            else
+            {
+                compositeBundleItems.Add(new CompositeBundleLine(poolItem.Id, poolItem.ItemId, poolItem.ItemName, poolItem.IsUnique, 1));
+            }
+        }
+        if (!HasCompositeBundle)
+        {
+            selectedCompositeBundle = false;
+        }
+        RefreshCompositeBundleTitle();
+        wiredCompositeBundlePayload = null;
+        LogTreasureAlloc("composite-count", new
+        {
+            kind = "composite",
+            clientBundleId = compositeBundleClientId,
+            itemId,
+            delta,
+            units = CompositeBundleUnitCount
+        });
+    }
+
+    private void RemoveCompositeBundleItem(int itemId)
+    {
+        compositeBundleItems.RemoveAll(i => i.ItemId == itemId);
+        selectedCompositeBundle = HasCompositeBundle && selectedCompositeBundle;
+        RefreshCompositeBundleTitle();
+        wiredCompositeBundlePayload = null;
+        LogTreasureAlloc("composite-remove", new
+        {
+            kind = "composite",
+            clientBundleId = compositeBundleClientId,
+            itemId,
+            units = CompositeBundleUnitCount
+        });
+    }
+
+    private void ToggleCompositeBundleSelection()
+    {
+        if (!HasCompositeBundle) return;
+        selectedCompositeBundle = !selectedCompositeBundle;
+        if (selectedCompositeBundle)
+        {
+            selectedPool.Clear();
+        }
+        LogTreasureAlloc("composite-select", new
+        {
+            kind = "composite",
+            clientBundleId = compositeBundleClientId,
+            selectedCompositeBundle,
+            units = CompositeBundleUnitCount
+        });
+    }
+
+    private void CancelCompositeBundle()
+    {
+        LogTreasureAlloc("composite-cancel", new
+        {
+            kind = "composite",
+            clientBundleId = compositeBundleClientId,
+            units = CompositeBundleUnitCount
+        });
+        ClearCompositeBundle();
+    }
+
+    private void ClearCompositeBundle()
+    {
+        compositeBundleItems.Clear();
+        compositeBundleTitle = "";
+        lastCompositeBundleAutoTitle = "";
+        compositeBundlePoolItemId = null;
+        compositeBundleAddCount = 1;
+        compositeBundleError = null;
+        selectedCompositeBundle = false;
+        wiredCompositeBundlePayload = null;
+        compositeBundleClientId = NewCompositeBundleClientId();
+    }
+
+    private void NormalizeCompositeBundleAgainstPool()
+    {
+        var poolById = poolItems.ToDictionary(p => p.Id);
+        var changed = false;
+        foreach (var line in compositeBundleItems.ToList())
+        {
+            if (!poolById.TryGetValue(line.PoolItemId, out var poolItem))
+            {
+                compositeBundleItems.Remove(line);
+                changed = true;
+                continue;
+            }
+            var reservedBeforeLine = compositeBundleItems
+                .TakeWhile(i => !ReferenceEquals(i, line))
+                .Where(i => i.PoolItemId == line.PoolItemId)
+                .Sum(i => i.Count);
+            var max = Math.Max(0, poolItem.Count - reservedBeforeLine);
+            if (line.Count > max)
+            {
+                compositeBundleItems.Remove(line);
+                if (max > 0)
+                {
+                    compositeBundleItems.Add(line with { Count = max });
+                }
+                changed = true;
+            }
+        }
+        if (!HasCompositeBundle)
+        {
+            selectedCompositeBundle = false;
+        }
+        if (changed)
+        {
+            RefreshCompositeBundleTitle();
+            wiredCompositeBundlePayload = null;
+        }
+    }
+
+    private string? GetCompositeBundleValidationError()
+    {
+        if (!HasCompositeBundle) return "Balíček je prázdný.";
+        foreach (var line in compositeBundleItems)
+        {
+            var poolItem = poolItems.FirstOrDefault(p => p.Id == line.PoolItemId);
+            if (poolItem is null) return $"{line.ItemName} už není v zásobníku.";
+            if (line.Count <= 0 || line.Count > poolItem.Count)
+                return $"Počet pro {line.ItemName} musí být mezi 1 a {poolItem.Count}.";
+        }
+        return null;
+    }
+
+    private List<PoolItemAssignDto> BuildCompositeBundleAssignments() =>
+        compositeBundleItems
+            .GroupBy(i => i.PoolItemId)
+            .Select(g => new PoolItemAssignDto(g.Key, g.Sum(i => i.Count)))
+            .ToList();
+
+    private string BuildCompositeBundlePayload() =>
+        JsonSerializer.Serialize(new
+        {
+            Kind = "composite",
+            ClientBundleId = compositeBundleClientId,
+            Title = EffectiveCompositeBundleTitle,
+            Count = CompositeBundleUnitCount,
+            Items = compositeBundleItems.Select(i => new
+            {
+                i.PoolItemId,
+                i.ItemId,
+                i.ItemName,
+                i.Count,
+                i.IsUnique
+            })
+        });
 
     // ===== Stage filter =====
     private HashSet<string>? activeStages;
@@ -908,6 +1330,8 @@ else
         markersPlaced = false;
         focusedLocationId = null;
         selectedPool.Clear();
+        CancelCompositeBundle();
+        isCompositeBundleComposerOpen = false;
         treasuresRegionFilter = null;
         quickAllocation = null;
         allocationError = null;
@@ -946,6 +1370,7 @@ else
         // Prune selection of items that left the pool.
         var poolIds = poolItems.Select(p => p.Id).ToHashSet();
         selectedPool.RemoveAll(s => !poolIds.Contains(s.Id));
+        NormalizeCompositeBundleAgainstPool();
         if (treasuresRegionFilter is not null
             && !GetRegionOptions(locationCards).Contains(treasuresRegionFilter, StringComparer.CurrentCultureIgnoreCase))
             treasuresRegionFilter = null;
@@ -971,6 +1396,27 @@ else
             catch { /* prerender / JS unavailable */ }
         }
         await PlaceMarkersIfReadyAsync();
+        await WireCompositeBundleDragAsync();
+    }
+
+    private async Task WireCompositeBundleDragAsync()
+    {
+        if (!HasCompositeBundle)
+        {
+            wiredCompositeBundlePayload = null;
+            return;
+        }
+
+        var payload = BuildCompositeBundlePayload();
+        if (payload == wiredCompositeBundlePayload) return;
+        wiredCompositeBundlePayload = payload;
+        await JS.InvokeVoidAsync("ovcinaDnd.setDraggable", compositeBundleElement, payload);
+        LogTreasureAlloc("composite-drag-wire", new
+        {
+            kind = "composite",
+            clientBundleId = compositeBundleClientId,
+            units = CompositeBundleUnitCount
+        });
     }
 
     // Issue #200: persist Mapa ↔ Karty selection. Same shape as Timeline's
@@ -1182,8 +1628,15 @@ else
         {
             locationId,
             selectedCount = selectedPool.Count,
+            selectedCompositeBundle,
             view = treasuresView
         });
+
+        if (selectedCompositeBundle && HasCompositeBundle)
+        {
+            await QuickAssignCompositeBundleAsync(locationId, "click-fallback");
+            return;
+        }
 
         if (selectedPool.Count == 1)
         {
@@ -1209,6 +1662,12 @@ else
 
     private async Task StartAddToFocusedLocation(string source)
     {
+        if (focusedLocationId is int compositeLocationId && selectedCompositeBundle && HasCompositeBundle)
+        {
+            await QuickAssignCompositeBundleAsync(compositeLocationId, source);
+            return;
+        }
+
         if (focusedLocationId is int locationId && selectedPool.Count == 1)
         {
             await QuickAssignPoolItemAsync(selectedPool[0], locationId, source);
@@ -1220,7 +1679,8 @@ else
         {
             source,
             focusedLocationId,
-            selectedCount = selectedPool.Count
+            selectedCount = selectedPool.Count,
+            selectedCompositeBundle
         });
     }
 
@@ -1235,6 +1695,17 @@ else
                 args.Payload
             });
             using var doc = JsonDocument.Parse(args.Payload);
+            var payloadKind = doc.RootElement.TryGetProperty("Kind", out var kindElement)
+                ? kindElement.GetString()
+                : doc.RootElement.TryGetProperty("kind", out kindElement)
+                    ? kindElement.GetString()
+                    : null;
+            if (string.Equals(payloadKind, "composite", StringComparison.OrdinalIgnoreCase))
+            {
+                await QuickAssignCompositeBundleAsync(args.LocationId, "drop");
+                return;
+            }
+
             var poolItemId = doc.RootElement.GetProperty("PoolItemId").GetInt32();
             var picked = poolItems.FirstOrDefault(p => p.Id == poolItemId);
             if (picked is null)
@@ -1261,6 +1732,85 @@ else
     {
         focusedLocationId = null;
         focusTab = "prehled";
+    }
+
+    private async Task QuickAssignCompositeBundleAsync(int locationId, string source)
+    {
+        allocationError = null;
+        compositeBundleError = null;
+        var validationError = GetCompositeBundleValidationError();
+        if (validationError is not null)
+        {
+            compositeBundleError = validationError;
+            allocationError = validationError;
+            LogTreasureAlloc("composite-drop-commit-rejected", new
+            {
+                kind = "composite",
+                clientBundleId = compositeBundleClientId,
+                source,
+                locationId,
+                validationError
+            });
+            StateHasChanged();
+            return;
+        }
+
+        focusedLocationId = locationId;
+        focusTab = "prehled";
+        var assignments = BuildCompositeBundleAssignments();
+        var dto = new AssignTreasureDto(
+            Title: EffectiveCompositeBundleTitle,
+            Difficulty: lastUsedDifficulty,
+            GameId: gameId,
+            LocationId: locationId,
+            PoolItems: assignments);
+
+        LogTreasureAlloc("composite-drop-commit", new
+        {
+            kind = "composite",
+            clientBundleId = compositeBundleClientId,
+            source,
+            target = "location",
+            locationId,
+            dto.Title,
+            poolRows = assignments.Count,
+            poolUnits = assignments.Sum(a => a.Count)
+        });
+
+        var result = await Api.PostWithProblemAsync<AssignTreasureDto, TreasureQuestDetailDto>("/api/treasure-planning/assign", dto);
+        if (!result.Ok || result.Value is null)
+        {
+            allocationError = result.ProblemDetail ?? "Přiřazení balíčku se nepodařilo.";
+            compositeBundleError = allocationError;
+            LogTreasureAlloc("composite-drop-commit-rejected", new
+            {
+                kind = "composite",
+                clientBundleId = compositeBundleClientId,
+                source,
+                allocationError
+            });
+            StateHasChanged();
+            return;
+        }
+
+        lastUsedDifficulty = dto.Difficulty;
+        var completedBundleId = compositeBundleClientId;
+        var completedUnits = CompositeBundleUnitCount;
+        ClearCompositeBundle();
+        isCompositeBundleComposerOpen = false;
+        markersPlaced = false;
+        await LoadAllAsync();
+        await PlaceMarkersIfReadyAsync();
+        LogTreasureAlloc("composite-drop-commit-success", new
+        {
+            kind = "composite",
+            clientBundleId = completedBundleId,
+            source,
+            questId = result.Value.Id,
+            locationId,
+            poolUnits = completedUnits
+        });
+        StateHasChanged();
     }
 
     private async Task QuickAssignPoolItemAsync(TreasurePoolItemDto item, int locationId, string source)
@@ -1529,6 +2079,13 @@ else
     private async Task HandlePoolRemoveAsync(TreasurePoolItemDto item)
     {
         poolRemoveError = null;
+        if (GetCompositeBundleReservedCount(item.Id) > 0)
+        {
+            poolRemoveError = $"„{item.ItemName}“ je v rozpracovaném balíčku. Nejdřív položku odeber z balíčku nebo balíček zruš.";
+            StateHasChanged();
+            return;
+        }
+
         var ok = await Api.DeleteAsync($"/api/treasure-planning/pool/{item.Id}");
         if (!ok)
         {

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2509,6 +2509,24 @@
 .oh-tp-pool-tile-remove:hover{opacity:1;transform:scale(1.08);background:rgba(140,36,35,.98)}
 .oh-tp-pool-tile-remove:focus-visible{outline:2px solid var(--oh-stage-early);outline-offset:1px;opacity:1}
 .oh-tp-pool-tile-remove i{font-size:.6875rem;line-height:1}
+.oh-tp-bundle-composer{display:flex;flex-direction:column;gap:10px;margin-bottom:10px;padding:10px;border:1px solid var(--oh-stage-early);border-radius:8px;background:var(--oh-stage-early-soft)}
+.oh-tp-bundle-head{display:flex;gap:10px;align-items:flex-start;justify-content:space-between}
+.oh-tp-bundle-head strong{display:block;color:var(--oh-primary);font:700 .9rem var(--oh-font-body)}
+.oh-tp-bundle-head span{display:block;font-size:.75rem;color:var(--oh-text-secondary);line-height:1.25}
+.oh-tp-bundle-title{display:grid;gap:4px}
+.oh-tp-bundle-add{display:flex;gap:6px;align-items:end}
+.oh-tp-bundle-lines{display:flex;flex-direction:column;gap:4px}
+.oh-tp-bundle-line{display:flex;align-items:center;gap:7px;padding:5px 7px;border:1px solid rgba(45,80,22,.18);border-radius:7px;background:rgba(255,255,255,.72)}
+.oh-tp-bundle-line-name{flex:1;font-weight:700;font-size:.82rem;color:var(--oh-text)}
+.oh-tp-bundle-line .remove{background:none;border:none;color:var(--oh-error);padding:0 2px}
+.oh-tp-composite-tile{display:flex;align-items:center;gap:10px;margin-bottom:10px;padding:10px;border:1px solid var(--oh-primary);border-radius:8px;background:linear-gradient(135deg,var(--oh-primary-surface),#fff8ec);box-shadow:var(--oh-shadow);cursor:grab;user-select:none;transition:box-shadow .15s,transform .15s}
+.oh-tp-composite-tile:hover{transform:translateY(-1px);box-shadow:var(--oh-shadow-lg)}
+.oh-tp-composite-tile.selected{box-shadow:0 0 0 2px var(--oh-primary-light) inset,var(--oh-shadow-lg)}
+.oh-tp-composite-icon{width:36px;height:36px;border-radius:8px;background:var(--oh-primary);color:#fff;display:flex;align-items:center;justify-content:center;font-size:1.1rem;flex:0 0 auto}
+.oh-tp-composite-body{display:flex;flex-direction:column;gap:2px;min-width:0;flex:1}
+.oh-tp-composite-body strong{font:700 .9rem var(--oh-font-body);color:var(--oh-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.oh-tp-composite-body span{font:.76rem var(--oh-font-mono);color:var(--oh-text-secondary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.oh-tp-composite-count{font:800 .95rem var(--oh-font-mono);color:var(--oh-primary);padding:.18rem .45rem;border-radius:999px;background:#fff;border:1px solid rgba(45,80,22,.22)}
 
 /* Drag hint banner */
 .oh-tp-drag-hint{display:flex;align-items:center;gap:8px;padding:8px 12px;background:var(--oh-stage-early-soft);border:1px dashed var(--oh-stage-early);border-radius:var(--oh-radius-sm);color:var(--oh-text);font-size:.8125rem;margin-bottom:8px}

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2519,7 +2519,7 @@
 .oh-tp-bundle-line{display:flex;align-items:center;gap:7px;padding:5px 7px;border:1px solid rgba(45,80,22,.18);border-radius:7px;background:rgba(255,255,255,.72)}
 .oh-tp-bundle-line-name{flex:1;font-weight:700;font-size:.82rem;color:var(--oh-text)}
 .oh-tp-bundle-line .remove{background:none;border:none;color:var(--oh-error);padding:0 2px}
-.oh-tp-composite-tile{display:flex;align-items:center;gap:10px;margin-bottom:10px;padding:10px;border:1px solid var(--oh-primary);border-radius:8px;background:linear-gradient(135deg,var(--oh-primary-surface),#fff8ec);box-shadow:var(--oh-shadow);cursor:grab;user-select:none;transition:box-shadow .15s,transform .15s}
+.oh-tp-composite-tile{display:flex;align-items:center;gap:10px;width:100%;margin-bottom:10px;padding:10px;border:1px solid var(--oh-primary);border-radius:8px;background:linear-gradient(135deg,var(--oh-primary-surface),#fff8ec);box-shadow:var(--oh-shadow);cursor:grab;user-select:none;text-align:left;font:inherit;transition:box-shadow .15s,transform .15s}
 .oh-tp-composite-tile:hover{transform:translateY(-1px);box-shadow:var(--oh-shadow-lg)}
 .oh-tp-composite-tile.selected{box-shadow:0 0 0 2px var(--oh-primary-light) inset,var(--oh-shadow-lg)}
 .oh-tp-composite-icon{width:36px;height:36px;border-radius:8px;background:var(--oh-primary);color:#fff;display:flex;align-items:center;justify-content:center;font-size:1.1rem;flex:0 0 auto}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
@@ -154,6 +154,44 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
     }
 
     [Fact]
+    public async Task AssignTreasure_WithCompositePoolItems_CreatesOneQuestAndSplitsRows()
+    {
+        var game = await CreateGameAsync();
+        var location = await CreateLocationAsync();
+        var silver = await CreateItemAsync("Stříbro");
+        var bronze = await CreateItemAsync("Bronz");
+        await AssignItemToGameAsync(game.Id, silver.Id);
+        await AssignItemToGameAsync(game.Id, bronze.Id);
+        var silverPool = await AddPoolItemAsync(game.Id, silver.Id, count: 5);
+        var bronzePool = await AddPoolItemAsync(game.Id, bronze.Id, count: 3);
+
+        var assignResponse = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto(
+                Title: "Balíček: Stříbro × 2 + Bronz × 1",
+                Difficulty: GameTimePhase.Early,
+                GameId: game.Id,
+                LocationId: location.Id,
+                PoolItems:
+                [
+                    new PoolItemAssignDto(silverPool.Id, 2),
+                    new PoolItemAssignDto(bronzePool.Id, 1)
+                ]));
+        assignResponse.EnsureSuccessStatusCode();
+
+        var quest = (await assignResponse.Content.ReadFromJsonAsync<TreasureQuestDetailDto>())!;
+        Assert.Equal(2, quest.Items.Count);
+        Assert.Equal(location.Id, quest.LocationId);
+        Assert.All(quest.Items, item => Assert.Equal(quest.Id, item.TreasureQuestId));
+        Assert.Equal(2, Assert.Single(quest.Items, i => i.ItemId == silver.Id).Count);
+        Assert.Equal(1, Assert.Single(quest.Items, i => i.ItemId == bronze.Id).Count);
+
+        var poolAfterAssign = await Client.GetFromJsonAsync<List<TreasurePoolItemDto>>(
+            $"/api/treasure-planning/pool/{game.Id}");
+        Assert.Equal(3, Assert.Single(poolAfterAssign!, p => p.ItemId == silver.Id).Count);
+        Assert.Equal(2, Assert.Single(poolAfterAssign!, p => p.ItemId == bronze.Id).Count);
+    }
+
+    [Fact]
     public async Task RemoveFromPool_NonExistentRow_ReturnsNotFound()
     {
         var response = await Client.DeleteAsync("/api/treasure-planning/pool/999999");


### PR DESCRIPTION
## Summary
- add a transient inline "Vytvořit balíček" composer under the treasure pool
- reserve pool counts live while composing and render a draggable/clickable composite tile
- allocate the composed bundle as one TreasureQuest transaction through the existing PoolItems contract
- add permanent [treasure-alloc] composite/server per-item logs and an API regression test

## Verification
- dotnet build OvcinaHra.slnx --no-restore
- dotnet test OvcinaHra.slnx --no-build
- browser smoke against local client/API: compose 2× Stříbro + 1× Bronz, composite tile appears, click location allocates bundle

closes #349