### PR TITLE
[Phase 0 — markers only] chore(map): add #392 pin click diagnostics

### DIFF
--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -79,6 +79,7 @@
                                  OnMapClick="OnMapClickAsync" />
                         @if (_shortcutMoveActive)
                         {
+                            Console.WriteLine("[map-diag] map.location.move_mode.banner.rendered visible=true");
                             <div class="oh-map-move-hint" role="status" aria-live="polite">
                                 <span><strong>Přesun: @_shortcutMoveName</strong> — klikni na novou pozici.</span>
                                 @if (_shortcutMoveError is not null)
@@ -579,6 +580,7 @@
         var loc = _data?.Locations.FirstOrDefault(l => l.Id == e.Id);
         Console.WriteLine($"[map-diag] MapPage.OnPinMoveShortcutStarted locationId={e.Id} from={{lng:{FormatCoord(e.Lng)},lat:{FormatCoord(e.Lat)}}}");
         _shortcutMoveActive = true;
+        Console.WriteLine($"[map-diag] map.location.move_mode.state_set isActive=true locationId={e.Id}");
         _shortcutMoveId = e.Id;
         _shortcutMoveName = loc?.EffectiveName ?? loc?.Name ?? "tato lokace";
         _shortcutMoveFromLat = e.Lat;

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -1301,6 +1301,20 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     wrapper.appendChild(pin);
     var self = this;
     wrapper.addEventListener('click', function (e) {
+        var modifier = {
+            ctrl: !!(e && (e.ctrlKey || e.metaKey)),
+            shift: !!(e && e.shiftKey),
+            meta: !!(e && e.metaKey)
+        };
+        self._mapDiag('location.pin.click.enter', {
+            locationId: id,
+            modifier: modifier,
+            target: self._eventTargetName(e && e.target),
+            currentTarget: self._eventTargetName(e && e.currentTarget),
+            moveShortcutActive: !!self._moveShortcutActive,
+            hasDotNetRef: !!self._dotnetRef,
+            defaultPrevented: !!(e && e.defaultPrevented)
+        });
         var payload = self._clickDiagPayload(e, 'location-pin', { lat: lat, lng: lon }, { locationId: id });
         self._mapDiag('feature.click.enter', payload);
         self._mapDiag('location.click.enter', payload);
@@ -1317,6 +1331,7 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
             locationId: id
         });
         if (self._moveShortcutActive) {
+            self._mapDiag('location.pin.click.move_target_branch_taken', { locationId: id });
             e.preventDefault();
             e.stopPropagation();
             self._mapDiag('location.relocate.target', { source: 'location-pin', locationId: id, lng: lon, lat: lat });
@@ -1324,12 +1339,15 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
             return;
         }
         if (payload.ctrl && payload.shift) {
+            self._mapDiag('location.pin.click.ctrlshift_branch_taken', { locationId: id });
             e.preventDefault();
             e.stopPropagation();
             self._mapDiag('location.relocate.start', { locationId: id, from: { lng: lon, lat: lat } });
+            self._mapDiag('location.move_mode.dispatch.attempt', { locationId: id, hasDotNetRef: !!self._dotnetRef });
             if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnLocationMoveShortcutStarted', id, lat, lon);
             return;
         }
+        self._mapDiag('location.pin.click.default_branch_taken', { locationId: id });
         e.stopPropagation();
         if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapPinClicked', 'location', id);
     });


### PR DESCRIPTION
## Phase 0 — markers only

Adds diagnostics for #392 before changing behavior. This is intentionally a draft PR so the deployed build can capture the missing transition from Ctrl+Shift+pin click to move mode.

## Markers added

- `[map-diag] map.location.pin.click.enter` as the first line of the location-pin DOM click handler, before payload construction or branch logic
- `[map-diag] map.location.pin.click.ctrlshift_branch_taken`
- `[map-diag] map.location.pin.click.default_branch_taken`
- `[map-diag] map.location.pin.click.move_target_branch_taken`
- `[map-diag] map.location.move_mode.dispatch.attempt`
- `[map-diag] map.location.move_mode.state_set isActive=true locationId=N`
- `[map-diag] map.location.move_mode.banner.rendered visible=true`

## Phase 0 findings before user repro

File location: `src/OvcinaHra.Client/wwwroot/js/map-interop.js`, `window.ovcinaMap.addLocationPin`, DOM click handler near the map-page pin override.

Current best hypothesis remains H1/H2 boundary:
- If `map.location.pin.click.enter` is absent in the new repro, the click is swallowed before this handler.
- If `pin.click.enter` appears but no branch marker appears, branch logic/payload construction is broken.
- If `ctrlshift_branch_taken` and `dispatch.attempt` appear but no state/banner markers appear, the JS-to-Blazor dispatch is not completing.

Refs #392

## Verification

- `node --check src/OvcinaHra.Client/wwwroot/js/map-interop.js`
- `dotnet build OvcinaHra.slnx --nologo -v:minimal`
- `dotnet test OvcinaHra.slnx --no-build --nologo -v:minimal`