### PR TITLE
Fix chat Enter key submit

### DIFF
--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor
@@ -111,6 +111,7 @@
     private const string PersonaStorageKey = "oh-bot-last-persona";
     private const string Rulemaster = "rulemaster";
     private const string Loremaster = "loremaster";
+    private const int MaxDraftShortcutAttachAttempts = 5;
 
     private readonly List<BotMessage> _messages = [];
     private bool _enabled;
@@ -119,6 +120,7 @@
     private bool _drozdIconFailed;
     private bool _draftShortcutAttached;
     private bool _draftShortcutUnavailable;
+    private int _draftShortcutAttachAttempts;
     private string _persona = Loremaster;
     private string _draft = string.Empty;
     private ElementReference _draftInput;
@@ -137,8 +139,18 @@
             StateHasChanged();
         }
 
-        if (_open && !_draftShortcutAttached && !_draftShortcutUnavailable)
-            await AttachDraftShortcutAsync();
+        if (_open
+            && !_draftShortcutAttached
+            && !_draftShortcutUnavailable
+            && _draftShortcutAttachAttempts < MaxDraftShortcutAttachAttempts)
+        {
+            var attached = await AttachDraftShortcutAsync();
+            if (!attached && _open && !_draftShortcutUnavailable)
+            {
+                await Task.Delay(25);
+                StateHasChanged();
+            }
+        }
     }
 
     private async Task LoadAvailabilityAsync()
@@ -180,6 +192,7 @@
     {
         _open = true;
         _draftShortcutAttached = false;
+        _draftShortcutAttachAttempts = 0;
     }
 
     private void Close()
@@ -211,8 +224,12 @@
 
     private async Task SendAsync()
     {
+        LogChatInput($"SendAsync entry canSend={Flag(CanSend)} sending={Flag(_sending)}");
         if (!CanSend)
+        {
+            LogChatInput("SendAsync exit sent=false");
             return;
+        }
 
         var persona = _persona;
         var text = _draft.Trim();
@@ -242,36 +259,63 @@
         finally
         {
             _sending = false;
+            LogChatInput("SendAsync exit sent=true");
         }
     }
 
     [JSInvokable]
     public async Task SendDraftFromKeyboardAsync()
     {
-        await SendAsync();
-        await InvokeAsync(StateHasChanged);
+        try
+        {
+            await SendAsync();
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (ObjectDisposedException ex)
+        {
+            LogChatInput("keyboard-submit-disposed");
+            Logger.LogDebug(ex, "Bot consult drawer keyboard submit reached a disposed component.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            LogChatInput("keyboard-submit-failed invalid-operation");
+            Logger.LogDebug(ex, "Bot consult drawer keyboard submit failed.");
+        }
     }
 
-    private async Task AttachDraftShortcutAsync()
+    private async Task<bool> AttachDraftShortcutAsync()
     {
         try
         {
+            _draftShortcutAttachAttempts++;
             _keyboardModule ??= await Js.InvokeAsync<IJSObjectReference>(
                 "import",
                 "./Components/BotConsultDrawer.razor.js");
             _selfReference ??= DotNetObjectReference.Create(this);
-            await _keyboardModule.InvokeVoidAsync("attachEnterToSend", _draftInput, _selfReference);
-            _draftShortcutAttached = true;
+            var attached = await _keyboardModule.InvokeAsync<bool>("attachEnterToSend", _draftInput, _selfReference);
+            _draftShortcutAttached = attached;
+            if (attached)
+                _draftShortcutAttachAttempts = 0;
+            else if (_draftShortcutAttachAttempts >= MaxDraftShortcutAttachAttempts)
+                Logger.LogWarning("Bot consult drawer Enter-to-send shortcut did not attach after {Attempts} attempts.", _draftShortcutAttachAttempts);
+
+            return attached;
         }
         catch (JSException ex)
         {
             DisableDraftShortcut(ex);
+            return false;
         }
         catch (InvalidOperationException ex)
         {
             DisableDraftShortcut(ex);
+            return false;
         }
     }
+
+    private static void LogChatInput(string message) => Console.WriteLine($"[chat-input] {message}");
+
+    private static string Flag(bool value) => value ? "true" : "false";
 
     private void DisableDraftShortcut(Exception exception)
     {

--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.js
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.js
@@ -1,20 +1,33 @@
 export function attachEnterToSend(textarea, dotNetRef) {
+    const textareaPresent = Boolean(textarea);
+    logChatInput(`attached textareaPresent=${textareaPresent}`);
+
     if (!textarea) {
-        return;
+        return false;
     }
 
     if (textarea._ohBotEnterHandler) {
-        textarea.removeEventListener('keydown', textarea._ohBotEnterHandler);
+        textarea.removeEventListener('keydown', textarea._ohBotEnterHandler, true);
     }
 
     let sending = false;
     const handler = async (event) => {
-        if (event.key !== 'Enter'
-            || event.shiftKey
-            || event.altKey
-            || event.ctrlKey
-            || event.metaKey
-            || event.isComposing) {
+        if (event.key !== 'Enter') {
+            return;
+        }
+
+        logChatInput(`keydown key=Enter shift=${flag(event.shiftKey)} composing=${flag(event.isComposing)}`);
+
+        if (event.isComposing) {
+            return;
+        }
+
+        if (event.shiftKey) {
+            logChatInput('newline-via-shift-enter');
+            return;
+        }
+
+        if (event.altKey || event.ctrlKey || event.metaKey) {
             return;
         }
 
@@ -27,10 +40,12 @@ export function attachEnterToSend(textarea, dotNetRef) {
             return;
         }
 
+        logChatInput('submit-via-enter');
         sending = true;
         try {
             await dotNetRef.invokeMethodAsync('SendDraftFromKeyboardAsync');
         } catch (error) {
+            logChatInput('submit-via-enter failed');
             console.warn('Bot consult drawer Enter-to-send failed.', error);
         } finally {
             sending = false;
@@ -38,5 +53,14 @@ export function attachEnterToSend(textarea, dotNetRef) {
     };
 
     textarea._ohBotEnterHandler = handler;
-    textarea.addEventListener('keydown', handler);
+    textarea.addEventListener('keydown', handler, { capture: true });
+    return true;
+}
+
+function logChatInput(message) {
+    console.debug(`[chat-input] ${message}`);
+}
+
+function flag(value) {
+    return value ? 't' : 'f';
 }


### PR DESCRIPTION
## Summary
- Harden the existing BotConsultDrawer Enter-to-send JS bridge instead of replacing it with Blazor-only key handling.
- Only mark the shortcut attached when JS confirms the textarea exists; retry a few times after drawer open.
- Attach the keydown listener in capture phase, keep IME composition and Shift+Enter safe, and prevent the default newline before invoking .NET.
- Add permanent `[chat-input]` markers for attach, keydown, Enter submit, Shift+Enter newline, and SendAsync entry/exit.

## Tests
- `dotnet build OvcinaHra.slnx --no-restore`
- JS logic smoke: plain Enter prevents default and invokes `SendDraftFromKeyboardAsync`; Shift+Enter does not prevent or submit; composing Enter does not prevent or submit; listener attaches with `capture: true`.

No csproj version bump.

Closes #402