### PR TITLE
feat(locations): allow clearing parent location

### DIFF
--- a/src/OvcinaHra.Client/Components/LocationEditPopup.razor
+++ b/src/OvcinaHra.Client/Components/LocationEditPopup.razor
@@ -446,6 +446,10 @@
     private void OnParentChangeRequested(int? newParentId)
     {
         model.ParentLocationId = newParentId;
+        parentId = newParentId;
+        parentName = newParentId.HasValue
+            ? AllLocations.FirstOrDefault(l => l.Id == newParentId.Value)?.Name ?? $"Lokace #{newParentId}"
+            : null;
     }
 
     private void SetParentChoices(IEnumerable<LocationListDto> candidates)

--- a/src/OvcinaHra.Client/Components/LocationEditPopup.razor
+++ b/src/OvcinaHra.Client/Components/LocationEditPopup.razor
@@ -139,10 +139,13 @@
                     <DxMemo @bind-Text="@model.SetupNotes" Rows="3" data-testid="location-setup" />
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Rodič" ColSpanMd="12">
-                    <DxComboBox Data="@parentCandidates" Value="@model.ParentLocationId"
-                                ValueChanged="@((int? v) => OnParentChangeRequested(v))"
-                                TextFieldName="Name" ValueFieldName="Id"
-                                NullText="(žádný — tato lokace je kořenová)"
+                    <DxComboBox TData="ParentLocationChoice" TValue="int?"
+                                Data="@parentChoices"
+                                Value="@model.ParentLocationId"
+                                ValueChanged="@OnParentChangeRequested"
+                                TextFieldName="@nameof(ParentLocationChoice.Name)"
+                                ValueFieldName="@nameof(ParentLocationChoice.Id)"
+                                NullText="Bez nadřazené lokace"
                                 ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
                                 SearchMode="ListSearchMode.AutoSearch" />
                 </DxFormLayoutItem>
@@ -329,16 +332,6 @@
     </BodyContentTemplate>
 </DxPopup>
 
-<DxPopup @bind-Visible="@isParentChangeVisible" HeaderText="Změnit rodiče?" Width="400px">
-    <BodyContentTemplate Context="popupContext">
-        <p>Změnit rodičovskou lokaci na <strong>@pendingParentName</strong>?</p>
-        <div class="d-flex gap-2 justify-content-end">
-            <button class="btn btn-secondary" @onclick="CancelParentChange">Zrušit</button>
-            <button class="btn btn-primary" @onclick="ConfirmParentChange">Změnit</button>
-        </div>
-    </BodyContentTemplate>
-</DxPopup>
-
 <DxPopup @bind-Visible="@isRemoveStashVisible" HeaderText="Odebrat skrýš z lokace?" Width="400px">
     <BodyContentTemplate Context="popupContext">
         <p>Opravdu chcete odebrat skrýš <strong>@stashToRemoveName</strong> z této lokace v této hře? Samotná skrýš z katalogu odstraněna nebude.</p>
@@ -359,9 +352,6 @@
 
     private bool isVisible, isDeleteVisible, isSaving;
     private bool isLoreEditable;
-    private bool isParentChangeVisible;
-    private int? pendingParentId;
-    private string pendingParentName = "";
     private int activeTab;
     private string modalTitle = "";
     private string? error;
@@ -371,10 +361,11 @@
     private int? parentId;
     private string? parentName;
     private List<LocationVariantDto> variants = [];
-    private List<LocationListDto> parentCandidates = [];
+    private List<ParentLocationChoice> parentChoices = [];
 
     private static readonly List<KindItem> kindValues = Enum.GetValues<LocationKind>()
         .Select(k => new KindItem(k, k.GetDisplayName())).ToList();
+    private static readonly ParentLocationChoice NoParentChoice = new(null, "Bez nadřazené lokace");
     record KindItem(LocationKind Value, string Display);
 
     /// <summary>Open for editing an existing location.</summary>
@@ -401,10 +392,7 @@
         parentName = parentId.HasValue
             ? AllLocations.FirstOrDefault(l => l.Id == parentId.Value)?.Name ?? $"Lokace #{parentId}"
             : null;
-        parentCandidates = AllLocations
-            .Where(l => l.Id != locationId && l.ParentLocationId != locationId)
-            .OrderBy(l => l.Name)
-            .ToList();
+        SetParentChoices(AllLocations.Where(l => l.Id != locationId && l.ParentLocationId != locationId));
 
         // Reset stash tab state; data loaded on demand by LoadStashesAsync below
         stashCards = [];
@@ -440,7 +428,7 @@
         variants = [];
         parentId = null;
         parentName = null;
-        parentCandidates = AllLocations.OrderBy(l => l.Name).ToList();
+        SetParentChoices(AllLocations);
         isVisible = true;
     }
 
@@ -457,21 +445,18 @@
 
     private void OnParentChangeRequested(int? newParentId)
     {
-        if (newParentId == model.ParentLocationId) return;
-        pendingParentId = newParentId;
-        pendingParentName = newParentId.HasValue
-            ? parentCandidates.FirstOrDefault(l => l.Id == newParentId.Value)?.Name ?? $"#{newParentId}"
-            : "(žádný — kořenová)";
-        isParentChangeVisible = true;
+        model.ParentLocationId = newParentId;
     }
 
-    private void ConfirmParentChange()
+    private void SetParentChoices(IEnumerable<LocationListDto> candidates)
     {
-        model.ParentLocationId = pendingParentId;
-        isParentChangeVisible = false;
+        parentChoices = [NoParentChoice];
+        parentChoices.AddRange(candidates
+            .OrderBy(l => l.Name)
+            .Select(l => new ParentLocationChoice(l.Id, l.Name)));
     }
 
-    private void CancelParentChange() => isParentChangeVisible = false;
+    private sealed record ParentLocationChoice(int? Id, string Name);
 
     private async Task SaveAsync()
     {

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -257,11 +257,15 @@ else
                         <DxTextBox @bind-Text="@region" NullText="(volitelné)" />
                     </DxFormLayoutItem>
                     <DxFormLayoutItem Caption="Rodič" ColSpanMd="6">
-                        <DxComboBox TData="LocationListDto" TValue="int?"
-                                    Data="@parentCandidates" Value="@parentLocationId"
+                        <DxComboBox TData="ParentLocationChoice" TValue="int?"
+                                    Data="@parentChoices"
+                                    Value="@parentLocationId"
                                     ValueChanged="@OnParentLocationChanged"
-                                    TextFieldName="Name" ValueFieldName="Id"
-                                    NullText="(žádný)" SearchMode="ListSearchMode.AutoSearch" />
+                                    TextFieldName="@nameof(ParentLocationChoice.Name)"
+                                    ValueFieldName="@nameof(ParentLocationChoice.Id)"
+                                    NullText="Bez nadřazené lokace"
+                                    ClearButtonDisplayMode="DataEditorClearButtonDisplayMode.Auto"
+                                    SearchMode="ListSearchMode.AutoSearch" />
                     </DxFormLayoutItem>
                 </DxFormLayout>
             </div>
@@ -470,7 +474,7 @@ else
     private LocationListDto? loc;
     private LocationListDto? parent;
     private List<LocationListDto> variants = [];
-    private List<LocationListDto> parentCandidates = [];
+    private List<ParentLocationChoice> parentChoices = [];
     private List<LocationQuestSummaryDto> locationQuests = [];
     // Cached so the mini-map can paint surrounding orientation pins (issue #74)
     // without re-fetching the catalog on every render.
@@ -490,6 +494,7 @@ else
     private int? parentLocationId;
 
     private static readonly LocationKind[] kindValues = Enum.GetValues<LocationKind>();
+    private static readonly ParentLocationChoice NoParentChoice = new(null, "Bez nadřazené lokace");
 
     // LocationKind marker colors — canonical, distinct from kingdom palette.
     // Matches MapPage markerColors and Claude Design brief. Used for the
@@ -602,7 +607,7 @@ else
 
             // Parent + variants (and cached for the mini-map orientation pins, issue #74).
             allLocations = await Api.GetListAsync<LocationListDto>("/api/locations");
-            parentCandidates = allLocations.Where(l => l.Id != Id).ToList();
+            SetParentChoices(allLocations.Where(l => l.Id != Id));
             parent = detail.ParentLocationId.HasValue
                 ? allLocations.FirstOrDefault(l => l.Id == detail.ParentLocationId.Value)
                 : null;
@@ -666,6 +671,16 @@ else
         latitudeStr = loc?.Latitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "";
         longitudeStr = loc?.Longitude?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "";
     }
+
+    private void SetParentChoices(IEnumerable<LocationListDto> candidates)
+    {
+        parentChoices = [NoParentChoice];
+        parentChoices.AddRange(candidates
+            .OrderBy(l => l.Name)
+            .Select(l => new ParentLocationChoice(l.Id, l.Name)));
+    }
+
+    private sealed record ParentLocationChoice(int? Id, string Name);
 
     private void RefreshInheritedCoordinates()
     {

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -662,6 +662,9 @@ else
     private void OnParentLocationChanged(int? value)
     {
         parentLocationId = value;
+        parent = value.HasValue
+            ? allLocations.FirstOrDefault(l => l.Id == value.Value)
+            : null;
         if (parentLocationId.HasValue)
         {
             RefreshInheritedCoordinates();


### PR DESCRIPTION
## Summary
- Adds explicit `Bez nadřazené lokace` option to the location detail parent picker.
- Keeps the same no-parent option in the shared location edit popup so create/edit surfaces match.
- Removes the extra parent-change confirmation popup; the existing `Uložit` action remains the commit point.

Closes #388

## Verification
- `dotnet build OvcinaHra.slnx`
- `dotnet test OvcinaHra.slnx --no-build`
- `git diff --check` (line-ending warnings only)

## Visual smoke
- Local API/client started and reachable.
- Browser smoke blocked by local Playwright Chromium launch timeout in this environment; local smoke seed data was cleaned up.