### PR TITLE
fix(api): organizer role endpoint nits

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
@@ -119,8 +119,8 @@ public static class OrganizerRoleEndpoints
         if (slotIds.Count == 0)
         {
             return Problem(
-                "Hra nemá žádné časové sloty.",
                 "Nejdřív vytvořte časové bloky v harmonogramu.",
+                "Hra nemá časové sloty",
                 StatusCodes.Status400BadRequest);
         }
 
@@ -270,6 +270,14 @@ public static class OrganizerRoleEndpoints
         CancellationToken ct,
         int? slotId = null)
     {
+        if (!await db.Games.AnyAsync(g => g.Id == gameId, ct))
+        {
+            return Problem(
+                "Požadovaná hra nebyla nalezena.",
+                "Hra neexistuje",
+                StatusCodes.Status404NotFound);
+        }
+
         if (personId <= 0 || string.IsNullOrWhiteSpace(personName))
         {
             return Problem(
@@ -300,14 +308,6 @@ public static class OrganizerRoleEndpoints
                 $"Poznámka může mít nejvýše {NotesMaxLength} znaků.",
                 "Poznámka je příliš dlouhá",
                 StatusCodes.Status400BadRequest);
-        }
-
-        if (!await db.Games.AnyAsync(g => g.Id == gameId, ct))
-        {
-            return Problem(
-                "Požadovaná hra nebyla nalezena.",
-                "Hra neexistuje",
-                StatusCodes.Status404NotFound);
         }
 
         if (slotId is int sid && !await db.GameTimeSlots.AnyAsync(s => s.Id == sid && s.GameId == gameId, ct))

--- a/tests/OvcinaHra.Api.Tests/Endpoints/OrganizerRoleEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/OrganizerRoleEndpointTests.cs
@@ -143,6 +143,38 @@ public class OrganizerRoleEndpointTests(PostgresFixture postgres) : IntegrationT
     }
 
     [Fact]
+    public async Task BulkAssign_NonexistentGame_ReturnsNotFoundBeforePayloadValidation()
+    {
+        var response = await Client.PostAsJsonAsync(
+            "/api/games/999999999/organizer-role-assignments/bulk",
+            new BulkOrganizerRoleAssignmentDto(1, 0, "", null));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Hra neexistuje", problem.Title);
+        Assert.Equal("Požadovaná hra nebyla nalezena.", problem.Detail);
+    }
+
+    [Fact]
+    public async Task BulkAssign_GameWithoutTimeSlots_ReturnsPolishedProblemDetails()
+    {
+        var game = await CreateGameAsync();
+        var npc = await CreateNpcAsync("Bez slotů", NpcRole.Monster);
+        await AssignNpcAsync(game.Id, npc.Id);
+
+        var response = await Client.PostAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/bulk",
+            new BulkOrganizerRoleAssignmentDto(npc.Id, 501, "Pavel Dospělý", "pavel@example.com"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Hra nemá časové sloty", problem.Title);
+        Assert.Equal("Nejdřív vytvořte časové bloky v harmonogramu.", problem.Detail);
+    }
+
+    [Fact]
     public async Task UpsertSlotAssignment_RejectsTooLongPersonFieldsWithProblemDetails()
     {
         var (game, npc, slots) = await CreateGameWithNpcAndSlotsAsync(slotCount: 1);


### PR DESCRIPTION
## Summary
- Closes #390.
- Reorders OrganizerRoleEndpoints target validation so missing game IDs return 404 before payload-shape 400s.
- Polishes the no-slots BulkAssign ProblemDetails to noun-phrase title + sentence detail.

## Verification
- dotnet build OvcinaHra.slnx
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter "OrganizerRoleEndpointTests"
- dotnet test OvcinaHra.slnx --no-build
- dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
- git diff --check

## Smoke
- POST /api/games/999999999/organizer-role-assignments/bulk with invalid payload -> 404, title "Hra neexistuje", detail "Požadovaná hra nebyla nalezena."
- POST /api/games/{newGameWithoutSlots}/organizer-role-assignments/bulk -> 400, title "Hra nemá časové sloty", detail "Nejdřív vytvořte časové bloky v harmonogramu."

## Notes
- Single-file API change.
- No csproj <Version> bump.
- Orchestrator owns merge.