### PR TITLE
Add treasure count badges to map pins

### DIFF
--- a/src/OvcinaHra.Api/Services/MapDataService.cs
+++ b/src/OvcinaHra.Api/Services/MapDataService.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
@@ -10,10 +12,15 @@ public interface IMapDataService
     Task<MapDataDto> GetMapDataAsync(int gameId, CancellationToken ct = default);
 }
 
-public sealed class MapDataService(WorldDbContext db, IBlobStorageService blob) : IMapDataService
+public sealed class MapDataService(
+    WorldDbContext db,
+    IBlobStorageService blob,
+    ILogger<MapDataService> logger) : IMapDataService
 {
     public async Task<MapDataDto> GetMapDataAsync(int gameId, CancellationToken ct = default)
     {
+        var stopwatch = Stopwatch.StartNew();
+
         // Game-scoped locations. Only parent locations get pinned — variants
         // share their parent's GPS and would stack identical markers.
         var locationRows = await db.GameLocations
@@ -38,19 +45,24 @@ public sealed class MapDataService(WorldDbContext db, IBlobStorageService blob) 
             })
             .ToListAsync(ct);
 
-        var locations = locationRows.Select(r => new MapLocationDto(
-            r.LocationId, r.Name,
-            (double)r.Lat, (double)r.Lon,
-            r.LocationKind,
-            // Kingdom not stored on Location/GameLocation today. Return null
-            // so the cockpit's kingdom-tint chip stays inert until a follow-up
-            // adds the relationship.
-            KingdomId: null, KingdomName: null,
-            ThumbnailUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath),
-            RenderKind: r.HobbitChildName is null ? null : LocationKind.Hobbit,
-            RenderName: r.HobbitChildName is null
-                ? null
-                : $"{r.HobbitChildName} ({r.Name})")).ToList();
+        var parentLocationIds = locationRows.Select(r => r.LocationId).ToList();
+        var childParentRows = await db.Locations
+            .AsNoTracking()
+            .Where(l => l.ParentLocationId.HasValue
+                && parentLocationIds.Contains(l.ParentLocationId.Value))
+            .Select(l => new
+            {
+                l.Id,
+                ParentId = l.ParentLocationId!.Value,
+            })
+            .ToListAsync(ct);
+
+        var parentIdByLocationId = parentLocationIds.ToDictionary(id => id, id => id);
+        foreach (var child in childParentRows)
+        {
+            parentIdByLocationId[child.Id] = child.ParentId;
+        }
+        var visibleLocationIds = parentIdByLocationId.Keys.ToList();
 
         // Game-scoped stashes. Each pin sits at GameSecretStash.LocationId
         // (which has GPS via Location.Coordinates). Treasure count + highest
@@ -69,13 +81,76 @@ public sealed class MapDataService(WorldDbContext db, IBlobStorageService blob) 
             })
             .ToListAsync(ct);
 
+        var treasureCountsByLocation = parentLocationIds
+            .ToDictionary(id => id, _ => new TreasureCountAccumulator());
+
+        if (visibleLocationIds.Count > 0)
+        {
+            var locationTreasureRows = await db.TreasureQuests
+                .AsNoTracking()
+                .Where(t => t.GameId == gameId
+                    && t.LocationId != null
+                    && visibleLocationIds.Contains(t.LocationId.Value))
+                .Select(t => new
+                {
+                    t.LocationId,
+                    t.Difficulty,
+                    ItemCount = t.TreasureItems.Sum(ti => (int?)ti.Count) ?? 0,
+                })
+                .ToListAsync(ct);
+
+            foreach (var row in locationTreasureRows)
+            {
+                if (row.LocationId is int locationId
+                    && parentIdByLocationId.TryGetValue(locationId, out var parentId))
+                {
+                    treasureCountsByLocation[parentId].Add(row.Difficulty, row.ItemCount);
+                }
+            }
+        }
+
         // Pull treasures attached to each stash for this game so the count +
         // highest-stage badge are accurate. One query keeps it cheap.
         var treasureRows = await db.TreasureQuests
             .AsNoTracking()
             .Where(t => t.GameId == gameId && t.SecretStashId != null)
-            .Select(t => new { t.SecretStashId, t.Difficulty })
+            .Select(t => new
+            {
+                t.SecretStashId,
+                t.Difficulty,
+                ItemCount = t.TreasureItems.Sum(ti => (int?)ti.Count) ?? 0,
+            })
             .ToListAsync(ct);
+
+        var parentIdByStashId = stashRows
+            .Where(r => parentIdByLocationId.ContainsKey(r.LocationId))
+            .ToDictionary(r => r.SecretStashId, r => parentIdByLocationId[r.LocationId]);
+
+        foreach (var row in treasureRows)
+        {
+            if (row.SecretStashId is int stashId
+                && parentIdByStashId.TryGetValue(stashId, out var parentId))
+            {
+                treasureCountsByLocation[parentId].Add(row.Difficulty, row.ItemCount);
+            }
+        }
+
+        var locations = locationRows.Select(r => new MapLocationDto(
+            r.LocationId, r.Name,
+            (double)r.Lat, (double)r.Lon,
+            r.LocationKind,
+            // Kingdom not stored on Location/GameLocation today. Return null
+            // so the cockpit's kingdom-tint chip stays inert until a follow-up
+            // adds the relationship.
+            KingdomId: null, KingdomName: null,
+            ThumbnailUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : blob.GetSasUrl(r.ImagePath),
+            RenderKind: r.HobbitChildName is null ? null : LocationKind.Hobbit,
+            RenderName: r.HobbitChildName is null
+                ? null
+                : $"{r.HobbitChildName} ({r.Name})",
+            TreasureCounts: treasureCountsByLocation.GetValueOrDefault(r.LocationId)?.ToDto()
+                ?? TreasureCountAccumulator.Empty.ToDto())).ToList();
+
         var byStash = treasureRows
             .GroupBy(t => t.SecretStashId!.Value)
             .ToDictionary(g => g.Key, g => g.ToList());
@@ -92,6 +167,45 @@ public sealed class MapDataService(WorldDbContext db, IBlobStorageService blob) 
                     : entries.Max(t => t.Difficulty));
         }).ToList();
 
+        logger.LogInformation(
+            "[treasure-map] count-data loaded gameId={GameId} locationCount={LocationCount} elapsedMs={ElapsedMs}",
+            gameId,
+            locations.Count,
+            stopwatch.ElapsedMilliseconds);
+
         return new MapDataDto(locations, stashes);
+    }
+
+    private sealed class TreasureCountAccumulator
+    {
+        public static TreasureCountAccumulator Empty { get; } = new();
+
+        private int Total { get; set; }
+        private int Start { get; set; }
+        private int Mid { get; set; }
+        private int End { get; set; }
+
+        public void Add(GameTimePhase phase, int count)
+        {
+            if (count <= 0) return;
+
+            Total += count;
+            switch (phase)
+            {
+                case GameTimePhase.Start:
+                    Start += count;
+                    break;
+                case GameTimePhase.Early:
+                case GameTimePhase.Midgame:
+                    Mid += count;
+                    break;
+                case GameTimePhase.Lategame:
+                case GameTimePhase.EndGame:
+                    End += count;
+                    break;
+            }
+        }
+
+        public TreasureCountByPhaseDto ToDto() => new(Total, Start, Mid, End);
     }
 }

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -55,6 +55,18 @@
                                    OnKindToggle="OnKindToggle" />
 
                     <div class="oh-map-canvas">
+                        <div class="oh-map-treasure-filter" role="group" aria-label="Filtr pokladů podle fáze">
+                            <span class="oh-map-treasure-filter-lbl">Poklady</span>
+                            @foreach (var phase in TreasureMapPhaseOptions)
+                            {
+                                <button type="button"
+                                        class="oh-map-treasure-chip @(_treasurePhaseFilter == phase.Key ? "is-active" : "")"
+                                        data-stage="@phase.StageKey"
+                                        @onclick="() => SetTreasurePhaseFilterAsync(phase.Key)">
+                                    @phase.Label
+                                </button>
+                            }
+                        </div>
                         <div class="oh-map-style-toolbar">
                             <button class="oh-map-style-btn @(_activeStyle == "tourist" ? "is-active" : "")"
                                     @onclick='() => SetStyleAsync("tourist")'>Turistická</button>
@@ -215,10 +227,22 @@
     // also persists HiddenKinds). Old v1 entries without HiddenKinds
     // continue to deserialize via the record's default value.
     private const string LayerStateKey = "oh-map-layers-v2";
+    private const string TreasurePhaseAll = "all";
+    private const string TreasurePhaseStart = "start";
+    private const string TreasurePhaseMid = "mid";
+    private const string TreasurePhaseEnd = "end";
+    private static readonly IReadOnlyList<TreasureMapPhaseOption> TreasureMapPhaseOptions =
+    [
+        new(TreasurePhaseAll, "Vše", "all"),
+        new(TreasurePhaseStart, "Start", "start"),
+        new(TreasurePhaseMid, "Hra", "mid"),
+        new(TreasurePhaseEnd, "Konec", "end"),
+    ];
 
     private MapView? _mapView;
     private string _mode = "pro-hru";
     private string _activeStyle = "tourist";
+    private string _treasurePhaseFilter = TreasurePhaseAll;
     private bool _locationsVisible = true;
     private bool _stashesVisible = true;
     private bool _overlaysVisible = true;
@@ -427,8 +451,12 @@
                 // counts in the rail still show the underlying total, but
                 // the pins drop out of the painted set.
                 if (_hiddenKinds.Contains(l.EffectiveKind)) continue;
+                var filteredCount = GetTreasureCount(l, _treasurePhaseFilter);
+                var totalCount = l.TreasureCounts?.Total ?? 0;
+                Console.WriteLine($"[treasure-map] count-pin render locationId={l.Id} totalCount={totalCount} filteredCount={filteredCount} phase={TreasurePhaseLogName(_treasurePhaseFilter)}");
                 await JS.InvokeVoidAsync("ovcinaMap.addLocationPin",
-                    l.Id, l.Lat, l.Lon, l.EffectiveName, l.EffectiveKind.ToString());
+                    l.Id, l.Lat, l.Lon, l.EffectiveName, l.EffectiveKind.ToString(),
+                    filteredCount, TreasurePhaseUiName(_treasurePhaseFilter));
             }
         }
         if (_stashesVisible)
@@ -441,6 +469,43 @@
             }
         }
     }
+
+    private async Task SetTreasurePhaseFilterAsync(string phase)
+    {
+        if (_treasurePhaseFilter == phase) return;
+
+        var previous = _treasurePhaseFilter;
+        _treasurePhaseFilter = phase;
+        Console.WriteLine($"[treasure-map] phase-filter changed from={TreasurePhaseLogName(previous)} to={TreasurePhaseLogName(phase)}");
+        await PaintPinsAsync();
+    }
+
+    private static int GetTreasureCount(MapLocationDto location, string phase)
+        => location.TreasureCounts is null
+            ? 0
+            : phase switch
+            {
+                TreasurePhaseStart => location.TreasureCounts.Start,
+                TreasurePhaseMid => location.TreasureCounts.Mid,
+                TreasurePhaseEnd => location.TreasureCounts.End,
+                _ => location.TreasureCounts.Total,
+            };
+
+    private static string TreasurePhaseLogName(string phase) => phase switch
+    {
+        TreasurePhaseStart => "Start",
+        TreasurePhaseMid => "Mid",
+        TreasurePhaseEnd => "End",
+        _ => "All",
+    };
+
+    private static string TreasurePhaseUiName(string phase) => phase switch
+    {
+        TreasurePhaseStart => "Start",
+        TreasurePhaseMid => "Hra",
+        TreasurePhaseEnd => "Konec",
+        _ => "Vše",
+    };
 
     private async Task OnLayerVisibilityChange((string Layer, bool Visible) change)
     {
@@ -863,6 +928,8 @@
     // Persistence schema. HiddenKinds defaults to an empty list so a v1
     // entry without the field deserializes cleanly (System.Text.Json
     // tolerates missing properties on records with default values).
+    private sealed record TreasureMapPhaseOption(string Key, string Label, string StageKey);
+
     private record LayerState(
         bool Locations,
         bool Stashes,

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3756,6 +3756,22 @@
 .oh-map-style-btn{padding:3px 9px;border-radius:99px;border:none;background:transparent;
     color:var(--oh-text,#2a2a2a);font:600 .72rem var(--oh-font-body);cursor:pointer}
 .oh-map-style-btn.is-active{background:#2D5016;color:#fff}
+.oh-map-treasure-filter{position:absolute;top:8px;left:8px;z-index:10;display:flex;align-items:center;
+    gap:4px;flex-wrap:wrap;max-width:calc(100% - 360px);background:rgba(250,246,236,.94);
+    padding:3px;border-radius:99px;box-shadow:0 1px 4px rgba(0,0,0,.12)}
+.oh-map-treasure-filter-lbl{padding:0 5px;color:var(--oh-text-secondary,#6b6257);
+    font:700 .68rem var(--oh-font-body);letter-spacing:0;text-transform:uppercase}
+.oh-map-treasure-chip{padding:3px 9px;border-radius:99px;border:none;background:transparent;
+    color:var(--oh-text,#2a2a2a);font:600 .72rem var(--oh-font-body);cursor:pointer}
+.oh-map-treasure-chip:hover{background:rgba(45,80,22,.08);color:#2D5016}
+.oh-map-treasure-chip.is-active{background:var(--c,#2D5016);color:#fff}
+.oh-map-treasure-chip[data-stage="all"]{--c:#2D5016}
+.oh-map-treasure-chip[data-stage="start"]{--c:var(--oh-stage-start)}
+.oh-map-treasure-chip[data-stage="mid"]{--c:var(--oh-stage-midgame)}
+.oh-map-treasure-chip[data-stage="end"]{--c:var(--oh-stage-endgame)}
+@media (max-width: 900px){
+    .oh-map-treasure-filter{top:48px;right:8px;max-width:calc(100% - 16px)}
+}
 /* Issue #257 — tear-drop pins. Outer .oh-map-pin is a transparent
    anchor box; the round bubble + downward tail are painted by
    .oh-map-pin-bg and its ::after triangle. Per-kind colors flow via
@@ -3867,6 +3883,7 @@ body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label{display:block}
     body.oh-map-print nav,
     body.oh-map-print header,
     body.oh-map-print .oh-map-style-toolbar,
+    body.oh-map-print .oh-map-treasure-filter,
     body.oh-map-print .maplibregl-ctrl-top-right,
     body.oh-map-print .oh-map-zoom-indicator{display:none !important}
     body.oh-map-print{background:#fff !important}

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -1223,7 +1223,7 @@ window.ovcinaMap._kindIconFor = function (kindRaw) {
     return this._kindIcon[k] || 'bi-geo-alt-fill';
 };
 
-window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
+window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind, treasureCount, treasurePhase) {
     if (!this._map) {
         if (this._pinDiag()) console.warn('[pin-diag] addLocationPin called but no map — id=' + id);
         return;
@@ -1253,6 +1253,10 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     wrapper.style.cursor = 'pointer';
     var pin = document.createElement('div');
     pin.className = 'oh-map-pin oh-map-pin-loc';
+    var count = Number(treasureCount);
+    if (!isFinite(count)) count = 0;
+    count = Math.max(0, Math.trunc(count));
+    var phaseText = treasurePhase || '';
     var kindKey = (kind || 'wilderness').toLowerCase();
     pin.setAttribute('data-kind', kindKey);
     // Issue #273 — graduated label-visibility-by-zoom. Each pin advertises
@@ -1262,7 +1266,7 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     var minZoom = this._kindMinZoomFor(kindKey);
     pin.setAttribute('data-minzoom', String(minZoom));
     if (this._map.getZoom() >= minZoom) pin.classList.add('oh-pin-label-on');
-    wrapper.title = name || '';
+    wrapper.title = (name || '') + (count > 0 ? ' · ' + count + ' pokladů' + (phaseText ? ' (' + phaseText + ')' : '') : '');
     // Issue #257 — tear-drop pin chrome. The bubble (oh-map-pin-bg) carries
     // the per-kind background and the downward triangle tail (::after); the
     // glyph (Bootstrap-Icons bi-*) sits inside. Anchor moves to 'bottom' so
@@ -1278,6 +1282,13 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind) {
     glyph.setAttribute('aria-hidden', 'true');
     bg.appendChild(glyph);
     pin.appendChild(bg);
+    if (count > 0) {
+        var countBadge = document.createElement('span');
+        countBadge.className = 'oh-map-pin-count oh-map-pin-treasure-count';
+        countBadge.textContent = String(count);
+        countBadge.title = count + ' pokladů' + (phaseText ? ' (' + phaseText + ')' : '');
+        pin.appendChild(countBadge);
+    }
     if (name) {
         var label = document.createElement('div');
         label.className = 'oh-map-pin-label';

--- a/src/OvcinaHra.Shared/Dtos/MapDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MapDtos.cs
@@ -32,7 +32,8 @@ public record MapLocationDto(
     string? KingdomName,
     string? ThumbnailUrl,
     LocationKind? RenderKind = null,
-    string? RenderName = null)
+    string? RenderName = null,
+    TreasureCountByPhaseDto? TreasureCounts = null)
 {
     [JsonIgnore]
     public string KindDisplay => Kind.GetDisplayName();
@@ -46,6 +47,8 @@ public record MapLocationDto(
     [JsonIgnore]
     public string EffectiveKindDisplay => EffectiveKind.GetDisplayName();
 }
+
+public record TreasureCountByPhaseDto(int Total, int Start, int Mid, int End);
 
 /// <summary>
 /// One stash pin. Always sits at <see cref="Lat"/>/<see cref="Lon"/> of

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
@@ -168,6 +168,125 @@ public class MapEndpointsTests(PostgresFixture postgres)
     }
 
     [Fact]
+    public async Task Data_LocationPinsIncludeTreasureItemCountsByCollapsedPhase()
+    {
+        var game = await CreateGameAsync();
+        int parentId, emptyId;
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var parent = new Location
+            {
+                Name = "Pokladová lokace",
+                LocationKind = LocationKind.Village,
+                Coordinates = new GpsCoordinates(49.5m, 17.1m),
+            };
+            var empty = new Location
+            {
+                Name = "Bez pokladů",
+                LocationKind = LocationKind.Wilderness,
+                Coordinates = new GpsCoordinates(49.6m, 17.2m),
+            };
+            db.Locations.AddRange(parent, empty);
+            await db.SaveChangesAsync();
+
+            var child = new Location
+            {
+                Name = "Dětská varianta",
+                LocationKind = LocationKind.Dungeon,
+                ParentLocationId = parent.Id,
+            };
+            var stash = new SecretStash { Name = "Skrýš ve vsi" };
+            var item = new Item
+            {
+                Name = "Testovací mince",
+                ItemType = ItemType.Money,
+                ClassRequirements = new ClassRequirements(0, 0, 0, 0),
+            };
+            db.Locations.Add(child);
+            db.SecretStashes.Add(stash);
+            db.Items.Add(item);
+            await db.SaveChangesAsync();
+
+            db.GameLocations.AddRange(
+                new GameLocation { GameId = game.Id, LocationId = parent.Id },
+                new GameLocation { GameId = game.Id, LocationId = empty.Id });
+            db.GameSecretStashes.Add(new GameSecretStash
+            {
+                GameId = game.Id,
+                SecretStashId = stash.Id,
+                LocationId = parent.Id,
+            });
+            await db.SaveChangesAsync();
+
+            var start = new TreasureQuest
+            {
+                Title = "Start",
+                Difficulty = GameTimePhase.Start,
+                LocationId = parent.Id,
+                GameId = game.Id,
+            };
+            var childEarly = new TreasureQuest
+            {
+                Title = "Child early",
+                Difficulty = GameTimePhase.Early,
+                LocationId = child.Id,
+                GameId = game.Id,
+            };
+            var stashMid = new TreasureQuest
+            {
+                Title = "Stash mid",
+                Difficulty = GameTimePhase.Midgame,
+                SecretStashId = stash.Id,
+                GameId = game.Id,
+            };
+            var late = new TreasureQuest
+            {
+                Title = "Late",
+                Difficulty = GameTimePhase.Lategame,
+                LocationId = parent.Id,
+                GameId = game.Id,
+            };
+            var end = new TreasureQuest
+            {
+                Title = "End",
+                Difficulty = GameTimePhase.EndGame,
+                SecretStashId = stash.Id,
+                GameId = game.Id,
+            };
+            db.TreasureQuests.AddRange(start, childEarly, stashMid, late, end);
+            await db.SaveChangesAsync();
+
+            db.TreasureItems.AddRange(
+                new TreasureItem { GameId = game.Id, ItemId = item.Id, TreasureQuestId = start.Id, Count = 2 },
+                new TreasureItem { GameId = game.Id, ItemId = item.Id, TreasureQuestId = childEarly.Id, Count = 3 },
+                new TreasureItem { GameId = game.Id, ItemId = item.Id, TreasureQuestId = stashMid.Id, Count = 4 },
+                new TreasureItem { GameId = game.Id, ItemId = item.Id, TreasureQuestId = late.Id, Count = 5 },
+                new TreasureItem { GameId = game.Id, ItemId = item.Id, TreasureQuestId = end.Id, Count = 6 });
+            await db.SaveChangesAsync();
+
+            parentId = parent.Id;
+            emptyId = empty.Id;
+        }
+
+        var data = await Client.GetFromJsonAsync<MapDataDto>(
+            $"/api/map/data?gameId={game.Id}");
+
+        Assert.NotNull(data);
+        var parentPin = Assert.Single(data.Locations, l => l.Id == parentId);
+        Assert.NotNull(parentPin.TreasureCounts);
+        Assert.Equal(20, parentPin.TreasureCounts.Total);
+        Assert.Equal(2, parentPin.TreasureCounts.Start);
+        Assert.Equal(7, parentPin.TreasureCounts.Mid);
+        Assert.Equal(11, parentPin.TreasureCounts.End);
+
+        var emptyPin = Assert.Single(data.Locations, l => l.Id == emptyId);
+        Assert.NotNull(emptyPin.TreasureCounts);
+        Assert.Equal(0, emptyPin.TreasureCounts.Total);
+    }
+
+    [Fact]
     public async Task Peek_NonExistentLocation_Returns404()
     {
         var game = await CreateGameAsync();


### PR DESCRIPTION
Refs #418.

## Summary
- Adds per-location treasure count buckets to /api/map/data and logs [treasure-map] count-data markers.
- Adds live-map phase chips: Vše / Start / Hra / Konec.
- Renders non-zero filtered counts as badges on location pins and logs count-pin render markers.
- Adds regression coverage for parent, child, stash, and collapsed phase rollups.

## Verification
- dotnet restore OvcinaHra.slnx
- dotnet build OvcinaHra.slnx --no-restore --verbosity minimal
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter "FullyQualifiedName~MapEndpointsTests" --no-build --logger "console;verbosity=minimal"
- git diff --check

## Visual smoke after deploy
- Open game 30 map view.
- Confirm default Vše shows count badges on locations with treasures.
- Switch Start / Hra / Konec and confirm badge counts change without moving pins.
- Confirm locations with zero matching treasures have no badge.
- Cross-check a few counts against /treasures.
