### PR TITLE
feat(organizer): add role assignment matrix

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/NpcConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/NpcConfiguration.cs
@@ -29,3 +29,27 @@ public class GameNpcConfiguration : IEntityTypeConfiguration<GameNpc>
         builder.Property(e => e.PlayedByEmail).HasMaxLength(200);
     }
 }
+
+public class OrganizerRoleAssignmentConfiguration : IEntityTypeConfiguration<OrganizerRoleAssignment>
+{
+    public void Configure(EntityTypeBuilder<OrganizerRoleAssignment> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.PersonName).IsRequired().HasMaxLength(200);
+        builder.Property(e => e.PersonEmail).HasMaxLength(200);
+        builder.Property(e => e.Notes).HasMaxLength(1000);
+
+        builder.HasIndex(e => new { e.GameId, e.GameTimeSlotId, e.NpcId }).IsUnique();
+        builder.HasIndex(e => new { e.GameId, e.PersonId });
+
+        builder.HasOne(e => e.Game)
+            .WithMany(g => g.OrganizerRoleAssignments)
+            .HasForeignKey(e => e.GameId);
+        builder.HasOne(e => e.TimeSlot)
+            .WithMany(ts => ts.OrganizerRoleAssignments)
+            .HasForeignKey(e => e.GameTimeSlotId);
+        builder.HasOne(e => e.Npc)
+            .WithMany(n => n.OrganizerRoleAssignments)
+            .HasForeignKey(e => e.NpcId);
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -32,6 +32,7 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<Monster> Monsters => Set<Monster>();
     public DbSet<Npc> Npcs => Set<Npc>();
     public DbSet<GameNpc> GameNpcs => Set<GameNpc>();
+    public DbSet<OrganizerRoleAssignment> OrganizerRoleAssignments => Set<OrganizerRoleAssignment>();
     public DbSet<MonsterTagLink> MonsterTagLinks => Set<MonsterTagLink>();
     public DbSet<MonsterLoot> MonsterLoots => Set<MonsterLoot>();
     public DbSet<GameMonster> GameMonsters => Set<GameMonster>();

--- a/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
@@ -189,6 +189,9 @@ public static class NpcEndpoints
     {
         var gn = await db.GameNpcs.FindAsync(gameId, npcId);
         if (gn is null) return TypedResults.NotFound();
+        await db.OrganizerRoleAssignments
+            .Where(a => a.GameId == gameId && a.NpcId == npcId)
+            .ExecuteDeleteAsync();
         db.GameNpcs.Remove(gn);
         await db.SaveChangesAsync();
         return TypedResults.NoContent();

--- a/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
@@ -1,0 +1,321 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Endpoints;
+
+public static class OrganizerRoleEndpoints
+{
+    public static RouteGroupBuilder MapOrganizerRoleEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/games/{gameId:int}/organizer-role-assignments")
+            .WithTags("OrganizerRoles");
+
+        group.MapGet("/", GetMatrix);
+        group.MapPost("/bulk", BulkAssign);
+        group.MapPut("/slots/{slotId:int}/npcs/{npcId:int}", UpsertSlotAssignment);
+        group.MapDelete("/slots/{slotId:int}/npcs/{npcId:int}", DeleteSlotAssignment);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<OrganizerRoleMatrixDto>, NotFound>> GetMatrix(
+        int gameId,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("OrganizerRoleEndpoints");
+        if (!await db.Games.AnyAsync(g => g.Id == gameId, ct))
+        {
+            logger.LogInformation("[organizer-roles] matrix game_not_found gameId={GameId}", gameId);
+            return TypedResults.NotFound();
+        }
+
+        var slots = await db.GameTimeSlots
+            .AsNoTracking()
+            .Where(s => s.GameId == gameId)
+            .OrderBy(s => s.StartTime)
+            .Select(s => new OrganizerRoleTimeSlotDto(
+                s.Id,
+                s.StartTime,
+                (decimal)s.Duration.TotalHours,
+                s.InGameYear,
+                s.Stage))
+            .ToListAsync(ct);
+
+        var npcs = await db.GameNpcs
+            .AsNoTracking()
+            .Where(gn => gn.GameId == gameId)
+            .OrderBy(gn => gn.Npc.Role)
+            .ThenBy(gn => gn.Npc.Name)
+            .Select(gn => new OrganizerRoleNpcDto(
+                gn.NpcId,
+                gn.Npc.Name,
+                gn.Npc.Role,
+                gn.Npc.Description))
+            .ToListAsync(ct);
+
+        var assignments = await db.OrganizerRoleAssignments
+            .AsNoTracking()
+            .Where(a => a.GameId == gameId)
+            .OrderBy(a => a.GameTimeSlotId)
+            .ThenBy(a => a.NpcId)
+            .Select(a => new OrganizerRoleAssignmentDto(
+                a.Id,
+                a.GameId,
+                a.GameTimeSlotId,
+                a.NpcId,
+                a.PersonId,
+                a.PersonName,
+                a.PersonEmail,
+                a.Notes,
+                a.CreatedAtUtc,
+                a.UpdatedAtUtc))
+            .ToListAsync(ct);
+
+        logger.LogInformation(
+            "[organizer-roles] matrix loaded gameId={GameId} slots={SlotCount} npcs={NpcCount} assignments={AssignmentCount}",
+            gameId,
+            slots.Count,
+            npcs.Count,
+            assignments.Count);
+
+        return TypedResults.Ok(new OrganizerRoleMatrixDto(gameId, slots, npcs, assignments));
+    }
+
+    private static async Task<Results<Ok<BulkOrganizerRoleAssignmentResultDto>, NotFound, ProblemHttpResult>> BulkAssign(
+        int gameId,
+        BulkOrganizerRoleAssignmentDto dto,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("OrganizerRoleEndpoints");
+        var validation = await ValidateAssignmentTargetAsync(gameId, dto.NpcId, dto.PersonId, dto.PersonName, db, ct);
+        if (validation is not null) return validation;
+
+        var slotIds = await db.GameTimeSlots
+            .Where(s => s.GameId == gameId)
+            .OrderBy(s => s.StartTime)
+            .Select(s => s.Id)
+            .ToListAsync(ct);
+
+        if (slotIds.Count == 0)
+        {
+            return Problem(
+                "Hra nemá žádné časové sloty.",
+                "Nejdřív vytvořte časové bloky v harmonogramu.",
+                StatusCodes.Status400BadRequest);
+        }
+
+        var existing = await db.OrganizerRoleAssignments
+            .Where(a => a.GameId == gameId && a.NpcId == dto.NpcId && slotIds.Contains(a.GameTimeSlotId))
+            .ToDictionaryAsync(a => a.GameTimeSlotId, ct);
+
+        var now = DateTime.UtcNow;
+        var created = 0;
+        var updated = 0;
+        foreach (var slotId in slotIds)
+        {
+            if (existing.TryGetValue(slotId, out var assignment))
+            {
+                assignment.PersonId = dto.PersonId;
+                assignment.PersonName = dto.PersonName.Trim();
+                assignment.PersonEmail = NullIfWhiteSpace(dto.PersonEmail);
+                assignment.Notes = NullIfWhiteSpace(dto.Notes);
+                assignment.UpdatedAtUtc = now;
+                updated++;
+                continue;
+            }
+
+            db.OrganizerRoleAssignments.Add(new OrganizerRoleAssignment
+            {
+                GameId = gameId,
+                GameTimeSlotId = slotId,
+                NpcId = dto.NpcId,
+                PersonId = dto.PersonId,
+                PersonName = dto.PersonName.Trim(),
+                PersonEmail = NullIfWhiteSpace(dto.PersonEmail),
+                Notes = NullIfWhiteSpace(dto.Notes),
+                CreatedAtUtc = now,
+                UpdatedAtUtc = now
+            });
+            created++;
+        }
+
+        await db.SaveChangesAsync(ct);
+        var assignments = await LoadAssignmentsForNpcAsync(gameId, dto.NpcId, db, ct);
+        logger.LogInformation(
+            "[organizer-roles] bulk assigned gameId={GameId} npcId={NpcId} personId={PersonId} created={CreatedCount} updated={UpdatedCount}",
+            gameId,
+            dto.NpcId,
+            dto.PersonId,
+            created,
+            updated);
+
+        return TypedResults.Ok(new BulkOrganizerRoleAssignmentResultDto(created, updated, assignments));
+    }
+
+    private static async Task<Results<Ok<OrganizerRoleAssignmentDto>, NotFound, ProblemHttpResult>> UpsertSlotAssignment(
+        int gameId,
+        int slotId,
+        int npcId,
+        UpsertOrganizerRoleAssignmentDto dto,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("OrganizerRoleEndpoints");
+        var validation = await ValidateAssignmentTargetAsync(gameId, npcId, dto.PersonId, dto.PersonName, db, ct, slotId);
+        if (validation is not null) return validation;
+
+        var existing = await db.OrganizerRoleAssignments
+            .SingleOrDefaultAsync(a => a.GameId == gameId && a.GameTimeSlotId == slotId && a.NpcId == npcId, ct);
+
+        var now = DateTime.UtcNow;
+        if (existing is null)
+        {
+            existing = new OrganizerRoleAssignment
+            {
+                GameId = gameId,
+                GameTimeSlotId = slotId,
+                NpcId = npcId,
+                PersonId = dto.PersonId,
+                PersonName = dto.PersonName.Trim(),
+                PersonEmail = NullIfWhiteSpace(dto.PersonEmail),
+                Notes = NullIfWhiteSpace(dto.Notes),
+                CreatedAtUtc = now,
+                UpdatedAtUtc = now
+            };
+            db.OrganizerRoleAssignments.Add(existing);
+        }
+        else
+        {
+            existing.PersonId = dto.PersonId;
+            existing.PersonName = dto.PersonName.Trim();
+            existing.PersonEmail = NullIfWhiteSpace(dto.PersonEmail);
+            existing.Notes = NullIfWhiteSpace(dto.Notes);
+            existing.UpdatedAtUtc = now;
+        }
+
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation(
+            "[organizer-roles] slot assigned gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId}",
+            gameId,
+            slotId,
+            npcId,
+            dto.PersonId);
+
+        return TypedResults.Ok(ToDto(existing));
+    }
+
+    private static async Task<Results<NoContent, NotFound>> DeleteSlotAssignment(
+        int gameId,
+        int slotId,
+        int npcId,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var assignment = await db.OrganizerRoleAssignments
+            .SingleOrDefaultAsync(a => a.GameId == gameId && a.GameTimeSlotId == slotId && a.NpcId == npcId, ct);
+        if (assignment is null) return TypedResults.NotFound();
+
+        db.OrganizerRoleAssignments.Remove(assignment);
+        await db.SaveChangesAsync(ct);
+
+        loggerFactory.CreateLogger("OrganizerRoleEndpoints").LogInformation(
+            "[organizer-roles] slot unassigned gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId}",
+            gameId,
+            slotId,
+            npcId,
+            assignment.PersonId);
+
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<ProblemHttpResult?> ValidateAssignmentTargetAsync(
+        int gameId,
+        int npcId,
+        int personId,
+        string personName,
+        WorldDbContext db,
+        CancellationToken ct,
+        int? slotId = null)
+    {
+        if (personId <= 0 || string.IsNullOrWhiteSpace(personName))
+        {
+            return Problem(
+                "Vyberte dospělého z registrace.",
+                "Chybí dospělý",
+                StatusCodes.Status400BadRequest);
+        }
+
+        if (!await db.Games.AnyAsync(g => g.Id == gameId, ct))
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+
+        if (slotId is int sid && !await db.GameTimeSlots.AnyAsync(s => s.Id == sid && s.GameId == gameId, ct))
+        {
+            return Problem(
+                "Časový slot nepatří k této hře.",
+                "Neplatný časový slot",
+                StatusCodes.Status400BadRequest);
+        }
+
+        if (!await db.GameNpcs.AnyAsync(gn => gn.GameId == gameId && gn.NpcId == npcId, ct))
+        {
+            return Problem(
+                "NPC role není přiřazená k této hře.",
+                "Neplatná NPC role",
+                StatusCodes.Status400BadRequest);
+        }
+
+        return null;
+    }
+
+    private static async Task<List<OrganizerRoleAssignmentDto>> LoadAssignmentsForNpcAsync(
+        int gameId,
+        int npcId,
+        WorldDbContext db,
+        CancellationToken ct)
+    {
+        return await db.OrganizerRoleAssignments
+            .AsNoTracking()
+            .Where(a => a.GameId == gameId && a.NpcId == npcId)
+            .OrderBy(a => a.GameTimeSlotId)
+            .Select(a => new OrganizerRoleAssignmentDto(
+                a.Id,
+                a.GameId,
+                a.GameTimeSlotId,
+                a.NpcId,
+                a.PersonId,
+                a.PersonName,
+                a.PersonEmail,
+                a.Notes,
+                a.CreatedAtUtc,
+                a.UpdatedAtUtc))
+            .ToListAsync(ct);
+    }
+
+    private static OrganizerRoleAssignmentDto ToDto(OrganizerRoleAssignment a) =>
+        new(
+            a.Id,
+            a.GameId,
+            a.GameTimeSlotId,
+            a.NpcId,
+            a.PersonId,
+            a.PersonName,
+            a.PersonEmail,
+            a.Notes,
+            a.CreatedAtUtc,
+            a.UpdatedAtUtc);
+
+    private static ProblemHttpResult Problem(string detail, string title, int statusCode) =>
+        TypedResults.Problem(detail: detail, title: title, statusCode: statusCode);
+
+    private static string? NullIfWhiteSpace(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
@@ -8,6 +8,11 @@ namespace OvcinaHra.Api.Endpoints;
 
 public static class OrganizerRoleEndpoints
 {
+    private const string LoggerCategory = "OvcinaHra.Api.Endpoints.OrganizerRoleEndpoints";
+    private const int PersonNameMaxLength = 200;
+    private const int PersonEmailMaxLength = 200;
+    private const int NotesMaxLength = 1000;
+
     public static RouteGroupBuilder MapOrganizerRoleEndpoints(this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/games/{gameId:int}/organizer-role-assignments")
@@ -27,7 +32,7 @@ public static class OrganizerRoleEndpoints
         ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
-        var logger = loggerFactory.CreateLogger("OrganizerRoleEndpoints");
+        var logger = loggerFactory.CreateLogger(LoggerCategory);
         if (!await db.Games.AnyAsync(g => g.Id == gameId, ct))
         {
             logger.LogInformation("[organizer-roles] matrix game_not_found gameId={GameId}", gameId);
@@ -93,8 +98,16 @@ public static class OrganizerRoleEndpoints
         ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
-        var logger = loggerFactory.CreateLogger("OrganizerRoleEndpoints");
-        var validation = await ValidateAssignmentTargetAsync(gameId, dto.NpcId, dto.PersonId, dto.PersonName, db, ct);
+        var logger = loggerFactory.CreateLogger(LoggerCategory);
+        var validation = await ValidateAssignmentTargetAsync(
+            gameId,
+            dto.NpcId,
+            dto.PersonId,
+            dto.PersonName,
+            dto.PersonEmail,
+            dto.Notes,
+            db,
+            ct);
         if (validation is not null) return validation;
 
         var slotIds = await db.GameTimeSlots
@@ -168,8 +181,17 @@ public static class OrganizerRoleEndpoints
         ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
-        var logger = loggerFactory.CreateLogger("OrganizerRoleEndpoints");
-        var validation = await ValidateAssignmentTargetAsync(gameId, npcId, dto.PersonId, dto.PersonName, db, ct, slotId);
+        var logger = loggerFactory.CreateLogger(LoggerCategory);
+        var validation = await ValidateAssignmentTargetAsync(
+            gameId,
+            npcId,
+            dto.PersonId,
+            dto.PersonName,
+            dto.PersonEmail,
+            dto.Notes,
+            db,
+            ct,
+            slotId);
         if (validation is not null) return validation;
 
         var existing = await db.OrganizerRoleAssignments
@@ -227,7 +249,7 @@ public static class OrganizerRoleEndpoints
         db.OrganizerRoleAssignments.Remove(assignment);
         await db.SaveChangesAsync(ct);
 
-        loggerFactory.CreateLogger("OrganizerRoleEndpoints").LogInformation(
+        loggerFactory.CreateLogger(LoggerCategory).LogInformation(
             "[organizer-roles] slot unassigned gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId}",
             gameId,
             slotId,
@@ -242,6 +264,8 @@ public static class OrganizerRoleEndpoints
         int npcId,
         int personId,
         string personName,
+        string? personEmail,
+        string? notes,
         WorldDbContext db,
         CancellationToken ct,
         int? slotId = null)
@@ -254,8 +278,37 @@ public static class OrganizerRoleEndpoints
                 StatusCodes.Status400BadRequest);
         }
 
+        if (personName.Trim().Length > PersonNameMaxLength)
+        {
+            return Problem(
+                $"Jméno dospělého může mít nejvýše {PersonNameMaxLength} znaků.",
+                "Jméno dospělého je příliš dlouhé",
+                StatusCodes.Status400BadRequest);
+        }
+
+        if (!string.IsNullOrWhiteSpace(personEmail) && personEmail.Trim().Length > PersonEmailMaxLength)
+        {
+            return Problem(
+                $"E-mail dospělého může mít nejvýše {PersonEmailMaxLength} znaků.",
+                "E-mail dospělého je příliš dlouhý",
+                StatusCodes.Status400BadRequest);
+        }
+
+        if (!string.IsNullOrWhiteSpace(notes) && notes.Trim().Length > NotesMaxLength)
+        {
+            return Problem(
+                $"Poznámka může mít nejvýše {NotesMaxLength} znaků.",
+                "Poznámka je příliš dlouhá",
+                StatusCodes.Status400BadRequest);
+        }
+
         if (!await db.Games.AnyAsync(g => g.Id == gameId, ct))
-            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        {
+            return Problem(
+                "Požadovaná hra nebyla nalezena.",
+                "Hra neexistuje",
+                StatusCodes.Status404NotFound);
+        }
 
         if (slotId is int sid && !await db.GameTimeSlots.AnyAsync(s => s.Id == sid && s.GameId == gameId, ct))
         {

--- a/src/OvcinaHra.Api/Migrations/20260429065801_AddOrganizerRoleAssignments.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260429065801_AddOrganizerRoleAssignments.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429065801_AddOrganizerRoleAssignments")]
+    partial class AddOrganizerRoleAssignments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260429065801_AddOrganizerRoleAssignments.cs
+++ b/src/OvcinaHra.Api/Migrations/20260429065801_AddOrganizerRoleAssignments.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrganizerRoleAssignments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OrganizerRoleAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    GameTimeSlotId = table.Column<int>(type: "integer", nullable: false),
+                    NpcId = table.Column<int>(type: "integer", nullable: false),
+                    PersonId = table.Column<int>(type: "integer", nullable: false),
+                    PersonName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    PersonEmail = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    Notes = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrganizerRoleAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrganizerRoleAssignments_GameTimeSlots_GameTimeSlotId",
+                        column: x => x.GameTimeSlotId,
+                        principalTable: "GameTimeSlots",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OrganizerRoleAssignments_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OrganizerRoleAssignments_Npcs_NpcId",
+                        column: x => x.NpcId,
+                        principalTable: "Npcs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizerRoleAssignments_GameId_GameTimeSlotId_NpcId",
+                table: "OrganizerRoleAssignments",
+                columns: new[] { "GameId", "GameTimeSlotId", "NpcId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizerRoleAssignments_GameId_PersonId",
+                table: "OrganizerRoleAssignments",
+                columns: new[] { "GameId", "PersonId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizerRoleAssignments_GameTimeSlotId",
+                table: "OrganizerRoleAssignments",
+                column: "GameTimeSlotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizerRoleAssignments_NpcId",
+                table: "OrganizerRoleAssignments",
+                column: "NpcId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrganizerRoleAssignments");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -279,6 +279,7 @@ try
     app.MapTreasurePlanningEndpoints().RequireAuthorization();
     app.MapTimelineEndpoints().RequireAuthorization();
     app.MapDashboardEndpoints().RequireAuthorization();
+    app.MapOrganizerRoleEndpoints().RequireAuthorization();
     app.MapConsultEndpoints();
     app.MapMapEndpoints().RequireAuthorization();
     app.MapGameEventEndpoints();

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -95,6 +95,10 @@
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-calendar-event-fill ni"></i><span class="oh-nav-label">Události</span>
                     </NavLink>
+                    <NavLink class="oh-nav-item" href="organizer-roles">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-people-fill ni"></i><span class="oh-nav-label">Rozpis rolí</span>
+                    </NavLink>
                     <NavLink class="oh-nav-item" href="locations">
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-geo-alt-fill ni"></i><span class="oh-nav-label">Lokace</span>

--- a/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor
+++ b/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor
@@ -1,0 +1,617 @@
+@page "/organizer-roles"
+@attribute [Authorize]
+@using System.Globalization
+@inject ApiClient Api
+@inject GameContextService GameContext
+@implements IDisposable
+
+<PageTitle>Rozpis rolí</PageTitle>
+
+<div class="oh-orgrole-bar">
+    <div>
+        <h1>Rozpis rolí</h1>
+        <div class="oh-orgrole-sub">@(GameContext.GameName ?? "Žádná hra")</div>
+    </div>
+    <div class="oh-orgrole-actions">
+        <button type="button"
+                class="btn btn-primary"
+                @onclick="OpenBulkAssign"
+                disabled="@(!CanEdit)">
+            <i class="bi bi-person-plus-fill"></i>
+            Přiřadit dospělého na všechny sloty
+        </button>
+    </div>
+</div>
+
+<div class="oh-orgrole-filters">
+    <label>
+        <span>Typ role</span>
+        <DxComboBox TData="RoleFilterOption" TValue="NpcRole?"
+                    Data="@roleFilterOptions"
+                    @bind-Value="@selectedRole"
+                    TextFieldName="@nameof(RoleFilterOption.Display)"
+                    ValueFieldName="@nameof(RoleFilterOption.Value)"
+                    NullText="Všechny typy"
+                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+    </label>
+    <label>
+        <span>Dospělý</span>
+        <DxComboBox TData="AdultOption" TValue="int?"
+                    Data="@adultOptions"
+                    @bind-Value="@selectedAdultPersonId"
+                    TextFieldName="@nameof(AdultOption.Display)"
+                    ValueFieldName="@nameof(AdultOption.PersonId)"
+                    NullText="Všichni dospělí"
+                    SearchMode="ListSearchMode.AutoSearch"
+                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto" />
+    </label>
+    @if (selectedAdultPersonId is not null)
+    {
+        <span class="oh-orgrole-filter-note">
+            Záznamy ostatních dospělých jsou ztlumené.
+        </span>
+    }
+</div>
+
+@if (!string.IsNullOrWhiteSpace(error))
+{
+    <div class="alert alert-danger">@error</div>
+}
+@if (!string.IsNullOrWhiteSpace(adultsLoadError))
+{
+    <div class="alert alert-warning">@adultsLoadError</div>
+}
+
+@if (loading)
+{
+    <p class="text-muted">Načítám rozpis rolí...</p>
+}
+else if (GameContext.SelectedGameId is null)
+{
+    <div class="oh-orgrole-empty">
+        <i class="bi bi-calendar2-x"></i>
+        <h2>Vyberte hru</h2>
+        <p>Rozpis rolí je vždy navázaný na jednu konkrétní hru.</p>
+    </div>
+}
+else if (slots.Count == 0)
+{
+    <div class="oh-orgrole-empty">
+        <i class="bi bi-clock-history"></i>
+        <h2>Nejsou vytvořené časové sloty</h2>
+        <p>Nejdřív připravte harmonogram hry, potom půjde obsadit role.</p>
+        <a class="btn btn-outline-primary" href="/timeline">Otevřít harmonogram</a>
+    </div>
+}
+else if (npcs.Count == 0)
+{
+    <div class="oh-orgrole-empty">
+        <i class="bi bi-person-badge"></i>
+        <h2>Žádné NPC role v této hře</h2>
+        <p>Přidejte NPC do hry na stránce NPC, potom se objeví v rozpisu.</p>
+        <a class="btn btn-outline-primary" href="/npcs">Otevřít NPC</a>
+    </div>
+}
+else
+{
+    <div class="oh-orgrole-matrix-wrap">
+        <table class="oh-orgrole-matrix">
+            <thead>
+                <tr>
+                    <th class="oh-orgrole-role-head">NPC role</th>
+                    @foreach (var slot in slots)
+                    {
+                        <th @key="slot.Id">
+                            <div class="oh-orgrole-slot">
+                                <span>@FormatSlotTime(slot)</span>
+                                <small>@slot.Stage.GetDisplayName()</small>
+                            </div>
+                        </th>
+                    }
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var npc in FilteredNpcs)
+                {
+                    <tr @key="npc.NpcId">
+                        <th class="oh-orgrole-role-cell">
+                            <span>@npc.NpcName</span>
+                            <small>@npc.Role.GetDisplayName()</small>
+                        </th>
+                        @foreach (var slot in slots)
+                        {
+                            var assignment = GetAssignment(slot.Id, npc.NpcId);
+                            <td class="@CellCss(assignment)" @key="slot.Id">
+                                <button type="button"
+                                        class="oh-orgrole-cell-btn"
+                                        @onclick="() => OpenCellEditor(slot, npc, assignment)">
+                                    @if (assignment is null)
+                                    {
+                                        <span class="oh-orgrole-empty-cell">+</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="oh-orgrole-person">@assignment.PersonName</span>
+                                        @if (!string.IsNullOrWhiteSpace(assignment.PersonEmail))
+                                        {
+                                            <small>@assignment.PersonEmail</small>
+                                        }
+                                        @if (IsDuplicateAdultSlot(assignment))
+                                        {
+                                            <span class="oh-orgrole-dup">více rolí</span>
+                                        }
+                                    }
+                                </button>
+                            </td>
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+<DxPopup @bind-Visible="@isBulkVisible" HeaderText="Přiřadit dospělého na všechny sloty" Width="560px">
+    <BodyContentTemplate Context="bulkContext">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="NPC role" ColSpanMd="12">
+                <DxComboBox TData="NpcOption" TValue="int?"
+                            Data="@npcOptions"
+                            @bind-Value="@bulkNpcId"
+                            TextFieldName="@nameof(NpcOption.Display)"
+                            ValueFieldName="@nameof(NpcOption.NpcId)"
+                            NullText="Vyberte NPC roli..."
+                            SearchMode="ListSearchMode.AutoSearch" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Dospělý" ColSpanMd="12">
+                <DxComboBox TData="AdultOption" TValue="int?"
+                            Data="@adultOptions"
+                            @bind-Value="@bulkPersonId"
+                            TextFieldName="@nameof(AdultOption.Display)"
+                            ValueFieldName="@nameof(AdultOption.PersonId)"
+                            NullText="Vyberte dospělého..."
+                            SearchMode="ListSearchMode.AutoSearch" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Poznámka" ColSpanMd="12">
+                <DxMemo @bind-Text="@bulkNotes" Rows="2" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        @if (BulkWillOverwrite)
+        {
+            <div class="alert alert-warning mt-3">
+                Tato akce přepíše existující obsazení vybrané NPC role ve @ExistingBulkAssignmentCount slotech.
+            </div>
+        }
+        @if (!string.IsNullOrWhiteSpace(bulkError))
+        {
+            <div class="alert alert-danger mt-3">@bulkError</div>
+        }
+        <div class="d-flex justify-content-end gap-2 mt-3">
+            <button type="button" class="btn btn-secondary" @onclick="() => isBulkVisible = false" disabled="@isSaving">Zrušit</button>
+            <button type="button" class="btn btn-primary" @onclick="SaveBulkAsync" disabled="@(isSaving || bulkNpcId is null || bulkPersonId is null)">
+                Přiřadit na všechny sloty
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<DxPopup @bind-Visible="@isCellVisible" HeaderText="@cellTitle" Width="520px">
+    <BodyContentTemplate Context="cellContext">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Dospělý" ColSpanMd="12">
+                <DxComboBox TData="AdultOption" TValue="int?"
+                            Data="@adultOptions"
+                            @bind-Value="@editPersonId"
+                            TextFieldName="@nameof(AdultOption.Display)"
+                            ValueFieldName="@nameof(AdultOption.PersonId)"
+                            NullText="Vyberte dospělého..."
+                            SearchMode="ListSearchMode.AutoSearch" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Poznámka" ColSpanMd="12">
+                <DxMemo @bind-Text="@editNotes" Rows="2" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        @if (!string.IsNullOrWhiteSpace(cellError))
+        {
+            <div class="alert alert-danger mt-3">@cellError</div>
+        }
+        <div class="d-flex justify-content-end gap-2 mt-3">
+            @if (editingAssignment is not null)
+            {
+                <button type="button" class="btn btn-outline-danger me-auto" @onclick="() => isRemoveConfirmVisible = true" disabled="@isSaving">
+                    Odebrat ze slotu
+                </button>
+            }
+            <button type="button" class="btn btn-secondary" @onclick="() => isCellVisible = false" disabled="@isSaving">Zrušit</button>
+            <button type="button" class="btn btn-primary" @onclick="SaveCellAsync" disabled="@(isSaving || editPersonId is null)">Uložit</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<DxPopup @bind-Visible="@isBulkConfirmVisible" HeaderText="Potvrdit přepsání" Width="460px">
+    <BodyContentTemplate Context="confirmBulkContext">
+        <p>
+            Opravdu chcete přepsat existující obsazení vybrané NPC role ve
+            <strong>@ExistingBulkAssignmentCount</strong> slotech?
+        </p>
+        <div class="d-flex justify-content-end gap-2">
+            <button type="button" class="btn btn-secondary" @onclick="() => isBulkConfirmVisible = false" disabled="@isSaving">Zrušit</button>
+            <button type="button" class="btn btn-danger" @onclick="ExecuteBulkAsync" disabled="@isSaving">Přepsat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+<DxPopup @bind-Visible="@isRemoveConfirmVisible" HeaderText="Potvrdit odebrání" Width="420px">
+    <BodyContentTemplate Context="confirmRemoveContext">
+        <p>Odebrat dospělého z této NPC role jen pro vybraný časový slot?</p>
+        <div class="d-flex justify-content-end gap-2">
+            <button type="button" class="btn btn-secondary" @onclick="() => isRemoveConfirmVisible = false" disabled="@isSaving">Zrušit</button>
+            <button type="button" class="btn btn-danger" @onclick="RemoveCellAsync" disabled="@isSaving">Odebrat</button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    private static readonly CultureInfo Czech = CultureInfo.GetCultureInfo("cs-CZ");
+
+    private List<OrganizerRoleTimeSlotDto> slots = [];
+    private List<OrganizerRoleNpcDto> npcs = [];
+    private List<OrganizerRoleAssignmentDto> assignments = [];
+    private List<RegistraceAdultDto> adults = [];
+    private List<AdultOption> adultOptions = [];
+    private List<NpcOption> npcOptions = [];
+    private List<RoleFilterOption> roleFilterOptions = [new(null, "Všechny typy")];
+    private Dictionary<(int SlotId, int NpcId), OrganizerRoleAssignmentDto> assignmentLookup = [];
+    private HashSet<int> duplicateAdultSlotAssignmentIds = [];
+
+    private bool loading = true;
+    private bool isSaving;
+    private string? error;
+    private string? adultsLoadError;
+
+    private NpcRole? selectedRole;
+    private int? selectedAdultPersonId;
+
+    private bool isBulkVisible;
+    private bool isBulkConfirmVisible;
+    private int? bulkNpcId;
+    private int? bulkPersonId;
+    private string? bulkNotes;
+    private string? bulkError;
+
+    private bool isCellVisible;
+    private bool isRemoveConfirmVisible;
+    private OrganizerRoleTimeSlotDto? editingSlot;
+    private OrganizerRoleNpcDto? editingNpc;
+    private OrganizerRoleAssignmentDto? editingAssignment;
+    private int? editPersonId;
+    private string? editNotes;
+    private string? cellError;
+
+    private bool CanEdit => GameContext.SelectedGameId is not null
+        && slots.Count > 0
+        && npcs.Count > 0
+        && adultOptions.Count > 0
+        && adultsLoadError is null;
+
+    private IEnumerable<OrganizerRoleNpcDto> FilteredNpcs =>
+        selectedRole is null ? npcs : npcs.Where(n => n.Role == selectedRole);
+
+    private int ExistingBulkAssignmentCount =>
+        bulkNpcId is int npcId ? assignments.Count(a => a.NpcId == npcId) : 0;
+
+    private bool BulkWillOverwrite => ExistingBulkAssignmentCount > 0;
+
+    private string cellTitle => editingSlot is null || editingNpc is null
+        ? "Upravit obsazení"
+        : $"{editingNpc.NpcName} - {FormatSlotTime(editingSlot)}";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        GameContext.OnGameChanged += OnGameChanged;
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        error = null;
+        adultsLoadError = null;
+        try
+        {
+            await LoadMatrixAsync();
+            await LoadAdultsAsync();
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            Console.WriteLine($"[organizer-roles] load failed message={ex.Message}");
+        }
+        finally
+        {
+            loading = false;
+        }
+    }
+
+    private async Task LoadMatrixAsync()
+    {
+        slots = [];
+        npcs = [];
+        assignments = [];
+        if (GameContext.SelectedGameId is not int gameId)
+        {
+            RebuildDerivedState();
+            return;
+        }
+
+        Console.WriteLine($"[organizer-roles] matrix load.start gameId={gameId}");
+        var matrix = await Api.GetAsync<OrganizerRoleMatrixDto>($"/api/games/{gameId}/organizer-role-assignments");
+        if (matrix is null)
+        {
+            error = "Hra nebyla nalezena.";
+            RebuildDerivedState();
+            return;
+        }
+
+        slots = matrix.TimeSlots.OrderBy(s => s.StartTime).ToList();
+        npcs = matrix.Npcs.OrderBy(n => n.Role.GetDisplayName()).ThenBy(n => n.NpcName).ToList();
+        assignments = matrix.Assignments;
+        RebuildDerivedState();
+        Console.WriteLine($"[organizer-roles] matrix load.ok gameId={gameId} slots={slots.Count} npcs={npcs.Count} assignments={assignments.Count}");
+    }
+
+    private async Task LoadAdultsAsync()
+    {
+        adults = [];
+        adultOptions = [];
+        if (GameContext.SelectedGameId is not int gameId) return;
+
+        try
+        {
+            Console.WriteLine($"[organizer-roles] adults load.start gameId={gameId}");
+            var (ok, value, problemDetail) =
+                await Api.GetWithProblemAsync<List<RegistraceAdultDto>>($"/api/npcs/available-players/{gameId}");
+            if (!ok)
+            {
+                adultsLoadError = problemDetail ?? "Dospělé z registrace se nepodařilo načíst.";
+                Console.WriteLine($"[organizer-roles] adults load.failed gameId={gameId} message={adultsLoadError}");
+                return;
+            }
+
+            adults = value ?? [];
+            adultOptions = adults
+                .Select(a =>
+                {
+                    var name = $"{a.FirstName} {a.LastName}".Trim();
+                    var display = string.IsNullOrWhiteSpace(a.Email) ? name : $"{name} - {a.Email}";
+                    return new AdultOption(a.PersonId, name, a.Email, display);
+                })
+                .OrderBy(a => a.Name)
+                .ToList();
+            Console.WriteLine($"[organizer-roles] adults load.ok gameId={gameId} count={adultOptions.Count}");
+        }
+        catch (Exception ex)
+        {
+            adultsLoadError = $"Dospělé z registrace se nepodařilo načíst: {ex.Message}";
+            Console.WriteLine($"[organizer-roles] adults load.failed gameId={gameId} message={ex.Message}");
+        }
+    }
+
+    private void RebuildDerivedState()
+    {
+        assignmentLookup = assignments.ToDictionary(a => (a.GameTimeSlotId, a.NpcId));
+        duplicateAdultSlotAssignmentIds = assignments
+            .GroupBy(a => (a.GameTimeSlotId, a.PersonId))
+            .Where(g => g.Count() > 1)
+            .SelectMany(g => g.Select(a => a.Id))
+            .ToHashSet();
+        roleFilterOptions = [new(null, "Všechny typy"), .. npcs
+            .Select(n => n.Role)
+            .Distinct()
+            .OrderBy(r => r.GetDisplayName())
+            .Select(r => new RoleFilterOption(r, r.GetDisplayName()))];
+        npcOptions = npcs
+            .Select(n => new NpcOption(n.NpcId, $"{n.NpcName} ({n.Role.GetDisplayName()})", n.Role))
+            .ToList();
+
+        if (selectedRole is not null && !npcs.Any(n => n.Role == selectedRole))
+            selectedRole = null;
+        if (selectedAdultPersonId is not null && adultOptions.All(a => a.PersonId != selectedAdultPersonId))
+            selectedAdultPersonId = null;
+    }
+
+    private OrganizerRoleAssignmentDto? GetAssignment(int slotId, int npcId) =>
+        assignmentLookup.TryGetValue((slotId, npcId), out var assignment) ? assignment : null;
+
+    private string FormatSlotTime(OrganizerRoleTimeSlotDto slot)
+    {
+        var start = slot.StartTime.ToLocalTime();
+        var end = start.AddHours((double)slot.DurationHours);
+        return $"{start.ToString("d.M. HH:mm", Czech)}-{end.ToString("HH:mm", Czech)}";
+    }
+
+    private string CellCss(OrganizerRoleAssignmentDto? assignment)
+    {
+        var classes = new List<string> { "oh-orgrole-cell" };
+        if (assignment is null) classes.Add("is-empty");
+        if (selectedAdultPersonId is int adultId)
+            classes.Add(assignment?.PersonId == adultId ? "is-match" : "is-dimmed");
+        if (assignment is not null && IsDuplicateAdultSlot(assignment))
+            classes.Add("has-duplicate");
+        return string.Join(' ', classes);
+    }
+
+    private bool IsDuplicateAdultSlot(OrganizerRoleAssignmentDto assignment) =>
+        duplicateAdultSlotAssignmentIds.Contains(assignment.Id);
+
+    private void OpenBulkAssign()
+    {
+        bulkError = null;
+        bulkNotes = null;
+        bulkNpcId = FilteredNpcs.FirstOrDefault()?.NpcId ?? npcs.FirstOrDefault()?.NpcId;
+        bulkPersonId = selectedAdultPersonId;
+        isBulkVisible = true;
+        Console.WriteLine($"[organizer-roles] bulk popup.open gameId={GameContext.SelectedGameId}");
+    }
+
+    private async Task SaveBulkAsync()
+    {
+        bulkError = null;
+        if (BulkWillOverwrite)
+        {
+            isBulkConfirmVisible = true;
+            return;
+        }
+
+        await ExecuteBulkAsync();
+    }
+
+    private async Task ExecuteBulkAsync()
+    {
+        if (GameContext.SelectedGameId is not int gameId || bulkNpcId is not int npcId || bulkPersonId is not int personId)
+            return;
+
+        var adult = adultOptions.FirstOrDefault(a => a.PersonId == personId);
+        if (adult is null)
+        {
+            bulkError = "Vybraný dospělý nebyl nalezen.";
+            return;
+        }
+
+        isSaving = true;
+        try
+        {
+            Console.WriteLine($"[organizer-roles] bulk save.start gameId={gameId} npcId={npcId} personId={personId}");
+            var dto = new BulkOrganizerRoleAssignmentDto(npcId, personId, adult.Name, adult.Email, bulkNotes);
+            var (ok, _, problemDetail) = await Api.PostWithProblemAsync<BulkOrganizerRoleAssignmentDto, BulkOrganizerRoleAssignmentResultDto>(
+                $"/api/games/{gameId}/organizer-role-assignments/bulk",
+                dto);
+            if (!ok)
+            {
+                bulkError = problemDetail ?? "Obsazení se nepodařilo uložit.";
+                return;
+            }
+
+            isBulkConfirmVisible = false;
+            isBulkVisible = false;
+            await LoadMatrixAsync();
+            Console.WriteLine($"[organizer-roles] bulk save.ok gameId={gameId} npcId={npcId} personId={personId}");
+        }
+        catch (Exception ex)
+        {
+            bulkError = ex.Message;
+            Console.WriteLine($"[organizer-roles] bulk save.failed gameId={gameId} message={ex.Message}");
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+
+    private void OpenCellEditor(
+        OrganizerRoleTimeSlotDto slot,
+        OrganizerRoleNpcDto npc,
+        OrganizerRoleAssignmentDto? assignment)
+    {
+        cellError = null;
+        editingSlot = slot;
+        editingNpc = npc;
+        editingAssignment = assignment;
+        editPersonId = assignment?.PersonId ?? selectedAdultPersonId;
+        editNotes = assignment?.Notes;
+        isCellVisible = true;
+        Console.WriteLine($"[organizer-roles] cell popup.open gameId={GameContext.SelectedGameId} slotId={slot.Id} npcId={npc.NpcId}");
+    }
+
+    private async Task SaveCellAsync()
+    {
+        if (GameContext.SelectedGameId is not int gameId
+            || editingSlot is null
+            || editingNpc is null
+            || editPersonId is not int personId)
+            return;
+
+        var adult = adultOptions.FirstOrDefault(a => a.PersonId == personId);
+        if (adult is null)
+        {
+            cellError = "Vybraný dospělý nebyl nalezen.";
+            return;
+        }
+
+        isSaving = true;
+        try
+        {
+            Console.WriteLine($"[organizer-roles] cell save.start gameId={gameId} slotId={editingSlot.Id} npcId={editingNpc.NpcId} personId={personId}");
+            var dto = new UpsertOrganizerRoleAssignmentDto(personId, adult.Name, adult.Email, editNotes);
+            var (ok, problemDetail) = await Api.PutWithProblemAsync(
+                $"/api/games/{gameId}/organizer-role-assignments/slots/{editingSlot.Id}/npcs/{editingNpc.NpcId}",
+                dto);
+            if (!ok)
+            {
+                cellError = problemDetail ?? "Obsazení se nepodařilo uložit.";
+                return;
+            }
+
+            isCellVisible = false;
+            await LoadMatrixAsync();
+            Console.WriteLine($"[organizer-roles] cell save.ok gameId={gameId} slotId={editingSlot.Id} npcId={editingNpc.NpcId}");
+        }
+        catch (Exception ex)
+        {
+            cellError = ex.Message;
+            Console.WriteLine($"[organizer-roles] cell save.failed gameId={gameId} message={ex.Message}");
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+
+    private async Task RemoveCellAsync()
+    {
+        if (GameContext.SelectedGameId is not int gameId || editingSlot is null || editingNpc is null)
+            return;
+
+        isSaving = true;
+        try
+        {
+            Console.WriteLine($"[organizer-roles] cell remove.start gameId={gameId} slotId={editingSlot.Id} npcId={editingNpc.NpcId}");
+            var (ok, problemDetail) = await Api.DeleteWithProblemAsync(
+                $"/api/games/{gameId}/organizer-role-assignments/slots/{editingSlot.Id}/npcs/{editingNpc.NpcId}");
+            if (!ok)
+            {
+                cellError = problemDetail ?? "Obsazení se nepodařilo odebrat.";
+                return;
+            }
+
+            isRemoveConfirmVisible = false;
+            isCellVisible = false;
+            await LoadMatrixAsync();
+            Console.WriteLine($"[organizer-roles] cell remove.ok gameId={gameId} slotId={editingSlot.Id} npcId={editingNpc.NpcId}");
+        }
+        catch (Exception ex)
+        {
+            cellError = ex.Message;
+            Console.WriteLine($"[organizer-roles] cell remove.failed gameId={gameId} message={ex.Message}");
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+
+    private async void OnGameChanged()
+    {
+        try { await InvokeAsync(LoadAsync); } catch { /* best-effort UI refresh */ }
+    }
+
+    public void Dispose()
+    {
+        GameContext.OnGameChanged -= OnGameChanged;
+    }
+
+    private record RoleFilterOption(NpcRole? Value, string Display);
+    private record AdultOption(int PersonId, string Name, string? Email, string Display);
+    private record NpcOption(int NpcId, string Display, NpcRole Role);
+}

--- a/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor
+++ b/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor
@@ -124,6 +124,7 @@ else
                             <td class="@CellCss(assignment)" @key="slot.Id">
                                 <button type="button"
                                         class="oh-orgrole-cell-btn"
+                                        aria-label="@CellButtonLabel(slot, npc, assignment)"
                                         @onclick="() => OpenCellEditor(slot, npc, assignment)">
                                     @if (assignment is null)
                                     {
@@ -322,6 +323,7 @@ else
         {
             await LoadMatrixAsync();
             await LoadAdultsAsync();
+            RebuildDerivedState();
         }
         catch (Exception ex)
         {
@@ -429,6 +431,16 @@ else
         var start = slot.StartTime.ToLocalTime();
         var end = start.AddHours((double)slot.DurationHours);
         return $"{start.ToString("d.M. HH:mm", Czech)}-{end.ToString("HH:mm", Czech)}";
+    }
+
+    private string CellButtonLabel(
+        OrganizerRoleTimeSlotDto slot,
+        OrganizerRoleNpcDto npc,
+        OrganizerRoleAssignmentDto? assignment)
+    {
+        var action = assignment is null ? "Přiřadit dospělého" : "Upravit přiřazení";
+        var person = assignment is null ? null : $" - {assignment.PersonName}";
+        return $"{action}: {npc.NpcName}, {FormatSlotTime(slot)}{person}";
     }
 
     private string CellCss(OrganizerRoleAssignmentDto? assignment)

--- a/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor.css
+++ b/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor.css
@@ -1,0 +1,191 @@
+.oh-orgrole-bar {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.oh-orgrole-bar h1 {
+    margin: 0;
+    font-size: 1.75rem;
+}
+
+.oh-orgrole-sub {
+    color: var(--bs-secondary-color);
+    font-size: 0.95rem;
+}
+
+.oh-orgrole-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.oh-orgrole-filters {
+    display: grid;
+    grid-template-columns: minmax(220px, 300px) minmax(260px, 380px) 1fr;
+    gap: 12px;
+    align-items: end;
+    margin-bottom: 16px;
+}
+
+.oh-orgrole-filters label {
+    display: grid;
+    gap: 4px;
+    font-weight: 600;
+}
+
+.oh-orgrole-filter-note {
+    color: var(--bs-secondary-color);
+    font-size: 0.875rem;
+    padding-bottom: 8px;
+}
+
+.oh-orgrole-empty {
+    border: 1px solid var(--bs-border-color);
+    padding: 24px;
+    background: var(--bs-body-bg);
+    text-align: center;
+}
+
+.oh-orgrole-empty i {
+    display: block;
+    color: var(--oh-stage-early);
+    font-size: 2rem;
+    margin-bottom: 8px;
+}
+
+.oh-orgrole-empty h2 {
+    font-size: 1.25rem;
+    margin: 0 0 8px;
+}
+
+.oh-orgrole-matrix-wrap {
+    overflow: auto;
+    border: 1px solid var(--bs-border-color);
+    max-height: calc(100vh - 260px);
+    background: var(--bs-body-bg);
+}
+
+.oh-orgrole-matrix {
+    border-collapse: separate;
+    border-spacing: 0;
+    min-width: 900px;
+    width: 100%;
+}
+
+.oh-orgrole-matrix th,
+.oh-orgrole-matrix td {
+    border-right: 1px solid var(--bs-border-color);
+    border-bottom: 1px solid var(--bs-border-color);
+    vertical-align: top;
+}
+
+.oh-orgrole-matrix thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--bs-tertiary-bg);
+    padding: 8px;
+}
+
+.oh-orgrole-role-head,
+.oh-orgrole-role-cell {
+    position: sticky;
+    left: 0;
+    z-index: 3;
+    width: 220px;
+    min-width: 220px;
+    background: var(--bs-body-bg);
+}
+
+.oh-orgrole-role-head {
+    background: var(--bs-tertiary-bg);
+}
+
+.oh-orgrole-role-cell {
+    padding: 10px;
+}
+
+.oh-orgrole-role-cell span,
+.oh-orgrole-person {
+    display: block;
+    font-weight: 700;
+}
+
+.oh-orgrole-role-cell small,
+.oh-orgrole-slot small,
+.oh-orgrole-cell-btn small {
+    display: block;
+    color: var(--bs-secondary-color);
+    font-size: 0.78rem;
+}
+
+.oh-orgrole-slot {
+    min-width: 150px;
+}
+
+.oh-orgrole-cell {
+    min-width: 150px;
+    height: 72px;
+    padding: 0;
+    background: var(--bs-body-bg);
+}
+
+.oh-orgrole-cell-btn {
+    width: 100%;
+    min-height: 72px;
+    height: 100%;
+    border: 0;
+    background: transparent;
+    text-align: left;
+    padding: 8px;
+    color: inherit;
+}
+
+.oh-orgrole-cell-btn:hover,
+.oh-orgrole-cell-btn:focus {
+    background: color-mix(in srgb, var(--oh-stage-early) 14%, transparent);
+    outline: 2px solid color-mix(in srgb, var(--oh-stage-early) 45%, transparent);
+    outline-offset: -2px;
+}
+
+.oh-orgrole-empty-cell {
+    color: var(--bs-secondary-color);
+    font-size: 1.2rem;
+}
+
+.oh-orgrole-cell.is-dimmed {
+    opacity: 0.34;
+}
+
+.oh-orgrole-cell.is-match {
+    background: color-mix(in srgb, var(--oh-stage-early) 16%, var(--bs-body-bg));
+}
+
+.oh-orgrole-cell.has-duplicate {
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, #b58100 65%, transparent);
+}
+
+.oh-orgrole-dup {
+    display: inline-block;
+    margin-top: 4px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    background: #fff3cd;
+    color: #6f4e00;
+    font-size: 0.72rem;
+    font-weight: 700;
+}
+
+@media (max-width: 900px) {
+    .oh-orgrole-bar {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .oh-orgrole-filters {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/OvcinaHra.Client/Services/ApiClient.cs
+++ b/src/OvcinaHra.Client/Services/ApiClient.cs
@@ -57,6 +57,8 @@ public class ApiClient
         using var response = await _http.GetAsync(url, cancellationToken);
         if (!response.IsSuccessStatusCode)
             return (false, default, await ReadProblemDetailAsync(response));
+        if (response.Content.Headers.ContentLength == 0 || response.StatusCode == HttpStatusCode.NoContent)
+            return (true, default, null);
 
         return (true, await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken), null);
     }

--- a/src/OvcinaHra.Client/Services/ApiClient.cs
+++ b/src/OvcinaHra.Client/Services/ApiClient.cs
@@ -50,6 +50,17 @@ public class ApiClient
         return (true, response.StatusCode, await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken));
     }
 
+    public async Task<(bool Ok, T? Value, string? ProblemDetail)> GetWithProblemAsync<T>(
+        string url,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await _http.GetAsync(url, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+            return (false, default, await ReadProblemDetailAsync(response));
+
+        return (true, await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken), null);
+    }
+
     public async Task<TResponse?> PostAsync<TRequest, TResponse>(
         string url,
         TRequest data,

--- a/src/OvcinaHra.Shared/Domain/Entities/Game.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Game.cs
@@ -42,4 +42,5 @@ public class Game
     public ICollection<BattlefieldBonus> BattlefieldBonuses { get; set; } = [];
     public ICollection<GameNpc> GameNpcs { get; set; } = [];
     public ICollection<GameEvent> GameEvents { get; set; } = [];
+    public ICollection<OrganizerRoleAssignment> OrganizerRoleAssignments { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/GameTimeSlot.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/GameTimeSlot.cs
@@ -17,4 +17,5 @@ public class GameTimeSlot
     public Game Game { get; set; } = null!;
     public ICollection<GameEventTimeSlot> EventTimeSlots { get; set; } = [];
     public ICollection<Quest> Quests { get; set; } = [];
+    public ICollection<OrganizerRoleAssignment> OrganizerRoleAssignments { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/Npc.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Npc.cs
@@ -18,4 +18,5 @@ public class Npc
 
     public ICollection<GameNpc> GameNpcs { get; set; } = [];
     public ICollection<GameEventNpc> EventNpcs { get; set; } = [];
+    public ICollection<OrganizerRoleAssignment> OrganizerRoleAssignments { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/OrganizerRoleAssignment.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/OrganizerRoleAssignment.cs
@@ -1,0 +1,21 @@
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class OrganizerRoleAssignment
+{
+    public int Id { get; set; }
+    public int GameId { get; set; }
+    public int GameTimeSlotId { get; set; }
+    public int NpcId { get; set; }
+
+    public int PersonId { get; set; }
+    public required string PersonName { get; set; }
+    public string? PersonEmail { get; set; }
+    public string? Notes { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public Game Game { get; set; } = null!;
+    public GameTimeSlot TimeSlot { get; set; } = null!;
+    public Npc Npc { get; set; } = null!;
+}

--- a/src/OvcinaHra.Shared/Dtos/OrganizerRoleDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/OrganizerRoleDtos.cs
@@ -1,0 +1,52 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Dtos;
+
+public record OrganizerRoleMatrixDto(
+    int GameId,
+    List<OrganizerRoleTimeSlotDto> TimeSlots,
+    List<OrganizerRoleNpcDto> Npcs,
+    List<OrganizerRoleAssignmentDto> Assignments);
+
+public record OrganizerRoleTimeSlotDto(
+    int Id,
+    DateTime StartTime,
+    decimal DurationHours,
+    int? InGameYear,
+    GameTimePhase Stage);
+
+public record OrganizerRoleNpcDto(
+    int NpcId,
+    string NpcName,
+    NpcRole Role,
+    string? Description);
+
+public record OrganizerRoleAssignmentDto(
+    int Id,
+    int GameId,
+    int GameTimeSlotId,
+    int NpcId,
+    int PersonId,
+    string PersonName,
+    string? PersonEmail,
+    string? Notes,
+    DateTime CreatedAtUtc,
+    DateTime UpdatedAtUtc);
+
+public record UpsertOrganizerRoleAssignmentDto(
+    int PersonId,
+    string PersonName,
+    string? PersonEmail,
+    string? Notes = null);
+
+public record BulkOrganizerRoleAssignmentDto(
+    int NpcId,
+    int PersonId,
+    string PersonName,
+    string? PersonEmail,
+    string? Notes = null);
+
+public record BulkOrganizerRoleAssignmentResultDto(
+    int CreatedCount,
+    int UpdatedCount,
+    List<OrganizerRoleAssignmentDto> Assignments);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/OrganizerRoleEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/OrganizerRoleEndpointTests.cs
@@ -1,0 +1,202 @@
+using System.Net;
+using System.Net.Http.Json;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+public class OrganizerRoleEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    [Fact]
+    public async Task BulkAssign_CreatesAssignmentForEveryGameTimeSlot()
+    {
+        var (game, npc, slots) = await CreateGameWithNpcAndSlotsAsync(slotCount: 2);
+
+        var response = await Client.PostAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/bulk",
+            new BulkOrganizerRoleAssignmentDto(npc.Id, 501, "Pavel Dospělý", "pavel@example.com", "celá hra"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = (await response.Content.ReadFromJsonAsync<BulkOrganizerRoleAssignmentResultDto>())!;
+        Assert.Equal(2, result.CreatedCount);
+        Assert.Equal(0, result.UpdatedCount);
+        Assert.Equal(slots.Select(s => s.Id).Order(), result.Assignments.Select(a => a.GameTimeSlotId).Order());
+
+        var matrix = await LoadMatrixAsync(game.Id);
+        Assert.Equal(2, matrix.TimeSlots.Count);
+        Assert.Single(matrix.Npcs);
+        Assert.All(matrix.Assignments, a =>
+        {
+            Assert.Equal(npc.Id, a.NpcId);
+            Assert.Equal(501, a.PersonId);
+            Assert.Equal("Pavel Dospělý", a.PersonName);
+        });
+    }
+
+    [Fact]
+    public async Task BulkAssign_UpdatesExistingNpcSlotAssignments()
+    {
+        var (game, npc, slots) = await CreateGameWithNpcAndSlotsAsync(slotCount: 2);
+        var firstSlot = slots[0];
+
+        var initial = await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{firstSlot.Id}/npcs/{npc.Id}",
+            new UpsertOrganizerRoleAssignmentDto(501, "Pavel Dospělý", "pavel@example.com"));
+        Assert.Equal(HttpStatusCode.OK, initial.StatusCode);
+
+        var response = await Client.PostAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/bulk",
+            new BulkOrganizerRoleAssignmentDto(npc.Id, 777, "Jana Dospělá", "jana@example.com"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = (await response.Content.ReadFromJsonAsync<BulkOrganizerRoleAssignmentResultDto>())!;
+        Assert.Equal(1, result.CreatedCount);
+        Assert.Equal(1, result.UpdatedCount);
+
+        var matrix = await LoadMatrixAsync(game.Id);
+        Assert.Equal(2, matrix.Assignments.Count);
+        Assert.All(matrix.Assignments, a => Assert.Equal(777, a.PersonId));
+    }
+
+    [Fact]
+    public async Task UpsertSlotAssignment_AllowsSameAdultAcrossMultipleNpcRolesInSameSlot()
+    {
+        var game = await CreateGameAsync();
+        var slot = await CreateSlotAsync(game.Id, hour: 10);
+        var merchant = await CreateNpcAsync("Kupec", NpcRole.Merchant);
+        var monster = await CreateNpcAsync("Vlkodlak", NpcRole.Monster);
+        await AssignNpcAsync(game.Id, merchant.Id);
+        await AssignNpcAsync(game.Id, monster.Id);
+
+        var dto = new UpsertOrganizerRoleAssignmentDto(501, "Pavel Dospělý", "pavel@example.com");
+        var first = await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{slot.Id}/npcs/{merchant.Id}",
+            dto);
+        var second = await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{slot.Id}/npcs/{monster.Id}",
+            dto);
+
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+
+        var matrix = await LoadMatrixAsync(game.Id);
+        Assert.Equal(2, matrix.Assignments.Count);
+        Assert.All(matrix.Assignments, a =>
+        {
+            Assert.Equal(slot.Id, a.GameTimeSlotId);
+            Assert.Equal(501, a.PersonId);
+        });
+    }
+
+    [Fact]
+    public async Task UpsertSlotAssignment_ReplacesExistingPersonForNpcSlot()
+    {
+        var (game, npc, slots) = await CreateGameWithNpcAndSlotsAsync(slotCount: 1);
+        var slot = slots[0];
+
+        await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{slot.Id}/npcs/{npc.Id}",
+            new UpsertOrganizerRoleAssignmentDto(501, "Pavel Dospělý", "pavel@example.com"));
+        var response = await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{slot.Id}/npcs/{npc.Id}",
+            new UpsertOrganizerRoleAssignmentDto(777, "Jana Dospělá", "jana@example.com"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var matrix = await LoadMatrixAsync(game.Id);
+        var assignment = Assert.Single(matrix.Assignments);
+        Assert.Equal(777, assignment.PersonId);
+        Assert.Equal("Jana Dospělá", assignment.PersonName);
+    }
+
+    [Fact]
+    public async Task DeleteSlotAssignment_RemovesOnlySelectedSlotAssignment()
+    {
+        var (game, npc, slots) = await CreateGameWithNpcAndSlotsAsync(slotCount: 2);
+        await Client.PostAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/bulk",
+            new BulkOrganizerRoleAssignmentDto(npc.Id, 501, "Pavel Dospělý", "pavel@example.com"));
+
+        var response = await Client.DeleteAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{slots[0].Id}/npcs/{npc.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var matrix = await LoadMatrixAsync(game.Id);
+        var assignment = Assert.Single(matrix.Assignments);
+        Assert.Equal(slots[1].Id, assignment.GameTimeSlotId);
+    }
+
+    [Fact]
+    public async Task DeleteGameNpc_RemovesOrganizerRoleAssignmentsForThatNpc()
+    {
+        var (game, npc, _) = await CreateGameWithNpcAndSlotsAsync(slotCount: 1);
+        await Client.PostAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/bulk",
+            new BulkOrganizerRoleAssignmentDto(npc.Id, 501, "Pavel Dospělý", "pavel@example.com"));
+
+        var response = await Client.DeleteAsync($"/api/npcs/game-npc/{game.Id}/{npc.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var matrix = await LoadMatrixAsync(game.Id);
+        Assert.Empty(matrix.Assignments);
+    }
+
+    private async Task<(GameDetailDto Game, NpcDetailDto Npc, List<GameTimeSlotDto> Slots)> CreateGameWithNpcAndSlotsAsync(int slotCount)
+    {
+        var game = await CreateGameAsync();
+        var npc = await CreateNpcAsync("Gobliní král", NpcRole.Monster);
+        await AssignNpcAsync(game.Id, npc.Id);
+
+        var slots = new List<GameTimeSlotDto>();
+        for (var i = 0; i < slotCount; i++)
+        {
+            slots.Add(await CreateSlotAsync(game.Id, 10 + i));
+        }
+
+        return (game, npc, slots);
+    }
+
+    private async Task<GameDetailDto> CreateGameAsync()
+    {
+        var response = await Client.PostAsJsonAsync(
+            "/api/games",
+            new CreateGameDto("Rozpis rolí", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    private async Task<NpcDetailDto> CreateNpcAsync(string name, NpcRole role)
+    {
+        var response = await Client.PostAsJsonAsync(
+            "/api/npcs",
+            new CreateNpcDto(name, role, "Role pro organizátorský rozpis"));
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return (await response.Content.ReadFromJsonAsync<NpcDetailDto>())!;
+    }
+
+    private async Task AssignNpcAsync(int gameId, int npcId)
+    {
+        var response = await Client.PostAsJsonAsync("/api/npcs/game-npc", new CreateGameNpcDto(gameId, npcId));
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    private async Task<GameTimeSlotDto> CreateSlotAsync(int gameId, int hour)
+    {
+        var response = await Client.PostAsJsonAsync(
+            "/api/timeline/slots",
+            new CreateGameTimeSlotDto(
+                GameId: gameId,
+                StartTime: new DateTime(2026, 5, 1, hour, 0, 0, DateTimeKind.Utc),
+                DurationHours: 1,
+                InGameYear: 1247));
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return (await response.Content.ReadFromJsonAsync<GameTimeSlotDto>())!;
+    }
+
+    private async Task<OrganizerRoleMatrixDto> LoadMatrixAsync(int gameId)
+    {
+        var matrix = await Client.GetFromJsonAsync<OrganizerRoleMatrixDto>(
+            $"/api/games/{gameId}/organizer-role-assignments");
+        return matrix!;
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/OrganizerRoleEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/OrganizerRoleEndpointTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
@@ -139,6 +140,23 @@ public class OrganizerRoleEndpointTests(PostgresFixture postgres) : IntegrationT
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         var matrix = await LoadMatrixAsync(game.Id);
         Assert.Empty(matrix.Assignments);
+    }
+
+    [Fact]
+    public async Task UpsertSlotAssignment_RejectsTooLongPersonFieldsWithProblemDetails()
+    {
+        var (game, npc, slots) = await CreateGameWithNpcAndSlotsAsync(slotCount: 1);
+        var tooLongName = new string('A', 201);
+
+        var response = await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{slots[0].Id}/npcs/{npc.Id}",
+            new UpsertOrganizerRoleAssignmentDto(501, tooLongName, "pavel@example.com"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Jméno dospělého je příliš dlouhé", problem.Title);
+        Assert.Contains("200", problem.Detail ?? "");
     }
 
     private async Task<(GameDetailDto Game, NpcDetailDto Npc, List<GameTimeSlotDto> Slots)> CreateGameWithNpcAndSlotsAsync(int slotCount)


### PR DESCRIPTION
## Summary
- Closes #370 by adding an organizer role assignment matrix for Adults x NPC roles x time slots.
- Adds OrganizerRoleAssignment persistence with unique (GameId, GameTimeSlotId, NpcId), no adult-slot uniqueness, plus bulk whole-game assignment and per-slot upsert/remove endpoints.
- Adds the /organizer-roles page with role-type + adult filters, duplicate-adult visual flagging, DxPopup edit/confirm flows, and [organizer-roles] diagnostics.
- Adds ApiClient.GetWithProblemAsync so the Registrace adults load can surface Czech ProblemDetails instead of raw HttpRequestException text.

## Verification
- dotnet build OvcinaHra.slnx
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter "OrganizerRoleEndpointTests|DatabaseMigrationTests"
- dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include changed C# files
- git diff --check

## Browser smoke
- Local route /organizer-roles renders after dev auth.
- Seeded one active-game slot + NPC role locally; matrix rendered 1 cell and [organizer-roles] load markers.
- Local game is not linked to Registrace, so adult picker editing could not be fully exercised in browser; the page now shows the Czech ProblemDetails message for that state and endpoint tests cover assignment/editing behavior.

## Notes
- No csproj <Version> bump.
- Orchestrator owns merge.