### PR TITLE
hotfix(locations): client-side photo resize + dashboard quick-launch tile (refs #383)

### DIFF
--- a/src/OvcinaHra.Client/Components/QuickLaunchTiles.razor
+++ b/src/OvcinaHra.Client/Components/QuickLaunchTiles.razor
@@ -30,5 +30,9 @@
         new("spl",   "Kouzla",     "bi-magic",          "/spells"),
         new("stash", "Skrýše",     "bi-archive",        "/secret-stashes"),
         new("tre",   "Poklady",    "bi-gem",            "/treasures"),
+        // Issue #383 follow-up: one-tap entry from cockpit straight into
+        // the placement wizard. Query string is parsed by /locations and
+        // auto-opens the wizard.
+        new("place", "Umístění lokace", "bi-camera-fill", "/locations?placement=1"),
     };
 }

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -1,10 +1,12 @@
 @page "/locations"
 @using System.Globalization
 @using System.Net.Http.Headers
+@using Microsoft.JSInterop
 @attribute [Authorize]
 @inject ApiClient Api
 @inject GameContextService GameContext
 @inject NavigationManager Nav
+@inject IJSRuntime JS
 @implements IDisposable
 
 <div class="d-flex justify-content-between align-items-center mb-3">
@@ -761,7 +763,17 @@ else
     private string? placementNotes;
     private string? placementError;
     private string? placementToastMessage;
-    private const long PlacementMaxFileSize = 5 * 1024 * 1024;
+    // Camera-side: phone JPEGs frequently land in the 8–20 MB range, so we
+    // accept generously here. Resize happens client-side in JS canvas; the
+    // server still enforces its own multipart limit, but we cap the post-
+    // resize byte count below to stay well clear of it.
+    private const long PlacementMaxIngressFileSize = 30 * 1024 * 1024;
+    private const long PlacementMaxUploadFileSize = 5 * 1024 * 1024;
+    private const int PlacementResizeMaxDim = 1920;
+    private const double PlacementResizeQuality = 0.85;
+    private byte[]? placementPhotoBytes;
+    private string placementPhotoUploadContentType = "image/jpeg";
+    private bool placementAutoOpenHandled;
 
     // Toolbar filter state
     private string? searchText
@@ -981,6 +993,7 @@ else
         placementSelectedLocationId = locations.FirstOrDefault(l => !l.IsPlaced)?.Id
             ?? locations.FirstOrDefault()?.Id;
         placementPhotoFile = null;
+        placementPhotoBytes = null;
         placementPreviewUrl = null;
         placementNotes = null;
         isPlacementVisible = true;
@@ -993,6 +1006,7 @@ else
         isPlacementVisible = false;
         placementError = null;
         placementPhotoFile = null;
+        placementPhotoBytes = null;
         placementPreviewUrl = null;
         placementNotes = null;
         Console.WriteLine($"[loc-placement] wizard.cancel gameId={gameId}");
@@ -1002,23 +1016,79 @@ else
     {
         placementError = null;
         placementPhotoFile = e.File;
-        if (placementPhotoFile.Size > PlacementMaxFileSize)
+        placementPhotoBytes = null;
+        placementPreviewUrl = null;
+        if (placementPhotoFile.Size > PlacementMaxIngressFileSize)
         {
             placementPhotoFile = null;
-            placementPreviewUrl = null;
-            placementError = "Soubor je příliš velký (max 5 MB).";
-            Console.WriteLine($"[loc-placement] wizard.photo-selected.failed gameId={gameId} reason=too-large");
+            placementError = $"Soubor je příliš velký (max {PlacementMaxIngressFileSize / 1024 / 1024} MB).";
+            Console.WriteLine($"[loc-placement] wizard.photo-selected.failed gameId={gameId} reason=ingress-too-large size={e.File.Size}");
             return;
         }
 
         var contentType = string.IsNullOrWhiteSpace(placementPhotoFile.ContentType)
             ? "image/jpeg"
             : placementPhotoFile.ContentType;
-        await using var stream = placementPhotoFile.OpenReadStream(maxAllowedSize: PlacementMaxFileSize);
-        using var buffer = new MemoryStream();
-        await stream.CopyToAsync(buffer);
-        placementPreviewUrl = $"data:{contentType};base64,{Convert.ToBase64String(buffer.ToArray())}";
-        Console.WriteLine($"[loc-placement] wizard.photo-selected gameId={gameId} size={placementPhotoFile.Size}");
+        string originalDataUrl;
+        try
+        {
+            await using var stream = placementPhotoFile.OpenReadStream(maxAllowedSize: PlacementMaxIngressFileSize);
+            using var buffer = new MemoryStream();
+            await stream.CopyToAsync(buffer);
+            originalDataUrl = $"data:{contentType};base64,{Convert.ToBase64String(buffer.ToArray())}";
+            Console.WriteLine($"[loc-placement] wizard.photo-selected gameId={gameId} size={placementPhotoFile.Size}");
+        }
+        catch (Exception ex)
+        {
+            placementPhotoFile = null;
+            placementError = "Fotku se nepodařilo načíst.";
+            Console.WriteLine($"[loc-placement] wizard.photo-selected.failed gameId={gameId} reason=read-failed detail={ex.Message}");
+            return;
+        }
+
+        // Client-side canvas resize. Phone cameras emit 10–20 MB JPEGs that
+        // exceed the server's 5 MB multipart limit; resize re-encodes as
+        // JPEG @ q=0.85 with longest side capped at 1920 px. Typical output
+        // lands in the 200–500 KB range.
+        string resizedDataUrl;
+        try
+        {
+            resizedDataUrl = await JS.InvokeAsync<string>(
+                "ovcinaImageResize.fromBase64",
+                originalDataUrl,
+                PlacementResizeMaxDim,
+                PlacementResizeQuality);
+        }
+        catch (Exception ex)
+        {
+            placementPhotoFile = null;
+            placementError = "Fotku se nepodařilo zmenšit.";
+            Console.WriteLine($"[loc-placement] wizard.photo-resize.failed gameId={gameId} detail={ex.Message}");
+            return;
+        }
+
+        var commaIdx = resizedDataUrl.IndexOf(',');
+        if (commaIdx < 0)
+        {
+            placementPhotoFile = null;
+            placementError = "Fotku se nepodařilo zpracovat.";
+            Console.WriteLine($"[loc-placement] wizard.photo-resize.failed gameId={gameId} reason=invalid-data-url");
+            return;
+        }
+
+        var resizedBytes = Convert.FromBase64String(resizedDataUrl[(commaIdx + 1)..]);
+        if (resizedBytes.LongLength > PlacementMaxUploadFileSize)
+        {
+            placementPhotoFile = null;
+            placementError = $"Fotku se nepodařilo zmenšit pod {PlacementMaxUploadFileSize / 1024 / 1024} MB. Zkuste prosím jiný snímek.";
+            Console.WriteLine($"[loc-placement] wizard.photo-resize.too-large-after gameId={gameId} resizedSize={resizedBytes.LongLength}");
+            return;
+        }
+
+        placementPhotoBytes = resizedBytes;
+        placementPhotoUploadContentType = "image/jpeg";
+        placementPreviewUrl = resizedDataUrl;
+        Console.WriteLine($"[loc-placement] wizard.photo-resized gameId={gameId} originalSize={placementPhotoFile.Size} resizedSize={resizedBytes.LongLength}");
     }
 
     private async Task SubmitPlacementAsync()
@@ -1029,7 +1099,7 @@ else
             placementError = "Vyberte lokaci.";
             return;
         }
-        if (placementPhotoFile is null)
+        if (placementPhotoFile is null || placementPhotoBytes is null)
         {
             placementError = "Nejprve vyfoťte nebo nahrajte fotku umístění.";
             return;
@@ -1037,15 +1107,18 @@ else
 
         placementSaving = true;
         var locationId = SelectedPlacementLocation.Id;
-        Console.WriteLine($"[loc-placement] wizard.submit.start gameId={gameId} locationId={locationId}");
+        Console.WriteLine($"[loc-placement] wizard.submit.start gameId={gameId} locationId={locationId} bytes={placementPhotoBytes.LongLength}");
         try
         {
             using var content = new MultipartFormDataContent();
-            await using var stream = placementPhotoFile.OpenReadStream(maxAllowedSize: PlacementMaxFileSize);
-            using var fileContent = new StreamContent(stream);
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue(
-                string.IsNullOrWhiteSpace(placementPhotoFile.ContentType) ? "image/jpeg" : placementPhotoFile.ContentType);
-            content.Add(fileContent, "file", placementPhotoFile.Name);
+            using var fileContent = new ByteArrayContent(placementPhotoBytes);
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue(placementPhotoUploadContentType);
+            // Always send a JPEG filename since the canvas resize re-encodes
+            // to JPEG regardless of the original format.
+            var uploadFilename = Path.ChangeExtension(
+                string.IsNullOrWhiteSpace(placementPhotoFile.Name) ? "placement" : placementPhotoFile.Name,
+                "jpg");
+            content.Add(fileContent, "file", uploadFilename);
 
             var (uploadOk, uploadResult, uploadProblem, uploadStatus) =
                 await Api.PostMultipartWithProblemAsync<ImageUploadResult>(
@@ -1327,6 +1400,27 @@ else
     {
         await GameContext.InitializeAsync();
         GameContext.OnGameChanged += OnGameChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || placementAutoOpenHandled) return;
+        placementAutoOpenHandled = true;
+        // Quick-launch tile on Home (#383 follow-up): /locations?placement=1
+        // auto-opens the placement wizard so an organizer can go from
+        // dashboard to camera in one tap. Fire after first render so the
+        // location list has a chance to load.
+        var query = new Uri(Nav.Uri).Query;
+        if (query.Contains("placement=1", StringComparison.OrdinalIgnoreCase)
+            || query.Contains("placement=true", StringComparison.OrdinalIgnoreCase))
+        {
+            // Make sure locations are loaded before opening the wizard so the
+            // dropdown isn't empty when the user lands.
+            if (locations.Count == 0) await LoadDataAsync();
+            OpenPlacementWizard();
+            Console.WriteLine($"[loc-placement] wizard.auto-open gameId={gameId} via=query-string");
+            StateHasChanged();
+        }
     }
 
     private async void OnGameChanged() { await LoadDataAsync(); StateHasChanged(); }

--- a/src/OvcinaHra.Client/wwwroot/index.html
+++ b/src/OvcinaHra.Client/wwwroot/index.html
@@ -44,6 +44,7 @@
     <script src="js/map-interop.js?v=20260411"></script>
     <script src="js/overlay-interop.js?v=20260428"></script>
     <script src="js/download-interop.js?v=20260427"></script>
+    <script src="js/image-resize-interop.js?v=20260429"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script>navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' });</script>
     <script>

--- a/src/OvcinaHra.Client/wwwroot/js/image-resize-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/image-resize-interop.js
@@ -1,0 +1,52 @@
+// [loc-placement] client-side image resize before upload.
+// Phone cameras commonly produce 10–20 MB JPEGs which blow past
+// the server's accept limit; we resize to maxDim on the longest
+// side and re-encode as JPEG at the requested quality.
+window.ovcinaImageResize = window.ovcinaImageResize || {};
+
+window.ovcinaImageResize.fromBase64 = async function (dataUrl, maxDim, quality) {
+    return new Promise((resolve, reject) => {
+        if (typeof dataUrl !== "string" || dataUrl.length === 0) {
+            console.log("[loc-placement] resize.failed reason=empty-input");
+            reject(new Error("Empty data URL"));
+            return;
+        }
+        const img = new Image();
+        img.onload = function () {
+            try {
+                const w = img.width;
+                const h = img.height;
+                let nw = w;
+                let nh = h;
+                if (Math.max(w, h) > maxDim) {
+                    if (w >= h) {
+                        nw = maxDim;
+                        nh = Math.round(h * (maxDim / w));
+                    } else {
+                        nh = maxDim;
+                        nw = Math.round(w * (maxDim / h));
+                    }
+                }
+                const canvas = document.createElement("canvas");
+                canvas.width = nw;
+                canvas.height = nh;
+                const ctx = canvas.getContext("2d");
+                ctx.drawImage(img, 0, 0, nw, nh);
+                const out = canvas.toDataURL("image/jpeg", quality);
+                console.log(
+                    `[loc-placement] resize.done original=${w}x${h} resized=${nw}x${nh} ` +
+                    `originalDataUrlBytes=${dataUrl.length} resizedDataUrlBytes=${out.length}`
+                );
+                resolve(out);
+            } catch (err) {
+                console.log(`[loc-placement] resize.failed reason=draw-error detail=${err && err.message}`);
+                reject(err);
+            }
+        };
+        img.onerror = function () {
+            console.log("[loc-placement] resize.failed reason=image-load-error");
+            reject(new Error("Failed to load image for resize"));
+        };
+        img.src = dataUrl;
+    });
+};


### PR DESCRIPTION
## Summary

ASAP hotfix on top of #399 (mobile location placement). Two pieces:

1. **Client-side photo resize before upload.** Phone cameras emit 10–20 MB JPEGs that blow past the 5 MB server multipart limit and break field organisers' placement uploads. New \`wwwroot/js/image-resize-interop.js\` runs the picture through a canvas (longest side capped at 1920 px, JPEG q=0.85) before posting; typical output lands at 200–500 KB.
2. **Dashboard quick-launch tile.** New 'Umístění lokace' tile in \`QuickLaunchTiles\` links to \`/locations?placement=1\`. \`LocationList\` parses the query string in \`OnAfterRenderAsync\` and auto-opens the placement wizard, giving organisers one-tap dashboard → camera.

## Changes

- New \`wwwroot/js/image-resize-interop.js\` — \`ovcinaImageResize.fromBase64\` with permanent \`[loc-placement] resize.*\` markers
- \`LocationList.razor\` — bump ingress limit to 30 MB, JS resize via \`IJSRuntime\`, cap uploaded bytes at 5 MB, swap \`StreamContent\` → \`ByteArrayContent\`, force \`.jpg\` filename, add \`resize.*\` markers, add \`OnAfterRenderAsync\` query-string parsing for \`?placement=1\`
- \`index.html\` — load the new interop script
- \`QuickLaunchTiles.razor\` — add 9th tile

## Test plan

- [ ] CI passes: build, build-and-test, GitGuardian
- [ ] Manual smoke on a real phone with a multi-MB camera shot:
  - Open \`/locations\` for game 30 in 'Jen tato hra'
  - Tap 'Umístění lokace' → wizard opens
  - Tap 'Vybrat fotku' → take photo (or pick a 10+ MB existing photo)
  - Console shows \`[loc-placement] resize.done original=WxH resized=WxH\` markers
  - Submit → upload succeeds, GameEvent recorded, dropdown ✓ appears
- [ ] From dashboard: tap 'Umístění lokace' tile → lands on \`/locations\` with wizard already open

## Risk

Low. New JS interop is additive; existing upload path retained but routed through resize. Original \`InputFile\` UI unchanged. Server contract unchanged. Auto-bump CI handles \`<Version>\` per memory rule §18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)