### PR TITLE
Revise map relocation shortcut picker

### DIFF
--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -152,12 +152,6 @@
     /// boundary.</summary>
     [Parameter] public EventCallback<(int Id, double Lat, double Lng)> OnMapPagePinDrag { get; set; }
 
-    /// <summary>Fires when Ctrl+Shift+click on a map-page location pin starts shortcut move mode.</summary>
-    [Parameter] public EventCallback<(int Id, double Lat, double Lng)> OnMapPagePinMoveShortcut { get; set; }
-
-    /// <summary>Fires when Escape cancels shortcut move mode before coordinates are committed.</summary>
-    [Parameter] public EventCallback OnMapPagePinMoveShortcutCancel { get; set; }
-
     /// <summary>
     /// When set, the map loads the game's vector overlay (issue #96) and
     /// surfaces the "Upravit překryv" editor button.
@@ -806,20 +800,6 @@
     {
         Console.WriteLine($"[map-diag] MapView.OnLocationPinDragged entry id={id} lat={lat} lng={lng} hasDelegate={OnMapPagePinDrag.HasDelegate}");
         await OnMapPagePinDrag.InvokeAsync((id, lat, lng));
-    }
-
-    [JSInvokable]
-    public async Task OnLocationMoveShortcutStarted(int id, double lat, double lng)
-    {
-        Console.WriteLine($"[map-diag] MapView.OnLocationMoveShortcutStarted entry id={id} lat={lat} lng={lng} hasDelegate={OnMapPagePinMoveShortcut.HasDelegate}");
-        await OnMapPagePinMoveShortcut.InvokeAsync((id, lat, lng));
-    }
-
-    [JSInvokable]
-    public async Task OnLocationMoveShortcutCanceled()
-    {
-        Console.WriteLine($"[map-diag] MapView.OnLocationMoveShortcutCanceled entry hasDelegate={OnMapPagePinMoveShortcutCancel.HasDelegate}");
-        await OnMapPagePinMoveShortcutCancel.InvokeAsync();
     }
 
     [JSInvokable]

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -74,30 +74,7 @@
                                  OnStyleLoaded="OnMapReadyAsync"
                                  OnMapPagePinClick="OnPinClickedAsync"
                                  OnMapPagePinDrag="OnPinDraggedAsync"
-                                 OnMapPagePinMoveShortcut="OnPinMoveShortcutStartedAsync"
-                                 OnMapPagePinMoveShortcutCancel="CancelShortcutMoveAsync"
                                  OnMapClick="OnMapClickAsync" />
-                        @if (_shortcutMoveActive)
-                        {
-                            Console.WriteLine("[map-diag] map.location.move_mode.banner.rendered visible=true");
-                            <div class="oh-map-move-hint" role="status" aria-live="polite">
-                                <span><strong>Přesun: @_shortcutMoveName</strong> — klikni na novou pozici.</span>
-                                @if (_shortcutMoveError is not null)
-                                {
-                                    <span class="oh-map-move-hint-error">@_shortcutMoveError</span>
-                                }
-                                @if (_shortcutMoveSaving)
-                                {
-                                    <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
-                                }
-                                <button type="button"
-                                        class="btn btn-sm btn-light"
-                                        @onclick="CancelShortcutMoveAsync"
-                                        disabled="@_shortcutMoveSaving">
-                                    Esc zruší
-                                </button>
-                            </div>
-                        }
                     </div>
 
                     <MapPinPeek Visible="@_peekVisible"
@@ -140,10 +117,13 @@
             @* Ctrl+Click placement picker — Ctrl+Clicking on the map
                opens this popup; the user picks an ungeocoded parent
                location from the active game and the clicked coords
-               become its new GPS. Coarse-pointer users (touch / tablet)
-               can't easily Ctrl+Click; that's by design — placing is a
-               PC-only workflow same as drag-relocate. *@
-            <DxPopup @bind-Visible="@_placeVisible"
+               become its new GPS. Ctrl+Shift+Click on empty map uses
+               the same picker but includes located locations and PATCHes
+               the selected one to the clicked destination. Coarse-pointer
+               users (touch / tablet) can't easily Ctrl+Click; that's by
+               design — placing is a PC-only workflow same as drag-relocate. *@
+            <DxPopup Visible="@_placeVisible"
+                     VisibleChanged="OnPlaceVisibleChanged"
                      HeaderText="@(_placeMode == "move" ? "Přesunout lokaci sem" : "Vyber lokaci k umístění")"
                      Width="540px"
                      CloseOnEscape="true">
@@ -219,7 +199,7 @@
                         <div class="alert alert-danger py-2 mt-2 mb-0">@_placeError</div>
                     }
                     <div class="d-flex justify-content-end mt-3">
-                        <button class="btn btn-secondary" @onclick="() => _placeVisible = false" disabled="@_placeSaving">Zavřít</button>
+                        <button class="btn btn-secondary" @onclick="CancelPlacePickerAsync" disabled="@_placeSaving">Zavřít</button>
                     </div>
                 </BodyContentTemplate>
             </DxPopup>
@@ -262,7 +242,7 @@
     private bool _pendingDragSaving;
     private string? _pendingDragError;
 
-    // Ctrl+Click placement / Ctrl+Shift+Click move state.
+    // Ctrl+Click placement / Ctrl+Shift+Click relocation picker state.
     //   "place" → picker shows only ungeocoded parent locations
     //   "move"  → picker shows all parent locations (current GPS overwritten)
     // Same DxPopup, header + list filter swap based on mode.
@@ -274,15 +254,6 @@
     private string _placeSearch = "";
     private bool _placeSaving;
     private string? _placeError;
-    // Ctrl+Shift+clicking a rendered location pin enters a direct move mode:
-    // the next map click writes that pin's GPS via the coordinates PATCH.
-    private bool _shortcutMoveActive;
-    private int? _shortcutMoveId;
-    private string _shortcutMoveName = "";
-    private double _shortcutMoveFromLat;
-    private double _shortcutMoveFromLng;
-    private bool _shortcutMoveSaving;
-    private string? _shortcutMoveError;
     // Issue #216 — phone-only layer rail toggle. CSS gates the visible
     // surface so on tablet/desktop this flag has no effect.
     private bool _railOpen;
@@ -575,125 +546,30 @@
         await PaintPinsAsync();
     }
 
-    private async Task OnPinMoveShortcutStartedAsync((int Id, double Lat, double Lng) e)
-    {
-        var loc = _data?.Locations.FirstOrDefault(l => l.Id == e.Id);
-        Console.WriteLine($"[map-diag] MapPage.OnPinMoveShortcutStarted locationId={e.Id} from={{lng:{FormatCoord(e.Lng)},lat:{FormatCoord(e.Lat)}}}");
-        _shortcutMoveActive = true;
-        Console.WriteLine($"[map-diag] map.location.move_mode.state_set isActive=true locationId={e.Id}");
-        _shortcutMoveId = e.Id;
-        _shortcutMoveName = loc?.EffectiveName ?? loc?.Name ?? "tato lokace";
-        _shortcutMoveFromLat = e.Lat;
-        _shortcutMoveFromLng = e.Lng;
-        _shortcutMoveSaving = false;
-        _shortcutMoveError = null;
-
-        _pendingDragVisible = false;
-        _placeVisible = false;
-        _peekRequestId++;
-        _peekVisible = false;
-        _peek = null;
-        _selectedLocationId = null;
-        PushUrl();
-
-        await SetShortcutMoveModeAsync(true);
-        await InvokeAsync(StateHasChanged);
-    }
-
-    private async Task CancelShortcutMoveAsync()
-    {
-        if (!_shortcutMoveActive || _shortcutMoveSaving) return;
-        Console.WriteLine($"[map-diag] MapPage.ShortcutMove cancel locationId={_shortcutMoveId?.ToString() ?? "null"}");
-        ClearShortcutMoveState();
-        await SetShortcutMoveModeAsync(false);
-        await InvokeAsync(StateHasChanged);
-    }
-
-    private async Task CompleteShortcutMoveAsync(double lat, double lng)
-    {
-        if (_shortcutMoveId is not int id)
-        {
-            await CancelShortcutMoveAsync();
-            return;
-        }
-
-        _shortcutMoveSaving = true;
-        _shortcutMoveError = null;
-        await InvokeAsync(StateHasChanged);
-
-        try
-        {
-            Console.WriteLine($"[map-diag] map.location.relocate.dispatch locationId={id} from={{lng:{FormatCoord(_shortcutMoveFromLng)},lat:{FormatCoord(_shortcutMoveFromLat)}}} to={{lng:{FormatCoord(lng)},lat:{FormatCoord(lat)}}}");
-            var (ok, problem) = await Api.PatchWithProblemAsync(
-                $"/api/locations/{id}/coordinates",
-                new LocationCoordinatesPatchDto((decimal)lat, (decimal)lng));
-            if (!ok)
-            {
-                _shortcutMoveError = problem ?? "Uložení souřadnic selhalo.";
-                Console.WriteLine($"[map-diag] MapPage.ShortcutMove failed locationId={id} problem={_shortcutMoveError}");
-                return;
-            }
-
-            ClearShortcutMoveState();
-            await SetShortcutMoveModeAsync(false);
-            await ReloadDataAndRenderAsync();
-            Console.WriteLine($"[map-diag] MapPage.ShortcutMove saved locationId={id}");
-        }
-        catch (Exception ex)
-        {
-            _shortcutMoveError = ex.Message;
-            Console.WriteLine($"[map-diag] MapPage.ShortcutMove error locationId={id} type={ex.GetType().Name} message={ex.Message}");
-        }
-        finally
-        {
-            if (_shortcutMoveActive)
-            {
-                _shortcutMoveSaving = false;
-                await InvokeAsync(StateHasChanged);
-            }
-        }
-    }
-
-    private async Task SetShortcutMoveModeAsync(bool active)
-    {
-        try { await JS.InvokeVoidAsync("ovcinaMap.setMoveShortcutMode", active); }
-        catch (Exception ex) { Console.WriteLine($"[map-diag] MapPage.ShortcutMove js-mode-failed active={active} type={ex.GetType().Name} message={ex.Message}"); }
-    }
-
-    private void ClearShortcutMoveState()
-    {
-        _shortcutMoveActive = false;
-        _shortcutMoveId = null;
-        _shortcutMoveName = "";
-        _shortcutMoveFromLat = 0;
-        _shortcutMoveFromLng = 0;
-        _shortcutMoveSaving = false;
-        _shortcutMoveError = null;
-    }
-
     private static string FormatCoord(double value)
         => value.ToString("F6", CultureInfo.InvariantCulture);
+
+    private static string FormatCoord(decimal? value)
+        => value.HasValue ? ((double)value.Value).ToString("F6", CultureInfo.InvariantCulture) : "null";
 
     /// <summary>
     /// Map click handler. Plain click does nothing (peek only opens via
     /// pin clicks). Modifier-clicks open the placement picker:
     ///   Ctrl+Click       → place an ungeocoded parent location
-    ///   Ctrl+Shift+Click → move any parent location (current GPS overwritten)
+    ///   Ctrl+Shift+Click → choose a parent location to relocate here
     /// </summary>
     private async Task OnMapClickAsync(OvcinaMapClickEventArgs e)
     {
         Console.WriteLine($"[map-diag] MapPage.OnMapClick entry lat={e.Latitude} lng={e.Longitude} ctrl={e.CtrlKey} shift={e.ShiftKey} gameId={GameContext.SelectedGameId?.ToString() ?? "null"}");
         Console.WriteLine($"[map-diag] MapPage.OnMapClick modifier_branch branch={(e.CtrlKey && e.ShiftKey ? "ctrl_shift_relocate" : (e.CtrlKey ? "default" : "none"))}");
-        if (_shortcutMoveActive)
-        {
-            Console.WriteLine($"[map-diag] MapPage.OnMapClick shortcut-target lat={e.Latitude} lng={e.Longitude}");
-            await CompleteShortcutMoveAsync(e.Latitude, e.Longitude);
-            return;
-        }
         if (!e.CtrlKey)
         {
             Console.WriteLine("[map-diag] MapPage.OnMapClick ignored-no-ctrl");
             return;
+        }
+        if (e.ShiftKey)
+        {
+            Console.WriteLine($"[map-diag] map.click.modifier_held ctrl=true shift=true atLngLat={{lng:{FormatCoord(e.Longitude)},lat:{FormatCoord(e.Latitude)}}}");
         }
         if (GameContext.SelectedGameId is not int gid)
         {
@@ -718,7 +594,14 @@
             .ToList();
         Console.WriteLine($"[map-diag] MapPage.OnMapClick candidates-filtered mode={_placeMode} count={_placeCandidates.Count}");
         _placeVisible = true;
-        Console.WriteLine("[map-diag] MapPage.OnMapClick popup-visible");
+        if (_placeMode == "move")
+        {
+            Console.WriteLine($"[map-diag] map.click.relocation_picker.opened atLngLat={{lng:{FormatCoord(_placeLng)},lat:{FormatCoord(_placeLat)}}}");
+        }
+        else
+        {
+            Console.WriteLine("[map-diag] MapPage.OnMapClick popup-visible");
+        }
         await InvokeAsync(StateHasChanged);
     }
 
@@ -728,28 +611,70 @@
         _placeSaving = true;
         try
         {
-            // Round-trip GET → PUT so we don't wipe Description / Details /
-            // NpcInfo. Mirrors the OnPinDragged flow.
-            var detail = await Api.GetAsync<LocationDetailDto>($"/api/locations/{loc.Id}");
-            if (detail is null) { _placeError = "Lokace nenalezena."; return; }
-            await Api.PutAsync($"/api/locations/{loc.Id}",
-                new UpdateLocationDto(
-                    detail.Name, detail.LocationKind,
-                    Latitude: (decimal)_placeLat, Longitude: (decimal)_placeLng,
-                    Description: detail.Description,
-                    Details: detail.Details,
-                    GamePotential: detail.GamePotential,
-                    Prompt: detail.Prompt,
-                    Region: detail.Region,
-                    NpcInfo: detail.NpcInfo,
-                    SetupNotes: detail.SetupNotes,
-                    ParentLocationId: detail.ParentLocationId));
-            _placeVisible = false;
-            _placeCandidates = null;
+            if (_placeMode == "move")
+            {
+                Console.WriteLine($"[map-diag] map.click.relocation_picker.picked locationId={loc.Id} atLngLat={{lng:{FormatCoord(_placeLng)},lat:{FormatCoord(_placeLat)}}}");
+                Console.WriteLine($"[map-diag] map.location.relocate.dispatch locationId={loc.Id} from={{lng:{FormatCoord(loc.Longitude)},lat:{FormatCoord(loc.Latitude)}}} to={{lng:{FormatCoord(_placeLng)},lat:{FormatCoord(_placeLat)}}}");
+            }
+
+            // Issue #411 reuses the same coordinates-only PATCH endpoint as
+            // drag relocate. It cannot clobber other location fields edited
+            // concurrently because the body carries only Latitude/Longitude.
+            var (ok, problem) = await Api.PatchWithProblemAsync(
+                $"/api/locations/{loc.Id}/coordinates",
+                new LocationCoordinatesPatchDto((decimal)_placeLat, (decimal)_placeLng));
+            if (!ok)
+            {
+                _placeError = problem ?? "Uložení souřadnic selhalo.";
+                return;
+            }
+
+            ClearPlacePicker();
             await ReloadDataAndRenderAsync();
         }
         catch (Exception ex) { _placeError = ex.Message; }
         finally { _placeSaving = false; }
+    }
+
+    private Task CancelPlacePickerAsync()
+    {
+        if (_placeMode == "move")
+        {
+            Console.WriteLine("[map-diag] map.click.relocation_picker.cancelled");
+        }
+        ClearPlacePicker();
+        return Task.CompletedTask;
+    }
+
+    private Task OnPlaceVisibleChanged(bool visible)
+    {
+        if (_placeVisible == visible)
+            return Task.CompletedTask;
+
+        if (!visible)
+        {
+            if (_placeMode == "move")
+            {
+                Console.WriteLine("[map-diag] map.click.relocation_picker.cancelled");
+            }
+            ClearPlacePicker();
+        }
+        else
+        {
+            _placeVisible = true;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ClearPlacePicker()
+    {
+        _placeVisible = false;
+        _placeCandidates = null;
+        _placeSearch = "";
+        _placeError = null;
+        _placeSaving = false;
+        _placeMode = "place";
     }
 
     private async Task OnKindToggle(LocationKind kind)

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3805,12 +3805,10 @@
     border:1.5px solid var(--oh-border,#d8d2be);min-width:14px;text-align:center;
     box-shadow:0 1px 2px rgba(0,0,0,.18);z-index:3}
 /* Ctrl/Meta held over the map → crosshair cursor (visual hint that
-   Ctrl+Click will place an ungeocoded location, Ctrl+Shift+Click will
-   move an existing one). Class toggled by map-interop.js keydown/keyup. */
+   Ctrl+Click places an ungeocoded location and Ctrl+Shift+Click opens
+   the relocation picker). Class toggled by map-interop.js keydown/keyup. */
 .oh-map-ctrl-held .maplibregl-canvas-container,
-.oh-map-ctrl-held .maplibregl-canvas,
-.oh-map-move-shortcut-active .maplibregl-canvas-container,
-.oh-map-move-shortcut-active .maplibregl-canvas{cursor:crosshair !important}
+.oh-map-ctrl-held .maplibregl-canvas{cursor:crosshair !important}
 
 /* Issue #273 — graduated location labels. Each pin advertises a
    `data-minzoom` (set in JS from KIND_MIN_ZOOM) and the zoomend handler

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -5,7 +5,6 @@ window.ovcinaMap = {
     _dotnetRef: null,
     _elementId: null,
     _apiKey: null,
-    _moveShortcutActive: false,
 
     // Glyph URL — required by MapLibre for any layer with `text-field` in
     // its layout (e.g. the overlay editor's `oh-overlay-preview-text` text
@@ -93,7 +92,6 @@ window.ovcinaMap = {
         this._dotnetRef = dotnetRef;
         this._elementId = elementId;
         this._apiKey = (mapyCzApiKey && mapyCzApiKey.length > 5) ? mapyCzApiKey : null;
-        this._moveShortcutActive = false;
         // Resolved at init so every style construction below picks up the
         // environment-specific URL (#166). Empty/missing/whitespace-only →
         // fall back to the demotiles dev URL so local smoke testing still
@@ -137,6 +135,14 @@ window.ovcinaMap = {
                 shift: shift,
                 target: 'map-canvas'
             });
+            if (ctrl && shift) {
+                if (orig && typeof orig.preventDefault === 'function') orig.preventDefault();
+                this._mapDiag('click.modifier_held', {
+                    ctrl: true,
+                    shift: true,
+                    atLngLat: { lng: e.lngLat.lng, lat: e.lngLat.lat }
+                });
+            }
             this._mapDiag('click', {
                 elementId: this._elementId,
                 lat: e.lngLat.lat,
@@ -148,7 +154,7 @@ window.ovcinaMap = {
             if (this._dotnetRef) {
                 // Forward Ctrl/Meta + Shift state — /map uses
                 //   Ctrl+Click       → place ungeocoded location
-                //   Ctrl+Shift+Click → move existing location (any)
+                //   Ctrl+Shift+Click → choose a location to relocate here
                 this._mapDiag('click.invoke-dotnet', { ctrl: ctrl, shift: shift });
                 this._dotnetRef.invokeMethodAsync('OnMapClicked', e.lngLat.lat, e.lngLat.lng, ctrl, shift);
             }
@@ -202,14 +208,6 @@ window.ovcinaMap = {
         // rest of the time. Listeners cleared in dispose().
         var mapContainer = this._map.getContainer();
         var keyDown = function (e) {
-            if (e.key === 'Escape' && window.ovcinaMap._moveShortcutActive) {
-                e.preventDefault();
-                window.ovcinaMap._mapDiag('location.relocate.cancel', { source: 'escape' });
-                if (window.ovcinaMap._dotnetRef) {
-                    window.ovcinaMap._dotnetRef.invokeMethodAsync('OnLocationMoveShortcutCanceled');
-                }
-                return;
-            }
             if (e.key === 'Control' || e.key === 'Meta') {
                 mapContainer.classList.add('oh-map-ctrl-held');
                 window.ovcinaMap._mapDiag('modifier.down', { key: e.key, ctrl: e.ctrlKey || e.metaKey, shift: e.shiftKey });
@@ -335,17 +333,6 @@ window.ovcinaMap = {
         }
     },
 
-    setMoveShortcutMode: function (active) {
-        this._moveShortcutActive = !!active;
-        if (this._map) {
-            var container = this._map.getContainer();
-            if (container) {
-                container.classList.toggle('oh-map-move-shortcut-active', this._moveShortcutActive);
-            }
-        }
-        this._mapDiag('location.relocate.mode', { active: this._moveShortcutActive });
-    },
-
     addMarker: function (id, lat, lon, name, kind, color) {
         if (!this._map) return;
         this.removeMarker(id);
@@ -443,7 +430,6 @@ window.ovcinaMap = {
     },
 
     dispose: function () {
-        this._moveShortcutActive = false;
         this.clearMarkers();
         if (this._map) {
             this._map.remove();
@@ -1311,7 +1297,6 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
             modifier: modifier,
             target: self._eventTargetName(e && e.target),
             currentTarget: self._eventTargetName(e && e.currentTarget),
-            moveShortcutActive: !!self._moveShortcutActive,
             hasDotNetRef: !!self._dotnetRef,
             defaultPrevented: !!(e && e.defaultPrevented)
         });
@@ -1330,21 +1315,10 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
             target: 'location',
             locationId: id
         });
-        if (self._moveShortcutActive) {
-            self._mapDiag('location.pin.click.move_target_branch_taken', { locationId: id });
-            e.preventDefault();
-            e.stopPropagation();
-            self._mapDiag('location.relocate.target', { source: 'location-pin', locationId: id, lng: lon, lat: lat });
-            if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapClicked', lat, lon, false, false);
-            return;
-        }
         if (payload.ctrl && payload.shift) {
-            self._mapDiag('location.pin.click.ctrlshift_branch_taken', { locationId: id });
+            self._mapDiag('location.pin.click.ctrlshift_ignored_empty_map_required', { locationId: id });
             e.preventDefault();
             e.stopPropagation();
-            self._mapDiag('location.relocate.start', { locationId: id, from: { lng: lon, lat: lat } });
-            self._mapDiag('location.move_mode.dispatch.attempt', { locationId: id, hasDotNetRef: !!self._dotnetRef });
-            if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnLocationMoveShortcutStarted', id, lat, lon);
             return;
         }
         self._mapDiag('location.pin.click.default_branch_taken', { locationId: id });
@@ -1440,18 +1414,14 @@ window.ovcinaMap.addStashPin = function (id, locationId, lat, lon, name, count, 
             target: 'stash-location',
             locationId: locationId
         });
-        if (self._moveShortcutActive) {
-            e.preventDefault();
-            e.stopPropagation();
-            self._mapDiag('location.relocate.target', { source: 'stash-pin', locationId: locationId, stashId: id, lng: lon, lat: lat });
-            if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnMapClicked', lat, lon, false, false);
-            return;
-        }
         if (payload.ctrl && payload.shift) {
             e.preventDefault();
             e.stopPropagation();
-            self._mapDiag('location.relocate.start', { source: 'stash-pin', locationId: locationId, stashId: id, from: { lng: lon, lat: lat } });
-            if (self._dotnetRef) self._dotnetRef.invokeMethodAsync('OnLocationMoveShortcutStarted', locationId, lat, lon);
+            self._mapDiag('location.pin.click.ctrlshift_ignored_empty_map_required', {
+                source: 'stash-pin',
+                locationId: locationId,
+                stashId: id
+            });
             return;
         }
         e.stopPropagation();


### PR DESCRIPTION
## Summary
- replace the old Ctrl+Shift+pin move-mode with Ctrl+Shift+empty-map relocation picker
- reuse the existing searchable map placement popup and include all parent locations in relocation mode
- save selected relocation through PATCH /api/locations/{id}/coordinates and add the #411 map-diag marker series
- suppress Ctrl+Shift on existing pins so the abandoned pin-click flow cannot start

## Phase 0
- No schema/API change needed; existing coordinates PATCH is sufficient.
- No standalone shared location picker exists; MapPage already had the searchable Ctrl+click placement popup, so this PR extends that surface.

## Verification
- node --check src/OvcinaHra.Client/wwwroot/js/map-interop.js
- dotnet format OvcinaHra.slnx --include src/OvcinaHra.Client/Components/MapView.razor src/OvcinaHra.Client/Pages/Map/MapPage.razor --verify-no-changes --verbosity minimal
- dotnet build OvcinaHra.slnx --no-restore --verbosity minimal
- dotnet test OvcinaHra.slnx --no-build --verbosity minimal

## Visual smoke after deploy
- Open game 30 map edit.
- Pan to the desired destination, hold Ctrl+Shift, click empty map.
- Picker opens; select Brodečko.
- Brodečko pin jumps to the clicked position and remains there after refresh.
- Open picker again and close with Esc/close: no location changes.

Closes #411
Supersedes #392