### PR TITLE
feat(exports): polish filenames and magic book layout

### DIFF
--- a/src/OvcinaHra.Api/Services/ExplorerMapExportService.cs
+++ b/src/OvcinaHra.Api/Services/ExplorerMapExportService.cs
@@ -582,41 +582,17 @@ public sealed class ExplorerMapExportService(
         _ => "#2D5016"
     };
 
-    private static string Slugify(string value)
-    {
-        var normalized = NormalizePdfText(value, 80).ToLowerInvariant();
-        var builder = new StringBuilder(normalized.Length);
-        var previousDash = false;
-
-        foreach (var ch in normalized)
-        {
-            if (ch is >= 'a' and <= 'z' or >= '0' and <= '9')
-            {
-                builder.Append(ch);
-                previousDash = false;
-            }
-            else if (!previousDash)
-            {
-                builder.Append('-');
-                previousDash = true;
-            }
-        }
-
-        var result = builder.ToString().Trim('-');
-        return string.IsNullOrWhiteSpace(result) ? "ovcina" : result;
-    }
-
     private static string BuildFileName(string gameName, MapExportKind kind)
     {
-        var suffix = kind switch
+        var exportType = kind switch
         {
-            MapExportKind.Explorer => "postavy",
-            MapExportKind.Organizer => "organizatori",
-            MapExportKind.Kingdom => "kralovstvi-A3",
-            _ => "mapa"
+            MapExportKind.Explorer => "PostavyA4",
+            MapExportKind.Organizer => "OrganizatorA4",
+            MapExportKind.Kingdom => "KralovstviA3",
+            _ => "Mapa"
         };
 
-        return $"{Slugify(gameName)}-{suffix}-{DateTime.Today:yyyy-MM-dd}.pdf";
+        return ExportFilenameBuilder.BuildExportFilename(exportType, gameName, includeDate: true);
     }
 
     private static string NormalizePdfText(string value, int maxLength)

--- a/src/OvcinaHra.Api/Services/ExportFilenameBuilder.cs
+++ b/src/OvcinaHra.Api/Services/ExportFilenameBuilder.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+using System.Text;
+
+namespace OvcinaHra.Api.Services;
+
+public static class ExportFilenameBuilder
+{
+    public static string BuildExportFilename(string exportType, string gameName, bool includeDate = false)
+    {
+        var date = includeDate ? $"_{DateTime.Today:yyyy-MM-dd}" : string.Empty;
+        return $"{SanitizePart(exportType, "Export")}_{SanitizePart(gameName, "Hra")}{date}.pdf";
+    }
+
+    private static string SanitizePart(string value, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        var normalized = value.Normalize(NormalizationForm.FormD);
+        var builder = new StringBuilder(normalized.Length);
+        var previousDash = false;
+
+        foreach (var ch in normalized)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) == UnicodeCategory.NonSpacingMark)
+                continue;
+
+            var current = ch switch
+            {
+                '–' or '—' or '−' => '-',
+                'Ł' => 'L',
+                'ł' => 'l',
+                _ => ch
+            };
+
+            if (current is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9')
+            {
+                builder.Append(current);
+                previousDash = false;
+                continue;
+            }
+
+            if (!previousDash)
+            {
+                builder.Append('-');
+                previousDash = true;
+            }
+        }
+
+        var result = builder.ToString().Trim('-');
+        return string.IsNullOrWhiteSpace(result) ? fallback : result;
+    }
+}

--- a/src/OvcinaHra.Api/Services/MagicBookExportPlanner.cs
+++ b/src/OvcinaHra.Api/Services/MagicBookExportPlanner.cs
@@ -70,7 +70,7 @@ public sealed class MagicBookExportPlanner(WorldDbContext db) : IMagicBookExport
                 BuildPage(1, "Úrovně I-III", LowLevelPage, spells),
                 BuildPage(2, "Úrovně IV-V", HighLevelPage, spells)
             ],
-            MagicBookImpositionPlan.TwoUpA4Duplex());
+            MagicBookImpositionPlan.FourUpA4Duplex());
     }
 
     private static MagicBookPage BuildPage(
@@ -143,7 +143,7 @@ public sealed record MagicBookImpositionPlan(
     double SafeMarginMm,
     IReadOnlyList<MagicBookImpositionSheet> Sheets)
 {
-    public static MagicBookImpositionPlan TwoUpA4Duplex() => new(
+    public static MagicBookImpositionPlan FourUpA4Duplex() => new(
         MagicBookExportPlanner.A4WidthMm,
         MagicBookExportPlanner.A4HeightMm,
         MagicBookExportPlanner.A6WidthMm,
@@ -154,20 +154,27 @@ public sealed record MagicBookImpositionPlan(
                 1,
                 "front",
                 [
-                    new MagicBookImpositionSlot(1, 1, CenteredA6X, 0),
-                    new MagicBookImpositionSlot(2, 1, CenteredA6X, A4HalfY)
+                    new MagicBookImpositionSlot(1, 1, LeftA6X, TopA6Y),
+                    new MagicBookImpositionSlot(2, 1, RightA6X, TopA6Y),
+                    new MagicBookImpositionSlot(3, 1, LeftA6X, BottomA6Y),
+                    new MagicBookImpositionSlot(4, 1, RightA6X, BottomA6Y)
                 ]),
             new MagicBookImpositionSheet(
                 2,
                 "back",
                 [
-                    new MagicBookImpositionSlot(1, 2, CenteredA6X, 0),
-                    new MagicBookImpositionSlot(2, 2, CenteredA6X, A4HalfY)
+                    new MagicBookImpositionSlot(1, 2, LeftA6X, TopA6Y),
+                    new MagicBookImpositionSlot(2, 2, RightA6X, TopA6Y),
+                    new MagicBookImpositionSlot(3, 2, LeftA6X, BottomA6Y),
+                    new MagicBookImpositionSlot(4, 2, RightA6X, BottomA6Y)
                 ])
         ]);
 
-    private const double CenteredA6X = (MagicBookExportPlanner.A4WidthMm - MagicBookExportPlanner.A6WidthMm) / 2;
-    private const double A4HalfY = MagicBookExportPlanner.A4HeightMm / 2;
+    private const double LeftA6X = 0;
+    private const double RightA6X = MagicBookExportPlanner.A6WidthMm;
+    private const double TopA6Y =
+        (MagicBookExportPlanner.A4HeightMm - MagicBookExportPlanner.A6HeightMm * 2) / 2;
+    private const double BottomA6Y = TopA6Y + MagicBookExportPlanner.A6HeightMm;
 }
 
 public sealed record MagicBookImpositionSheet(

--- a/src/OvcinaHra.Api/Services/MagicBookExportService.cs
+++ b/src/OvcinaHra.Api/Services/MagicBookExportService.cs
@@ -36,10 +36,15 @@ public sealed class MagicBookExportService(
     private const int A6WidthPx = 1240;
     private const int A6HeightPx = 1748;
     private const int SafeMarginPx = 60;
+    private const int SectionGapPx = 24;
+    private const int SectionPaddingPx = 18;
+    private const int SectionHeaderHeightPx = 48;
+    private const int SpellNameLineHeightPx = 36;
+    private const int BodyLineHeightPx = 30;
+    private const int SpellGapPx = 14;
 
     private static readonly Color Paper = Color.ParseHex("#fff8e8");
     private static readonly Color Ink = Color.ParseHex("#26180f");
-    private static readonly Color Muted = Color.ParseHex("#6d5a45");
     private static readonly Color Border = Color.ParseHex("#3b2b18");
 
     public async Task<MagicBookExportFile> RenderMagicBookAsync(int gameId, CancellationToken ct = default)
@@ -51,8 +56,8 @@ public sealed class MagicBookExportService(
             throw new MagicBookExportProblemException("Vybraná hra nemá přiřazená žádná kouzla.");
 
         var fonts = LoadFonts();
-        using var lowLevelPage = RenderA6Page(document, document.Pages[0], fonts);
-        using var highLevelPage = RenderA6Page(document, document.Pages[1], fonts);
+        using var lowLevelPage = RenderA6Page(document.Pages[0], fonts);
+        using var highLevelPage = RenderA6Page(document.Pages[1], fonts);
         var sheets = new[]
         {
             await RenderA4SheetAsync(lowLevelPage, ct),
@@ -68,12 +73,14 @@ public sealed class MagicBookExportService(
             .ToList();
 
         var pdf = SimpleImagePdfWriter.Build(pages);
-        var fileName = $"{Slugify(document.GameName)}-kniha-magie-{DateTime.Today:yyyy-MM-dd}.pdf";
+        var fileName = ExportFilenameBuilder.BuildExportFilename(
+            "KnihaMagie",
+            document.GameName,
+            includeDate: true);
         return new MagicBookExportFile(pdf, fileName);
     }
 
     private static Image<Rgba32> RenderA6Page(
-        MagicBookDocument document,
         MagicBookPage page,
         MagicBookFonts fonts)
     {
@@ -81,93 +88,109 @@ public sealed class MagicBookExportService(
         image.Mutate(ctx =>
         {
             ctx.Draw(Border, 4, new RectangularPolygon(18, 18, A6WidthPx - 36, A6HeightPx - 36));
-            DrawText(ctx, $"Kniha magie - {document.GameName}", fonts.Title, Ink, SafeMarginPx, 44);
-            DrawText(ctx, page.Title, fonts.Meta, Muted, SafeMarginPx, 96);
+            var sectionPlans = BuildSectionPlans(page, maxEffectLines: 2);
+            if (TotalSectionHeight(sectionPlans) > A6HeightPx - SafeMarginPx * 2)
+                sectionPlans = BuildSectionPlans(page, maxEffectLines: 1);
 
-            var y = 145f;
-            foreach (var section in page.Sections)
-            {
-                if (section.Spells.Count == 0)
-                    continue;
-
-                DrawSectionHeader(ctx, section, fonts, ref y);
-                foreach (var spell in section.Spells)
-                    DrawSpell(ctx, spell, fonts, ref y, A6HeightPx - SafeMarginPx);
-            }
+            var y = (float)SafeMarginPx;
+            foreach (var section in sectionPlans)
+                DrawSection(ctx, section, fonts, ref y);
         });
         return image;
     }
 
-    private static void DrawSectionHeader(
+    private static List<MagicBookSectionPlan> BuildSectionPlans(MagicBookPage page, int maxEffectLines) =>
+        page.Sections
+            .Where(section => section.Spells.Count > 0)
+            .Select(section =>
+            {
+                var spells = section.Spells
+                    .Select(spell =>
+                    {
+                        var brief = string.IsNullOrWhiteSpace(spell.Effect)
+                            ? spell.Description ?? string.Empty
+                            : spell.Effect;
+                        var lines = Wrap(brief, 70).Take(maxEffectLines).ToList();
+                        var height = SpellNameLineHeightPx + lines.Count * BodyLineHeightPx + SpellGapPx;
+                        return new MagicBookSpellPlan(spell, lines, height);
+                    })
+                    .ToList();
+                var height = SectionPaddingPx * 2
+                    + SectionHeaderHeightPx
+                    + spells.Sum(spell => spell.Height);
+                return new MagicBookSectionPlan(section, spells, height);
+            })
+            .ToList();
+
+    private static float TotalSectionHeight(IReadOnlyList<MagicBookSectionPlan> sections) =>
+        sections.Sum(section => section.Height) + Math.Max(0, sections.Count - 1) * SectionGapPx;
+
+    private static void DrawSection(
         IImageProcessingContext ctx,
-        MagicBookLevelSection section,
+        MagicBookSectionPlan plan,
         MagicBookFonts fonts,
         ref float y)
     {
-        var color = Color.ParseHex(section.ColorHex);
-        ctx.Fill(color, new RectangularPolygon(SafeMarginPx, y, A6WidthPx - SafeMarginPx * 2, 38));
-        ctx.Draw(Border, 2, new RectangularPolygon(SafeMarginPx, y, A6WidthPx - SafeMarginPx * 2, 38));
-        DrawText(ctx, $"Úroveň {section.LevelRoman}", fonts.Section, Ink, SafeMarginPx + 14, y + 3);
-        y += 52;
+        var color = Color.ParseHex(plan.Section.ColorHex);
+        var textColor = plan.Section.Level == 5 ? Color.White : Ink;
+        var box = new RectangularPolygon(SafeMarginPx, y, A6WidthPx - SafeMarginPx * 2, plan.Height);
+        ctx.Fill(color, box);
+        ctx.Draw(Border, 3, box);
+
+        var header = $"Kouzla úrovně {plan.Section.LevelRoman}";
+        DrawCenteredText(
+            ctx,
+            header,
+            fonts.Section,
+            textColor,
+            SafeMarginPx,
+            y + SectionPaddingPx - 2,
+            A6WidthPx - SafeMarginPx * 2);
+
+        y += SectionPaddingPx + SectionHeaderHeightPx;
+        foreach (var spell in plan.Spells)
+            DrawSpell(ctx, spell, fonts, textColor, ref y);
+
+        y += SectionPaddingPx + SectionGapPx;
     }
 
     private static void DrawSpell(
         IImageProcessingContext ctx,
-        MagicBookSpell spell,
+        MagicBookSpellPlan plan,
         MagicBookFonts fonts,
-        ref float y,
-        float bottom)
+        Color textColor,
+        ref float y)
     {
-        if (y > bottom - 72)
-            return;
-
-        DrawText(ctx, spell.Name, fonts.SpellName, Ink, SafeMarginPx, y);
-        var meta = BuildMetaLine(spell);
-        if (!string.IsNullOrWhiteSpace(meta))
-            DrawText(ctx, meta, fonts.Meta, Muted, SafeMarginPx + 420, y + 4);
-
-        y += 29;
-        foreach (var line in Wrap(spell.Effect, 88).Take(3))
+        DrawText(ctx, plan.Spell.Name, fonts.SpellName, textColor, SafeMarginPx + SectionPaddingPx, y);
+        y += SpellNameLineHeightPx;
+        foreach (var line in plan.EffectLines)
         {
-            DrawText(ctx, line, fonts.Body, Ink, SafeMarginPx, y);
-            y += 25;
+            DrawText(ctx, line, fonts.Body, textColor, SafeMarginPx + SectionPaddingPx, y);
+            y += BodyLineHeightPx;
         }
 
-        if (!string.IsNullOrWhiteSpace(spell.Description) && y < bottom - 38)
-        {
-            foreach (var line in Wrap(spell.Description, 96).Take(1))
-            {
-                DrawText(ctx, line, fonts.Small, Muted, SafeMarginPx, y);
-                y += 21;
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(spell.AvailabilityNotes) && y < bottom - 38)
-        {
-            foreach (var line in Wrap(spell.AvailabilityNotes, 96).Take(1))
-            {
-                DrawText(ctx, line, fonts.Small, Muted, SafeMarginPx, y);
-                y += 21;
-            }
-        }
-
-        y += 12;
+        y += SpellGapPx;
     }
 
     private static async Task<PdfImage> RenderA4SheetAsync(Image<Rgba32> bookPage, CancellationToken ct)
     {
         using var sheet = new Image<Rgba32>(A4WidthPx, A4HeightPx, Color.White);
-        var x = (A4WidthPx - A6WidthPx) / 2;
-        var halfHeight = A4HeightPx / 2;
-        var topY = (halfHeight - A6HeightPx) / 2;
-        var bottomY = halfHeight + topY;
+        var topY = (A4HeightPx - A6HeightPx * 2) / 2;
+        var slots = new[]
+        {
+            new Point(0, topY),
+            new Point(A6WidthPx, topY),
+            new Point(0, topY + A6HeightPx),
+            new Point(A6WidthPx, topY + A6HeightPx)
+        };
 
         sheet.Mutate(ctx =>
         {
-            ctx.DrawImage(bookPage, new Point(x, topY), 1f);
-            ctx.DrawImage(bookPage, new Point(x, bottomY), 1f);
-            ctx.Draw(Color.ParseHex("#dddddd"), 2, new RectangularPolygon(x, topY, A6WidthPx, A6HeightPx));
-            ctx.Draw(Color.ParseHex("#dddddd"), 2, new RectangularPolygon(x, bottomY, A6WidthPx, A6HeightPx));
+            foreach (var slot in slots)
+            {
+                ctx.DrawImage(bookPage, slot, 1f);
+                ctx.Draw(Color.ParseHex("#dddddd"), 2, new RectangularPolygon(slot.X, slot.Y, A6WidthPx, A6HeightPx));
+            }
         });
 
         await using var stream = new MemoryStream();
@@ -183,12 +206,9 @@ public sealed class MagicBookExportService(
         var bold = fonts.Add(System.IO.Path.Combine(fontRoot, "Kalam-Bold.ttf"));
 
         return new MagicBookFonts(
-            Title: bold.CreateFont(38),
-            Section: bold.CreateFont(28),
-            SpellName: bold.CreateFont(25),
-            Body: regular.CreateFont(22),
-            Meta: regular.CreateFont(18),
-            Small: regular.CreateFont(17));
+            Section: bold.CreateFont(34),
+            SpellName: bold.CreateFont(30),
+            Body: regular.CreateFont(25));
     }
 
     private static void DrawText(
@@ -199,6 +219,19 @@ public sealed class MagicBookExportService(
         float x,
         float y) =>
         ctx.DrawText(text, font, color, new PointF(x, y));
+
+    private static void DrawCenteredText(
+        IImageProcessingContext ctx,
+        string text,
+        Font font,
+        Color color,
+        float x,
+        float y,
+        float width)
+    {
+        var size = TextMeasurer.MeasureSize(text, new TextOptions(font));
+        DrawText(ctx, text, font, color, x + (width - size.Width) / 2, y);
+    }
 
     private static IEnumerable<string> Wrap(string value, int maxChars)
     {
@@ -226,45 +259,20 @@ public sealed class MagicBookExportService(
             yield return current;
     }
 
-    private static string BuildMetaLine(MagicBookSpell spell)
-    {
-        var parts = new List<string> { $"mana {spell.ManaCost}" };
-        if (spell.MinMageLevel > 1)
-            parts.Add($"mág {LevelRoman(spell.MinMageLevel)}");
-        if (spell.EffectivePrice is int price)
-            parts.Add($"{price} gr");
-        if (spell.IsReaction)
-            parts.Add("reakce");
-        if (spell.IsFindable)
-            parts.Add("nález");
-        return string.Join(" · ", parts);
-    }
-
-    private static string LevelRoman(int level) => level switch
-    {
-        1 => "I",
-        2 => "II",
-        3 => "III",
-        4 => "IV",
-        5 => "V",
-        _ => level.ToString(System.Globalization.CultureInfo.InvariantCulture)
-    };
-
     private static string Pt(double value) => value.ToString("0.###", CultureInfo.InvariantCulture);
 
-    private static string Slugify(string value)
-    {
-        var normalized = value.ToLowerInvariant();
-        var chars = normalized.Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray();
-        return string.Join('-', new string(chars)
-            .Split('-', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
-    }
-
     private sealed record MagicBookFonts(
-        Font Title,
         Font Section,
         Font SpellName,
-        Font Body,
-        Font Meta,
-        Font Small);
+        Font Body);
+
+    private sealed record MagicBookSectionPlan(
+        MagicBookLevelSection Section,
+        IReadOnlyList<MagicBookSpellPlan> Spells,
+        float Height);
+
+    private sealed record MagicBookSpellPlan(
+        MagicBookSpell Spell,
+        IReadOnlyList<string> EffectLines,
+        float Height);
 }

--- a/src/OvcinaHra.Client/Pages/Exports/Exports.razor
+++ b/src/OvcinaHra.Client/Pages/Exports/Exports.razor
@@ -60,7 +60,7 @@
         </button>
         <button type="button"
                 class="oh-exports-card oh-exports-card-button"
-                title="Vyexportuje knihu kouzel do A4 PDF, které po rozstřižení dá dvě A6 knížečky."
+                title="Vyexportuje knihu kouzel do A4 PDF, které po rozstřižení dá čtyři A6 knížečky."
                 disabled="@isMagicBookDownloading"
                 @onclick="DownloadMagicBookAsync">
             <div class="oh-exports-card-icon">
@@ -75,7 +75,7 @@
             </div>
             <div class="oh-exports-card-body">
                 <h3>Export Knihy magie (A4 → A6)</h3>
-                <p>Dvě A6 stránky kouzel aktuální hry, vytištěné dvakrát na A4.</p>
+                <p>Dvě A6 stránky kouzel aktuální hry, vytištěné čtyřikrát na A4.</p>
             </div>
         </button>
     </div>

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ExportEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ExportEndpointTests.cs
@@ -242,7 +242,9 @@ public class ExportEndpointTests(PostgresFixture postgres)
         var bytes = await response.Content.ReadAsByteArrayAsync();
         var pdfText = Encoding.ASCII.GetString(bytes);
         Assert.Contains("/MediaBox [0 0 841.89 1190.551]", pdfText);
-        Assert.Contains("edition-30-kralovstvi-A3-", response.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
+        Assert.Equal(
+            $"KralovstviA3_Edition-30_{DateTime.Today:yyyy-MM-dd}.pdf",
+            response.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
         WriteMapSmokeArtifact("kingdom-smoke.pdf", bytes);
     }
 
@@ -347,7 +349,9 @@ public class ExportEndpointTests(PostgresFixture postgres)
 
         response.EnsureSuccessStatusCode();
         Assert.Equal("application/pdf", response.Content.Headers.ContentType?.MediaType);
-        Assert.Contains("edition-30-kniha-magie-", response.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
+        Assert.Equal(
+            $"KnihaMagie_Edition-30_{DateTime.Today:yyyy-MM-dd}.pdf",
+            response.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
         var bytes = await response.Content.ReadAsByteArrayAsync();
         Assert.StartsWith("%PDF-1.4", Encoding.ASCII.GetString(bytes, 0, 8));
         var pdfText = Encoding.ASCII.GetString(bytes);

--- a/tests/OvcinaHra.Api.Tests/Services/ExportFilenameBuilderTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Services/ExportFilenameBuilderTests.cs
@@ -1,0 +1,27 @@
+using OvcinaHra.Api.Services;
+
+namespace OvcinaHra.Api.Tests.Services;
+
+public class ExportFilenameBuilderTests
+{
+    [Fact]
+    public void BuildExportFilename_UsesExportTypeGameAndOptionalDate()
+    {
+        var fileName = ExportFilenameBuilder.BuildExportFilename(
+            "OrganizatorA4",
+            "Balinova pozvánka",
+            includeDate: true);
+
+        Assert.Equal($"OrganizatorA4_Balinova-pozvanka_{DateTime.Today:yyyy-MM-dd}.pdf", fileName);
+    }
+
+    [Fact]
+    public void BuildExportFilename_SanitizesDiacriticsAndUnsafeSeparators()
+    {
+        var fileName = ExportFilenameBuilder.BuildExportFilename(
+            "SeznamKouzel",
+            "Žluťoučký kůň / Černý:les");
+
+        Assert.Equal("SeznamKouzel_Zlutoucky-kun-Cerny-les.pdf", fileName);
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Services/MagicBookExportPlannerTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Services/MagicBookExportPlannerTests.cs
@@ -127,7 +127,7 @@ public class MagicBookExportPlannerTests(PostgresFixture postgres)
     }
 
     [Fact]
-    public async Task BuildAsync_CarriesTwoUpA4DuplexPlan()
+    public async Task BuildAsync_CarriesFourUpA4DuplexPlan()
     {
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
@@ -150,9 +150,14 @@ public class MagicBookExportPlannerTests(PostgresFixture postgres)
         Assert.Equal(105, document.Imposition.SlotWidthMm);
         Assert.Equal(148, document.Imposition.SlotHeightMm);
         Assert.Equal(2, document.Imposition.Sheets.Count);
-        Assert.All(document.Imposition.Sheets, sheet => Assert.Equal(2, sheet.Slots.Count));
+        Assert.All(document.Imposition.Sheets, sheet => Assert.Equal(4, sheet.Slots.Count));
         Assert.All(document.Imposition.Sheets[0].Slots, slot => Assert.Equal(1, slot.MagicBookPageNumber));
         Assert.All(document.Imposition.Sheets[1].Slots, slot => Assert.Equal(2, slot.MagicBookPageNumber));
+        Assert.Equal(new[] { 1, 2, 3, 4 }, document.Imposition.Sheets[0].Slots.Select(slot => slot.CopyNumber));
+        Assert.Equal(0, document.Imposition.Sheets[0].Slots[0].XMm);
+        Assert.Equal(105, document.Imposition.Sheets[0].Slots[1].XMm);
+        Assert.Equal(0.5, document.Imposition.Sheets[0].Slots[0].YMm, precision: 3);
+        Assert.Equal(148.5, document.Imposition.Sheets[0].Slots[2].YMm, precision: 3);
     }
 
     private static Game CreateGame(string name, int edition) => new()


### PR DESCRIPTION
## Summary
- add shared ASCII-safe export filename builder and wire map + magic book downloads to export-type/game/date names
- switch Magic book A4 export to 4-up A6 imposition and update the export card copy
- simplify magic book pages: no redundant game header/subtitle, no mana/price metadata, full-color level boxes with centered headings and larger Kalam text

Closes #371
Closes #372
Closes #374

## Verification
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter FullyQualifiedName~ExportFilenameBuilderTests|FullyQualifiedName~MagicBookExportPlannerTests|FullyQualifiedName~ExportEndpointTests --logger console;verbosity=minimal
- dotnet build OvcinaHra.slnx --no-restore -c Release
- dotnet test tests/OvcinaHra.Api.Tests --no-build --no-restore -c Release --logger console;verbosity=minimal
- dotnet publish src/OvcinaHra.Client -c Release -o publish --no-build --verbosity minimal
- OVCINA_WRITE_MAGIC_BOOK_SMOKE=1 focused magic-book test wrote .tmp/magic-book-A4.pdf