### PR TITLE
feat(locations): add mobile placement recording

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/WorldActivityConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/WorldActivityConfiguration.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class WorldActivityConfiguration : IEntityTypeConfiguration<WorldActivity>
+{
+    public void Configure(EntityTypeBuilder<WorldActivity> builder)
+    {
+        builder.HasKey(a => a.Id);
+        builder.Property(a => a.OrganizerUserId).IsRequired().HasMaxLength(200);
+        builder.Property(a => a.OrganizerName).IsRequired().HasMaxLength(200);
+        builder.Property(a => a.ActivityType).HasConversion<string>().HasMaxLength(64);
+        builder.Property(a => a.Description).IsRequired().HasMaxLength(500);
+        builder.Property(a => a.DataJson).HasColumnType("jsonb");
+
+        builder.HasOne(a => a.Game)
+            .WithMany(g => g.WorldActivities)
+            .HasForeignKey(a => a.GameId);
+        builder.HasOne(a => a.Location)
+            .WithMany()
+            .HasForeignKey(a => a.LocationId)
+            .OnDelete(DeleteBehavior.SetNull);
+        builder.HasOne(a => a.CharacterAssignment)
+            .WithMany()
+            .HasForeignKey(a => a.CharacterAssignmentId)
+            .OnDelete(DeleteBehavior.SetNull);
+        builder.HasOne(a => a.Quest)
+            .WithMany()
+            .HasForeignKey(a => a.QuestId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasIndex(a => new { a.GameId, a.TimestampUtc });
+        builder.HasIndex(a => a.LocationId);
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -56,6 +56,7 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<CharacterAssignment> CharacterAssignments => Set<CharacterAssignment>();
     public DbSet<CharacterEvent> CharacterEvents => Set<CharacterEvent>();
     public DbSet<EventIdempotency> EventIdempotencies => Set<EventIdempotency>();
+    public DbSet<WorldActivity> WorldActivities => Set<WorldActivity>();
     public DbSet<GameEvent> GameEvents => Set<GameEvent>();
     public DbSet<GameEventTimeSlot> GameEventTimeSlots => Set<GameEventTimeSlot>();
     public DbSet<GameEventLocation> GameEventLocations => Set<GameEventLocation>();

--- a/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Endpoints;
@@ -107,17 +108,42 @@ public static class DashboardEndpoints
         count == 0 ? "low" : count < 5 ? "low" : count < 15 ? "mid" : "high";
 
     /// <summary>
-    /// Powers RecentActivityFeed — last-N edits across the entities that
-    /// carry a meaningful timestamp. <b>Stub:</b> no WorldChange audit
-    /// log exists yet, so we cherry-pick the entity tables that already
-    /// have <c>UpdatedAtUtc</c> (Character, GameEvent, Npc) and merge.
-    /// Verb is hard-coded to "upravil" — replace with real change tracking
-    /// once the WorldChange table lands. Flagged as follow-up.
+    /// Powers RecentActivityFeed — real WorldActivity recordings first,
+    /// followed by legacy per-entity timestamp rows until every workflow
+    /// records through WorldActivity.
     /// </summary>
     private static async Task<Ok<List<DashboardActivityDto>>> GetActivity(
-        int gameId, WorldDbContext db, int? limit = 10)
+        int gameId, WorldDbContext db, HttpContext http, int? limit = 10)
     {
         var take = Math.Clamp(limit ?? 10, 1, 50);
+
+        var activityRows = await db.WorldActivities
+            .Where(a => a.GameId == gameId)
+            .OrderByDescending(a => a.TimestampUtc)
+            .Take(take)
+            .Select(a => new
+            {
+                a.Id,
+                a.LocationId,
+                a.Description,
+                a.OrganizerName,
+                a.TimestampUtc,
+                a.ActivityType,
+                LocationName = a.Location != null ? a.Location.Name : null,
+                PlacementPhotoPath = a.Location != null ? a.Location.PlacementPhotoPath : null
+            })
+            .ToListAsync();
+
+        var activities = activityRows.Select(a => new DashboardActivityDto(
+            a.LocationId.HasValue ? "location" : "activity",
+            a.LocationId ?? a.Id,
+            a.LocationName ?? a.Description,
+            a.LocationId.HasValue && !string.IsNullOrWhiteSpace(a.PlacementPhotoPath)
+                ? ImageEndpoints.ThumbUrl(http, "locationplacements", a.LocationId.Value, "small")
+                : null,
+            ActivityVerb(a.ActivityType),
+            a.OrganizerName,
+            a.TimestampUtc)).ToList();
 
         // Per-entity slices, each ordered DESC and capped at `take` so the
         // merged result has enough material to slice the global top-N from.
@@ -150,6 +176,7 @@ public static class DashboardEndpoints
             .ToListAsync();
 
         var merged = characters
+            .Concat(activities)
             .Concat(events)
             .Concat(npcs)
             .OrderByDescending(x => x.OccurredUtc)
@@ -158,6 +185,14 @@ public static class DashboardEndpoints
 
         return TypedResults.Ok(merged);
     }
+
+    private static string ActivityVerb(WorldActivityType type) => type switch
+    {
+        WorldActivityType.LocationPlaced => "umístil",
+        WorldActivityType.CharacterLevelUp => "zapsal level",
+        WorldActivityType.QuestCompleted => "dokončil quest",
+        _ => "zapsal"
+    };
 
     /// <summary>
     /// Powers TimelinePreview — upcoming and currently-running GameTimeSlot

--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Dtos;
@@ -10,13 +11,10 @@ namespace OvcinaHra.Api.Endpoints;
 
 public static class ImageEndpoints
 {
-    // "locationstamps" is a logical alias keyed by Location.Id that reads /
-    // writes Location.StampImagePath. Exposed as its own entity type so that
-    // the thumbnail cache, pre-gen, and backfill pipelines treat the rubber
-    // stamp as an independent image (its cache keys don't collide with the
-    // main location image). See GetEntityImagePaths and the Upload DbContext
-    // switch for the dispatch.
-    private static readonly HashSet<string> ValidEntityTypes = ["locations", "locationstamps", "items", "monsters", "secretstashes", "npcs", "buildings", "characters", "kingdoms", "spells", "quests"];
+    // "locationstamps" and "locationplacements" are logical aliases keyed by
+    // Location.Id. They write Location.StampImagePath / PlacementPhotoPath but
+    // keep independent thumbnail cache keys from the main location image.
+    private static readonly HashSet<string> ValidEntityTypes = ["locations", "locationstamps", "locationplacements", "items", "monsters", "secretstashes", "npcs", "buildings", "characters", "kingdoms", "spells", "quests"];
     private static readonly HashSet<string> AllowedContentTypes = ["image/jpeg", "image/png", "image/webp"];
     private const long MaxFileSize = 5 * 1024 * 1024; // 5 MB
     private const int LocationStampMinimumPixels = 200;
@@ -116,61 +114,98 @@ public static class ImageEndpoints
     private static async Task<Results<Ok<ImageUploadResult>, NotFound, BadRequest<ProblemDetails>>> Upload(
         string entityType, int entityId, IFormFile file, IBlobStorageService blobService,
         IThumbnailService thumbnailService, ILogger<ThumbnailService> thumbLogger,
-        WorldDbContext db, CancellationToken ct, string? field = null)
+        WorldDbContext db, HttpContext http, ILoggerFactory loggerFactory,
+        CancellationToken ct, string? field = null, int? gameId = null)
     {
-        if (!ValidEntityTypes.Contains(entityType))
-            return TypedResults.BadRequest(ImageValidationProblem($"Neplatný typ entity '{entityType}'."));
-
-        if (file.Length > MaxFileSize)
-            return TypedResults.BadRequest(ImageValidationProblem($"Soubor je příliš velký. Maximální velikost je {MaxFileSize / (1024 * 1024)} MB."));
-
-        if (!AllowedContentTypes.Contains(file.ContentType))
-            return TypedResults.BadRequest(ImageValidationProblem($"Neplatný typ souboru '{file.ContentType}'. Povolené typy: {string.Join(", ", AllowedContentTypes)}."));
-
-        if (!await EntityExists(db, entityType, entityId))
-            return TypedResults.NotFound();
-
-        var isPlacement = string.Equals(field, "placement", StringComparison.OrdinalIgnoreCase);
-        var suffix = isPlacement ? "placement" : "image";
-        var ext = file.ContentType switch
+        var isLocationPlacement = string.Equals(entityType, "locationplacements", StringComparison.Ordinal);
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.ImageEndpoints");
+        var userId = GetUserId(http.User);
+        if (isLocationPlacement)
         {
-            "image/jpeg" => "jpg",
-            "image/png" => "png",
-            "image/webp" => "webp",
-            _ => "bin"
-        };
-        var blobKey = $"{entityType}/{entityId}/{suffix}.{ext}";
-
-        await using var stream = file.OpenReadStream();
-        if (entityType == "locationstamps")
-        {
-            var validationProblem = await ValidateLocationStampImageAsync(stream, ct);
-            if (validationProblem is not null)
-                return TypedResults.BadRequest(validationProblem);
-        }
-        if (stream.CanSeek)
-            stream.Position = 0;
-
-        await blobService.UploadAsync(blobKey, stream, file.ContentType, ct);
-
-        // Invalidate any cached thumbnails for this entity — they were resized
-        // from the previous source image and are stale now. Only apply to the
-        // main image path; placement photos are detail-only and not cached.
-        if (!isPlacement)
-        {
-            await blobService.DeletePrefixAsync($"{entityType}-thumbs/{entityId}-");
-            // Fire-and-forget pre-generation of all presets so the first
-            // list-page viewer hits the hot-cache 302-redirect path instead of
-            // paying cold resize cost. Upload response returns immediately;
-            // generation runs on a background task. Discard (_ =) silences
-            // CS4014 without a pragma.
-            _ = PreGenerateAllPresetsAsync(thumbnailService, thumbLogger, entityType, entityId, blobKey);
+            logger.LogInformation(
+                "[loc-placement] image.upload.entry gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                gameId,
+                entityId,
+                userId,
+                null);
         }
 
-        await UpdateEntityImagePath(db, entityType, entityId, blobKey, isPlacement);
+        try
+        {
+            if (!ValidEntityTypes.Contains(entityType))
+                return TypedResults.BadRequest(ImageValidationProblem($"Neplatný typ entity '{entityType}'."));
 
-        var url = await blobService.GetSasUrlAsync(blobKey);
-        return TypedResults.Ok(new ImageUploadResult(blobKey, url));
+            if (file.Length > MaxFileSize)
+                return TypedResults.BadRequest(ImageValidationProblem($"Soubor je příliš velký. Maximální velikost je {MaxFileSize / (1024 * 1024)} MB."));
+
+            if (!AllowedContentTypes.Contains(file.ContentType))
+                return TypedResults.BadRequest(ImageValidationProblem($"Neplatný typ souboru '{file.ContentType}'. Povolené typy: {string.Join(", ", AllowedContentTypes)}."));
+
+            if (!await EntityExists(db, entityType, entityId))
+                return TypedResults.NotFound();
+
+            var isPlacement = string.Equals(field, "placement", StringComparison.OrdinalIgnoreCase);
+            var suffix = isPlacement ? "placement" : "image";
+            var ext = file.ContentType switch
+            {
+                "image/jpeg" => "jpg",
+                "image/png" => "png",
+                "image/webp" => "webp",
+                _ => "bin"
+            };
+            var blobKey = $"{entityType}/{entityId}/{suffix}.{ext}";
+
+            await using var stream = file.OpenReadStream();
+            if (entityType == "locationstamps")
+            {
+                var validationProblem = await ValidateLocationStampImageAsync(stream, ct);
+                if (validationProblem is not null)
+                    return TypedResults.BadRequest(validationProblem);
+            }
+            if (stream.CanSeek)
+                stream.Position = 0;
+
+            await blobService.UploadAsync(blobKey, stream, file.ContentType, ct);
+            if (isLocationPlacement)
+            {
+                logger.LogInformation(
+                    "[loc-placement] image.upload.blob-uploaded gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                    gameId,
+                    entityId,
+                    userId,
+                    blobKey);
+            }
+
+            // Invalidate cached thumbnails for this logical image entity. Legacy
+            // ?field=placement uploads on "locations" skip this path; the canonical
+            // "locationplacements" alias gets its own cache namespace.
+            if (!isPlacement)
+            {
+                await blobService.DeletePrefixAsync($"{entityType}-thumbs/{entityId}-");
+                // Fire-and-forget pre-generation of all presets so the first
+                // list-page viewer hits the hot-cache 302-redirect path instead of
+                // paying cold resize cost. Upload response returns immediately;
+                // generation runs on a background task. Discard (_ =) silences
+                // CS4014 without a pragma.
+                _ = PreGenerateAllPresetsAsync(thumbnailService, thumbLogger, entityType, entityId, blobKey);
+            }
+
+            await UpdateEntityImagePath(db, entityType, entityId, blobKey, isPlacement);
+
+            var url = await blobService.GetSasUrlAsync(blobKey);
+            return TypedResults.Ok(new ImageUploadResult(blobKey, url));
+        }
+        catch (Exception ex) when (isLocationPlacement && ex is not OperationCanceledException)
+        {
+            logger.LogError(
+                ex,
+                "[loc-placement] image.upload.failed gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                gameId,
+                entityId,
+                userId,
+                null);
+            throw;
+        }
     }
 
     /// <summary>
@@ -279,6 +314,12 @@ public static class ImageEndpoints
             .Select(l => new { l.Id, BlobKey = l.StampImagePath! })
             .ToListAsync(ct))
             targets.Add(("locationstamps", row.Id, row.BlobKey));
+
+        foreach (var row in await db.Locations
+            .Where(l => l.PlacementPhotoPath != null && l.PlacementPhotoPath != "")
+            .Select(l => new { l.Id, BlobKey = l.PlacementPhotoPath! })
+            .ToListAsync(ct))
+            targets.Add(("locationplacements", row.Id, row.BlobKey));
 
         foreach (var row in await db.Items
             .Where(i => i.ImagePath != null && i.ImagePath != "")
@@ -450,6 +491,11 @@ public static class ImageEndpoints
                 if (locationForStamp is not null)
                     locationForStamp.StampImagePath = blobKey;
                 break;
+            case "locationplacements":
+                var locationForPlacement = await db.Locations.FindAsync(entityId);
+                if (locationForPlacement is not null)
+                    locationForPlacement.PlacementPhotoPath = blobKey;
+                break;
             case "items":
                 var item = await db.Items.FindAsync(entityId);
                 if (item is not null) item.ImagePath = blobKey;
@@ -501,6 +547,9 @@ public static class ImageEndpoints
                 .FirstOrDefaultAsync(),
             "locationstamps" => await db.Locations.Where(l => l.Id == entityId)
                 .Select(l => new ValueTuple<string?, string?, string?>(l.StampImagePath, null, l.StampImagePath))
+                .FirstOrDefaultAsync(),
+            "locationplacements" => await db.Locations.Where(l => l.Id == entityId)
+                .Select(l => new ValueTuple<string?, string?, string?>(l.PlacementPhotoPath, l.PlacementPhotoPath, null))
                 .FirstOrDefaultAsync(),
             "items" => await db.Items.Where(i => i.Id == entityId)
                 .Select(i => new ValueTuple<string?, string?, string?>(i.ImagePath, null, null))
@@ -573,6 +622,7 @@ public static class ImageEndpoints
         {
             "locations" => await db.Locations.AnyAsync(l => l.Id == entityId),
             "locationstamps" => await db.Locations.AnyAsync(l => l.Id == entityId),
+            "locationplacements" => await db.Locations.AnyAsync(l => l.Id == entityId),
             "items" => await db.Items.AnyAsync(i => i.Id == entityId),
             "monsters" => await db.Monsters.AnyAsync(m => m.Id == entityId),
             "secretstashes" => await db.SecretStashes.AnyAsync(s => s.Id == entityId),
@@ -585,4 +635,9 @@ public static class ImageEndpoints
             _ => false
         };
     }
+
+    private static string GetUserId(ClaimsPrincipal user) =>
+        user.FindFirstValue("sub")
+        ?? user.FindFirstValue(ClaimTypes.NameIdentifier)
+        ?? "unknown";
 }

--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -123,10 +123,11 @@ public static class ImageEndpoints
         if (isLocationPlacement)
         {
             logger.LogInformation(
-                "[loc-placement] image.upload.entry gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                "[loc-placement] image.upload.entry gameId={GameId} locationId={LocationId} userId={UserId} imageBlobKey={ImageBlobKey} imageBlobUrl={ImageBlobUrl}",
                 gameId,
                 entityId,
                 userId,
+                null,
                 null);
         }
 
@@ -169,11 +170,12 @@ public static class ImageEndpoints
             if (isLocationPlacement)
             {
                 logger.LogInformation(
-                    "[loc-placement] image.upload.blob-uploaded gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                    "[loc-placement] image.upload.blob-uploaded gameId={GameId} locationId={LocationId} userId={UserId} imageBlobKey={ImageBlobKey} imageBlobUrl={ImageBlobUrl}",
                     gameId,
                     entityId,
                     userId,
-                    blobKey);
+                    blobKey,
+                    null);
             }
 
             // Invalidate cached thumbnails for this logical image entity. Legacy
@@ -189,20 +191,36 @@ public static class ImageEndpoints
                 // CS4014 without a pragma.
                 _ = PreGenerateAllPresetsAsync(thumbnailService, thumbLogger, entityType, entityId, blobKey);
             }
+            else if (entityType == "locations")
+            {
+                await blobService.DeletePrefixAsync($"locationplacements-thumbs/{entityId}-");
+                _ = PreGenerateAllPresetsAsync(thumbnailService, thumbLogger, "locationplacements", entityId, blobKey);
+            }
 
             await UpdateEntityImagePath(db, entityType, entityId, blobKey, isPlacement);
 
             var url = await blobService.GetSasUrlAsync(blobKey);
+            if (isLocationPlacement)
+            {
+                logger.LogInformation(
+                    "[loc-placement] image.upload.url-ready gameId={GameId} locationId={LocationId} userId={UserId} imageBlobKey={ImageBlobKey} imageBlobUrl={ImageBlobUrl}",
+                    gameId,
+                    entityId,
+                    userId,
+                    blobKey,
+                    url);
+            }
             return TypedResults.Ok(new ImageUploadResult(blobKey, url));
         }
         catch (Exception ex) when (isLocationPlacement && ex is not OperationCanceledException)
         {
             logger.LogError(
                 ex,
-                "[loc-placement] image.upload.failed gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                "[loc-placement] image.upload.failed gameId={GameId} locationId={LocationId} userId={UserId} imageBlobKey={ImageBlobKey} imageBlobUrl={ImageBlobUrl}",
                 gameId,
                 entityId,
                 userId,
+                null,
                 null);
             throw;
         }
@@ -464,6 +482,10 @@ public static class ImageEndpoints
         if (pathToDelete is not null)
         {
             await blobService.DeleteAsync(pathToDelete);
+            if (isPlacement && entityType == "locations")
+                await blobService.DeletePrefixAsync($"locationplacements-thumbs/{entityId}-");
+            else if (!isPlacement)
+                await blobService.DeletePrefixAsync($"{entityType}-thumbs/{entityId}-");
             await UpdateEntityImagePath(db, entityType, entityId, null, isPlacement);
         }
 

--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -1,8 +1,12 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
+using System.Globalization;
+using System.Security.Claims;
+using System.Text.Json;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Domain.ValueObjects;
 using OvcinaHra.Shared.Dtos;
 
@@ -29,6 +33,7 @@ public static class LocationEndpoints
         group.MapPost("/", Create);
         group.MapPut("/{id:int}", Update);
         group.MapDelete("/{id:int}", Delete);
+        group.MapPost("/{id:int}/placement-record", RecordPlacement);
 
         // GameLocation assignment
         group.MapGet("/by-game/{gameId:int}", GetByGame);
@@ -62,6 +67,7 @@ public static class LocationEndpoints
                 l.NpcInfo,
                 l.SetupNotes,
                 l.ImagePath,
+                l.PlacementPhotoPath,
                 l.StampImagePath
             })
             .ToListAsync();
@@ -85,6 +91,8 @@ public static class LocationEndpoints
                 Array.Empty<LocationTreasureQuestDto>(),
                 ImagePath: r.ImagePath,
                 ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
+                PlacementPhotoPath: r.PlacementPhotoPath,
+                PlacementPhotoUrl: string.IsNullOrWhiteSpace(r.PlacementPhotoPath) ? null : ImageEndpoints.ThumbUrl(http, "locationplacements", r.Id, "small"),
                 StampImagePath: r.StampImagePath,
                 StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"),
                 IsLocated: effective.HasValue,
@@ -266,6 +274,112 @@ public static class LocationEndpoints
         return TypedResults.NoContent();
     }
 
+    private static async Task<Results<Ok<LocationPlacementStatusDto>, NotFound, ProblemHttpResult>> RecordPlacement(
+        int id,
+        LocationPlacementRecordRequest dto,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var organizer = GetOrganizer(http.User);
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.LocationEndpoints");
+        logger.LogInformation(
+            "[loc-placement] placement.record.entry gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+            dto.GameId,
+            id,
+            organizer.UserId,
+            null);
+
+        try
+        {
+            var location = await db.Locations
+                .Where(l => l.Id == id && l.GameLocations.Any(gl => gl.GameId == dto.GameId))
+                .FirstOrDefaultAsync(ct);
+            if (location is null)
+            {
+                logger.LogInformation(
+                    "[loc-placement] placement.record.not-found gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                    dto.GameId,
+                    id,
+                    organizer.UserId,
+                    null);
+                return TypedResults.NotFound();
+            }
+
+            if (string.IsNullOrWhiteSpace(location.PlacementPhotoPath))
+            {
+                logger.LogInformation(
+                    "[loc-placement] placement.record.missing-photo gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                    dto.GameId,
+                    id,
+                    organizer.UserId,
+                    null);
+                return PlacementProblem("Nejprve nahrajte fotografii umístění.");
+            }
+
+            var nowUtc = DateTime.UtcNow;
+            var localTimestamp = NormalizeLocalTimestamp(dto.LocalTimestampText, nowUtc);
+            var notes = dto.Notes?.Trim();
+            if (!string.IsNullOrWhiteSpace(notes))
+            {
+                var noteBlock = $"[{localTimestamp} {organizer.Name}] {notes}";
+                location.SetupNotes = string.IsNullOrWhiteSpace(location.SetupNotes)
+                    ? noteBlock
+                    : $"{noteBlock}{Environment.NewLine}----{Environment.NewLine}{location.SetupNotes}";
+            }
+
+            var activity = new WorldActivity
+            {
+                GameId = dto.GameId,
+                TimestampUtc = nowUtc,
+                OrganizerUserId = organizer.UserId,
+                OrganizerName = organizer.Name,
+                ActivityType = WorldActivityType.LocationPlaced,
+                Description = $"Umístěna lokace: {location.Name}",
+                LocationId = location.Id,
+                DataJson = JsonSerializer.Serialize(new
+                {
+                    notes,
+                    photoBlobKey = location.PlacementPhotoPath,
+                    localTimestamp,
+                    dto.ClientUtcOffsetMinutes
+                })
+            };
+            db.WorldActivities.Add(activity);
+            await db.SaveChangesAsync(ct);
+
+            logger.LogInformation(
+                "[loc-placement] placement.record.activity-inserted gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl} activityId={ActivityId}",
+                dto.GameId,
+                id,
+                organizer.UserId,
+                location.PlacementPhotoPath,
+                activity.Id);
+
+            return TypedResults.Ok(new LocationPlacementStatusDto(
+                location.Id,
+                location.Name,
+                true,
+                location.PlacementPhotoPath,
+                ImageEndpoints.ThumbUrl(http, "locationplacements", location.Id, "small"),
+                location.SetupNotes,
+                activity.TimestampUtc,
+                activity.OrganizerName));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(
+                ex,
+                "[loc-placement] placement.record.failed gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                dto.GameId,
+                id,
+                organizer.UserId,
+                null);
+            throw;
+        }
+    }
+
     private static async Task<Ok<List<LocationListDto>>> GetByGame(int gameId, WorldDbContext db, HttpContext http)
     {
         var rows = await db.Locations
@@ -286,6 +400,7 @@ public static class LocationEndpoints
                 l.NpcInfo,
                 l.SetupNotes,
                 l.ImagePath,
+                l.PlacementPhotoPath,
                 l.StampImagePath,
                 Stashes = l.GameSecretStashes
                     .Where(gss => gss.GameId == gameId)
@@ -353,6 +468,8 @@ public static class LocationEndpoints
                 LocationTreasureQuests: r.LocationTreasureQuests,
                 ImagePath: r.ImagePath,
                 ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locations", r.Id, "small"),
+                PlacementPhotoPath: r.PlacementPhotoPath,
+                PlacementPhotoUrl: string.IsNullOrWhiteSpace(r.PlacementPhotoPath) ? null : ImageEndpoints.ThumbUrl(http, "locationplacements", r.Id, "small"),
                 StampImagePath: r.StampImagePath,
                 StampImageUrl: string.IsNullOrWhiteSpace(r.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", r.Id, "small"),
                 IsLocated: effective.HasValue,
@@ -513,5 +630,30 @@ public static class LocationEndpoints
         await db.SaveChangesAsync();
         logger.LogInformation("[map-diag] location.coordinates.patch.committed locationId={LocationId}", id);
         return TypedResults.NoContent();
+    }
+
+    private static ProblemHttpResult PlacementProblem(string detail) =>
+        TypedResults.Problem(
+            title: "Umístění lokace se nepodařilo uložit",
+            detail: detail,
+            statusCode: StatusCodes.Status400BadRequest);
+
+    private static (string UserId, string Name) GetOrganizer(ClaimsPrincipal user)
+    {
+        var userId = user.FindFirstValue("sub")
+            ?? user.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? "unknown";
+        var name = user.FindFirstValue("name")
+            ?? user.FindFirstValue(ClaimTypes.Name)
+            ?? "Unknown";
+        return (userId, name);
+    }
+
+    private static string NormalizeLocalTimestamp(string? value, DateTime fallbackUtc)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed)
+            ? fallbackUtc.ToLocalTime().ToString("dd/MM HH:mm", CultureInfo.InvariantCulture)
+            : trimmed.Length <= 32 ? trimmed : trimmed[..32];
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -285,10 +285,11 @@ public static class LocationEndpoints
         var organizer = GetOrganizer(http.User);
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.LocationEndpoints");
         logger.LogInformation(
-            "[loc-placement] placement.record.entry gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+            "[loc-placement] placement.record.entry gameId={GameId} locationId={LocationId} userId={UserId} imageBlobKey={ImageBlobKey} imageBlobUrl={ImageBlobUrl}",
             dto.GameId,
             id,
             organizer.UserId,
+            null,
             null);
 
         try
@@ -299,10 +300,11 @@ public static class LocationEndpoints
             if (location is null)
             {
                 logger.LogInformation(
-                    "[loc-placement] placement.record.not-found gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                    "[loc-placement] placement.record.not-found gameId={GameId} locationId={LocationId} userId={UserId} imageBlobKey={ImageBlobKey} imageBlobUrl={ImageBlobUrl}",
                     dto.GameId,
                     id,
                     organizer.UserId,
+                    null,
                     null);
                 return TypedResults.NotFound();
             }
@@ -310,10 +312,11 @@ public static class LocationEndpoints
             if (string.IsNullOrWhiteSpace(location.PlacementPhotoPath))
             {
                 logger.LogInformation(
-                    "[loc-placement] placement.record.missing-photo gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                    "[loc-placement] placement.record.missing-photo gameId={GameId} locationId={LocationId} userId={UserId} imageBlobKey={ImageBlobKey} imageBlobUrl={ImageBlobUrl}",
                     dto.GameId,
                     id,
                     organizer.UserId,
+                    null,
                     null);
                 return PlacementProblem("Nejprve nahrajte fotografii umístění.");
             }
@@ -349,12 +352,14 @@ public static class LocationEndpoints
             db.WorldActivities.Add(activity);
             await db.SaveChangesAsync(ct);
 
+            var placementPhotoUrl = ImageEndpoints.ThumbUrl(http, "locationplacements", location.Id, "small");
             logger.LogInformation(
-                "[loc-placement] placement.record.activity-inserted gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl} activityId={ActivityId}",
+                "[loc-placement] placement.record.activity-inserted gameId={GameId} locationId={LocationId} userId={UserId} imageBlobKey={ImageBlobKey} imageBlobUrl={ImageBlobUrl} activityId={ActivityId}",
                 dto.GameId,
                 id,
                 organizer.UserId,
                 location.PlacementPhotoPath,
+                placementPhotoUrl,
                 activity.Id);
 
             return TypedResults.Ok(new LocationPlacementStatusDto(
@@ -362,7 +367,7 @@ public static class LocationEndpoints
                 location.Name,
                 true,
                 location.PlacementPhotoPath,
-                ImageEndpoints.ThumbUrl(http, "locationplacements", location.Id, "small"),
+                placementPhotoUrl,
                 location.SetupNotes,
                 activity.TimestampUtc,
                 activity.OrganizerName));
@@ -371,10 +376,11 @@ public static class LocationEndpoints
         {
             logger.LogError(
                 ex,
-                "[loc-placement] placement.record.failed gameId={GameId} locationId={LocationId} userId={UserId} imageBlobUrl={ImageBlobUrl}",
+                "[loc-placement] placement.record.failed gameId={GameId} locationId={LocationId} userId={UserId} imageBlobKey={ImageBlobKey} imageBlobUrl={ImageBlobUrl}",
                 dto.GameId,
                 id,
                 organizer.UserId,
+                null,
                 null);
             throw;
         }

--- a/src/OvcinaHra.Api/Migrations/20260429083148_AddWorldActivities.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260429083148_AddWorldActivities.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429083148_AddWorldActivities")]
+    partial class AddWorldActivities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260429083148_AddWorldActivities.cs
+++ b/src/OvcinaHra.Api/Migrations/20260429083148_AddWorldActivities.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorldActivities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WorldActivities",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    TimestampUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    OrganizerUserId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    OrganizerName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    ActivityType = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    LocationId = table.Column<int>(type: "integer", nullable: true),
+                    CharacterAssignmentId = table.Column<int>(type: "integer", nullable: true),
+                    QuestId = table.Column<int>(type: "integer", nullable: true),
+                    DataJson = table.Column<string>(type: "jsonb", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorldActivities", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WorldActivities_CharacterAssignments_CharacterAssignmentId",
+                        column: x => x.CharacterAssignmentId,
+                        principalTable: "CharacterAssignments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_WorldActivities_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_WorldActivities_Locations_LocationId",
+                        column: x => x.LocationId,
+                        principalTable: "Locations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_WorldActivities_Quests_QuestId",
+                        column: x => x.QuestId,
+                        principalTable: "Quests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorldActivities_GameId_TimestampUtc",
+                table: "WorldActivities",
+                columns: new[] { "GameId", "TimestampUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorldActivities_CharacterAssignmentId",
+                table: "WorldActivities",
+                column: "CharacterAssignmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorldActivities_LocationId",
+                table: "WorldActivities",
+                column: "LocationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorldActivities_QuestId",
+                table: "WorldActivities",
+                column: "QuestId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WorldActivities");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Components/RecentActivityFeed.razor
+++ b/src/OvcinaHra.Client/Components/RecentActivityFeed.razor
@@ -1,6 +1,5 @@
-@* Issue #158 — last-N edits with 1:1 thumbs. Verb is hard-coded
-   "upravil" until the WorldChange audit log lands (flagged as
-   follow-up). Each row navigates to the entity's detail page. *@
+@* Issue #158 + #383 — recent organizer activity. WorldActivity rows use
+   real actor/timestamp data; older entity timestamp rows remain as fallback. *@
 
 <section class="oh-home-act" aria-labelledby="oh-home-act-title">
     <header class="oh-home-act-head">
@@ -38,7 +37,7 @@
                 <span class="oh-home-act-body">
                     <span class="oh-home-act-name">@row.EntityName</span>
                     <span class="oh-home-act-meta text-muted small">
-                        @row.Verb · @TimeAgo(row.OccurredUtc)
+                        @MetaFor(row)
                     </span>
                 </span>
             </a>
@@ -53,6 +52,7 @@
     {
         "character" => $"/characters/{r.EntityId}",
         "event"     => $"/timeline",
+        "location"  => $"/locations/{r.EntityId}",
         "npc"       => $"/npcs/{r.EntityId}",
         _           => "/",
     };
@@ -61,9 +61,20 @@
     {
         "character" => "bi-person",
         "event"     => "bi-calendar-event",
+        "location"  => "bi-geo-alt",
         "npc"       => "bi-person-badge",
         _           => "bi-circle",
     };
+
+    private static string MetaFor(DashboardActivityDto row)
+    {
+        var actor = string.IsNullOrWhiteSpace(row.ActorName) || row.ActorName == "—"
+            ? null
+            : row.ActorName;
+        return actor is null
+            ? $"{row.Verb} · {TimeAgo(row.OccurredUtc)}"
+            : $"{actor} · {row.Verb} · {TimeAgo(row.OccurredUtc)}";
+    }
 
     private static string TimeAgo(DateTime utc)
     {

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -319,7 +319,7 @@ else
                     </div>
                     <div class="oh-lc-mv-col">
                         <small class="text-muted d-block mb-1">Fotka umístění (4:3)</small>
-                        <ImagePicker EntityType="locations" EntityId="@Id" Field="placement"
+                        <ImagePicker EntityType="locationplacements" EntityId="@Id"
                                      AspectRatio="4:3" Width="280px" Alt="Fotka umístění" />
                     </div>
                     @* Issue #172 — Razítko (rubber stamp) editor. Goes through

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -88,7 +88,7 @@
     <div class="oh-placement-toast" data-testid="location-placement-toast">
         <i class="bi bi-check-circle"></i>
         <span>@placementToastMessage</span>
-        <button type="button" title="Zavřít" @onclick="() => placementToastMessage = null">
+        <button type="button" title="Zavřít" aria-label="Zavřít" @onclick="() => placementToastMessage = null">
             <i class="bi bi-x-lg"></i>
         </button>
     </div>

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -1,4 +1,6 @@
 @page "/locations"
+@using System.Globalization
+@using System.Net.Http.Headers
 @attribute [Authorize]
 @inject ApiClient Api
 @inject GameContextService GameContext
@@ -59,6 +61,12 @@
     @if (!Catalog)
     {
         <button type="button"
+                class="btn btn-primary oh-placement-mobile-trigger"
+                data-testid="open-location-placement"
+                @onclick="OpenPlacementWizard">
+            <i class="bi bi-camera me-1"></i>Umístění lokace
+        </button>
+        <button type="button"
                 class="oh-lg-tb-toggle @(showCiphers ? "oh-lg-on" : "")"
                 disabled="@ciphersLoading"
                 @onclick="ToggleCiphersAsync">
@@ -74,6 +82,103 @@
         </button>
     }
 </div>
+
+@if (!string.IsNullOrWhiteSpace(placementToastMessage))
+{
+    <div class="oh-placement-toast" data-testid="location-placement-toast">
+        <i class="bi bi-check-circle"></i>
+        <span>@placementToastMessage</span>
+        <button type="button" title="Zavřít" @onclick="() => placementToastMessage = null">
+            <i class="bi bi-x-lg"></i>
+        </button>
+    </div>
+}
+
+<DxPopup @bind-Visible="@isPlacementVisible" HeaderText="Umístění lokace" Width="min(94vw, 520px)">
+    <BodyContentTemplate Context="popupContext">
+        <div class="oh-placement-wizard" data-testid="location-placement-wizard">
+            <label class="form-label">Lokace</label>
+            <DxComboBox TData="LocationListDto" TValue="int?"
+                        Data="@placementLocationChoices"
+                        @bind-Value="@placementSelectedLocationId"
+                        TextFieldName="PlacementChoiceText"
+                        ValueFieldName="Id"
+                        NullText="Vyber lokaci"
+                        SearchMode="ListSearchMode.AutoSearch"
+                        CssClass="w-100"
+                        data-testid="location-placement-select">
+                <ItemDisplayTemplate Context="choiceContext">
+                    @{ var choice = (LocationListDto)choiceContext.DataItem; }
+                    <div class="oh-placement-choice" title="@(choice.IsPlaced ? "Již umístěno" : "Ještě bez fotky umístění")">
+                        <span>@choice.Name</span>
+                        @if (choice.IsPlaced)
+                        {
+                            <span class="oh-placement-choice-badge">✓ Již umístěno</span>
+                        }
+                    </div>
+                </ItemDisplayTemplate>
+                <EditBoxDisplayTemplate Context="editContext">
+                    @if (SelectedPlacementLocation is not null)
+                    {
+                        @SelectedPlacementLocation.PlacementChoiceText
+                    }
+                </EditBoxDisplayTemplate>
+            </DxComboBox>
+
+            @if (SelectedPlacementLocation?.IsPlaced == true)
+            {
+                <div class="alert alert-warning py-2 my-2" data-testid="location-placement-existing-warning">
+                    Tahle lokace už má fotku umístění. Uložením ji přepíšeš a přidáš nový záznam.
+                </div>
+            }
+
+            <label class="form-label mt-3">Fotka</label>
+            <div class="oh-placement-photo">
+                @if (!string.IsNullOrWhiteSpace(placementPreviewUrl))
+                {
+                    <img src="@placementPreviewUrl" alt="Náhled fotky umístění" />
+                }
+                else
+                {
+                    <div class="oh-placement-photo-empty">
+                        <i class="bi bi-camera"></i>
+                        <span>Vyfoť nebo nahraj fotku</span>
+                    </div>
+                }
+            </div>
+            <label class="btn btn-outline-primary oh-placement-file-btn mt-2">
+                <i class="bi bi-camera me-1"></i>@(placementPhotoFile is null ? "Vybrat fotku" : "Vybrat jinou fotku")
+                <InputFile OnChange="HandlePlacementFileSelected"
+                           accept="image/*"
+                           capture="environment"
+                           disabled="@placementSaving"
+                           data-testid="location-placement-file" />
+            </label>
+
+            <label class="form-label mt-3">Poznámky</label>
+            <DxMemo @bind-Text="@placementNotes"
+                    Rows="3"
+                    NullText="Krátká poznámka pro přípravu..."
+                    data-testid="location-placement-notes" />
+
+            @if (!string.IsNullOrWhiteSpace(placementError))
+            {
+                <div class="alert alert-danger py-2 mt-3" data-testid="location-placement-error">@placementError</div>
+            }
+
+            <div class="d-flex gap-2 justify-content-end mt-3">
+                <button class="btn btn-secondary" @onclick="ClosePlacementWizard" disabled="@placementSaving">Zrušit</button>
+                <button class="btn btn-primary" @onclick="SubmitPlacementAsync" disabled="@placementSaving" data-testid="location-placement-submit">
+                    @if (placementSaving)
+                    {
+                        <span class="spinner-border spinner-border-sm me-1"></span>
+                    }
+                    Uložit umístění
+                </button>
+            </div>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
 
 @if (!string.IsNullOrWhiteSpace(cipherGridError))
 {
@@ -648,6 +753,15 @@ else
     private bool isLinkVisible;
     private bool isUnassignVisible;
     private bool isSaving;
+    private bool isPlacementVisible;
+    private bool placementSaving;
+    private int? placementSelectedLocationId;
+    private IBrowserFile? placementPhotoFile;
+    private string? placementPreviewUrl;
+    private string? placementNotes;
+    private string? placementError;
+    private string? placementToastMessage;
+    private const long PlacementMaxFileSize = 5 * 1024 * 1024;
 
     // Toolbar filter state
     private string? searchText
@@ -779,6 +893,14 @@ else
                  .OrderBy(r => r)
                  .ToList();
 
+    private List<LocationListDto> placementLocationChoices =>
+        locations.OrderBy(l => l.Name).ToList();
+
+    private LocationListDto? SelectedPlacementLocation =>
+        placementSelectedLocationId.HasValue
+            ? locations.FirstOrDefault(l => l.Id == placementSelectedLocationId.Value)
+            : null;
+
     private void RefreshVisibleRows()
     {
         bool Matches(LocationListDto l)
@@ -850,6 +972,141 @@ else
     private void OpenOnMap(LocationListDto loc)
     {
         Nav.NavigateTo($"/map?location={loc.Id}");
+    }
+
+    private void OpenPlacementWizard()
+    {
+        placementError = null;
+        placementToastMessage = null;
+        placementSelectedLocationId = locations.FirstOrDefault(l => !l.IsPlaced)?.Id
+            ?? locations.FirstOrDefault()?.Id;
+        placementPhotoFile = null;
+        placementPreviewUrl = null;
+        placementNotes = null;
+        isPlacementVisible = true;
+        Console.WriteLine($"[loc-placement] wizard.open gameId={gameId}");
+    }
+
+    private void ClosePlacementWizard()
+    {
+        if (placementSaving) return;
+        isPlacementVisible = false;
+        placementError = null;
+        placementPhotoFile = null;
+        placementPreviewUrl = null;
+        placementNotes = null;
+        Console.WriteLine($"[loc-placement] wizard.cancel gameId={gameId}");
+    }
+
+    private async Task HandlePlacementFileSelected(InputFileChangeEventArgs e)
+    {
+        placementError = null;
+        placementPhotoFile = e.File;
+        if (placementPhotoFile.Size > PlacementMaxFileSize)
+        {
+            placementPhotoFile = null;
+            placementPreviewUrl = null;
+            placementError = "Soubor je příliš velký (max 5 MB).";
+            Console.WriteLine($"[loc-placement] wizard.photo-selected.failed gameId={gameId} reason=too-large");
+            return;
+        }
+
+        var contentType = string.IsNullOrWhiteSpace(placementPhotoFile.ContentType)
+            ? "image/jpeg"
+            : placementPhotoFile.ContentType;
+        await using var stream = placementPhotoFile.OpenReadStream(maxAllowedSize: PlacementMaxFileSize);
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer);
+        placementPreviewUrl = $"data:{contentType};base64,{Convert.ToBase64String(buffer.ToArray())}";
+        Console.WriteLine($"[loc-placement] wizard.photo-selected gameId={gameId} size={placementPhotoFile.Size}");
+    }
+
+    private async Task SubmitPlacementAsync()
+    {
+        placementError = null;
+        if (SelectedPlacementLocation is null)
+        {
+            placementError = "Vyberte lokaci.";
+            return;
+        }
+        if (placementPhotoFile is null)
+        {
+            placementError = "Nejprve vyfoťte nebo nahrajte fotku umístění.";
+            return;
+        }
+
+        placementSaving = true;
+        var locationId = SelectedPlacementLocation.Id;
+        Console.WriteLine($"[loc-placement] wizard.submit.start gameId={gameId} locationId={locationId}");
+        try
+        {
+            using var content = new MultipartFormDataContent();
+            await using var stream = placementPhotoFile.OpenReadStream(maxAllowedSize: PlacementMaxFileSize);
+            using var fileContent = new StreamContent(stream);
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue(
+                string.IsNullOrWhiteSpace(placementPhotoFile.ContentType) ? "image/jpeg" : placementPhotoFile.ContentType);
+            content.Add(fileContent, "file", placementPhotoFile.Name);
+
+            var (uploadOk, uploadResult, uploadProblem, uploadStatus) =
+                await Api.PostMultipartWithProblemAsync<ImageUploadResult>(
+                    $"/api/images/locationplacements/{locationId}?gameId={gameId}", content);
+            if (!uploadOk || uploadResult is null)
+            {
+                placementError = uploadProblem ?? "Fotku se nepodařilo nahrát.";
+                Console.WriteLine($"[loc-placement] wizard.photo-upload.failed gameId={gameId} locationId={locationId} status={(int)uploadStatus}");
+                return;
+            }
+            Console.WriteLine($"[loc-placement] wizard.photo-uploaded gameId={gameId} locationId={locationId} blobKey={uploadResult.BlobKey}");
+
+            var localTimestamp = DateTime.Now.ToString("dd/MM HH:mm", CultureInfo.InvariantCulture);
+            var offsetMinutes = (int)DateTimeOffset.Now.Offset.TotalMinutes;
+            var request = new LocationPlacementRecordRequest(
+                gameId,
+                placementNotes,
+                localTimestamp,
+                offsetMinutes);
+            var (recordOk, status, recordProblem) =
+                await Api.PostWithProblemAsync<LocationPlacementRecordRequest, LocationPlacementStatusDto>(
+                    $"/api/locations/{locationId}/placement-record", request);
+            if (!recordOk || status is null)
+            {
+                placementError = recordProblem ?? "Záznam o umístění se nepodařilo uložit.";
+                Console.WriteLine($"[loc-placement] wizard.record.failed gameId={gameId} locationId={locationId} detail={placementError}");
+                return;
+            }
+
+            UpdatePlacementRow(status);
+            placementToastMessage = $"Umístění lokace {status.LocationName} uloženo.";
+            isPlacementVisible = false;
+            placementPhotoFile = null;
+            placementPreviewUrl = null;
+            placementNotes = null;
+            Console.WriteLine($"[loc-placement] wizard.submit.success gameId={gameId} locationId={locationId}");
+        }
+        catch (Exception ex)
+        {
+            placementError = ex.Message;
+            Console.WriteLine($"[loc-placement] wizard.submit.failed gameId={gameId} locationId={locationId} detail={placementError}");
+        }
+        finally
+        {
+            placementSaving = false;
+        }
+    }
+
+    private void UpdatePlacementRow(LocationPlacementStatusDto status)
+    {
+        var index = locations.FindIndex(l => l.Id == status.LocationId);
+        if (index >= 0)
+        {
+            locations[index] = locations[index] with
+            {
+                PlacementPhotoPath = status.PlacementPhotoPath,
+                PlacementPhotoUrl = status.PlacementPhotoUrl,
+                SetupNotes = status.SetupNotes
+            };
+        }
+        RefreshVisibleRows();
     }
 
     private void OnStashTileClick(int stashId)

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -1381,6 +1381,19 @@
 .oh-lg-tb-toggle.oh-lg-on{color:var(--oh-primary);border-color:rgba(74,124,52,.35);background:var(--oh-primary-surface)}
 .oh-lg-tb-toggle.oh-lg-on .oh-lg-sw{background:var(--oh-primary)}
 .oh-lg-tb-toggle.oh-lg-on .oh-lg-sw::before{left:13px}
+.oh-placement-mobile-trigger{display:inline-flex;align-items:center;white-space:nowrap}
+.oh-placement-toast{display:flex;align-items:center;gap:8px;margin:0 28px 12px;padding:9px 12px;border:1px solid rgba(39,174,96,.28);border-radius:var(--oh-radius-sm);background:rgba(39,174,96,.1);color:#1e6b38;font:600 .875rem var(--oh-font-body)}
+.oh-placement-toast button{margin-left:auto;border:0;background:transparent;color:inherit;padding:2px 4px;line-height:1}
+.oh-placement-wizard{display:flex;flex-direction:column}
+.oh-placement-photo{width:100%;aspect-ratio:4/3;border:1px dashed var(--oh-border);border-radius:var(--oh-radius-sm);background:var(--oh-surface-alt);overflow:hidden;display:flex;align-items:center;justify-content:center}
+.oh-placement-photo img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-placement-photo-empty{display:flex;flex-direction:column;align-items:center;gap:6px;color:var(--oh-text-secondary);font-size:.875rem}
+.oh-placement-photo-empty i{font-size:2rem;color:var(--oh-primary-light)}
+.oh-placement-file-btn{position:relative;overflow:hidden;align-self:flex-start}
+.oh-placement-file-btn input[type=file]{position:absolute;inset:0;opacity:0;cursor:pointer}
+.oh-placement-choice{display:flex;align-items:center;justify-content:space-between;gap:10px;width:100%}
+.oh-placement-choice-badge{font-size:.75rem;color:var(--oh-primary);background:var(--oh-primary-surface);border:1px solid rgba(74,124,52,.25);border-radius:99px;padding:1px 7px;white-space:nowrap}
+@media (min-width:1025px){.oh-placement-mobile-trigger{display:none!important}}
 
 /* ============================================================
    GRID

--- a/src/OvcinaHra.Shared/Domain/Entities/Game.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Game.cs
@@ -41,6 +41,7 @@ public class Game
     public ICollection<GameTimeSlot> TimeSlots { get; set; } = [];
     public ICollection<BattlefieldBonus> BattlefieldBonuses { get; set; } = [];
     public ICollection<GameNpc> GameNpcs { get; set; } = [];
+    public ICollection<WorldActivity> WorldActivities { get; set; } = [];
     public ICollection<GameEvent> GameEvents { get; set; } = [];
     public ICollection<OrganizerRoleAssignment> OrganizerRoleAssignments { get; set; } = [];
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/WorldActivity.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/WorldActivity.cs
@@ -1,0 +1,23 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class WorldActivity
+{
+    public int Id { get; set; }
+    public int GameId { get; set; }
+    public DateTime TimestampUtc { get; set; } = DateTime.UtcNow;
+    public required string OrganizerUserId { get; set; }
+    public required string OrganizerName { get; set; }
+    public WorldActivityType ActivityType { get; set; }
+    public required string Description { get; set; }
+    public int? LocationId { get; set; }
+    public int? CharacterAssignmentId { get; set; }
+    public int? QuestId { get; set; }
+    public string? DataJson { get; set; }
+
+    public Game Game { get; set; } = null!;
+    public Location? Location { get; set; }
+    public CharacterAssignment? CharacterAssignment { get; set; }
+    public Quest? Quest { get; set; }
+}

--- a/src/OvcinaHra.Shared/Domain/Enums/WorldActivityType.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/WorldActivityType.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace OvcinaHra.Shared.Domain.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum WorldActivityType
+{
+    LocationPlaced = 0,
+    CharacterLevelUp = 1,
+    QuestCompleted = 2
+}

--- a/src/OvcinaHra.Shared/Dtos/DashboardDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/DashboardDtos.cs
@@ -37,11 +37,9 @@ public record DashboardIssueDto(
 public record DashboardIssuesDto(IReadOnlyList<DashboardIssueDto> Issues);
 
 /// <summary>
-/// One row in the RecentActivityFeed. Pre-MVP audit log doesn't exist —
-/// the endpoint stubs <see cref="OccurredUtc"/> from per-entity
-/// <c>UpdatedAtUtc</c> (or <c>Id DESC</c> as a fallback for entities
-/// without timestamps) and reports <see cref="Verb"/> as the neutral
-/// "upravil" until a real WorldChange table replaces this.
+/// One row in the RecentActivityFeed. WorldActivity rows are real organizer
+/// recordings; legacy rows still come from entity timestamps until more
+/// activity types are wired through the same table.
 /// </summary>
 public record DashboardActivityDto(
     string EntityType,

--- a/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
@@ -22,6 +22,8 @@ public record LocationListDto(
     IReadOnlyList<LocationTreasureQuestDto> LocationTreasureQuests,
     string? ImagePath = null,
     string? ImageUrl = null,
+    string? PlacementPhotoPath = null,
+    string? PlacementPhotoUrl = null,
     string? StampImagePath = null,
     string? StampImageUrl = null,
     bool IsLocated = false,
@@ -30,6 +32,12 @@ public record LocationListDto(
 {
     [JsonIgnore]
     public string LocationKindDisplay => LocationKind.GetDisplayName();
+
+    [JsonIgnore]
+    public bool IsPlaced => !string.IsNullOrWhiteSpace(PlacementPhotoPath);
+
+    [JsonIgnore]
+    public string PlacementChoiceText => IsPlaced ? $"{Name} ✓ Již umístěno" : Name;
 }
 
 public record LocationStashDto(
@@ -128,6 +136,22 @@ public record UpdateLocationDto(
     int? ParentLocationId = null);
 
 public record GameLocationDto(int GameId, int LocationId);
+
+public record LocationPlacementRecordRequest(
+    int GameId,
+    string? Notes,
+    string? LocalTimestampText,
+    int? ClientUtcOffsetMinutes);
+
+public record LocationPlacementStatusDto(
+    int LocationId,
+    string LocationName,
+    bool IsPlaced,
+    string? PlacementPhotoPath,
+    string? PlacementPhotoUrl,
+    string? SetupNotes,
+    DateTime RecordedUtc,
+    string OrganizerName);
 
 /// <summary>
 /// Compact projection for the LocationDetail orientation map (issue #110).

--- a/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
@@ -189,6 +189,51 @@ public class DashboardEndpointsTests(PostgresFixture postgres)
     }
 
     [Fact]
+    public async Task Activity_WorldActivityLocationPlacement_ReturnsActorLocationAndThumbnail()
+    {
+        var game = await CreateGameAsync();
+        int locationId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var location = new Location
+            {
+                Name = "Starý brod",
+                LocationKind = LocationKind.Village,
+                PlacementPhotoPath = "locationplacements/1/image.png"
+            };
+            db.Locations.Add(location);
+            await db.SaveChangesAsync();
+            location.PlacementPhotoPath = $"locationplacements/{location.Id}/image.png";
+            db.GameLocations.Add(new GameLocation { GameId = game.Id, LocationId = location.Id });
+            db.WorldActivities.Add(new WorldActivity
+            {
+                GameId = game.Id,
+                TimestampUtc = DateTime.UtcNow.AddMinutes(-1),
+                OrganizerUserId = "test-user",
+                OrganizerName = "Test Organizátor",
+                ActivityType = WorldActivityType.LocationPlaced,
+                Description = $"Umístěna lokace: {location.Name}",
+                LocationId = location.Id,
+                DataJson = "{}"
+            });
+            await db.SaveChangesAsync();
+            locationId = location.Id;
+        }
+
+        var rows = await Client.GetFromJsonAsync<List<DashboardActivityDto>>(
+            $"/api/dashboard/activity?gameId={game.Id}");
+
+        var row = Assert.Single(rows!);
+        Assert.Equal("location", row.EntityType);
+        Assert.Equal(locationId, row.EntityId);
+        Assert.Equal("Starý brod", row.EntityName);
+        Assert.Equal("Test Organizátor", row.ActorName);
+        Assert.Equal("umístil", row.Verb);
+        Assert.Contains($"/api/images/locationplacements/{locationId}/thumb", row.ThumbnailUrl!);
+    }
+
+    [Fact]
     public async Task Timeline_PastSlot_IsExcluded()
     {
         var game = await CreateGameAsync();

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
@@ -107,6 +107,27 @@ public class ImageEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
     }
 
     [Fact]
+    public async Task Upload_LegacyLocationPlacement_InvalidatesPlacementThumbnailCache()
+    {
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Legacy umístění", LocationKind.Village, 49.5m, 17.1m));
+        var loc = await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+        var blob = (InMemoryBlobService)Factory.Services.GetRequiredService<IBlobStorageService>();
+        var staleThumbKey = $"locationplacements-thumbs/{loc!.Id}-stale.webp";
+        await blob.UploadAsync(staleThumbKey, new MemoryStream(ValidPng), "image/webp");
+
+        using var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(ValidPng);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        content.Add(fileContent, "file", "legacy-placement.png");
+
+        var response = await Client.PostAsync($"/api/images/locations/{loc.Id}?field=placement", content);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.False(blob.Contains(staleThumbKey));
+    }
+
+    [Fact]
     public async Task Upload_LocationStamp_TooSmall_ReturnsProblemDetails()
     {
         var locResponse = await Client.PostAsJsonAsync("/api/locations",

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
@@ -78,6 +78,35 @@ public class ImageEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
     }
 
     [Fact]
+    public async Task Upload_LocationPlacement_PersistsPlacementPathAndFullSasUrl()
+    {
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Umísťovaná lokace", LocationKind.Village, 49.5m, 17.1m));
+        var loc = await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        using var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(ValidPng);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        content.Add(fileContent, "file", "placement.png");
+
+        var response = await Client.PostAsync($"/api/images/locationplacements/{loc!.Id}?gameId=77", content);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ImageUploadResult>();
+        Assert.NotNull(result);
+        Assert.StartsWith($"locationplacements/{loc.Id}/", result.BlobKey);
+
+        var refreshed = await Client.GetFromJsonAsync<LocationDetailDto>($"/api/locations/{loc.Id}");
+        Assert.Equal(result.BlobKey, refreshed!.PlacementPhotoPath);
+
+        var locationUrls = await Client.GetFromJsonAsync<ImageUrlsDto>($"/api/images/locations/{loc.Id}");
+        Assert.Equal($"https://fake/{result.BlobKey}", locationUrls!.PlacementUrl);
+
+        var placementUrls = await Client.GetFromJsonAsync<ImageUrlsDto>($"/api/images/locationplacements/{loc.Id}");
+        Assert.Equal($"https://fake/{result.BlobKey}", placementUrls!.ImageUrl);
+    }
+
+    [Fact]
     public async Task Upload_LocationStamp_TooSmall_ReturnsProblemDetails()
     {
         var locResponse = await Client.PostAsJsonAsync("/api/locations",

--- a/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/LocationEndpointTests.cs
@@ -140,6 +140,74 @@ public class LocationEndpointTests(PostgresFixture postgres) : IntegrationTestBa
     }
 
     [Fact]
+    public async Task RecordPlacement_MissingLocation_ReturnsNotFoundBeforePhotoValidation()
+    {
+        var response = await Client.PostAsJsonAsync("/api/locations/999999/placement-record",
+            new LocationPlacementRecordRequest(123, "Poznámka", "29/04 10:31", 120));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RecordPlacement_WithoutUploadedPhoto_ReturnsProblemDetails()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Placement Missing Photo", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Bez fotky", LocationKind.Village, 49.5m, 17.1m));
+        var loc = await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+        await Client.PostAsJsonAsync("/api/locations/by-game", new GameLocationDto(game!.Id, loc!.Id));
+
+        var response = await Client.PostAsJsonAsync($"/api/locations/{loc.Id}/placement-record",
+            new LocationPlacementRecordRequest(game.Id, "Poznámka", "29/04 10:31", 120));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.Equal("Nejprve nahrajte fotografii umístění.", problem!.Detail);
+    }
+
+    [Fact]
+    public async Task RecordPlacement_WithPhotoAndNotes_PrependsSetupNotesAndCreatesWorldActivity()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Placement Success", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Starý brod", LocationKind.Village, 49.5m, 17.1m,
+                SetupNotes: "Starší poznámka"));
+        var loc = await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+        await Client.PostAsJsonAsync("/api/locations/by-game", new GameLocationDto(game!.Id, loc!.Id));
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var location = await db.Locations.FindAsync(loc.Id);
+            location!.PlacementPhotoPath = $"locationplacements/{loc.Id}/image.png";
+            await db.SaveChangesAsync();
+        }
+
+        var response = await Client.PostAsJsonAsync($"/api/locations/{loc.Id}/placement-record",
+            new LocationPlacementRecordRequest(game.Id, "Pověsit ceduli", "29/04 10:31", 120));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var status = await response.Content.ReadFromJsonAsync<LocationPlacementStatusDto>();
+        Assert.True(status!.IsPlaced);
+        Assert.StartsWith("[29/04 10:31 Test Organizátor] Pověsit ceduli", status.SetupNotes!);
+        Assert.Contains("----", status.SetupNotes!);
+        Assert.Contains("Starší poznámka", status.SetupNotes!);
+
+        using var verifyScope = Factory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var activity = await verifyDb.WorldActivities.SingleAsync(a => a.GameId == game.Id);
+        Assert.Equal(WorldActivityType.LocationPlaced, activity.ActivityType);
+        Assert.Equal(loc.Id, activity.LocationId);
+        Assert.Equal("Test Organizátor", activity.OrganizerName);
+        Assert.Contains("Pověsit ceduli", activity.DataJson!);
+        Assert.Contains($"locationplacements/{loc.Id}/image.png", activity.DataJson!);
+    }
+
+    [Fact]
     public async Task Update_ChangesCoordinates()
     {
         var createResponse = await Client.PostAsJsonAsync("/api/locations",


### PR DESCRIPTION
## Summary
- adds WorldActivity audit records for real organizer activity, starting with location placement
- adds canonical locationplacements image alias backed by Location.PlacementPhotoPath
- adds the mobile/tablet-only /locations placement wizard with photo upload, notes, placed-location status, and dashboard activity surfacing

## Verification
- dotnet build OvcinaHra.slnx
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj
- dotnet format --verify-no-changes on changed C# files

Browser smoke note: local Playwright JS launch hung even after installing Chromium; API flow and client build are covered, but I could not complete screenshot smoke locally.

refs #383