### PR TITLE
feat(treasures): cleanup quartet - coins, default stash, child filter, tile fix (closes #376 #377 #378 #379)

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -47,7 +47,9 @@ public static class TreasurePlanningEndpoints
     private static async Task<Ok<List<TreasurePoolItemDto>>> GetPool(int gameId, WorldDbContext db)
     {
         var items = await db.TreasureItems
-            .Where(ti => ti.GameId == gameId && ti.TreasureQuestId == null)
+            .Where(ti => ti.GameId == gameId
+                && ti.TreasureQuestId == null
+                && ti.Item.ItemType != ItemType.Money)
             .Include(ti => ti.Item)
             .OrderBy(ti => ti.Item.ItemType).ThenBy(ti => ti.Item.Name)
             .Select(ti => new TreasurePoolItemDto(ti.Id, ti.ItemId, ti.Item.Name, ti.Item.ItemType, ti.Count, ti.GameId, ti.Item.IsUnique))
@@ -65,6 +67,13 @@ public static class TreasurePlanningEndpoints
             return TypedResults.ValidationProblem(new Dictionary<string, string[]>
             {
                 ["ItemId"] = ["Předmět není přiřazen k této hře."]
+            });
+        }
+        if (gameItem.Item.ItemType == ItemType.Money)
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["ItemId"] = ["Peníze se do zásobníku nepřidávají. Použijte vytvoření pokladu z grošů na lokaci."]
             });
         }
 
@@ -125,7 +134,10 @@ public static class TreasurePlanningEndpoints
     {
         // Get limited findable items for this game
         var gameItems = await db.GameItems
-            .Where(gi => gi.GameId == gameId && gi.IsFindable && gi.StockCount != null)
+            .Where(gi => gi.GameId == gameId
+                && gi.IsFindable
+                && gi.StockCount != null
+                && gi.Item.ItemType != ItemType.Money)
             .Include(gi => gi.Item)
             .ToListAsync();
 
@@ -150,8 +162,12 @@ public static class TreasurePlanningEndpoints
         return TypedResults.Ok(result);
     }
 
-    private static async Task<Ok<List<TreasurePlanningLocationDto>>> GetLocationCards(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<TreasurePlanningLocationDto>>> GetLocationCards(
+        int gameId,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory)
     {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
         var gameLocationIds = await db.GameLocations
             .Where(gl => gl.GameId == gameId)
             .Select(gl => gl.LocationId)
@@ -164,15 +180,38 @@ public static class TreasurePlanningEndpoints
             .OrderBy(l => l.Name)
             .ToListAsync();
 
+        var childLocations = locations.Where(l => l.ParentLocationId.HasValue).ToList();
+        foreach (var child in childLocations)
+        {
+            LogTreasureAlloc(logger, LogLevel.Debug, "child location filtered", new
+            {
+                locationId = child.Id,
+                parentId = child.ParentLocationId
+            });
+        }
+
+        var childIdsByParent = childLocations
+            .GroupBy(l => l.ParentLocationId!.Value)
+            .ToDictionary(g => g.Key, g => g.Select(l => l.Id).ToList());
+        var parentLocations = locations
+            .Where(l => !l.ParentLocationId.HasValue)
+            .ToList();
+
         // Get all treasure quests for this game with their items
         var quests = await db.TreasureQuests
             .Where(tq => tq.GameId == gameId)
             .Include(tq => tq.TreasureItems)
             .ToListAsync();
 
-        var result = locations.Select(loc =>
+        var result = parentLocations.Select(loc =>
         {
-            var locationQuests = quests.Where(q => q.LocationId == loc.Id).ToList();
+            childIdsByParent.TryGetValue(loc.Id, out var childIds);
+            var visibleLocationIds = childIds is null
+                ? new HashSet<int> { loc.Id }
+                : childIds.Append(loc.Id).ToHashSet();
+            var locationQuests = quests
+                .Where(q => q.LocationId.HasValue && visibleLocationIds.Contains(q.LocationId.Value))
+                .ToList();
             var stashIds = loc.GameSecretStashes.Select(gs => gs.SecretStashId).ToHashSet();
             var stashQuests = quests.Where(q => q.SecretStashId.HasValue && stashIds.Contains(q.SecretStashId.Value)).ToList();
             var allQuests = locationQuests.Concat(stashQuests).ToList();
@@ -204,7 +243,9 @@ public static class TreasurePlanningEndpoints
     private static async Task<Ok<TreasureSummaryDto>> GetSummary(int gameId, WorldDbContext db)
     {
         var poolRemaining = await db.TreasureItems
-            .Where(ti => ti.GameId == gameId && ti.TreasureQuestId == null)
+            .Where(ti => ti.GameId == gameId
+                && ti.TreasureQuestId == null
+                && ti.Item.ItemType != ItemType.Money)
             .SumAsync(ti => ti.Count);
 
         var quests = await db.TreasureQuests
@@ -239,6 +280,8 @@ public static class TreasurePlanningEndpoints
         var poolCount = poolAssignments.Count + legacyPoolItemIds.Count;
         var unlimitedCount = dto.UnlimitedItems?.Count ?? 0;
         var isComposite = poolAssignments.Count > 1 || poolAssignments.Sum(p => p.Count) > 1;
+        var targetLocationId = dto.LocationId;
+        var targetSecretStashId = dto.SecretStashId;
         LogTreasureAlloc(logger, LogLevel.Information, "assign-entry", new
         {
             dto.GameId,
@@ -342,21 +385,44 @@ public static class TreasurePlanningEndpoints
             }
         }
 
+        if (targetLocationId is int locationId)
+        {
+            var defaultStash = await PickDefaultStashAsync(db, dto.GameId, locationId);
+            if (defaultStash is not null)
+            {
+                targetLocationId = null;
+                targetSecretStashId = defaultStash.SecretStashId;
+                LogTreasureAlloc(logger, LogLevel.Information, "default stash picked", new
+                {
+                    locationId,
+                    stashId = defaultStash.SecretStashId,
+                    reason = defaultStash.Reason
+                });
+            }
+        }
+
+        await LogGrosTreasureCreateIfNeededAsync(
+            db,
+            logger,
+            dto,
+            dto.LocationId,
+            targetSecretStashId);
+
         try
         {
             // Create the quest
             var quest = new TreasureQuest
             {
                 Title = dto.Title, Clue = dto.Clue, Difficulty = dto.Difficulty,
-                LocationId = dto.LocationId, SecretStashId = dto.SecretStashId, GameId = dto.GameId
+                LocationId = targetLocationId, SecretStashId = targetSecretStashId, GameId = dto.GameId
             };
             db.TreasureQuests.Add(quest);
             LogTreasureAlloc(logger, LogLevel.Information, "assign-before-save", new
             {
                 phase = "create-quest",
                 dto.GameId,
-                dto.LocationId,
-                dto.SecretStashId,
+                LocationId = targetLocationId,
+                SecretStashId = targetSecretStashId,
                 poolUnits = poolAssignments.Sum(p => p.Count)
             });
             await db.SaveChangesAsync(); // get the ID
@@ -382,8 +448,8 @@ public static class TreasurePlanningEndpoints
                     poolItem.ItemId,
                     requestedCount = assignment.Count,
                     availableCount = poolItem.Count,
-                    dto.LocationId,
-                    dto.SecretStashId
+                    LocationId = targetLocationId,
+                    SecretStashId = targetSecretStashId
                 });
                 AssignPoolItemToQuest(poolItem, assignment.Count, quest.Id, db);
                 LogTreasureAlloc(logger, LogLevel.Information, "assign-item-after", new
@@ -394,8 +460,8 @@ public static class TreasurePlanningEndpoints
                     poolItem.ItemId,
                     assignedCount = assignment.Count,
                     remainingPoolCount = poolItem.TreasureQuestId is null ? poolItem.Count : 0,
-                    dto.LocationId,
-                    dto.SecretStashId
+                    LocationId = targetLocationId,
+                    SecretStashId = targetSecretStashId
                 });
             }
 
@@ -455,6 +521,78 @@ public static class TreasurePlanningEndpoints
             throw;
         }
     }
+
+    private sealed record DefaultStashPick(int SecretStashId, string Reason);
+
+    private static async Task<DefaultStashPick?> PickDefaultStashAsync(WorldDbContext db, int gameId, int locationId)
+    {
+        var candidates = await db.GameSecretStashes
+            .Where(gs => gs.GameId == gameId && gs.LocationId == locationId)
+            .Select(gs => new
+            {
+                gs.SecretStashId,
+                gs.SecretStash.Name,
+                ItemCount = db.TreasureQuests
+                    .Where(tq => tq.GameId == gameId && tq.SecretStashId == gs.SecretStashId)
+                    .SelectMany(tq => tq.TreasureItems)
+                    .Sum(ti => (int?)ti.Count) ?? 0
+            })
+            .ToListAsync();
+
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        var minCount = candidates.Min(c => c.ItemCount);
+        var tied = candidates
+            .Where(c => c.ItemCount == minCount)
+            .OrderBy(c => c.Name, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(c => c.SecretStashId)
+            .ToList();
+
+        var selected = tied[0];
+        var reason = tied.Count > 1 ? "tiebreak-alpha" : "lowest-count";
+        return new DefaultStashPick(selected.SecretStashId, reason);
+    }
+
+    private static async Task LogGrosTreasureCreateIfNeededAsync(
+        WorldDbContext db,
+        ILogger logger,
+        AssignTreasureDto dto,
+        int? sourceLocationId,
+        int? targetSecretStashId)
+    {
+        if (dto.UnlimitedItems is not { Count: > 0 } unlimitedItems)
+        {
+            return;
+        }
+
+        var itemIds = unlimitedItems.Select(i => i.ItemId).ToHashSet();
+        var itemsById = await db.Items
+            .Where(i => itemIds.Contains(i.Id))
+            .ToDictionaryAsync(i => i.Id);
+        var gros = unlimitedItems.FirstOrDefault(ui =>
+            itemsById.TryGetValue(ui.ItemId, out var item)
+            && item.ItemType == ItemType.Money
+            && IsGrosItemName(item.Name));
+
+        if (gros is null)
+        {
+            return;
+        }
+
+        LogTreasureAlloc(logger, LogLevel.Information, "gros-treasure-create", new
+        {
+            locationId = sourceLocationId,
+            stashId = targetSecretStashId,
+            count = gros.Count
+        });
+    }
+
+    private static bool IsGrosItemName(string name) =>
+        string.Equals(name.Trim(), "Groše", StringComparison.CurrentCultureIgnoreCase)
+        || name.Contains("groš", StringComparison.CurrentCultureIgnoreCase);
 
     private static async Task<Results<Ok<TreasureItemDto>, ValidationProblem, NotFound>> AdjustTreasureItemCount(
         int id,
@@ -685,7 +823,10 @@ public static class TreasurePlanningEndpoints
 
         // 1. Fetch findable items with stock for this game.
         var gameItems = await db.GameItems
-            .Where(gi => gi.GameId == gameId && gi.IsFindable && gi.StockCount != null)
+            .Where(gi => gi.GameId == gameId
+                && gi.IsFindable
+                && gi.StockCount != null
+                && gi.Item.ItemType != ItemType.Money)
             .Include(gi => gi.Item)
             .ToListAsync();
 

--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -168,10 +168,19 @@ public static class TreasurePlanningEndpoints
         ILoggerFactory loggerFactory)
     {
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
-        var gameLocationIds = await db.GameLocations
+        var assignedLocationIds = await db.GameLocations
             .Where(gl => gl.GameId == gameId)
             .Select(gl => gl.LocationId)
             .ToListAsync();
+
+        var parentIdsForAssignedChildren = await db.Locations
+            .Where(l => assignedLocationIds.Contains(l.Id) && l.ParentLocationId.HasValue)
+            .Select(l => l.ParentLocationId!.Value)
+            .ToListAsync();
+        var gameLocationIds = assignedLocationIds
+            .Concat(parentIdsForAssignedChildren)
+            .Distinct()
+            .ToList();
 
         var locations = await db.Locations
             .Where(l => gameLocationIds.Contains(l.Id))
@@ -234,7 +243,11 @@ public static class TreasurePlanningEndpoints
                 allQuests.SelectMany(q => q.TreasureItems).Sum(ti => ti.Count),
                 loc.GameSecretStashes.Count, 3,
                 stashSummaries,
-                Region: loc.Region);
+                Region: loc.Region,
+                Latitude: loc.Coordinates?.Latitude,
+                Longitude: loc.Coordinates?.Longitude,
+                EffectiveLatitude: loc.Coordinates?.Latitude,
+                EffectiveLongitude: loc.Coordinates?.Longitude);
         }).ToList();
 
         return TypedResults.Ok(result);

--- a/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
+++ b/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
@@ -4,29 +4,35 @@
 @implements IAsyncDisposable
 
 <div @ref="elementRef"
-     role="button"
-     tabindex="0"
      class="@CssClass"
-     @key="Location.LocationId"
-     @onclick="HandleClick"
-     @onkeydown="HandleKeyDown">
-    <div class="oh-tp-card-hdr">
-        <span class="oh-tp-card-kind">@Location.LocationKind.GetDisplayName()</span>
-        <span class="oh-tp-card-count">@Location.TotalItems pokladů</span>
-    </div>
-    <div class="oh-tp-card-name">
-        @Location.LocationName <span class="oh-tp-card-name-count">(@Location.TotalItems)</span>
-    </div>
-    @if (Location.StashCount > 0)
-    {
-        <div class="oh-tp-card-stash">
-            <i class="bi bi-archive"></i> @Location.StashCount / @Location.MaxStashes skrýší
-            @if (Location.Stashes.Sum(s => s.ItemCount) > 0)
-            {
-                <span>· @Location.Stashes.Sum(s => s.ItemCount) ve skrýších</span>
-            }
+     @key="Location.LocationId">
+    <button type="button"
+            class="oh-tp-card-main"
+            @onclick="HandleClick">
+        <div class="oh-tp-card-hdr">
+            <span class="oh-tp-card-kind">@Location.LocationKind.GetDisplayName()</span>
+            <span class="oh-tp-card-count">@Location.TotalItems pokladů</span>
         </div>
-    }
+        <div class="oh-tp-card-name">
+            @Location.LocationName <span class="oh-tp-card-name-count">(@Location.TotalItems)</span>
+        </div>
+        @if (Location.StashCount > 0)
+        {
+            <div class="oh-tp-card-stash">
+                <i class="bi bi-archive"></i> @Location.StashCount / @Location.MaxStashes skrýší
+                @if (Location.Stashes.Sum(s => s.ItemCount) > 0)
+                {
+                    <span>· @Location.Stashes.Sum(s => s.ItemCount) ve skrýších</span>
+                }
+            </div>
+        }
+        @if (HasSelectedPool)
+        {
+            <div class="oh-tp-card-cta">
+                <i class="bi bi-plus-circle"></i> Přidat vybrané sem
+            </div>
+        }
+    </button>
     <div class="oh-tp-card-actions">
         <button type="button"
                 class="oh-tp-card-gros"
@@ -36,12 +42,6 @@
             <i class="bi bi-coin"></i> Vytvoř poklad z grošů
         </button>
     </div>
-    @if (HasSelectedPool)
-    {
-        <div class="oh-tp-card-cta">
-            <i class="bi bi-plus-circle"></i> Přidat vybrané sem
-        </div>
-    }
 </div>
 
 @code {
@@ -76,16 +76,6 @@
     private Task HandleClick() => OnClick.InvokeAsync(Location.LocationId);
 
     private Task HandleGrosClick() => OnCreateGrosTreasure.InvokeAsync(Location.LocationId);
-
-    private Task HandleKeyDown(KeyboardEventArgs args)
-    {
-        if (args.Key is "Enter" or " ")
-        {
-            return HandleClick();
-        }
-
-        return Task.CompletedTask;
-    }
 
     [JSInvokable]
     public Task OnTreasurePoolDropped(int locationId, string payload) =>

--- a/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
+++ b/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
@@ -3,11 +3,13 @@
 @inject IJSRuntime JS
 @implements IAsyncDisposable
 
-<button @ref="elementRef"
-        type="button"
-        class="@CssClass"
-        @key="Location.LocationId"
-        @onclick="HandleClick">
+<div @ref="elementRef"
+     role="button"
+     tabindex="0"
+     class="@CssClass"
+     @key="Location.LocationId"
+     @onclick="HandleClick"
+     @onkeydown="HandleKeyDown">
     <div class="oh-tp-card-hdr">
         <span class="oh-tp-card-kind">@Location.LocationKind.GetDisplayName()</span>
         <span class="oh-tp-card-count">@Location.TotalItems pokladů</span>
@@ -25,19 +27,29 @@
             }
         </div>
     }
+    <div class="oh-tp-card-actions">
+        <button type="button"
+                class="oh-tp-card-gros"
+                @onclick="HandleGrosClick"
+                @onclick:stopPropagation="true"
+                @onkeydown:stopPropagation="true">
+            <i class="bi bi-coin"></i> Vytvoř poklad z grošů
+        </button>
+    </div>
     @if (HasSelectedPool)
     {
         <div class="oh-tp-card-cta">
             <i class="bi bi-plus-circle"></i> Přidat vybrané sem
         </div>
     }
-</button>
+</div>
 
 @code {
     [Parameter, EditorRequired] public TreasurePlanningLocationDto Location { get; set; } = default!;
     [Parameter] public bool IsFocused { get; set; }
     [Parameter] public bool HasSelectedPool { get; set; }
     [Parameter] public EventCallback<int> OnClick { get; set; }
+    [Parameter] public EventCallback<int> OnCreateGrosTreasure { get; set; }
     [Parameter] public EventCallback<PiePayloadEventArgs> OnDrop { get; set; }
 
     private ElementReference elementRef;
@@ -62,6 +74,18 @@
     }
 
     private Task HandleClick() => OnClick.InvokeAsync(Location.LocationId);
+
+    private Task HandleGrosClick() => OnCreateGrosTreasure.InvokeAsync(Location.LocationId);
+
+    private Task HandleKeyDown(KeyboardEventArgs args)
+    {
+        if (args.Key is "Enter" or " ")
+        {
+            return HandleClick();
+        }
+
+        return Task.CompletedTask;
+    }
 
     [JSInvokable]
     public Task OnTreasurePoolDropped(int locationId, string payload) =>

--- a/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
+++ b/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
@@ -3,8 +3,10 @@
 @inject IJSRuntime JS
 
 <div @ref="elementRef"
+     id="@tileTargetId"
      class="oh-tp-pool-tile @(Selected ? "selected" : "") @(Item.IsUnique ? "is-unique" : "is-aggregate")"
-     title="@TileLabel"
+     @onmouseenter="() => isNameFlyoutOpen = true"
+     @onmouseleave="() => isNameFlyoutOpen = false"
      @onclick="OnClickInternal">
     @if (!imageFailed)
     {
@@ -20,7 +22,7 @@
     }
     @if (!Item.IsUnique)
     {
-        <div class="oh-tp-pool-tile-badge">@Item.ItemName × @Item.Count</div>
+        <div class="oh-tp-pool-tile-badge">× @Item.Count</div>
     }
 
     @* Unobtrusive remove affordance — unbundled from the draggable surface:
@@ -34,7 +36,6 @@
     <button type="button"
             class="oh-tp-pool-tile-remove"
             draggable="false"
-            title="Odebrat ze zásobníku"
             aria-label="Odebrat ze zásobníku"
             @onmousedown:stopPropagation="true"
             @onmousedown:preventDefault="true"
@@ -45,6 +46,14 @@
 
     <div class="oh-tp-pool-tile-name">@Item.ItemName</div>
 </div>
+
+<DxFlyout @bind-IsOpen="@isNameFlyoutOpen"
+          PositionTarget="@($"#{tileTargetId}")"
+          Position="FlyoutPosition.Top"
+          BodyText="@TileLabel"
+          HeaderVisible="false"
+          CloseOnOutsideClick="false"
+          Width="220px" />
 
 <DxPopup @bind-Visible="@isRemoveVisible"
          HeaderText="Odebrat ze zásobníku?"
@@ -85,7 +94,9 @@
     private int _wiredForPoolItemId = -1;
 
     private bool isRemoveVisible;
+    private bool isNameFlyoutOpen;
     private bool removing;
+    private string tileTargetId => $"oh-tp-pool-tile-{Item.Id}";
     private string TileLabel => Item.IsUnique ? Item.ItemName : $"{Item.ItemName} × {Item.Count}";
 
     protected override void OnParametersSet()

--- a/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
+++ b/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
@@ -5,8 +5,14 @@
 <div @ref="elementRef"
      id="@tileTargetId"
      class="oh-tp-pool-tile @(Selected ? "selected" : "") @(Item.IsUnique ? "is-unique" : "is-aggregate")"
+     role="button"
+     tabindex="0"
+     aria-label="@TileLabel"
+     title="@TileLabel"
      @onmouseenter="() => isNameFlyoutOpen = true"
      @onmouseleave="() => isNameFlyoutOpen = false"
+     @onfocus="() => isNameFlyoutOpen = true"
+     @onblur="() => isNameFlyoutOpen = false"
      @onclick="OnClickInternal">
     @if (!imageFailed)
     {
@@ -125,6 +131,7 @@
                 Kind = Item.IsUnique ? "unique" : "non-unique"
             });
             await JS.InvokeVoidAsync("ovcinaDnd.setDraggable", elementRef, payload);
+            await JS.InvokeVoidAsync("ovcinaDnd.setKeyboardButton", elementRef);
         }
     }
 

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -205,11 +205,12 @@ else
                                         @foreach (var loc in grp.OrderBy(l => l.LocationName))
                                         {
                                             var isFocused = focusedLocationId == loc.LocationId;
-                                            <TreasureLocationTargetCard Location="loc"
-                                                                        IsFocused="isFocused"
-                                                                        HasSelectedPool="@HasPendingAllocation"
-                                                                        OnClick="HandleLocationTargetClick"
-                                                                        OnDrop="HandlePieDrop" />
+                                             <TreasureLocationTargetCard Location="loc"
+                                                                         IsFocused="isFocused"
+                                                                         HasSelectedPool="@HasPendingAllocation"
+                                                                         OnClick="HandleLocationTargetClick"
+                                                                         OnCreateGrosTreasure="OpenGrosTreasureDialog"
+                                                                         OnDrop="HandlePieDrop" />
                                         }
                                     </div>
                                 </div>
@@ -433,6 +434,11 @@ else
                                         <i class="bi bi-plus-circle me-1"></i>Přiřadit vybrané sem
                                     </button>
                                 }
+                                <button type="button"
+                                        class="btn btn-sm btn-outline-primary"
+                                        @onclick="() => OpenGrosTreasureDialog(loc.LocationId)">
+                                    <i class="bi bi-coin me-1"></i>Vytvoř poklad z grošů
+                                </button>
                             </div>
                             @if (quickAllocation is { IsUnique: false } qa && qa.LocationId == loc.LocationId)
                             {
@@ -576,6 +582,31 @@ else
             <button class="btn btn-primary" @onclick="AddToPoolAsync" disabled="@(poolSaving || poolItemId is null)">
                 @if (poolSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
                 Přidat
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@* ================== CREATE GROS TREASURE POPUP ================== *@
+<DxPopup @bind-Visible="@isGrosDialogVisible" HeaderText="Vytvoř poklad z grošů" Width="420px">
+    <BodyContentTemplate Context="popupContext">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
+                <div class="oh-tp-gros-location">@GrosDialogLocationName</div>
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Kolik grošů?" ColSpanMd="12">
+                <DxSpinEdit @bind-Value="@grosCount" MinValue="1" MaxValue="9999" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        @if (grosError is not null)
+        {
+            <div class="alert alert-danger mt-2">@grosError</div>
+        }
+        <div class="d-flex gap-2 mt-3 justify-content-end">
+            <button class="btn btn-secondary" type="button" @onclick="CloseGrosDialog" disabled="@grosSaving">Zrušit</button>
+            <button class="btn btn-primary" type="button" @onclick="CreateGrosTreasureAsync" disabled="@(grosSaving || grosLocationId is null)">
+                @if (grosSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit
             </button>
         </div>
     </BodyContentTemplate>
@@ -1283,6 +1314,17 @@ else
     private string? poolError;
     private List<AvailablePoolItemDto> findableItems = [];
 
+    // ===== Groše treasure popup =====
+    private bool isGrosDialogVisible;
+    private bool grosSaving;
+    private int? grosLocationId;
+    private int grosCount = 1;
+    private string? grosError;
+    private string GrosDialogLocationName =>
+        grosLocationId is int id
+            ? locationCards.FirstOrDefault(l => l.LocationId == id)?.LocationName ?? $"Lokace #{id}"
+            : "";
+
     // ===== Edit-quest popup =====
     private bool isEditQuestVisible, isDeleteQuestVisible, editSaving;
     private int? editQuestId;
@@ -1501,6 +1543,7 @@ else
         // last resort) so games without placements still render somewhere
         // sensible.
         var placed = locations
+            .Where(l => !l.ParentLocationId.HasValue)
             .Select(ToLocatedTreasureLocation)
             .OfType<LocatedTreasureLocation>()
             .ToList();
@@ -1990,6 +2033,79 @@ else
         }
         catch (Exception ex) { poolError = ex.Message; }
         finally { poolSaving = false; }
+    }
+
+    // ===== Groše treasure popup =====
+    private void OpenGrosTreasureDialog(int locationId)
+    {
+        grosLocationId = locationId;
+        grosCount = 1;
+        grosError = null;
+        isGrosDialogVisible = true;
+        LogTreasureAlloc("gros-dialog open", new { locationId });
+    }
+
+    private void CloseGrosDialog()
+    {
+        if (grosSaving) return;
+        isGrosDialogVisible = false;
+        grosError = null;
+    }
+
+    private UnlimitedItemDto? FindGrosItem() =>
+        unlimitedItems.FirstOrDefault(i =>
+            i.ItemType == ItemType.Money
+            && (string.Equals(i.ItemName.Trim(), "Groše", StringComparison.CurrentCultureIgnoreCase)
+                || i.ItemName.Contains("groš", StringComparison.CurrentCultureIgnoreCase)));
+
+    private async Task CreateGrosTreasureAsync()
+    {
+        if (grosLocationId is not int locationId || grosSaving) return;
+        grosError = null;
+        var grosItem = FindGrosItem();
+        if (grosItem is null)
+        {
+            grosError = "Ve hře není nalézatelná položka Groše typu Peníze.";
+            return;
+        }
+
+        grosSaving = true;
+        try
+        {
+            var count = Math.Max(1, grosCount);
+            var dto = new AssignTreasureDto(
+                Title: $"Groše × {count}",
+                Difficulty: lastUsedDifficulty,
+                GameId: gameId,
+                LocationId: locationId,
+                UnlimitedItems: [new UnlimitedItemAssignDto(grosItem.ItemId, count)]);
+
+            var result = await Api.PostWithProblemAsync<AssignTreasureDto, TreasureQuestDetailDto>(
+                "/api/treasure-planning/assign",
+                dto);
+            if (!result.Ok || result.Value is null)
+            {
+                grosError = result.ProblemDetail ?? "Vytvoření pokladu z grošů se nepodařilo.";
+                return;
+            }
+
+            lastUsedDifficulty = dto.Difficulty;
+            isGrosDialogVisible = false;
+            markersPlaced = false;
+            await LoadAllAsync();
+            await PlaceMarkersIfReadyAsync();
+            LogTreasureAlloc("gros-treasure-create", new
+            {
+                locationId,
+                stashId = result.Value.SecretStashId,
+                count
+            });
+            StateHasChanged();
+        }
+        finally
+        {
+            grosSaving = false;
+        }
     }
 
     // ===== Bulk refill (issue #160) =====

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -1289,7 +1289,7 @@ else
     private MapView? mapView;
     private bool styleLoaded;
     private bool markersPlaced;
-    private sealed record LocatedTreasureLocation(LocationListDto Location, decimal Latitude, decimal Longitude);
+    private sealed record LocatedTreasureLocation(TreasurePlanningLocationDto Location, decimal Latitude, decimal Longitude);
 
     // ===== Overview =====
     private bool overviewVisible;
@@ -1542,28 +1542,25 @@ else
         // placed. Saved bbox stays as a fallback (and CZ countryside as a
         // last resort) so games without placements still render somewhere
         // sensible.
-        var placed = locations
-            .Where(l => !l.ParentLocationId.HasValue)
+        var placed = locationCards
             .Select(ToLocatedTreasureLocation)
             .OfType<LocatedTreasureLocation>()
             .ToList();
-        var cardsByLocationId = locationCards.ToDictionary(c => c.LocationId);
 
         await FitMapToLocationExtentOrFallbackAsync(placed);
         foreach (var placedLocation in placed)
         {
-            var loc = placedLocation.Location;
-            cardsByLocationId.TryGetValue(loc.Id, out var card);
-            if (card is null || card.TotalItems == 0)
+            var card = placedLocation.Location;
+            if (card.TotalItems == 0)
             {
-                await mapView.AddZeroMarkerAsync(loc.Id,
+                await mapView.AddZeroMarkerAsync(card.LocationId,
                     (double)placedLocation.Latitude, (double)placedLocation.Longitude,
-                    loc.Name, KindSlug(loc.LocationKind));
+                    card.LocationName, KindSlug(card.LocationKind));
             }
             else
             {
                 var counts = new[] { card.StartCount, card.EarlyCount, card.MidgameCount, card.LategameCount };
-                await mapView.AddPieMarkerAsync(loc.Id,
+                await mapView.AddPieMarkerAsync(card.LocationId,
                     (double)placedLocation.Latitude, (double)placedLocation.Longitude,
                     counts);
             }
@@ -1577,12 +1574,12 @@ else
     private int? _cachedBoundsGameId;
     private (double SwLat, double SwLng, double NeLat, double NeLng)? _cachedBounds;
 
-    private static LocatedTreasureLocation? ToLocatedTreasureLocation(LocationListDto location)
+    private static LocatedTreasureLocation? ToLocatedTreasureLocation(TreasurePlanningLocationDto location)
     {
         if (location.EffectiveLatitude.HasValue && location.EffectiveLongitude.HasValue)
             return new LocatedTreasureLocation(location, location.EffectiveLatitude.Value, location.EffectiveLongitude.Value);
 
-        if (!location.ParentLocationId.HasValue && location.Latitude.HasValue && location.Longitude.HasValue)
+        if (location.Latitude.HasValue && location.Longitude.HasValue)
             return new LocatedTreasureLocation(location, location.Latitude.Value, location.Longitude.Value);
 
         return null;

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3259,10 +3259,12 @@
     border-radius:8px;padding:.6rem .7rem;text-align:left;cursor:pointer;
     transition:.12s ease;display:flex;flex-direction:column;gap:.25rem}
 .oh-tp-card:hover{background:#F2EBD8;border-color:#2D5016}
-.oh-tp-card:focus-visible{outline:2px solid #C19A3A;outline-offset:2px}
+.oh-tp-card:focus-within{outline:2px solid #C19A3A;outline-offset:2px}
 .oh-tp-card.is-focused{border-color:#2D5016;box-shadow:0 0 0 2px rgba(45,80,22,.18)}
 .oh-tp-card.has-pending{border-style:dashed}
 .oh-tp-card.oh-tp-card-dragtarget{border-color:#2D5016;background:var(--oh-primary-surface,#E8F0E4);box-shadow:0 0 0 3px rgba(45,80,22,.18)}
+.oh-tp-card-main{display:flex;flex-direction:column;gap:.25rem;width:100%;padding:0;border:0;background:transparent;text-align:left;font:inherit;color:inherit;cursor:pointer}
+.oh-tp-card-main:focus-visible{outline:none}
 .oh-tp-card-hdr{display:flex;justify-content:space-between;align-items:center;gap:.4rem;font-size:.75rem;color:var(--oh-text-secondary,#666)}
 .oh-tp-card-kind{text-transform:capitalize;font-family:'JetBrains Mono',monospace}
 .oh-tp-card-count{background:#2D5016;color:#fff;border-radius:999px;padding:.05rem .4rem;font-size:.7rem;white-space:nowrap}

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2500,8 +2500,7 @@
 .oh-tp-pool-tile-img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
 .oh-tp-pool-tile-fallback{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:1.5rem;color:var(--oh-primary-light);background:var(--oh-surface-alt)}
 .oh-tp-pool-tile-name{position:absolute;left:4px;right:4px;bottom:4px;font:600 .75rem var(--oh-font-body);color:#fff;text-shadow:0 1px 3px rgba(0,0,0,.8);line-height:1.15;max-height:2.3em;overflow:hidden}
-.oh-tp-pool-tile-badge{position:absolute;top:4px;right:4px;left:4px;background:rgba(45,80,22,.92);color:#fff;border-radius:99px;padding:2px 7px;font:700 .75rem var(--oh-font-mono);letter-spacing:0;text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.oh-tp-pool-tile.is-aggregate .oh-tp-pool-tile-name{padding-top:1.2rem}
+.oh-tp-pool-tile-badge{position:absolute;top:4px;right:4px;z-index:3;background:rgba(45,80,22,.92);color:#fff;border-radius:99px;padding:2px 7px;font:700 .75rem var(--oh-font-mono);letter-spacing:0;text-align:center;white-space:nowrap;max-width:calc(100% - 32px);overflow:hidden;text-overflow:ellipsis}
 /* Remove affordance — sits at top-left so it doesn't collide with the count
    badge. Always visible but low-opacity; hover bumps to full opacity. Sized
    small enough to stay unobtrusive on the 5:7 tile. */
@@ -2569,6 +2568,7 @@
 .oh-tp-chosen-row .remove{background:none;border:none;color:var(--oh-error);cursor:pointer;padding:0 4px}
 .oh-tp-form-footer{display:flex;gap:8px;justify-content:flex-end;align-items:center;padding-top:12px;border-top:1px solid var(--oh-border);margin-top:12px}
 .oh-tp-form-footer .spacer{flex:1}
+.oh-tp-gros-location{font:700 .95rem var(--oh-font-body);color:var(--oh-primary);padding:.35rem .5rem;border:1px solid var(--oh-border);border-radius:6px;background:var(--oh-surface-alt)}
 
 /* Zone 3 — overview ---------------------------------------- */
 .oh-tp-z3{background:var(--oh-surface);border:1px solid var(--oh-card-border,var(--oh-border));border-radius:var(--oh-radius);box-shadow:var(--oh-shadow);overflow:hidden}
@@ -3259,6 +3259,7 @@
     border-radius:8px;padding:.6rem .7rem;text-align:left;cursor:pointer;
     transition:.12s ease;display:flex;flex-direction:column;gap:.25rem}
 .oh-tp-card:hover{background:#F2EBD8;border-color:#2D5016}
+.oh-tp-card:focus-visible{outline:2px solid #C19A3A;outline-offset:2px}
 .oh-tp-card.is-focused{border-color:#2D5016;box-shadow:0 0 0 2px rgba(45,80,22,.18)}
 .oh-tp-card.has-pending{border-style:dashed}
 .oh-tp-card.oh-tp-card-dragtarget{border-color:#2D5016;background:var(--oh-primary-surface,#E8F0E4);box-shadow:0 0 0 3px rgba(45,80,22,.18)}
@@ -3268,6 +3269,9 @@
 .oh-tp-card-name{font-weight:600;color:var(--oh-text,#2a2a2a);font-size:.95rem}
 .oh-tp-card-name-count{color:var(--oh-text-secondary,#666);font-family:'JetBrains Mono',monospace;font-size:.82rem}
 .oh-tp-card-stash{font-size:.75rem;color:var(--oh-text-secondary,#666);display:flex;align-items:center;gap:.3rem}
+.oh-tp-card-actions{display:flex;margin-top:.2rem}
+.oh-tp-card-gros{display:inline-flex;align-items:center;gap:.3rem;border:1px solid var(--oh-border,#D9CFB6);border-radius:999px;background:#fff8ec;color:#2D5016;padding:.2rem .55rem;font:700 .75rem var(--oh-font-body);cursor:pointer}
+.oh-tp-card-gros:hover{background:#F2EBD8;border-color:#B8A87A}
 .oh-tp-card-cta{margin-top:.2rem;display:inline-flex;align-items:center;gap:.3rem;color:#2D5016;font-weight:600;font-size:.78rem}
 .oh-tp-location-total{font-family:'JetBrains Mono',monospace;font-size:.85rem;color:var(--oh-text-secondary,#666);margin-left:.35rem}
 .oh-tp-stash-summary{display:flex;flex-wrap:wrap;gap:.35rem;margin:.45rem 0 .7rem}

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -765,6 +765,7 @@ window.ovcinaMap.setStageFilter = function (stages) {
 window.ovcinaDnd = {
     _wired: new WeakMap(),
     _dropTargets: new WeakMap(),
+    _keyboardButtons: new WeakSet(),
 
     parsePayload: function (payload) {
         try {
@@ -795,6 +796,16 @@ window.ovcinaDnd = {
         });
         element.addEventListener('dragend', function () {
             element.classList.remove('oh-tp-pool-tile-dragging');
+        });
+    },
+
+    setKeyboardButton: function (element) {
+        if (!element || this._keyboardButtons.has(element)) return;
+        this._keyboardButtons.add(element);
+        element.addEventListener('keydown', function (e) {
+            if (e.target !== element || (e.key !== ' ' && e.key !== 'Enter')) return;
+            e.preventDefault();
+            element.click();
         });
     },
 

--- a/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
@@ -60,7 +60,11 @@ public record TreasurePlanningLocationDto(
     int StartCount, int EarlyCount, int MidgameCount, int LategameCount,
     int TotalItems, int StashCount, int MaxStashes,
     List<StashSummaryDto> Stashes,
-    string? Region = null);
+    string? Region = null,
+    decimal? Latitude = null,
+    decimal? Longitude = null,
+    decimal? EffectiveLatitude = null,
+    decimal? EffectiveLongitude = null);
 
 public record StashSummaryDto(int Id, string Name, int ItemCount);
 

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
@@ -293,7 +293,6 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
         var game = await CreateGameAsync();
         var parent = await CreateLocationAsync("Starý brod");
         var child = await CreateLocationAsync("Starý brod - břeh", parent.Id);
-        await AssignLocationToGameAsync(game.Id, parent.Id);
         await AssignLocationToGameAsync(game.Id, child.Id);
         var gros = await CreateItemAsync("Groše", ItemType.Money);
 
@@ -308,6 +307,8 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
         Assert.NotNull(cards);
         var card = Assert.Single(cards!);
         Assert.Equal(parent.Id, card.LocationId);
+        Assert.Equal(49.5m, card.EffectiveLatitude);
+        Assert.Equal(17.1m, card.EffectiveLongitude);
         Assert.Equal(4, card.TotalItems);
         Assert.DoesNotContain(cards!, c => c.LocationId == child.Id);
     }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
@@ -19,27 +19,50 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
         return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
     }
 
-    private async Task<LocationDetailDto> CreateLocationAsync()
+    private async Task<LocationDetailDto> CreateLocationAsync(string name = "Skála", int? parentLocationId = null)
     {
         var response = await Client.PostAsJsonAsync("/api/locations",
-            new CreateLocationDto("Skála", LocationKind.Wilderness, 49.5m, 17.1m));
+            new CreateLocationDto(name, LocationKind.Wilderness, 49.5m, 17.1m, ParentLocationId: parentLocationId));
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<LocationDetailDto>())!;
     }
 
-    private async Task<ItemDetailDto> CreateItemAsync(string name)
+    private async Task<ItemDetailDto> CreateItemAsync(string name, ItemType itemType = ItemType.Potion)
     {
         var response = await Client.PostAsJsonAsync("/api/items",
-            new CreateItemDto(name, ItemType.Potion));
+            new CreateItemDto(name, itemType));
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<ItemDetailDto>())!;
     }
 
-    private async Task AssignItemToGameAsync(int gameId, int itemId)
+    private async Task AssignItemToGameAsync(int gameId, int itemId, int? stockCount = null, bool isFindable = false)
     {
         var response = await Client.PostAsJsonAsync("/api/items/game-item",
-            new CreateGameItemDto(gameId, itemId));
+            new CreateGameItemDto(gameId, itemId, StockCount: stockCount, IsFindable: isFindable));
         response.EnsureSuccessStatusCode();
+    }
+
+    private async Task AssignLocationToGameAsync(int gameId, int locationId)
+    {
+        var response = await Client.PostAsJsonAsync("/api/locations/by-game",
+            new GameLocationDto(gameId, locationId));
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<SecretStashDetailDto> CreateSecretStashAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/secret-stashes",
+            new CreateSecretStashDto(name));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<SecretStashDetailDto>())!;
+    }
+
+    private async Task<GameSecretStashDto> AssignStashToGameAsync(int gameId, int stashId, int locationId)
+    {
+        var response = await Client.PostAsJsonAsync("/api/secret-stashes/game-stash",
+            new CreateGameSecretStashDto(gameId, stashId, locationId));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameSecretStashDto>())!;
     }
 
     private async Task<TreasurePoolItemDto> AddPoolItemAsync(int gameId, int itemId, int count = 1)
@@ -189,6 +212,104 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
             $"/api/treasure-planning/pool/{game.Id}");
         Assert.Equal(3, Assert.Single(poolAfterAssign!, p => p.ItemId == silver.Id).Count);
         Assert.Equal(2, Assert.Single(poolAfterAssign!, p => p.ItemId == bronze.Id).Count);
+    }
+
+    [Fact]
+    public async Task MoneyItems_CannotBeAddedToPoolOrAvailableItems()
+    {
+        var game = await CreateGameAsync();
+        var bronze = await CreateItemAsync("Bronz", ItemType.Money);
+        await AssignItemToGameAsync(game.Id, bronze.Id, stockCount: 50, isFindable: true);
+
+        var addResponse = await Client.PostAsJsonAsync("/api/treasure-planning/pool",
+            new CreateTreasurePoolItemDto(bronze.Id, game.Id, 10));
+        Assert.Equal(HttpStatusCode.BadRequest, addResponse.StatusCode);
+
+        var available = await Client.GetFromJsonAsync<List<AvailablePoolItemDto>>(
+            $"/api/treasure-planning/available-items/{game.Id}");
+        Assert.NotNull(available);
+        Assert.DoesNotContain(available!, i => i.ItemId == bronze.Id);
+
+        var pool = await Client.GetFromJsonAsync<List<TreasurePoolItemDto>>(
+            $"/api/treasure-planning/pool/{game.Id}");
+        Assert.NotNull(pool);
+        Assert.DoesNotContain(pool!, i => i.ItemId == bronze.Id);
+    }
+
+    [Fact]
+    public async Task AssignTreasure_ToLocationWithStashes_DefaultsToLowestCountStashThenAlphabeticalTie()
+    {
+        var game = await CreateGameAsync();
+        var location = await CreateLocationAsync();
+        await AssignLocationToGameAsync(game.Id, location.Id);
+        var stashA = await CreateSecretStashAsync("Skrýš A");
+        var stashB = await CreateSecretStashAsync("Skrýš B");
+        var stashC = await CreateSecretStashAsync("Skrýš C");
+        await AssignStashToGameAsync(game.Id, stashA.Id, location.Id);
+        await AssignStashToGameAsync(game.Id, stashB.Id, location.Id);
+        await AssignStashToGameAsync(game.Id, stashC.Id, location.Id);
+        var filler = await CreateItemAsync("Výplň");
+        var bronze = await CreateItemAsync("Bronz");
+        await AssignItemToGameAsync(game.Id, bronze.Id);
+        var pool = await AddPoolItemAsync(game.Id, bronze.Id, count: 2);
+
+        var seedA = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto("A má pět", GameTimePhase.Early, game.Id,
+                SecretStashId: stashA.Id,
+                UnlimitedItems: [new UnlimitedItemAssignDto(filler.Id, 5)]));
+        seedA.EnsureSuccessStatusCode();
+        var seedB = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto("B má čtyři", GameTimePhase.Early, game.Id,
+                SecretStashId: stashB.Id,
+                UnlimitedItems: [new UnlimitedItemAssignDto(filler.Id, 4)]));
+        seedB.EnsureSuccessStatusCode();
+        var seedC = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto("C má pět", GameTimePhase.Early, game.Id,
+                SecretStashId: stashC.Id,
+                UnlimitedItems: [new UnlimitedItemAssignDto(filler.Id, 5)]));
+        seedC.EnsureSuccessStatusCode();
+
+        var firstAssign = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto("První bronz", GameTimePhase.Early, game.Id,
+                LocationId: location.Id,
+                PoolItems: [new PoolItemAssignDto(pool.Id, 1)]));
+        firstAssign.EnsureSuccessStatusCode();
+        var firstQuest = (await firstAssign.Content.ReadFromJsonAsync<TreasureQuestDetailDto>())!;
+        Assert.Null(firstQuest.LocationId);
+        Assert.Equal(stashB.Id, firstQuest.SecretStashId);
+
+        var secondAssign = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto("Druhý bronz", GameTimePhase.Early, game.Id,
+                LocationId: location.Id,
+                PoolItems: [new PoolItemAssignDto(pool.Id, 1)]));
+        secondAssign.EnsureSuccessStatusCode();
+        var secondQuest = (await secondAssign.Content.ReadFromJsonAsync<TreasureQuestDetailDto>())!;
+        Assert.Equal(stashA.Id, secondQuest.SecretStashId);
+    }
+
+    [Fact]
+    public async Task GetLocationCards_ExcludesChildLocationsAndRollsTheirDirectTreasuresIntoParent()
+    {
+        var game = await CreateGameAsync();
+        var parent = await CreateLocationAsync("Starý brod");
+        var child = await CreateLocationAsync("Starý brod - břeh", parent.Id);
+        await AssignLocationToGameAsync(game.Id, parent.Id);
+        await AssignLocationToGameAsync(game.Id, child.Id);
+        var gros = await CreateItemAsync("Groše", ItemType.Money);
+
+        var assignResponse = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto("Dětský poklad", GameTimePhase.Early, game.Id,
+                LocationId: child.Id,
+                UnlimitedItems: [new UnlimitedItemAssignDto(gros.Id, 4)]));
+        assignResponse.EnsureSuccessStatusCode();
+
+        var cards = await Client.GetFromJsonAsync<List<TreasurePlanningLocationDto>>(
+            $"/api/treasure-planning/locations/{game.Id}");
+        Assert.NotNull(cards);
+        var card = Assert.Single(cards!);
+        Assert.Equal(parent.Id, card.LocationId);
+        Assert.Equal(4, card.TotalItems);
+        Assert.DoesNotContain(cards!, c => c.LocationId == child.Id);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add per-location `Vytvoř poklad z grošů` flow using the existing assign endpoint and Groše unlimited item.
- Default location-target allocations to the lowest-count stash with alphabetical tie-breaker.
- Return parent-only treasure location cards while rolling child direct treasures into the parent count.
- Restore pool tile layout: one label, visible remove button, count badge, DxFlyout name hint.

## Verification
- `git diff --check`
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test OvcinaHra.slnx --no-build`
- Temporary local browser smoke: cards view, child hidden, money absent from pool, pool tile DOM has one label/badge/remove button, Groše popup creates 30 gr treasure in lowest-count stash.