### PR TITLE
Treasures: auto-detect currency and add groše bundle row

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -587,8 +587,7 @@ public static class TreasurePlanningEndpoints
             .ToDictionaryAsync(i => i.Id);
         var gros = unlimitedItems.FirstOrDefault(ui =>
             itemsById.TryGetValue(ui.ItemId, out var item)
-            && item.ItemType == ItemType.Money
-            && IsGrosItemName(item.Name));
+            && item.ItemType == ItemType.Money);
 
         if (gros is null)
         {
@@ -602,10 +601,6 @@ public static class TreasurePlanningEndpoints
             count = gros.Count
         });
     }
-
-    private static bool IsGrosItemName(string name) =>
-        string.Equals(name.Trim(), "Groše", StringComparison.CurrentCultureIgnoreCase)
-        || name.Contains("groš", StringComparison.CurrentCultureIgnoreCase);
 
     private static async Task<Results<Ok<TreasureItemDto>, ValidationProblem, NotFound>> AdjustTreasureItemCount(
         int id,

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -2049,22 +2049,34 @@ else
         grosError = null;
     }
 
-    private UnlimitedItemDto? FindGrosItem() =>
-        unlimitedItems.FirstOrDefault(i =>
-            i.ItemType == ItemType.Money
-            && (string.Equals(i.ItemName.Trim(), "Groše", StringComparison.CurrentCultureIgnoreCase)
-                || i.ItemName.Contains("groš", StringComparison.CurrentCultureIgnoreCase)));
+    private UnlimitedItemDto? FindCurrencyItem()
+    {
+        var moneyItems = unlimitedItems
+            .Where(i => i.ItemType == ItemType.Money)
+            .ToList();
+
+        return moneyItems.FirstOrDefault(IsGrosCurrencyName)
+            ?? moneyItems
+                .OrderBy(i => i.ItemName, StringComparer.CurrentCultureIgnoreCase)
+                .FirstOrDefault();
+    }
+
+    private static bool IsGrosCurrencyName(UnlimitedItemDto item) =>
+        string.Equals(item.ItemName.Trim(), "Groše", StringComparison.CurrentCultureIgnoreCase)
+        || item.ItemName.Contains("groš", StringComparison.CurrentCultureIgnoreCase);
 
     private async Task CreateGrosTreasureAsync()
     {
         if (grosLocationId is not int locationId || grosSaving) return;
         grosError = null;
-        var grosItem = FindGrosItem();
+        var grosItem = FindCurrencyItem();
         if (grosItem is null)
         {
-            grosError = "Ve hře není nalézatelná položka Groše typu Peníze.";
+            LogTreasureAlloc("currency-item-not-found", new { gameId });
+            grosError = "Hra nemá nastavenu měnu. Přidejte položku typu Peníze do herního inventáře.";
             return;
         }
+        LogTreasureAlloc("currency-item-detected", new { itemId = grosItem.ItemId, kind = nameof(ItemType.Money) });
 
         grosSaving = true;
         try

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -304,7 +304,31 @@ else
                                         <i class="bi bi-plus-circle"></i>
                                     </button>
                                 </div>
-                                @if (HasCompositeBundle)
+                                <div class="oh-tp-bundle-money">
+                                    <span class="oh-tp-bundle-money-name"><i class="bi bi-coin me-1"></i>Groše</span>
+                                    <button type="button"
+                                            class="oh-tp-bundle-money-btn"
+                                            disabled="@(CompositeBundleCurrencyCount <= 0)"
+                                            @onclick="() => ChangeCompositeBundleCurrencyCount(-1)"
+                                            aria-label="Odebrat groše">
+                                        <i class="bi bi-dash-lg"></i>
+                                    </button>
+                                    <DxSpinEdit TValue="int?"
+                                                Value="@compositeBundleCurrencyCount"
+                                                ValueChanged="@((int? value) => SetCompositeBundleCurrencyCount(value))"
+                                                ValueExpression="@(() => compositeBundleCurrencyCount)"
+                                                MinValue="0"
+                                                MaxValue="99999"
+                                                NullText="Kolik?"
+                                                CssClass="oh-tp-bundle-money-input" />
+                                    <button type="button"
+                                            class="oh-tp-bundle-money-btn"
+                                            @onclick="() => ChangeCompositeBundleCurrencyCount(1)"
+                                            aria-label="Přidat groše">
+                                        <i class="bi bi-plus-lg"></i>
+                                    </button>
+                                </div>
+                                @if (compositeBundleItems.Count > 0)
                                 {
                                     <div class="oh-tp-bundle-lines">
                                         @foreach (var line in GetCompositeBundleDisplayLines())
@@ -894,6 +918,7 @@ else
     private bool selectedCompositeBundle;
     private int? compositeBundlePoolItemId;
     private int compositeBundleAddCount = 1;
+    private int? compositeBundleCurrencyCount;
     private string compositeBundleTitle = "";
     private string lastCompositeBundleAutoTitle = "";
     private string? compositeBundleError;
@@ -905,11 +930,13 @@ else
     private sealed record CompositeBundleDisplayLine(int ItemId, string ItemName, int Count);
     private sealed record CompositeBundleChoice(int PoolItemId, int ItemId, string ItemName, string Label, int Available, bool IsUnique);
 
-    private bool HasCompositeBundle => compositeBundleItems.Count > 0;
-    private int CompositeBundleUnitCount => compositeBundleItems.Sum(i => i.Count);
+    private int CompositeBundleCurrencyCount => Math.Max(0, compositeBundleCurrencyCount ?? 0);
+    private bool HasCompositeBundleCurrency => CompositeBundleCurrencyCount > 0;
+    private bool HasCompositeBundle => compositeBundleItems.Count > 0 || HasCompositeBundleCurrency;
+    private int CompositeBundleUnitCount => compositeBundleItems.Sum(i => i.Count) + CompositeBundleCurrencyCount;
     private string EffectiveCompositeBundleTitle =>
         string.IsNullOrWhiteSpace(compositeBundleTitle) ? BuildCompositeBundleAutoTitle() : compositeBundleTitle.Trim();
-    private string CompositeBundleSummary => string.Join(" + ", GetCompositeBundleDisplayLines().Select(i => $"{i.ItemName} × {i.Count}"));
+    private string CompositeBundleSummary => string.Join(" + ", GetCompositeBundleSummaryParts());
     private int CompositeBundleAddMax => compositeBundlePoolItemId is int id
         ? Math.Max(1, GetCompositeBundleAvailableCount(id))
         : 1;
@@ -945,6 +972,19 @@ else
             .GroupBy(i => new { i.ItemId, i.ItemName })
             .OrderBy(g => g.Key.ItemName)
             .Select(g => new CompositeBundleDisplayLine(g.Key.ItemId, g.Key.ItemName, g.Sum(i => i.Count)));
+
+    private IEnumerable<string> GetCompositeBundleSummaryParts()
+    {
+        foreach (var line in GetCompositeBundleDisplayLines())
+        {
+            yield return $"{line.ItemName} × {line.Count}";
+        }
+
+        if (HasCompositeBundleCurrency)
+        {
+            yield return $"Groše × {CompositeBundleCurrencyCount}";
+        }
+    }
 
     private int GetCompositeBundleReservedCount(int poolItemId) =>
         compositeBundleItems.Where(i => i.PoolItemId == poolItemId).Sum(i => i.Count);
@@ -1019,6 +1059,35 @@ else
             count,
             reserved = GetCompositeBundleReservedCount(poolItemId)
         });
+    }
+
+    private void ChangeCompositeBundleCurrencyCount(int delta)
+    {
+        SetCompositeBundleCurrencyCount(CompositeBundleCurrencyCount + delta);
+    }
+
+    private void SetCompositeBundleCurrencyCount(int? value)
+    {
+        compositeBundleError = null;
+        var previous = CompositeBundleCurrencyCount;
+        var next = Math.Clamp(value ?? 0, 0, 99999);
+        compositeBundleCurrencyCount = next == 0 ? null : next;
+        if (next > 0)
+        {
+            selectedPool.Clear();
+            selectedCompositeBundle = true;
+        }
+        else if (!HasCompositeBundle)
+        {
+            selectedCompositeBundle = false;
+        }
+
+        RefreshCompositeBundleTitle();
+        wiredCompositeBundlePayload = null;
+        if (previous == 0 && next > 0)
+        {
+            LogTreasureAlloc("compose-row-add", new { kind = "currency", count = next });
+        }
     }
 
     private bool CanIncreaseCompositeBundleItem(int itemId) =>
@@ -1118,6 +1187,7 @@ else
         lastCompositeBundleAutoTitle = "";
         compositeBundlePoolItemId = null;
         compositeBundleAddCount = 1;
+        compositeBundleCurrencyCount = null;
         compositeBundleError = null;
         selectedCompositeBundle = false;
         wiredCompositeBundlePayload = null;
@@ -1165,6 +1235,12 @@ else
     private string? GetCompositeBundleValidationError()
     {
         if (!HasCompositeBundle) return "Balíček je prázdný.";
+        if (HasCompositeBundleCurrency && FindCurrencyItem() is null)
+        {
+            LogTreasureAlloc("currency-item-not-found", new { gameId });
+            return "Hra nemá nastavenu měnu. Přidejte položku typu Peníze do herního inventáře.";
+        }
+
         foreach (var line in compositeBundleItems)
         {
             var poolItem = poolItems.FirstOrDefault(p => p.Id == line.PoolItemId);
@@ -1181,6 +1257,16 @@ else
             .Select(g => new PoolItemAssignDto(g.Key, g.Sum(i => i.Count)))
             .ToList();
 
+    private List<UnlimitedItemAssignDto> BuildCompositeBundleUnlimitedAssignments()
+    {
+        if (!HasCompositeBundleCurrency) return [];
+        var currency = FindCurrencyItem();
+        if (currency is null) return [];
+
+        LogTreasureAlloc("currency-item-detected", new { itemId = currency.ItemId, kind = nameof(ItemType.Money) });
+        return [new UnlimitedItemAssignDto(currency.ItemId, CompositeBundleCurrencyCount)];
+    }
+
     private string BuildCompositeBundlePayload() =>
         JsonSerializer.Serialize(new
         {
@@ -1188,6 +1274,9 @@ else
             ClientBundleId = compositeBundleClientId,
             Title = EffectiveCompositeBundleTitle,
             Count = CompositeBundleUnitCount,
+            Currency = HasCompositeBundleCurrency
+                ? new { Count = CompositeBundleCurrencyCount }
+                : null,
             Items = compositeBundleItems.Select(i => new
             {
                 i.PoolItemId,
@@ -1801,12 +1890,14 @@ else
         focusedLocationId = locationId;
         focusTab = "prehled";
         var assignments = BuildCompositeBundleAssignments();
+        var unlimitedAssignments = BuildCompositeBundleUnlimitedAssignments();
         var dto = new AssignTreasureDto(
             Title: EffectiveCompositeBundleTitle,
             Difficulty: lastUsedDifficulty,
             GameId: gameId,
             LocationId: locationId,
-            PoolItems: assignments);
+            PoolItems: assignments,
+            UnlimitedItems: unlimitedAssignments);
 
         LogTreasureAlloc("composite-drop-commit", new
         {
@@ -1817,7 +1908,9 @@ else
             locationId,
             dto.Title,
             poolRows = assignments.Count,
-            poolUnits = assignments.Sum(a => a.Count)
+            poolUnits = assignments.Sum(a => a.Count),
+            unlimitedRows = unlimitedAssignments.Count,
+            unlimitedUnits = unlimitedAssignments.Sum(a => a.Count)
         });
 
         var result = await Api.PostWithProblemAsync<AssignTreasureDto, TreasureQuestDetailDto>("/api/treasure-planning/assign", dto);
@@ -1851,7 +1944,7 @@ else
             source,
             questId = result.Value.Id,
             locationId,
-            poolUnits = completedUnits
+            units = completedUnits
         });
         StateHasChanged();
     }

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2531,6 +2531,11 @@
 .oh-tp-bundle-line{display:flex;align-items:center;gap:7px;padding:5px 7px;border:1px solid rgba(45,80,22,.18);border-radius:7px;background:rgba(255,255,255,.72)}
 .oh-tp-bundle-line-name{flex:1;font-weight:700;font-size:.82rem;color:var(--oh-text)}
 .oh-tp-bundle-line .remove{background:none;border:none;color:var(--oh-error);padding:0 2px}
+.oh-tp-bundle-money{display:grid;grid-template-columns:minmax(5.5rem,1fr) 42px minmax(7rem,9rem) 42px;gap:8px;align-items:center;padding:7px;border:1px solid rgba(45,80,22,.2);border-radius:7px;background:rgba(255,255,255,.8)}
+.oh-tp-bundle-money-name{font-weight:800;font-size:.86rem;color:var(--oh-text)}
+.oh-tp-bundle-money-btn{width:42px;height:42px;display:inline-flex;align-items:center;justify-content:center;border:1px solid #2D5016;border-radius:8px;background:#fff;color:#2D5016;padding:0}
+.oh-tp-bundle-money-btn:disabled{opacity:.42;cursor:not-allowed}
+.oh-tp-bundle-money-input{width:100%;min-width:0}
 .oh-tp-composite-tile{display:flex;align-items:center;gap:10px;width:100%;margin-bottom:10px;padding:10px;border:1px solid var(--oh-primary);border-radius:8px;background:linear-gradient(135deg,var(--oh-primary-surface),#fff8ec);box-shadow:var(--oh-shadow);cursor:grab;user-select:none;text-align:left;font:inherit;transition:box-shadow .15s,transform .15s}
 .oh-tp-composite-tile:hover{transform:translateY(-1px);box-shadow:var(--oh-shadow-lg)}
 .oh-tp-composite-tile.selected{box-shadow:0 0 0 2px var(--oh-primary-light) inset,var(--oh-shadow-lg)}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
@@ -215,6 +215,48 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
     }
 
     [Fact]
+    public async Task AssignTreasure_WithCompositePoolItemsAndCurrency_CreatesOneQuestWithMixedRows()
+    {
+        var game = await CreateGameAsync();
+        var location = await CreateLocationAsync();
+        var silver = await CreateItemAsync("Stříbro");
+        var bronze = await CreateItemAsync("Bronz");
+        var currency = await CreateItemAsync("Peníze", ItemType.Money);
+        await AssignItemToGameAsync(game.Id, silver.Id);
+        await AssignItemToGameAsync(game.Id, bronze.Id);
+        await AssignItemToGameAsync(game.Id, currency.Id, isFindable: true);
+        var silverPool = await AddPoolItemAsync(game.Id, silver.Id, count: 5);
+        var bronzePool = await AddPoolItemAsync(game.Id, bronze.Id, count: 3);
+
+        var assignResponse = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto(
+                Title: "Balíček: Stříbro × 2 + Bronz × 1 + Groše × 42",
+                Difficulty: GameTimePhase.Early,
+                GameId: game.Id,
+                LocationId: location.Id,
+                UnlimitedItems: [new UnlimitedItemAssignDto(currency.Id, 42)],
+                PoolItems:
+                [
+                    new PoolItemAssignDto(silverPool.Id, 2),
+                    new PoolItemAssignDto(bronzePool.Id, 1)
+                ]));
+        assignResponse.EnsureSuccessStatusCode();
+
+        var quest = (await assignResponse.Content.ReadFromJsonAsync<TreasureQuestDetailDto>())!;
+        Assert.Equal(3, quest.Items.Count);
+        Assert.Equal(location.Id, quest.LocationId);
+        Assert.All(quest.Items, item => Assert.Equal(quest.Id, item.TreasureQuestId));
+        Assert.Equal(2, Assert.Single(quest.Items, i => i.ItemId == silver.Id).Count);
+        Assert.Equal(1, Assert.Single(quest.Items, i => i.ItemId == bronze.Id).Count);
+        Assert.Equal(42, Assert.Single(quest.Items, i => i.ItemId == currency.Id).Count);
+
+        var poolAfterAssign = await Client.GetFromJsonAsync<List<TreasurePoolItemDto>>(
+            $"/api/treasure-planning/pool/{game.Id}");
+        Assert.Equal(3, Assert.Single(poolAfterAssign!, p => p.ItemId == silver.Id).Count);
+        Assert.Equal(2, Assert.Single(poolAfterAssign!, p => p.ItemId == bronze.Id).Count);
+    }
+
+    [Fact]
     public async Task MoneyItems_CannotBeAddedToPoolButRemainUnlimitedCurrencyOptions()
     {
         var game = await CreateGameAsync();

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
@@ -215,11 +215,13 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
     }
 
     [Fact]
-    public async Task MoneyItems_CannotBeAddedToPoolOrAvailableItems()
+    public async Task MoneyItems_CannotBeAddedToPoolButRemainUnlimitedCurrencyOptions()
     {
         var game = await CreateGameAsync();
         var bronze = await CreateItemAsync("Bronz", ItemType.Money);
+        var currency = await CreateItemAsync("Peníze", ItemType.Money);
         await AssignItemToGameAsync(game.Id, bronze.Id, stockCount: 50, isFindable: true);
+        await AssignItemToGameAsync(game.Id, currency.Id, isFindable: true);
 
         var addResponse = await Client.PostAsJsonAsync("/api/treasure-planning/pool",
             new CreateTreasurePoolItemDto(bronze.Id, game.Id, 10));
@@ -234,6 +236,13 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
             $"/api/treasure-planning/pool/{game.Id}");
         Assert.NotNull(pool);
         Assert.DoesNotContain(pool!, i => i.ItemId == bronze.Id);
+
+        var unlimited = await Client.GetFromJsonAsync<List<UnlimitedItemDto>>(
+            $"/api/treasure-planning/unlimited/{game.Id}");
+        Assert.NotNull(unlimited);
+        var currencyOption = Assert.Single(unlimited!, i => i.ItemId == currency.Id);
+        Assert.Equal(ItemType.Money, currencyOption.ItemType);
+        Assert.Equal("Peníze", currencyOption.ItemName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Auto-detect the currency item from unlimited `ItemType.Money`, preserving the Groše-name precedence first.
- Add a thumb-friendly Groše row to the balíček composer and submit it as an unlimited assignment alongside pool rows.
- Keep permanent `[treasure-alloc]` diagnostics for currency detection, missing currency, and compose row add.

## Tests
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter "FullyQualifiedName~TreasurePlanningPoolEndpointTests" --logger "console;verbosity=minimal" --no-restore`

No csproj version bump.