### PR TITLE
fix(client): refresh button + lore preview rename quick wins

### DIFF
--- a/src/OvcinaHra.Client/Components/MapPinPeek.razor
+++ b/src/OvcinaHra.Client/Components/MapPinPeek.razor
@@ -67,7 +67,7 @@
         @if (!string.IsNullOrWhiteSpace(Peek.LorePreview))
         {
             <section class="oh-map-peek-sec">
-                <h3>Z náhledu lóru</h3>
+                <h3>Náhled Textu</h3>
                 <p class="oh-map-peek-lore">@Peek.LorePreview</p>
                 <a class="oh-map-peek-link" href="@($"/locations/{Peek.Id}")">
                     Otevřít detail lokace <i class="bi bi-arrow-right-short"></i>

--- a/src/OvcinaHra.Client/Components/VersionDriftBanner.razor
+++ b/src/OvcinaHra.Client/Components/VersionDriftBanner.razor
@@ -1,11 +1,9 @@
 @* Persistent strip rendered at the top of MainLayout when the server's
    /api/version commit no longer matches what we recorded at app boot.
-   Click "Obnovit" → location.reload(). The PWA service worker may need a
-   second refresh to actually swap shells; that's an inherent SW lifecycle
-   quirk, not a banner bug. *@
+   Click "Obnovit" → hard browser refresh through NavigationManager.Refresh. *@
 @implements IDisposable
 @inject VersionDriftService Drift
-@inject IJSRuntime JS
+@inject NavigationManager Nav
 
 @if (Drift.IsDrifted)
 {
@@ -28,6 +26,7 @@
 @code {
     private bool _started;
     private bool reloading;
+    private string? _lastLoggedRenderState;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -37,23 +36,33 @@
             Drift.StateChanged += OnStateChanged;
             await Drift.StartAsync();
         }
+
+        LogRenderState();
     }
 
-    private void OnStateChanged() => InvokeAsync(StateHasChanged);
-
-    private async Task ReloadAsync()
+    private void OnStateChanged()
     {
-        if (reloading) return;
+        Console.WriteLine($"[version-refresh] banner state changed drifted={Drift.IsDrifted} baseline={Drift.BaselineCommit ?? "(null)"} latest={Drift.LatestCommit ?? "(null)"}");
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private Task ReloadAsync()
+    {
+        if (reloading) return Task.CompletedTask;
         reloading = true;
-        try
-        {
-            await JS.InvokeVoidAsync("location.reload");
-        }
-        catch
-        {
-            // location.reload throws if the page is mid-unload — at which
-            // point the user is already heading toward the new bundle.
-        }
+        Console.WriteLine($"[version-refresh] refresh clicked url={Nav.Uri} baseline={Drift.BaselineCommit ?? "(null)"} latest={Drift.LatestCommit ?? "(null)"}");
+        Console.WriteLine("[version-refresh] reload requested method=NavigationManager.Refresh forceReload=True");
+        Nav.Refresh(forceReload: true);
+        return Task.CompletedTask;
+    }
+
+    private void LogRenderState()
+    {
+        var renderState = $"{Drift.IsDrifted}|{Drift.BaselineCommit}|{Drift.LatestCommit}";
+        if (_lastLoggedRenderState == renderState) return;
+
+        _lastLoggedRenderState = renderState;
+        Console.WriteLine($"[version-refresh] banner render drifted={Drift.IsDrifted} baseline={Drift.BaselineCommit ?? "(null)"} latest={Drift.LatestCommit ?? "(null)"}");
     }
 
     public void Dispose() => Drift.StateChanged -= OnStateChanged;

--- a/src/OvcinaHra.Client/Services/VersionDriftService.cs
+++ b/src/OvcinaHra.Client/Services/VersionDriftService.cs
@@ -52,6 +52,7 @@ public sealed class VersionDriftService : IDisposable
 
         BaselineCommit = await FetchCommitAsync();   // may be null on transient failure
         LatestCommit = BaselineCommit;
+        Console.WriteLine($"[version-refresh] baseline captured commit={BaselineCommit ?? "(null)"}");
 
         _cts = new CancellationTokenSource();
         _ = PollLoopAsync(_cts.Token);
@@ -74,6 +75,7 @@ public sealed class VersionDriftService : IDisposable
                 {
                     BaselineCommit = current;
                     LatestCommit = current;
+                    Console.WriteLine($"[version-refresh] baseline recovered commit={BaselineCommit}");
                     continue;
                 }
 
@@ -81,6 +83,7 @@ public sealed class VersionDriftService : IDisposable
 
                 LatestCommit = current;
                 IsDrifted = true;
+                Console.WriteLine($"[version-refresh] drift detected baseline={BaselineCommit} latest={LatestCommit}");
                 StateChanged?.Invoke();
                 // Stop polling — drift is sticky until the user reloads.
                 break;
@@ -103,7 +106,14 @@ public sealed class VersionDriftService : IDisposable
         try
         {
             var info = await _api.GetAsync<VersionInfo>("/api/version");
-            return info?.Commit;
+            if (info is null)
+            {
+                Console.WriteLine("[version-refresh] /api/version read commit=(null)");
+                return null;
+            }
+
+            Console.WriteLine($"[version-refresh] /api/version read commit={info.Commit} startedUtc={info.StartedUtc:O}");
+            return info.Commit;
         }
         catch (Exception ex)
         {

--- a/src/OvcinaHra.Client/Services/VersionDriftService.cs
+++ b/src/OvcinaHra.Client/Services/VersionDriftService.cs
@@ -108,11 +108,13 @@ public sealed class VersionDriftService : IDisposable
             var info = await _api.GetAsync<VersionInfo>("/api/version");
             if (info is null)
             {
-                Console.WriteLine("[version-refresh] /api/version read commit=(null)");
+                _logger.LogDebug("[version-refresh] /api/version returned null payload");
                 return null;
             }
 
-            Console.WriteLine($"[version-refresh] /api/version read commit={info.Commit} startedUtc={info.StartedUtc:O}");
+            _logger.LogDebug("[version-refresh] /api/version read commit={Commit} startedUtc={StartedUtc:O}",
+                info.Commit,
+                info.StartedUtc);
             return info.Commit;
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- closes #367 by changing the version drift banner refresh action from JS `location.reload()` to `NavigationManager.Refresh(forceReload: true)` and adding `[version-refresh]` markers around baseline capture/recovery, drift detection, banner render/state changes, and reload request
- closes #368 by renaming the map peek lore-preview heading from `Z náhledu lóru` to `Náhled Textu`
- addressed Copilot review by moving per-poll `/api/version` diagnostics to `_logger.LogDebug` instead of browser `Console.WriteLine`

## Verification
- `dotnet build OvcinaHra.slnx`
- `dotnet test OvcinaHra.slnx --no-build`
- browser smoke at `https://localhost:5290/`: brand version rendered `v 0.16.28`; `[version-refresh]` baseline/render markers appeared
- browser smoke with mocked `/api/version` drift: banner appeared, `Obnovit` clicked, console showed `reload requested method=NavigationManager.Refresh forceReload=True`
- map smoke: peek panel opened on local data; local locations had no lore preview section to render, so rename was source-verified with old-label grep returning no matches