### PR TITLE
Add recipe cards and adult organizer view

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/RecipeEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/RecipeEndpoints.cs
@@ -52,11 +52,12 @@ public static class RecipeEndpoints
                 r.OutputItemId,
                 OutputItemName = r.OutputItem.Name,
                 OutputItemImagePath = r.OutputItem.ImagePath,
+                OutputItemEffect = r.OutputItem.Effect,
                 r.LocationId,
                 LocationName = r.Location != null ? r.Location.Name : null,
                 Ingredients = r.Ingredients
                     .OrderBy(i => i.Item.Name)
-                    .Select(i => new { i.ItemId, ItemName = i.Item.Name, ItemImagePath = i.Item.ImagePath, i.Quantity })
+                    .Select(i => new { i.ItemId, ItemName = i.Item.Name, ItemImagePath = i.Item.ImagePath, ItemEffect = i.Item.Effect, i.Quantity })
                     .ToList(),
                 Buildings = r.BuildingRequirements
                     .OrderBy(br => br.Building.Name)
@@ -90,11 +91,12 @@ public static class RecipeEndpoints
                 r.OutputItemId,
                 OutputItemName = r.OutputItem.Name,
                 OutputItemImagePath = r.OutputItem.ImagePath,
+                OutputItemEffect = r.OutputItem.Effect,
                 r.LocationId,
                 LocationName = r.Location != null ? r.Location.Name : null,
                 Ingredients = r.Ingredients
                     .OrderBy(i => i.Item.Name)
-                    .Select(i => new { i.ItemId, ItemName = i.Item.Name, ItemImagePath = i.Item.ImagePath, i.Quantity })
+                    .Select(i => new { i.ItemId, ItemName = i.Item.Name, ItemImagePath = i.Item.ImagePath, ItemEffect = i.Item.Effect, i.Quantity })
                     .ToList(),
                 Buildings = r.BuildingRequirements
                     .OrderBy(br => br.Building.Name)
@@ -155,10 +157,11 @@ public static class RecipeEndpoints
                 r.OutputItem.ItemType, r.GameId, r.TemplateRecipeId,
                 r.OutputItemId, r.OutputItem.Name,
                 OutputItemThumbnailUrl: ThumbForItem(http, r.OutputItem),
+                OutputItemEffect: r.OutputItem.Effect,
                 OutputQuantity: 1,
                 r.LocationId, r.Location?.Name,
                 r.Ingredients.OrderBy(i => i.Item.Name).Select(i =>
-                    new RecipeIngredientChipDto(i.ItemId, i.Item.Name, ThumbForItem(http, i.Item), i.Quantity)).ToList(),
+                    new RecipeIngredientChipDto(i.ItemId, i.Item.Name, ThumbForItem(http, i.Item), i.Quantity, i.Item.Effect)).ToList(),
                 r.BuildingRequirements.OrderBy(br => br.Building.Name).Select(br =>
                     new RecipeBuildingChipDto(br.BuildingId, br.Building.Name)).ToList(),
                 r.SkillRequirements.OrderBy(sr => sr.GameSkill.Name).Select(sr =>
@@ -452,6 +455,7 @@ public static class RecipeEndpoints
     {
         string outputItemName = (string)r.OutputItemName;
         string? outputItemImagePath = (string?)r.OutputItemImagePath;
+        string? outputItemEffect = (string?)r.OutputItemEffect;
         int outputItemId = (int)r.OutputItemId;
         string? thumb = string.IsNullOrWhiteSpace(outputItemImagePath)
             ? null
@@ -463,7 +467,7 @@ public static class RecipeEndpoints
             string? ingThumb = string.IsNullOrWhiteSpace((string?)i.ItemImagePath)
                 ? null
                 : ImageEndpoints.ThumbUrl(http, "items", (int)i.ItemId, "small");
-            ingredients.Add(new RecipeIngredientChipDto((int)i.ItemId, (string)i.ItemName, ingThumb, (int)i.Quantity));
+            ingredients.Add(new RecipeIngredientChipDto((int)i.ItemId, (string)i.ItemName, ingThumb, (int)i.Quantity, (string?)i.ItemEffect));
         }
 
         var buildings = new List<RecipeBuildingChipDto>();
@@ -484,6 +488,7 @@ public static class RecipeEndpoints
             outputItemId,
             outputItemName,
             thumb,
+            outputItemEffect,
             OutputQuantity: 1,
             (int?)r.LocationId,
             (string?)r.LocationName,

--- a/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor
+++ b/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor
@@ -24,6 +24,21 @@
 </div>
 
 <div class="oh-orgrole-filters">
+    <div class="oh-orgrole-view-toggle" role="group" aria-label="Pohled rozpisu rolí">
+        <span>Pohled</span>
+        <div class="oh-orgrole-view-buttons">
+            <button type="button"
+                    class="@ViewButtonCss(OrganizerRoleViewMode.ByRole)"
+                    @onclick="() => SetViewMode(OrganizerRoleViewMode.ByRole)">
+                dle role
+            </button>
+            <button type="button"
+                    class="@ViewButtonCss(OrganizerRoleViewMode.ByAdult)"
+                    @onclick="() => SetViewMode(OrganizerRoleViewMode.ByAdult)">
+                dle dospělého
+            </button>
+        </div>
+    </div>
     <label>
         <span>Typ role</span>
         <DxComboBox TData="RoleFilterOption" TValue="NpcRole?"
@@ -48,7 +63,9 @@
     @if (selectedAdultPersonId is not null)
     {
         <span class="oh-orgrole-filter-note">
-            Záznamy ostatních dospělých jsou ztlumené.
+            @(viewMode == OrganizerRoleViewMode.ByRole
+                ? "Záznamy ostatních dospělých jsou ztlumené."
+                : "Zobrazený je vybraný dospělý.")
         </span>
     }
 </div>
@@ -94,62 +111,138 @@ else if (npcs.Count == 0)
 }
 else
 {
-    <div class="oh-orgrole-matrix-wrap">
-        <table class="oh-orgrole-matrix">
-            <thead>
-                <tr>
-                    <th class="oh-orgrole-role-head">NPC role</th>
-                    @foreach (var slot in slots)
-                    {
-                        <th @key="slot.Id">
-                            <div class="oh-orgrole-slot">
-                                <span>@FormatSlotTime(slot)</span>
-                                <small>@slot.Stage.GetDisplayName()</small>
-                            </div>
-                        </th>
-                    }
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var npc in FilteredNpcs)
-                {
-                    <tr @key="npc.NpcId">
-                        <th class="oh-orgrole-role-cell">
-                            <span>@npc.NpcName</span>
-                            <small>@npc.Role.GetDisplayName()</small>
-                        </th>
+    @if (viewMode == OrganizerRoleViewMode.ByRole)
+    {
+        <div class="oh-orgrole-matrix-wrap">
+            <table class="oh-orgrole-matrix">
+                <thead>
+                    <tr>
+                        <th class="oh-orgrole-role-head">NPC role</th>
                         @foreach (var slot in slots)
                         {
-                            var assignment = GetAssignment(slot.Id, npc.NpcId);
-                            <td class="@CellCss(assignment)" @key="slot.Id">
-                                <button type="button"
-                                        class="oh-orgrole-cell-btn"
-                                        aria-label="@CellButtonLabel(slot, npc, assignment)"
-                                        @onclick="() => OpenCellEditor(slot, npc, assignment)">
-                                    @if (assignment is null)
-                                    {
-                                        <span class="oh-orgrole-empty-cell">+</span>
-                                    }
-                                    else
-                                    {
-                                        <span class="oh-orgrole-person">@assignment.PersonName</span>
-                                        @if (!string.IsNullOrWhiteSpace(assignment.PersonEmail))
-                                        {
-                                            <small>@assignment.PersonEmail</small>
-                                        }
-                                        @if (IsDuplicateAdultSlot(assignment))
-                                        {
-                                            <span class="oh-orgrole-dup">více rolí</span>
-                                        }
-                                    }
-                                </button>
-                            </td>
+                            <th @key="slot.Id">
+                                <div class="oh-orgrole-slot">
+                                    <span>@FormatSlotTime(slot)</span>
+                                    <small>@slot.Stage.GetDisplayName()</small>
+                                </div>
+                            </th>
                         }
                     </tr>
-                }
-            </tbody>
-        </table>
-    </div>
+                </thead>
+                <tbody>
+                    @foreach (var npc in FilteredNpcs)
+                    {
+                        <tr @key="npc.NpcId">
+                            <th class="oh-orgrole-role-cell">
+                                <span>@npc.NpcName</span>
+                                <small>@npc.Role.GetDisplayName()</small>
+                            </th>
+                            @foreach (var slot in slots)
+                            {
+                                var assignment = GetAssignment(slot.Id, npc.NpcId);
+                                <td class="@CellCss(assignment)" @key="slot.Id">
+                                    <button type="button"
+                                            class="oh-orgrole-cell-btn"
+                                            aria-label="@CellButtonLabel(slot, npc, assignment)"
+                                            @onclick="() => OpenCellEditor(slot, npc, assignment)">
+                                        @if (assignment is null)
+                                        {
+                                            <span class="oh-orgrole-empty-cell">+</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="oh-orgrole-person">@assignment.PersonName</span>
+                                            @if (!string.IsNullOrWhiteSpace(assignment.PersonEmail))
+                                            {
+                                                <small>@assignment.PersonEmail</small>
+                                            }
+                                            @if (IsDuplicateAdultSlot(assignment))
+                                            {
+                                                <span class="oh-orgrole-dup">více rolí</span>
+                                            }
+                                        }
+                                    </button>
+                                </td>
+                            }
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else if (!FilteredAdults.Any())
+    {
+        <div class="oh-orgrole-empty">
+            <i class="bi bi-person-lines-fill"></i>
+            <h2>Žádní dospělí k zobrazení</h2>
+            <p>Upravte filtr dospělého nebo zkontrolujte napojení registrace.</p>
+        </div>
+    }
+    else
+    {
+        <div class="oh-orgrole-matrix-wrap">
+            <table class="oh-orgrole-matrix oh-orgrole-matrix--adult">
+                <thead>
+                    <tr>
+                        <th class="oh-orgrole-role-head">Dospělý</th>
+                        @foreach (var slot in slots)
+                        {
+                            <th @key="slot.Id">
+                                <div class="oh-orgrole-slot">
+                                    <span>@FormatSlotTime(slot)</span>
+                                    <small>@slot.Stage.GetDisplayName()</small>
+                                </div>
+                            </th>
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var adult in FilteredAdults)
+                    {
+                        <tr @key="adult.PersonId">
+                            <th class="oh-orgrole-role-cell oh-orgrole-adult-cell">
+                                <span>@adult.Name</span>
+                                @if (!string.IsNullOrWhiteSpace(adult.Email))
+                                {
+                                    <small>@adult.Email</small>
+                                }
+                            </th>
+                            @foreach (var slot in slots)
+                            {
+                                var slotAssignments = GetAdultAssignments(slot.Id, adult.PersonId);
+                                <td class="@AdultCellCss(slotAssignments)" @key="slot.Id">
+                                    <button type="button"
+                                            class="oh-orgrole-cell-btn"
+                                            aria-label="@AdultCellButtonLabel(slot, adult, slotAssignments)"
+                                            @onclick="() => OpenAdultCellEditor(slot, adult, slotAssignments)">
+                                        @if (slotAssignments.Count == 0)
+                                        {
+                                            <span class="oh-orgrole-empty-cell">—</span>
+                                        }
+                                        else
+                                        {
+                                            @foreach (var assignment in slotAssignments)
+                                            {
+                                                var npc = GetNpc(assignment.NpcId);
+                                                <span class="oh-orgrole-role-pill" @key="assignment.Id">
+                                                    <strong>@(npc?.NpcName ?? $"NPC #{assignment.NpcId}")</strong>
+                                                    <small>@(npc?.Role.GetDisplayName() ?? "Role")</small>
+                                                </span>
+                                            }
+                                            @if (slotAssignments.Count > 1)
+                                            {
+                                                <span class="oh-orgrole-dup">více rolí</span>
+                                            }
+                                        }
+                                    </button>
+                                </td>
+                            }
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
 }
 
 <DxPopup @bind-Visible="@isBulkVisible" HeaderText="Přiřadit dospělého na všechny sloty" Width="560px">
@@ -199,6 +292,18 @@ else
 <DxPopup @bind-Visible="@isCellVisible" HeaderText="@cellTitle" Width="520px">
     <BodyContentTemplate Context="cellContext">
         <DxFormLayout>
+            @if (editNpcCanChange)
+            {
+                <DxFormLayoutItem Caption="NPC role" ColSpanMd="12">
+                    <DxComboBox TData="NpcOption" TValue="int?"
+                                Data="@FilteredNpcOptions"
+                                @bind-Value="@editNpcId"
+                                TextFieldName="@nameof(NpcOption.Display)"
+                                ValueFieldName="@nameof(NpcOption.NpcId)"
+                                NullText="Vyberte NPC roli..."
+                                SearchMode="ListSearchMode.AutoSearch" />
+                </DxFormLayoutItem>
+            }
             <DxFormLayoutItem Caption="Dospělý" ColSpanMd="12">
                 <DxComboBox TData="AdultOption" TValue="int?"
                             Data="@adultOptions"
@@ -206,7 +311,8 @@ else
                             TextFieldName="@nameof(AdultOption.Display)"
                             ValueFieldName="@nameof(AdultOption.PersonId)"
                             NullText="Vyberte dospělého..."
-                            SearchMode="ListSearchMode.AutoSearch" />
+                            SearchMode="ListSearchMode.AutoSearch"
+                            Enabled="@(!editPersonLocked)" />
             </DxFormLayoutItem>
             <DxFormLayoutItem Caption="Poznámka" ColSpanMd="12">
                 <DxMemo @bind-Text="@editNotes" Rows="2" />
@@ -224,7 +330,7 @@ else
                 </button>
             }
             <button type="button" class="btn btn-secondary" @onclick="() => isCellVisible = false" disabled="@isSaving">Zrušit</button>
-            <button type="button" class="btn btn-primary" @onclick="SaveCellAsync" disabled="@(isSaving || editPersonId is null)">Uložit</button>
+            <button type="button" class="btn btn-primary" @onclick="SaveCellAsync" disabled="@(isSaving || editPersonId is null || editNpcId is null)">Uložit</button>
         </div>
     </BodyContentTemplate>
 </DxPopup>
@@ -254,7 +360,9 @@ else
 
 @code {
     private static readonly CultureInfo Czech = CultureInfo.GetCultureInfo("cs-CZ");
+    private enum OrganizerRoleViewMode { ByRole, ByAdult }
 
+    private OrganizerRoleViewMode viewMode = OrganizerRoleViewMode.ByRole;
     private List<OrganizerRoleTimeSlotDto> slots = [];
     private List<OrganizerRoleNpcDto> npcs = [];
     private List<OrganizerRoleAssignmentDto> assignments = [];
@@ -263,6 +371,8 @@ else
     private List<NpcOption> npcOptions = [];
     private List<RoleFilterOption> roleFilterOptions = [new(null, "Všechny typy")];
     private Dictionary<(int SlotId, int NpcId), OrganizerRoleAssignmentDto> assignmentLookup = [];
+    private Dictionary<(int SlotId, int PersonId), List<OrganizerRoleAssignmentDto>> adultSlotAssignments = [];
+    private Dictionary<int, OrganizerRoleNpcDto> npcLookup = [];
     private HashSet<int> duplicateAdultSlotAssignmentIds = [];
 
     private bool loading = true;
@@ -285,6 +395,9 @@ else
     private OrganizerRoleTimeSlotDto? editingSlot;
     private OrganizerRoleNpcDto? editingNpc;
     private OrganizerRoleAssignmentDto? editingAssignment;
+    private int? editNpcId;
+    private bool editNpcCanChange;
+    private bool editPersonLocked;
     private int? editPersonId;
     private string? editNotes;
     private string? cellError;
@@ -298,14 +411,27 @@ else
     private IEnumerable<OrganizerRoleNpcDto> FilteredNpcs =>
         selectedRole is null ? npcs : npcs.Where(n => n.Role == selectedRole);
 
+    private IEnumerable<NpcOption> FilteredNpcOptions =>
+        selectedRole is null ? npcOptions : npcOptions.Where(n => n.Role == selectedRole);
+
+    private IEnumerable<AdultOption> FilteredAdults =>
+        selectedAdultPersonId is int personId
+            ? adultOptions.Where(a => a.PersonId == personId)
+            : adultOptions;
+
     private int ExistingBulkAssignmentCount =>
         bulkNpcId is int npcId ? assignments.Count(a => a.NpcId == npcId) : 0;
 
     private bool BulkWillOverwrite => ExistingBulkAssignmentCount > 0;
 
-    private string cellTitle => editingSlot is null || editingNpc is null
+    private OrganizerRoleNpcDto? SelectedEditNpc =>
+        editNpcId is int npcId ? GetNpc(npcId) : editingNpc;
+
+    private string cellTitle => editingSlot is null
         ? "Upravit obsazení"
-        : $"{editingNpc.NpcName} - {FormatSlotTime(editingSlot)}";
+        : SelectedEditNpc is { } npc
+            ? $"{npc.NpcName} - {FormatSlotTime(editingSlot)}"
+            : $"Obsazení - {FormatSlotTime(editingSlot)}";
 
     protected override async Task OnInitializedAsync()
     {
@@ -403,6 +529,14 @@ else
     private void RebuildDerivedState()
     {
         assignmentLookup = assignments.ToDictionary(a => (a.GameTimeSlotId, a.NpcId));
+        npcLookup = npcs.ToDictionary(n => n.NpcId);
+        adultSlotAssignments = assignments
+            .GroupBy(a => (a.GameTimeSlotId, a.PersonId))
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderBy(a => GetNpc(a.NpcId)?.Role.GetDisplayName())
+                      .ThenBy(a => GetNpc(a.NpcId)?.NpcName)
+                      .ToList());
         duplicateAdultSlotAssignmentIds = assignments
             .GroupBy(a => (a.GameTimeSlotId, a.PersonId))
             .Where(g => g.Count() > 1)
@@ -421,10 +555,28 @@ else
             selectedRole = null;
         if (selectedAdultPersonId is not null && adultOptions.All(a => a.PersonId != selectedAdultPersonId))
             selectedAdultPersonId = null;
+        if (viewMode == OrganizerRoleViewMode.ByAdult)
+            LogAdultTranspose();
     }
 
     private OrganizerRoleAssignmentDto? GetAssignment(int slotId, int npcId) =>
         assignmentLookup.TryGetValue((slotId, npcId), out var assignment) ? assignment : null;
+
+    private OrganizerRoleNpcDto? GetNpc(int npcId) =>
+        npcLookup.TryGetValue(npcId, out var npc) ? npc : null;
+
+    private IReadOnlyList<OrganizerRoleAssignmentDto> GetAdultAssignments(int slotId, int personId)
+    {
+        if (!adultSlotAssignments.TryGetValue((slotId, personId), out var slotAssignments))
+            return Array.Empty<OrganizerRoleAssignmentDto>();
+
+        if (selectedRole is null)
+            return slotAssignments;
+
+        return slotAssignments
+            .Where(a => GetNpc(a.NpcId)?.Role == selectedRole)
+            .ToList();
+    }
 
     private string FormatSlotTime(OrganizerRoleTimeSlotDto slot)
     {
@@ -456,6 +608,42 @@ else
 
     private bool IsDuplicateAdultSlot(OrganizerRoleAssignmentDto assignment) =>
         duplicateAdultSlotAssignmentIds.Contains(assignment.Id);
+
+    private string AdultCellCss(IReadOnlyList<OrganizerRoleAssignmentDto> slotAssignments)
+    {
+        var classes = new List<string> { "oh-orgrole-cell" };
+        if (slotAssignments.Count == 0) classes.Add("is-empty");
+        if (slotAssignments.Any(a => IsDuplicateAdultSlot(a))) classes.Add("has-duplicate");
+        return string.Join(' ', classes);
+    }
+
+    private string AdultCellButtonLabel(
+        OrganizerRoleTimeSlotDto slot,
+        AdultOption adult,
+        IReadOnlyList<OrganizerRoleAssignmentDto> slotAssignments)
+    {
+        var action = slotAssignments.Count == 0 ? "Přiřadit NPC roli" : "Upravit přiřazení";
+        return $"{action}: {adult.Name}, {FormatSlotTime(slot)}";
+    }
+
+    private string ViewButtonCss(OrganizerRoleViewMode mode) =>
+        viewMode == mode ? "oh-orgrole-view-btn is-active" : "oh-orgrole-view-btn";
+
+    private void SetViewMode(OrganizerRoleViewMode mode)
+    {
+        if (viewMode == mode)
+            return;
+
+        viewMode = mode;
+        Console.WriteLine($"[organizer-roles] view-toggle clicked={(mode == OrganizerRoleViewMode.ByRole ? "byrole" : "byadult")}");
+        if (mode == OrganizerRoleViewMode.ByAdult)
+            LogAdultTranspose();
+    }
+
+    private void LogAdultTranspose()
+    {
+        Console.WriteLine($"[organizer-roles] transpose computed adultCount={FilteredAdults.Count()} slotCount={slots.Count}");
+    }
 
     private void OpenBulkAssign()
     {
@@ -530,19 +718,55 @@ else
         editingSlot = slot;
         editingNpc = npc;
         editingAssignment = assignment;
+        editNpcId = npc.NpcId;
+        editNpcCanChange = false;
+        editPersonLocked = false;
         editPersonId = assignment?.PersonId ?? selectedAdultPersonId;
         editNotes = assignment?.Notes;
         isCellVisible = true;
         Console.WriteLine($"[organizer-roles] cell popup.open gameId={GameContext.SelectedGameId} slotId={slot.Id} npcId={npc.NpcId}");
     }
 
+    private void OpenAdultCellEditor(
+        OrganizerRoleTimeSlotDto slot,
+        AdultOption adult,
+        IReadOnlyList<OrganizerRoleAssignmentDto> slotAssignments)
+    {
+        cellError = null;
+        var assignment = slotAssignments.FirstOrDefault();
+        var npc = assignment is null
+            ? FilteredNpcs.FirstOrDefault()
+            : GetNpc(assignment.NpcId);
+
+        editingSlot = slot;
+        editingNpc = npc;
+        editingAssignment = assignment;
+        editNpcId = assignment?.NpcId ?? npc?.NpcId;
+        editNpcCanChange = assignment is null;
+        editPersonLocked = assignment is null;
+        editPersonId = assignment?.PersonId ?? adult.PersonId;
+        editNotes = assignment?.Notes;
+        isCellVisible = true;
+        if (editNpcId is null)
+            cellError = "Vybraný typ role nemá žádné NPC.";
+
+        Console.WriteLine($"[organizer-roles] adult-cell popup.open gameId={GameContext.SelectedGameId} slotId={slot.Id} personId={adult.PersonId} npcId={editNpcId}");
+    }
+
     private async Task SaveCellAsync()
     {
         if (GameContext.SelectedGameId is not int gameId
             || editingSlot is null
-            || editingNpc is null
+            || editNpcId is not int npcId
             || editPersonId is not int personId)
             return;
+
+        var npc = GetNpc(npcId);
+        if (npc is null)
+        {
+            cellError = "Vybraná NPC role nebyla nalezena.";
+            return;
+        }
 
         var adult = adultOptions.FirstOrDefault(a => a.PersonId == personId);
         if (adult is null)
@@ -554,10 +778,10 @@ else
         isSaving = true;
         try
         {
-            Console.WriteLine($"[organizer-roles] cell save.start gameId={gameId} slotId={editingSlot.Id} npcId={editingNpc.NpcId} personId={personId}");
+            Console.WriteLine($"[organizer-roles] cell save.start gameId={gameId} slotId={editingSlot.Id} npcId={npcId} personId={personId}");
             var dto = new UpsertOrganizerRoleAssignmentDto(personId, adult.Name, adult.Email, editNotes);
             var (ok, problemDetail) = await Api.PutWithProblemAsync(
-                $"/api/games/{gameId}/organizer-role-assignments/slots/{editingSlot.Id}/npcs/{editingNpc.NpcId}",
+                $"/api/games/{gameId}/organizer-role-assignments/slots/{editingSlot.Id}/npcs/{npcId}",
                 dto);
             if (!ok)
             {
@@ -567,7 +791,7 @@ else
 
             isCellVisible = false;
             await LoadMatrixAsync();
-            Console.WriteLine($"[organizer-roles] cell save.ok gameId={gameId} slotId={editingSlot.Id} npcId={editingNpc.NpcId}");
+            Console.WriteLine($"[organizer-roles] cell save.ok gameId={gameId} slotId={editingSlot.Id} npcId={npcId}");
         }
         catch (Exception ex)
         {
@@ -582,15 +806,15 @@ else
 
     private async Task RemoveCellAsync()
     {
-        if (GameContext.SelectedGameId is not int gameId || editingSlot is null || editingNpc is null)
+        if (GameContext.SelectedGameId is not int gameId || editingSlot is null || editNpcId is not int npcId)
             return;
 
         isSaving = true;
         try
         {
-            Console.WriteLine($"[organizer-roles] cell remove.start gameId={gameId} slotId={editingSlot.Id} npcId={editingNpc.NpcId}");
+            Console.WriteLine($"[organizer-roles] cell remove.start gameId={gameId} slotId={editingSlot.Id} npcId={npcId}");
             var (ok, problemDetail) = await Api.DeleteWithProblemAsync(
-                $"/api/games/{gameId}/organizer-role-assignments/slots/{editingSlot.Id}/npcs/{editingNpc.NpcId}");
+                $"/api/games/{gameId}/organizer-role-assignments/slots/{editingSlot.Id}/npcs/{npcId}");
             if (!ok)
             {
                 cellError = problemDetail ?? "Obsazení se nepodařilo odebrat.";
@@ -600,7 +824,7 @@ else
             isRemoveConfirmVisible = false;
             isCellVisible = false;
             await LoadMatrixAsync();
-            Console.WriteLine($"[organizer-roles] cell remove.ok gameId={gameId} slotId={editingSlot.Id} npcId={editingNpc.NpcId}");
+            Console.WriteLine($"[organizer-roles] cell remove.ok gameId={gameId} slotId={editingSlot.Id} npcId={npcId}");
         }
         catch (Exception ex)
         {

--- a/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor
+++ b/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor
@@ -29,11 +29,13 @@
         <div class="oh-orgrole-view-buttons">
             <button type="button"
                     class="@ViewButtonCss(OrganizerRoleViewMode.ByRole)"
+                    aria-pressed="@(viewMode == OrganizerRoleViewMode.ByRole)"
                     @onclick="() => SetViewMode(OrganizerRoleViewMode.ByRole)">
                 dle role
             </button>
             <button type="button"
                     class="@ViewButtonCss(OrganizerRoleViewMode.ByAdult)"
+                    aria-pressed="@(viewMode == OrganizerRoleViewMode.ByAdult)"
                     @onclick="() => SetViewMode(OrganizerRoleViewMode.ByAdult)">
                 dle dospělého
             </button>
@@ -372,6 +374,7 @@ else
     private List<RoleFilterOption> roleFilterOptions = [new(null, "Všechny typy")];
     private Dictionary<(int SlotId, int NpcId), OrganizerRoleAssignmentDto> assignmentLookup = [];
     private Dictionary<(int SlotId, int PersonId), List<OrganizerRoleAssignmentDto>> adultSlotAssignments = [];
+    private Dictionary<(int SlotId, int PersonId, NpcRole Role), List<OrganizerRoleAssignmentDto>> adultSlotRoleAssignments = [];
     private Dictionary<int, OrganizerRoleNpcDto> npcLookup = [];
     private HashSet<int> duplicateAdultSlotAssignmentIds = [];
 
@@ -534,9 +537,14 @@ else
             .GroupBy(a => (a.GameTimeSlotId, a.PersonId))
             .ToDictionary(
                 g => g.Key,
-                g => g.OrderBy(a => GetNpc(a.NpcId)?.Role.GetDisplayName())
-                      .ThenBy(a => GetNpc(a.NpcId)?.NpcName)
-                      .ToList());
+                g => OrderAssignments(g).ToList());
+        adultSlotRoleAssignments = assignments
+            .Select(a => (Assignment: a, Npc: GetNpc(a.NpcId)))
+            .Where(row => row.Npc is not null)
+            .GroupBy(row => (row.Assignment.GameTimeSlotId, row.Assignment.PersonId, row.Npc!.Role))
+            .ToDictionary(
+                g => g.Key,
+                g => OrderAssignments(g.Select(row => row.Assignment)).ToList());
         duplicateAdultSlotAssignmentIds = assignments
             .GroupBy(a => (a.GameTimeSlotId, a.PersonId))
             .Where(g => g.Count() > 1)
@@ -573,10 +581,14 @@ else
         if (selectedRole is null)
             return slotAssignments;
 
-        return slotAssignments
-            .Where(a => GetNpc(a.NpcId)?.Role == selectedRole)
-            .ToList();
+        return adultSlotRoleAssignments.TryGetValue((slotId, personId, selectedRole.Value), out var filteredAssignments)
+            ? filteredAssignments
+            : Array.Empty<OrganizerRoleAssignmentDto>();
     }
+
+    private IOrderedEnumerable<OrganizerRoleAssignmentDto> OrderAssignments(IEnumerable<OrganizerRoleAssignmentDto> source) =>
+        source.OrderBy(a => GetNpc(a.NpcId)?.Role.GetDisplayName())
+            .ThenBy(a => GetNpc(a.NpcId)?.NpcName);
 
     private string FormatSlotTime(OrganizerRoleTimeSlotDto slot)
     {

--- a/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor.css
+++ b/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor.css
@@ -24,16 +24,48 @@
 
 .oh-orgrole-filters {
     display: grid;
-    grid-template-columns: minmax(220px, 300px) minmax(260px, 380px) 1fr;
+    grid-template-columns: minmax(220px, 280px) minmax(220px, 300px) minmax(260px, 380px) 1fr;
     gap: 12px;
     align-items: end;
     margin-bottom: 16px;
 }
 
-.oh-orgrole-filters label {
+.oh-orgrole-filters label,
+.oh-orgrole-view-toggle {
     display: grid;
     gap: 4px;
     font-weight: 600;
+}
+
+.oh-orgrole-view-buttons {
+    display: inline-flex;
+    min-height: 38px;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--bs-body-bg);
+}
+
+.oh-orgrole-view-btn {
+    border: 0;
+    padding: 6px 12px;
+    background: transparent;
+    color: var(--bs-body-color);
+    font-weight: 700;
+}
+
+.oh-orgrole-view-btn + .oh-orgrole-view-btn {
+    border-left: 1px solid var(--bs-border-color);
+}
+
+.oh-orgrole-view-btn:hover,
+.oh-orgrole-view-btn:focus {
+    background: color-mix(in srgb, var(--oh-stage-early) 12%, transparent);
+}
+
+.oh-orgrole-view-btn.is-active {
+    background: var(--oh-stage-early);
+    color: #fff;
 }
 
 .oh-orgrole-filter-note {
@@ -116,7 +148,8 @@
 
 .oh-orgrole-role-cell small,
 .oh-orgrole-slot small,
-.oh-orgrole-cell-btn small {
+.oh-orgrole-cell-btn small,
+.oh-orgrole-role-pill small {
     display: block;
     color: var(--bs-secondary-color);
     font-size: 0.78rem;
@@ -154,6 +187,28 @@
 .oh-orgrole-empty-cell {
     color: var(--bs-secondary-color);
     font-size: 1.2rem;
+}
+
+.oh-orgrole-adult-cell {
+    background: color-mix(in srgb, var(--bs-body-bg) 88%, var(--oh-stage-early) 12%);
+}
+
+.oh-orgrole-role-pill {
+    display: block;
+    padding: 4px 6px;
+    border: 1px solid color-mix(in srgb, var(--oh-stage-early) 28%, var(--bs-border-color));
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--oh-stage-early) 9%, var(--bs-body-bg));
+}
+
+.oh-orgrole-role-pill + .oh-orgrole-role-pill {
+    margin-top: 4px;
+}
+
+.oh-orgrole-role-pill strong {
+    display: block;
+    line-height: 1.15;
+    overflow-wrap: anywhere;
 }
 
 .oh-orgrole-cell.is-dimmed {

--- a/src/OvcinaHra.Client/Pages/Recipes/RecipeDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Recipes/RecipeDetail.razor
@@ -63,29 +63,74 @@ else
             }
             else
             {
-                <ul class="oh-rec-rel-list">
-                    @foreach (var ing in detail.Ingredients)
+                <div class="oh-rec-item-card-row">
+                    @foreach (var card in IngredientCards)
                     {
-                        <li>
-                            <strong>@ing.Name</strong>
-                            <span class="oh-rec-qty">×@ing.Quantity</span>
-                        </li>
+                        <div id="@card.TargetId"
+                             class="oh-rec-item-card"
+                             tabindex="0"
+                             title="@card.Name"
+                             @key="@card.TargetId"
+                             @onmouseenter="() => ShowItemFlyout(card)"
+                             @onmouseleave="HideItemFlyout"
+                             @onfocus="() => ShowItemFlyout(card)"
+                             @onblur="HideItemFlyout">
+                            @if (!failedRecipeItemImages.Contains(card.ItemId))
+                            {
+                                <img src="@ItemThumbUrl(card.ItemId)"
+                                     alt="@card.Name"
+                                     class="oh-rec-item-card-img"
+                                     @onerror="() => OnRecipeItemImageError(card)" />
+                            }
+                            else
+                            {
+                                <span class="oh-rec-item-card-img oh-rec-item-card-img--fallback">
+                                    <i class="bi bi-box"></i>
+                                </span>
+                            }
+                            <span class="oh-rec-item-card-body">
+                                <strong>@card.Name</strong>
+                                <span class="oh-rec-item-card-qty">×@card.Quantity</span>
+                            </span>
+                        </div>
                     }
-                </ul>
+                </div>
             }
         </section>
 
         <section class="oh-rec-rel-section">
             <h6><i class="bi bi-bag"></i> Výstupní artefakt</h6>
-            <ul class="oh-rec-rel-list">
-                <li>
-                    <strong>@detail.OutputItemName</strong>
-                    @if (detail.OutputQuantity > 1)
-                    {
-                        <span class="oh-rec-qty">×@detail.OutputQuantity</span>
-                    }
-                </li>
-            </ul>
+            @if (OutputCard is { } outputCard)
+            {
+                <div class="oh-rec-item-card-row">
+                    <div id="@outputCard.TargetId"
+                         class="oh-rec-item-card oh-rec-item-card--output"
+                         tabindex="0"
+                         title="@outputCard.Name"
+                         @onmouseenter="() => ShowItemFlyout(outputCard)"
+                         @onmouseleave="HideItemFlyout"
+                         @onfocus="() => ShowItemFlyout(outputCard)"
+                         @onblur="HideItemFlyout">
+                        @if (!failedRecipeItemImages.Contains(outputCard.ItemId))
+                        {
+                            <img src="@ItemThumbUrl(outputCard.ItemId)"
+                                 alt="@outputCard.Name"
+                                 class="oh-rec-item-card-img"
+                                 @onerror="() => OnRecipeItemImageError(outputCard)" />
+                        }
+                        else
+                        {
+                            <span class="oh-rec-item-card-img oh-rec-item-card-img--fallback">
+                                <i class="bi bi-bag"></i>
+                            </span>
+                        }
+                        <span class="oh-rec-item-card-body">
+                            <strong>@outputCard.Name</strong>
+                            <span class="oh-rec-item-card-qty">×@outputCard.Quantity</span>
+                        </span>
+                    </div>
+                </div>
+            }
         </section>
 
         <section class="oh-rec-rel-section">
@@ -163,6 +208,14 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+<DxFlyout @bind-IsOpen="@isItemFlyoutOpen"
+          PositionTarget="@itemFlyoutTarget"
+          Position="FlyoutPosition.Top"
+          BodyText="@ItemFlyoutText"
+          HeaderVisible="false"
+          CloseOnOutsideClick="false"
+          Width="260px" />
+
 @code {
     [Parameter] public int Id { get; set; }
 
@@ -173,9 +226,28 @@ else
     private bool isEditVisible;
     private bool isDeleteVisible;
     private string? deleteError;
+    private readonly HashSet<int> failedRecipeItemImages = [];
+    private bool isItemFlyoutOpen;
+    private string? itemFlyoutTarget;
+    private RecipeItemCard? itemFlyoutCard;
 
     private bool CanDelete =>
         detail is not null && (detail.GameId is not null || detail.ForksCount == 0);
+
+    private IEnumerable<RecipeItemCard> IngredientCards =>
+        detail?.Ingredients.Select(i => new RecipeItemCard("ingredient", i.ItemId, i.Name, i.Quantity, i.Effect)) ?? [];
+
+    private RecipeItemCard? OutputCard =>
+        detail is null
+            ? null
+            : new RecipeItemCard("output", detail.OutputItemId, detail.OutputItemName, detail.OutputQuantity, detail.OutputItemEffect);
+
+    private string ItemFlyoutText =>
+        itemFlyoutCard is null
+            ? string.Empty
+            : string.IsNullOrWhiteSpace(itemFlyoutCard.Effect)
+                ? "Efekt není vyplněný."
+                : Excerpt(itemFlyoutCard.Effect);
 
     protected override async Task OnInitializedAsync()
     {
@@ -198,9 +270,15 @@ else
     {
         loading = true;
         error = null;
+        failedRecipeItemImages.Clear();
+        HideItemFlyout();
         try
         {
             detail = await Api.GetAsync<RecipeDetailDto>($"/api/recipes/{Id}");
+            if (detail is not null)
+            {
+                Console.WriteLine($"[recipe-detail] loaded recipeId={detail.Id} ingredientCount={detail.Ingredients.Count} outputCount=1");
+            }
         }
         catch (Exception ex) { error = ex.Message; }
         finally { loading = false; StateHasChanged(); }
@@ -227,8 +305,41 @@ else
     // Adapter — RecipeFormulaCard accepts the list DTO; cast detail to it.
     private static RecipeListDto AsListDto(RecipeDetailDto d) =>
         new(d.Id, d.Name, d.Title, d.Category, d.GameId, d.TemplateRecipeId,
-            d.OutputItemId, d.OutputItemName, d.OutputItemThumbnailUrl, d.OutputQuantity,
+            d.OutputItemId, d.OutputItemName, d.OutputItemThumbnailUrl, d.OutputItemEffect, d.OutputQuantity,
             d.LocationId, d.LocationName,
             d.Ingredients, d.Buildings, d.Skills,
             d.IngredientNotes, d.ForksCount);
+
+    private static string ItemThumbUrl(int itemId) => $"/api/images/items/{itemId}/thumb?size=small";
+
+    private void ShowItemFlyout(RecipeItemCard card)
+    {
+        itemFlyoutCard = card;
+        itemFlyoutTarget = $"#{card.TargetId}";
+        isItemFlyoutOpen = true;
+    }
+
+    private void HideItemFlyout()
+    {
+        isItemFlyoutOpen = false;
+        itemFlyoutTarget = null;
+        itemFlyoutCard = null;
+    }
+
+    private void OnRecipeItemImageError(RecipeItemCard card)
+    {
+        failedRecipeItemImages.Add(card.ItemId);
+        Console.WriteLine($"[recipe-detail] image-load-failed recipeId={Id} itemId={card.ItemId} name={card.Name}");
+    }
+
+    private static string Excerpt(string text)
+    {
+        var normalized = string.Join(' ', text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+        return normalized.Length <= 220 ? normalized : normalized[..217] + "...";
+    }
+
+    private sealed record RecipeItemCard(string Kind, int ItemId, string Name, int Quantity, string? Effect)
+    {
+        public string TargetId => $"oh-rec-item-card-{Kind}-{ItemId}";
+    }
 }

--- a/src/OvcinaHra.Client/Pages/Recipes/RecipeDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Recipes/RecipeDetail.razor
@@ -73,11 +73,12 @@ else
                              @key="@card.TargetId"
                              @onmouseenter="() => ShowItemFlyout(card)"
                              @onmouseleave="HideItemFlyout"
-                             @onfocus="() => ShowItemFlyout(card)"
+                            @onfocus="() => ShowItemFlyout(card)"
                              @onblur="HideItemFlyout">
-                            @if (!failedRecipeItemImages.Contains(card.ItemId))
+                            @if (!failedRecipeItemImages.Contains(card.ItemId)
+                                && !string.IsNullOrWhiteSpace(card.ThumbnailUrl))
                             {
-                                <img src="@ItemThumbUrl(card.ItemId)"
+                                <img src="@card.ThumbnailUrl"
                                      alt="@card.Name"
                                      class="oh-rec-item-card-img"
                                      @onerror="() => OnRecipeItemImageError(card)" />
@@ -111,9 +112,10 @@ else
                          @onmouseleave="HideItemFlyout"
                          @onfocus="() => ShowItemFlyout(outputCard)"
                          @onblur="HideItemFlyout">
-                        @if (!failedRecipeItemImages.Contains(outputCard.ItemId))
+                        @if (!failedRecipeItemImages.Contains(outputCard.ItemId)
+                            && !string.IsNullOrWhiteSpace(outputCard.ThumbnailUrl))
                         {
-                            <img src="@ItemThumbUrl(outputCard.ItemId)"
+                            <img src="@outputCard.ThumbnailUrl"
                                  alt="@outputCard.Name"
                                  class="oh-rec-item-card-img"
                                  @onerror="() => OnRecipeItemImageError(outputCard)" />
@@ -235,12 +237,12 @@ else
         detail is not null && (detail.GameId is not null || detail.ForksCount == 0);
 
     private IEnumerable<RecipeItemCard> IngredientCards =>
-        detail?.Ingredients.Select(i => new RecipeItemCard("ingredient", i.ItemId, i.Name, i.Quantity, i.Effect)) ?? [];
+        detail?.Ingredients.Select(i => new RecipeItemCard("ingredient", i.ItemId, i.Name, i.Quantity, i.Effect, i.ThumbnailUrl)) ?? [];
 
     private RecipeItemCard? OutputCard =>
         detail is null
             ? null
-            : new RecipeItemCard("output", detail.OutputItemId, detail.OutputItemName, detail.OutputQuantity, detail.OutputItemEffect);
+            : new RecipeItemCard("output", detail.OutputItemId, detail.OutputItemName, detail.OutputQuantity, detail.OutputItemEffect, detail.OutputItemThumbnailUrl);
 
     private string ItemFlyoutText =>
         itemFlyoutCard is null
@@ -310,8 +312,6 @@ else
             d.Ingredients, d.Buildings, d.Skills,
             d.IngredientNotes, d.ForksCount);
 
-    private static string ItemThumbUrl(int itemId) => $"/api/images/items/{itemId}/thumb?size=small";
-
     private void ShowItemFlyout(RecipeItemCard card)
     {
         itemFlyoutCard = card;
@@ -338,7 +338,7 @@ else
         return normalized.Length <= 220 ? normalized : normalized[..217] + "...";
     }
 
-    private sealed record RecipeItemCard(string Kind, int ItemId, string Name, int Quantity, string? Effect)
+    private sealed record RecipeItemCard(string Kind, int ItemId, string Name, int Quantity, string? Effect, string? ThumbnailUrl)
     {
         public string TargetId => $"oh-rec-item-card-{Kind}-{ItemId}";
     }

--- a/src/OvcinaHra.Client/Pages/Recipes/RecipeDetail.razor.css
+++ b/src/OvcinaHra.Client/Pages/Recipes/RecipeDetail.razor.css
@@ -1,0 +1,74 @@
+.oh-rec-item-card-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.oh-rec-item-card {
+    display: grid;
+    grid-template-columns: 56px minmax(0, 1fr);
+    align-items: center;
+    gap: 10px;
+    width: min(100%, 260px);
+    min-height: 72px;
+    padding: 8px;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 8px;
+    background: var(--bs-body-bg);
+    color: var(--bs-body-color);
+    cursor: help;
+}
+
+.oh-rec-item-card:hover,
+.oh-rec-item-card:focus {
+    outline: 2px solid color-mix(in srgb, var(--bs-primary) 45%, transparent);
+    outline-offset: 1px;
+    border-color: color-mix(in srgb, var(--bs-primary) 45%, var(--bs-border-color));
+}
+
+.oh-rec-item-card--output {
+    border-color: color-mix(in srgb, var(--oh-stage-early, #4f7f24) 45%, var(--bs-border-color));
+}
+
+.oh-rec-item-card-img {
+    width: 56px;
+    height: 56px;
+    object-fit: cover;
+    border-radius: 6px;
+    background: var(--bs-tertiary-bg);
+}
+
+.oh-rec-item-card-img--fallback {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--bs-secondary-color);
+    font-size: 1.45rem;
+}
+
+.oh-rec-item-card-body {
+    display: grid;
+    min-width: 0;
+    gap: 4px;
+}
+
+.oh-rec-item-card-body strong {
+    overflow-wrap: anywhere;
+    line-height: 1.15;
+}
+
+.oh-rec-item-card-qty {
+    justify-self: start;
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: var(--bs-tertiary-bg);
+    color: var(--bs-secondary-color);
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+@media (max-width: 768px) {
+    .oh-rec-item-card {
+        width: 100%;
+    }
+}

--- a/src/OvcinaHra.Shared/Dtos/CraftingDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/CraftingDtos.cs
@@ -51,7 +51,7 @@ public record AddCraftingBuildingReqDto(int BuildingId);
 // /api/recipes surface. Tile/card/hero rendering powered by these.
 // ────────────────────────────────────────────────────────────────────────
 
-public record RecipeIngredientChipDto(int ItemId, string Name, string? ThumbnailUrl, int Quantity);
+public record RecipeIngredientChipDto(int ItemId, string Name, string? ThumbnailUrl, int Quantity, string? Effect = null);
 public record RecipeBuildingChipDto(int BuildingId, string Name);
 public record RecipeSkillChipDto(int SkillId, string Name);
 
@@ -67,6 +67,7 @@ public record RecipeListDto(
     int OutputItemId,
     string OutputItemName,
     string? OutputItemThumbnailUrl,
+    string? OutputItemEffect,
     int OutputQuantity,
     int? LocationId,
     string? LocationName,
@@ -92,6 +93,7 @@ public record RecipeDetailDto(
     int OutputItemId,
     string OutputItemName,
     string? OutputItemThumbnailUrl,
+    string? OutputItemEffect,
     int OutputQuantity,
     int? LocationId,
     string? LocationName,


### PR DESCRIPTION
## Summary
- Adds recipe detail ingredient/output cards with direct item thumbnail endpoint rendering, fallback icons, hover/focus DxFlyout effect excerpts, and [recipe-detail] diagnostics.
- Adds organizer roles view toggle: default role-centered matrix plus adult-centered transpose view backed by the same matrix payload.
- Extends the cell editor path so adult-view empty cells can pick an NPC role, and keeps [organizer-roles] view/transpose markers.

## Verification
- dotnet build
- dotnet test
- Browser smoke: /recipes/1 rendered recipeCards=1, flyout seen, mobile 390px card still rendered/wrapped.
- Browser smoke: /organizer-roles adult view rendered adultRows=2, adultRolePills=1, adult cell editor opened, toggled back to role view.
- §16 self-audit: changed client files use Api.* helpers; no raw HttpClient/JsonSerializer/EnsureSuccessStatusCode path introduced.

## Notes
- Local smoke used a temporary fake Registrace adults endpoint and restored local DB smoke changes afterwards.