### PR TITLE
Implement Ctrl+Shift location move shortcut

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -468,26 +468,50 @@ public static class LocationEndpoints
     // Location surface; defer until a broader audit need surfaces. See
     // Phase-0 Q&A on PR #284.
     private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> PatchCoordinates(
-        int id, LocationCoordinatesPatchDto dto, WorldDbContext db)
+        int id, LocationCoordinatesPatchDto dto, WorldDbContext db, ILoggerFactory loggerFactory)
     {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.LocationEndpoints");
+        logger.LogInformation(
+            "[map-diag] location.coordinates.patch.entry locationId={LocationId} lat={Latitude} lng={Longitude}",
+            id,
+            dto.Latitude,
+            dto.Longitude);
+
         var loc = await db.Locations.FindAsync(id);
         if (loc is null)
+        {
+            logger.LogInformation("[map-diag] location.coordinates.patch.not-found locationId={LocationId}", id);
             return TypedResults.NotFound();
+        }
 
         if (dto.Latitude < -90m || dto.Latitude > 90m)
+        {
+            logger.LogInformation(
+                "[map-diag] location.coordinates.patch.invalid-lat locationId={LocationId} lat={Latitude}",
+                id,
+                dto.Latitude);
             return TypedResults.Problem(
                 title: "Neplatná souřadnice",
                 detail: "Zeměpisná šířka musí být v rozsahu -90 až 90 stupňů.",
                 statusCode: StatusCodes.Status400BadRequest);
+        }
 
         if (dto.Longitude < -180m || dto.Longitude > 180m)
+        {
+            logger.LogInformation(
+                "[map-diag] location.coordinates.patch.invalid-lng locationId={LocationId} lng={Longitude}",
+                id,
+                dto.Longitude);
             return TypedResults.Problem(
                 title: "Neplatná souřadnice",
                 detail: "Zeměpisná délka musí být v rozsahu -180 až 180 stupňů.",
                 statusCode: StatusCodes.Status400BadRequest);
+        }
 
         loc.Coordinates = new GpsCoordinates(dto.Latitude, dto.Longitude);
+        logger.LogInformation("[map-diag] location.coordinates.patch.before-commit locationId={LocationId}", id);
         await db.SaveChangesAsync();
+        logger.LogInformation("[map-diag] location.coordinates.patch.committed locationId={LocationId}", id);
         return TypedResults.NoContent();
     }
 }

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -152,6 +152,12 @@
     /// boundary.</summary>
     [Parameter] public EventCallback<(int Id, double Lat, double Lng)> OnMapPagePinDrag { get; set; }
 
+    /// <summary>Fires when Ctrl+Shift+click on a map-page location pin starts shortcut move mode.</summary>
+    [Parameter] public EventCallback<(int Id, double Lat, double Lng)> OnMapPagePinMoveShortcut { get; set; }
+
+    /// <summary>Fires when Escape cancels shortcut move mode before coordinates are committed.</summary>
+    [Parameter] public EventCallback OnMapPagePinMoveShortcutCancel { get; set; }
+
     /// <summary>
     /// When set, the map loads the game's vector overlay (issue #96) and
     /// surfaces the "Upravit překryv" editor button.
@@ -800,6 +806,20 @@
     {
         Console.WriteLine($"[map-diag] MapView.OnLocationPinDragged entry id={id} lat={lat} lng={lng} hasDelegate={OnMapPagePinDrag.HasDelegate}");
         await OnMapPagePinDrag.InvokeAsync((id, lat, lng));
+    }
+
+    [JSInvokable]
+    public async Task OnLocationMoveShortcutStarted(int id, double lat, double lng)
+    {
+        Console.WriteLine($"[map-diag] MapView.OnLocationMoveShortcutStarted entry id={id} lat={lat} lng={lng} hasDelegate={OnMapPagePinMoveShortcut.HasDelegate}");
+        await OnMapPagePinMoveShortcut.InvokeAsync((id, lat, lng));
+    }
+
+    [JSInvokable]
+    public async Task OnLocationMoveShortcutCanceled()
+    {
+        Console.WriteLine($"[map-diag] MapView.OnLocationMoveShortcutCanceled entry hasDelegate={OnMapPagePinMoveShortcutCancel.HasDelegate}");
+        await OnMapPagePinMoveShortcutCancel.InvokeAsync();
     }
 
     [JSInvokable]

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -628,6 +628,7 @@
     [JSInvokable]
     public async Task OnMapPinClicked(string kind, int id)
     {
+        Console.WriteLine($"[map-diag] MapView.OnMapPinClicked entry kind={kind} id={id} hasDelegate={OnMapPagePinClick.HasDelegate}");
         if (OnMapPagePinClick.HasDelegate)
             await OnMapPagePinClick.InvokeAsync((kind, id));
     }
@@ -796,7 +797,10 @@
 
     [JSInvokable]
     public async Task OnLocationPinDragged(int id, double lat, double lng)
-        => await OnMapPagePinDrag.InvokeAsync((id, lat, lng));
+    {
+        Console.WriteLine($"[map-diag] MapView.OnLocationPinDragged entry id={id} lat={lat} lng={lng} hasDelegate={OnMapPagePinDrag.HasDelegate}");
+        await OnMapPagePinDrag.InvokeAsync((id, lat, lng));
+    }
 
     [JSInvokable]
     public async Task OnStyleLoadedCallback()

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -7,6 +7,7 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @implements IDisposable
 @using System.Security.Claims
+@using System.Globalization
 @using System.Web
 @using Microsoft.AspNetCore.Components.Authorization
 @using OvcinaHra.Shared.Dtos
@@ -73,7 +74,29 @@
                                  OnStyleLoaded="OnMapReadyAsync"
                                  OnMapPagePinClick="OnPinClickedAsync"
                                  OnMapPagePinDrag="OnPinDraggedAsync"
+                                 OnMapPagePinMoveShortcut="OnPinMoveShortcutStartedAsync"
+                                 OnMapPagePinMoveShortcutCancel="CancelShortcutMoveAsync"
                                  OnMapClick="OnMapClickAsync" />
+                        @if (_shortcutMoveActive)
+                        {
+                            <div class="oh-map-move-hint" role="status" aria-live="polite">
+                                <span><strong>Přesun: @_shortcutMoveName</strong> — klikni na novou pozici.</span>
+                                @if (_shortcutMoveError is not null)
+                                {
+                                    <span class="oh-map-move-hint-error">@_shortcutMoveError</span>
+                                }
+                                @if (_shortcutMoveSaving)
+                                {
+                                    <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+                                }
+                                <button type="button"
+                                        class="btn btn-sm btn-light"
+                                        @onclick="CancelShortcutMoveAsync"
+                                        disabled="@_shortcutMoveSaving">
+                                    Esc zruší
+                                </button>
+                            </div>
+                        }
                     </div>
 
                     <MapPinPeek Visible="@_peekVisible"
@@ -250,6 +273,15 @@
     private string _placeSearch = "";
     private bool _placeSaving;
     private string? _placeError;
+    // Ctrl+Shift+clicking a rendered location pin enters a direct move mode:
+    // the next map click writes that pin's GPS via the coordinates PATCH.
+    private bool _shortcutMoveActive;
+    private int? _shortcutMoveId;
+    private string _shortcutMoveName = "";
+    private double _shortcutMoveFromLat;
+    private double _shortcutMoveFromLng;
+    private bool _shortcutMoveSaving;
+    private string? _shortcutMoveError;
     // Issue #216 — phone-only layer rail toggle. CSS gates the visible
     // surface so on tablet/desktop this flag has no effect.
     private bool _railOpen;
@@ -542,6 +574,104 @@
         await PaintPinsAsync();
     }
 
+    private async Task OnPinMoveShortcutStartedAsync((int Id, double Lat, double Lng) e)
+    {
+        var loc = _data?.Locations.FirstOrDefault(l => l.Id == e.Id);
+        Console.WriteLine($"[map-diag] MapPage.OnPinMoveShortcutStarted locationId={e.Id} from={{lng:{FormatCoord(e.Lng)},lat:{FormatCoord(e.Lat)}}}");
+        _shortcutMoveActive = true;
+        _shortcutMoveId = e.Id;
+        _shortcutMoveName = loc?.EffectiveName ?? loc?.Name ?? "tato lokace";
+        _shortcutMoveFromLat = e.Lat;
+        _shortcutMoveFromLng = e.Lng;
+        _shortcutMoveSaving = false;
+        _shortcutMoveError = null;
+
+        _pendingDragVisible = false;
+        _placeVisible = false;
+        _peekRequestId++;
+        _peekVisible = false;
+        _peek = null;
+        _selectedLocationId = null;
+        PushUrl();
+
+        await SetShortcutMoveModeAsync(true);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task CancelShortcutMoveAsync()
+    {
+        if (!_shortcutMoveActive || _shortcutMoveSaving) return;
+        Console.WriteLine($"[map-diag] MapPage.ShortcutMove cancel locationId={_shortcutMoveId?.ToString() ?? "null"}");
+        ClearShortcutMoveState();
+        await SetShortcutMoveModeAsync(false);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task CompleteShortcutMoveAsync(double lat, double lng)
+    {
+        if (_shortcutMoveId is not int id)
+        {
+            await CancelShortcutMoveAsync();
+            return;
+        }
+
+        _shortcutMoveSaving = true;
+        _shortcutMoveError = null;
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            Console.WriteLine($"[map-diag] map.location.relocate.dispatch locationId={id} from={{lng:{FormatCoord(_shortcutMoveFromLng)},lat:{FormatCoord(_shortcutMoveFromLat)}}} to={{lng:{FormatCoord(lng)},lat:{FormatCoord(lat)}}}");
+            var (ok, problem) = await Api.PatchWithProblemAsync(
+                $"/api/locations/{id}/coordinates",
+                new LocationCoordinatesPatchDto((decimal)lat, (decimal)lng));
+            if (!ok)
+            {
+                _shortcutMoveError = problem ?? "Uložení souřadnic selhalo.";
+                Console.WriteLine($"[map-diag] MapPage.ShortcutMove failed locationId={id} problem={_shortcutMoveError}");
+                return;
+            }
+
+            ClearShortcutMoveState();
+            await SetShortcutMoveModeAsync(false);
+            await ReloadDataAndRenderAsync();
+            Console.WriteLine($"[map-diag] MapPage.ShortcutMove saved locationId={id}");
+        }
+        catch (Exception ex)
+        {
+            _shortcutMoveError = ex.Message;
+            Console.WriteLine($"[map-diag] MapPage.ShortcutMove error locationId={id} type={ex.GetType().Name} message={ex.Message}");
+        }
+        finally
+        {
+            if (_shortcutMoveActive)
+            {
+                _shortcutMoveSaving = false;
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+    }
+
+    private async Task SetShortcutMoveModeAsync(bool active)
+    {
+        try { await JS.InvokeVoidAsync("ovcinaMap.setMoveShortcutMode", active); }
+        catch (Exception ex) { Console.WriteLine($"[map-diag] MapPage.ShortcutMove js-mode-failed active={active} type={ex.GetType().Name} message={ex.Message}"); }
+    }
+
+    private void ClearShortcutMoveState()
+    {
+        _shortcutMoveActive = false;
+        _shortcutMoveId = null;
+        _shortcutMoveName = "";
+        _shortcutMoveFromLat = 0;
+        _shortcutMoveFromLng = 0;
+        _shortcutMoveSaving = false;
+        _shortcutMoveError = null;
+    }
+
+    private static string FormatCoord(double value)
+        => value.ToString("F6", CultureInfo.InvariantCulture);
+
     /// <summary>
     /// Map click handler. Plain click does nothing (peek only opens via
     /// pin clicks). Modifier-clicks open the placement picker:
@@ -552,6 +682,12 @@
     {
         Console.WriteLine($"[map-diag] MapPage.OnMapClick entry lat={e.Latitude} lng={e.Longitude} ctrl={e.CtrlKey} shift={e.ShiftKey} gameId={GameContext.SelectedGameId?.ToString() ?? "null"}");
         Console.WriteLine($"[map-diag] MapPage.OnMapClick modifier_branch branch={(e.CtrlKey && e.ShiftKey ? "ctrl_shift_relocate" : (e.CtrlKey ? "default" : "none"))}");
+        if (_shortcutMoveActive)
+        {
+            Console.WriteLine($"[map-diag] MapPage.OnMapClick shortcut-target lat={e.Latitude} lng={e.Longitude}");
+            await CompleteShortcutMoveAsync(e.Latitude, e.Longitude);
+            return;
+        }
         if (!e.CtrlKey)
         {
             Console.WriteLine("[map-diag] MapPage.OnMapClick ignored-no-ctrl");

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -479,6 +479,7 @@
     /// </summary>
     private Task OnPinDraggedAsync((int Id, double Lat, double Lng) e)
     {
+        Console.WriteLine($"[map-diag] MapPage.OnPinDragged entry locationId={e.Id} lat={e.Lat} lng={e.Lng}");
         _pendingDragId = e.Id;
         _pendingDragName = _data?.Locations.FirstOrDefault(l => l.Id == e.Id)?.Name ?? "tato lokace";
         _pendingDragLat = e.Lat;
@@ -486,6 +487,7 @@
         _pendingDragError = null;
         _pendingDragSaving = false;
         _pendingDragVisible = true;
+        Console.WriteLine($"[map-diag] MapPage.OnPinDragged popup-visible locationId={e.Id}");
         return Task.CompletedTask;
     }
 
@@ -496,6 +498,7 @@
         _pendingDragSaving = true;
         try
         {
+            Console.WriteLine($"[map-diag] MapPage.ConfirmDrag location.relocate.dispatch locationId={id} lat={_pendingDragLat} lng={_pendingDragLng}");
             // Issue #252 — PATCH /api/locations/{id}/coordinates writes only
             // Latitude + Longitude, so a concurrent organizer edit on
             // Description / Details / NpcInfo / etc. can't be clobbered.
@@ -517,9 +520,11 @@
             _pendingDragId = null;
             // Reload so the peek + pin position pick up the saved GPS.
             await ReloadDataAndRenderAsync();
+            Console.WriteLine($"[map-diag] MapPage.ConfirmDrag saved locationId={id}");
         }
         catch (Exception ex)
         {
+            Console.WriteLine($"[map-diag] MapPage.ConfirmDrag error locationId={id} type={ex.GetType().Name} message={ex.Message}");
             _pendingDragError = ex.Message;
         }
         finally
@@ -546,6 +551,7 @@
     private async Task OnMapClickAsync(OvcinaMapClickEventArgs e)
     {
         Console.WriteLine($"[map-diag] MapPage.OnMapClick entry lat={e.Latitude} lng={e.Longitude} ctrl={e.CtrlKey} shift={e.ShiftKey} gameId={GameContext.SelectedGameId?.ToString() ?? "null"}");
+        Console.WriteLine($"[map-diag] MapPage.OnMapClick modifier_branch branch={(e.CtrlKey && e.ShiftKey ? "ctrl_shift_relocate" : (e.CtrlKey ? "default" : "none"))}");
         if (!e.CtrlKey)
         {
             Console.WriteLine("[map-diag] MapPage.OnMapClick ignored-no-ctrl");
@@ -639,7 +645,12 @@
 
     private async Task OnPinClickedAsync((string Kind, int Id) click)
     {
-        if (click.Kind != "location") return;
+        Console.WriteLine($"[map-diag] MapPage.OnPinClicked entry kind={click.Kind} id={click.Id}");
+        if (click.Kind != "location")
+        {
+            Console.WriteLine($"[map-diag] MapPage.OnPinClicked ignored-kind kind={click.Kind}");
+            return;
+        }
         await OpenPeekAsync(click.Id);
     }
 

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3720,6 +3720,12 @@
 .oh-map-kind-lbl{flex:1;font-size:.875rem}
 .oh-map-kind-num{font-variant-numeric:tabular-nums;font-size:.8rem;color:var(--oh-text-muted,#6b6453)}
 .oh-map-canvas{position:relative;border:1px solid var(--oh-border,#d8d2be);border-radius:8px;overflow:hidden}
+.oh-map-move-hint{position:absolute;left:50%;top:52px;z-index:12;transform:translateX(-50%);
+    display:flex;align-items:center;flex-wrap:wrap;gap:10px;max-width:min(720px,calc(100% - 24px));
+    padding:8px 10px;border-radius:6px;background:rgba(45,80,22,.95);color:#fff;
+    box-shadow:0 2px 10px rgba(0,0,0,.22);font:600 .86rem var(--oh-font-body,sans-serif)}
+.oh-map-move-hint-error{color:#ffe1df;font-weight:700}
+.oh-map-move-hint .btn{white-space:nowrap;padding:2px 8px;font-size:.78rem}
 .oh-map-style-toolbar{position:absolute;top:8px;right:8px;z-index:10;display:flex;gap:4px;
     background:rgba(250,246,236,.92);padding:3px;border-radius:99px;
     box-shadow:0 1px 4px rgba(0,0,0,.12)}
@@ -3778,7 +3784,9 @@
    Ctrl+Click will place an ungeocoded location, Ctrl+Shift+Click will
    move an existing one). Class toggled by map-interop.js keydown/keyup. */
 .oh-map-ctrl-held .maplibregl-canvas-container,
-.oh-map-ctrl-held .maplibregl-canvas{cursor:crosshair !important}
+.oh-map-ctrl-held .maplibregl-canvas,
+.oh-map-move-shortcut-active .maplibregl-canvas-container,
+.oh-map-move-shortcut-active .maplibregl-canvas{cursor:crosshair !important}
 
 /* Issue #273 — graduated location labels. Each pin advertises a
    `data-minzoom` (set in JS from KIND_MIN_ZOOM) and the zoomend handler

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -58,6 +58,33 @@ window.ovcinaMap = {
         } catch (e) { }
     },
 
+    _eventTargetName: function (target) {
+        try {
+            if (!target) return null;
+            var tag = target.tagName ? String(target.tagName).toLowerCase() : 'unknown';
+            var cls = typeof target.className === 'string'
+                ? target.className
+                : (target.className && target.className.baseVal ? target.className.baseVal : '');
+            var suffix = cls ? '.' + String(cls).split(/\s+/).filter(Boolean).slice(0, 3).join('.') : '';
+            return tag + suffix;
+        } catch (e) {
+            return null;
+        }
+    },
+
+    _clickDiagPayload: function (e, target, lngLat, extra) {
+        var orig = e && (e.originalEvent || e);
+        var payload = {
+            ctrl: !!(orig && (orig.ctrlKey || orig.metaKey)),
+            shift: !!(orig && orig.shiftKey),
+            alt: !!(orig && orig.altKey),
+            meta: !!(orig && orig.metaKey),
+            target: target || this._eventTargetName(orig && orig.target),
+            lngLat: lngLat ? { lat: lngLat.lat, lng: lngLat.lng } : null
+        };
+        return Object.assign(payload, extra || {});
+    },
+
     init: function (elementId, dotnetRef, centerLat, centerLon, zoom, mapyCzApiKey, glyphsUrl) {
         if (this._pinDiag()) {
             console.log('[pin-diag] init() — elementId=' + elementId + ', existingMap=' + (this._map ? 'YES' : 'no') + ', center=[' + centerLon + ',' + centerLat + '], zoom=' + zoom);
@@ -90,6 +117,24 @@ window.ovcinaMap = {
             var orig = e.originalEvent;
             var ctrl = !!(orig && (orig.ctrlKey || orig.metaKey));
             var shift = !!(orig && orig.shiftKey);
+            this._mapDiag('click.enter', this._clickDiagPayload(e, 'map-canvas', e.lngLat, {
+                elementId: this._elementId,
+                hasDotNetRef: !!this._dotnetRef
+            }));
+            var features = [];
+            try { features = this._map.queryRenderedFeatures(e.point) || []; }
+            catch (err) { features = []; }
+            this._mapDiag('click.hit-test', {
+                path: features.length > 0 ? 'map-feature' : 'map-background',
+                featureCount: features.length,
+                layerIds: features.slice(0, 5).map(function (f) { return f && f.layer && f.layer.id; }).filter(Boolean)
+            });
+            this._mapDiag('click.modifier_branch', {
+                branch: ctrl && shift ? 'ctrl_shift_relocate' : (ctrl ? 'default' : 'none'),
+                ctrl: ctrl,
+                shift: shift,
+                target: 'map-canvas'
+            });
             this._mapDiag('click', {
                 elementId: this._elementId,
                 lat: e.lngLat.lat,
@@ -1223,6 +1268,21 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     wrapper.appendChild(pin);
     var self = this;
     wrapper.addEventListener('click', function (e) {
+        var payload = self._clickDiagPayload(e, 'location-pin', { lat: lat, lng: lon }, { locationId: id });
+        self._mapDiag('feature.click.enter', payload);
+        self._mapDiag('location.click.enter', payload);
+        self._mapDiag('click.hit-test', {
+            path: 'location-marker-dom',
+            target: 'location',
+            locationId: id
+        });
+        self._mapDiag('click.modifier_branch', {
+            branch: payload.ctrl && payload.shift ? 'ctrl_shift_relocate' : 'default',
+            ctrl: payload.ctrl,
+            shift: payload.shift,
+            target: 'location',
+            locationId: id
+        });
         e.stopPropagation();
         if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapPinClicked', 'location', id);
     });
@@ -1250,6 +1310,12 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
         marker.on('dragend', function () {
             var newPos = marker.getLngLat();
             if (self._dotnetRef) {
+                self._mapDiag('location.relocate.dispatch', {
+                    source: 'dragend',
+                    locationId: id,
+                    lng: newPos.lng,
+                    lat: newPos.lat
+                });
                 self._dotnetRef.invokeMethodAsync('OnLocationPinDragged', id, newPos.lat, newPos.lng);
             }
         });
@@ -1293,6 +1359,22 @@ window.ovcinaMap.addStashPin = function (id, locationId, lat, lon, name, count, 
     wrapper.appendChild(pin);
     var self = this;
     wrapper.addEventListener('click', function (e) {
+        var payload = self._clickDiagPayload(e, 'stash-pin', { lat: lat, lng: lon }, { stashId: id, locationId: locationId });
+        self._mapDiag('feature.click.enter', payload);
+        self._mapDiag('location.click.enter', payload);
+        self._mapDiag('click.hit-test', {
+            path: 'stash-marker-dom',
+            target: 'location',
+            stashId: id,
+            locationId: locationId
+        });
+        self._mapDiag('click.modifier_branch', {
+            branch: payload.ctrl && payload.shift ? 'ctrl_shift_relocate' : 'default',
+            ctrl: payload.ctrl,
+            shift: payload.shift,
+            target: 'stash-location',
+            locationId: locationId
+        });
         e.stopPropagation();
         // Stash pins open the host location's peek per the brief —
         // "stash IS at the location" — keeps one peek surface.

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -5,6 +5,7 @@ window.ovcinaMap = {
     _dotnetRef: null,
     _elementId: null,
     _apiKey: null,
+    _moveShortcutActive: false,
 
     // Glyph URL — required by MapLibre for any layer with `text-field` in
     // its layout (e.g. the overlay editor's `oh-overlay-preview-text` text
@@ -92,6 +93,7 @@ window.ovcinaMap = {
         this._dotnetRef = dotnetRef;
         this._elementId = elementId;
         this._apiKey = (mapyCzApiKey && mapyCzApiKey.length > 5) ? mapyCzApiKey : null;
+        this._moveShortcutActive = false;
         // Resolved at init so every style construction below picks up the
         // environment-specific URL (#166). Empty/missing/whitespace-only →
         // fall back to the demotiles dev URL so local smoke testing still
@@ -200,6 +202,14 @@ window.ovcinaMap = {
         // rest of the time. Listeners cleared in dispose().
         var mapContainer = this._map.getContainer();
         var keyDown = function (e) {
+            if (e.key === 'Escape' && window.ovcinaMap._moveShortcutActive) {
+                e.preventDefault();
+                window.ovcinaMap._mapDiag('location.relocate.cancel', { source: 'escape' });
+                if (window.ovcinaMap._dotnetRef) {
+                    window.ovcinaMap._dotnetRef.invokeMethodAsync('OnLocationMoveShortcutCanceled');
+                }
+                return;
+            }
             if (e.key === 'Control' || e.key === 'Meta') {
                 mapContainer.classList.add('oh-map-ctrl-held');
                 window.ovcinaMap._mapDiag('modifier.down', { key: e.key, ctrl: e.ctrlKey || e.metaKey, shift: e.shiftKey });
@@ -325,6 +335,17 @@ window.ovcinaMap = {
         }
     },
 
+    setMoveShortcutMode: function (active) {
+        this._moveShortcutActive = !!active;
+        if (this._map) {
+            var container = this._map.getContainer();
+            if (container) {
+                container.classList.toggle('oh-map-move-shortcut-active', this._moveShortcutActive);
+            }
+        }
+        this._mapDiag('location.relocate.mode', { active: this._moveShortcutActive });
+    },
+
     addMarker: function (id, lat, lon, name, kind, color) {
         if (!this._map) return;
         this.removeMarker(id);
@@ -422,6 +443,7 @@ window.ovcinaMap = {
     },
 
     dispose: function () {
+        this._moveShortcutActive = false;
         this.clearMarkers();
         if (this._map) {
             this._map.remove();
@@ -1283,6 +1305,20 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
             target: 'location',
             locationId: id
         });
+        if (self._moveShortcutActive) {
+            e.preventDefault();
+            e.stopPropagation();
+            self._mapDiag('location.relocate.target', { source: 'location-pin', locationId: id, lng: lon, lat: lat });
+            if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapClicked', lat, lon, false, false);
+            return;
+        }
+        if (payload.ctrl && payload.shift) {
+            e.preventDefault();
+            e.stopPropagation();
+            self._mapDiag('location.relocate.start', { locationId: id, from: { lng: lon, lat: lat } });
+            if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnLocationMoveShortcutStarted', id, lat, lon);
+            return;
+        }
         e.stopPropagation();
         if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapPinClicked', 'location', id);
     });
@@ -1375,6 +1411,20 @@ window.ovcinaMap.addStashPin = function (id, locationId, lat, lon, name, count, 
             target: 'stash-location',
             locationId: locationId
         });
+        if (self._moveShortcutActive) {
+            e.preventDefault();
+            e.stopPropagation();
+            self._mapDiag('location.relocate.target', { source: 'stash-pin', locationId: locationId, stashId: id, lng: lon, lat: lat });
+            if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapClicked', lat, lon, false, false);
+            return;
+        }
+        if (payload.ctrl && payload.shift) {
+            e.preventDefault();
+            e.stopPropagation();
+            self._mapDiag('location.relocate.start', { source: 'stash-pin', locationId: locationId, stashId: id, from: { lng: lon, lat: lat } });
+            if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnLocationMoveShortcutStarted', locationId, lat, lon);
+            return;
+        }
         e.stopPropagation();
         // Stash pins open the host location's peek per the brief —
         // "stash IS at the location" — keeps one peek surface.


### PR DESCRIPTION
## Summary

Implements issue #343 Q3 after Phase-0 diagnosis confirmed the DOM marker click handler was swallowing Ctrl+Shift before the MapLibre canvas click path could dispatch relocate behavior.

## Phase 0 diagnostics kept permanent

- Added `[map-diag]` markers for map canvas clicks, DOM location/stash pin clicks, Blazor bridge handlers, map-page handlers, and `PATCH /api/locations/{id}/coordinates`.
- Confirmed location/stash pins are DOM markers and their click handlers call `stopPropagation()`, so Ctrl+Shift pin clicks previously opened the peek instead of reaching the map click move path.

## Phase 1 behavior

- Ctrl+Shift+click on a location pin suppresses the peek and enters shortcut move mode for that location.
- Shortcut move mode shows a visible banner (`Přesun: ... — klikni na novou pozici.`) and crosshair cursor.
- The next map click persists the new coordinates through the existing `PATCH /api/locations/{id}/coordinates` endpoint.
- Escape or the banner button cancels before any server write.
- Added required dispatch marker: `[map-diag] map.location.relocate.dispatch locationId=... from={...} to={...}`.

## Verification

- `node --check src/OvcinaHra.Client/wwwroot/js/map-interop.js`
- `dotnet build OvcinaHra.slnx --nologo -v:minimal`
- `dotnet test OvcinaHra.slnx --no-build --nologo -v:minimal`

Refs #343