### PR TITLE
feat(locations): gallery upload + EXIF GPS auto-update

### DIFF
--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -166,6 +166,33 @@
                 </label>
             </div>
 
+            @if (placementGpsPromptVisible && placementPhotoGps is not null)
+            {
+                <div class="alert alert-info py-2 mt-3" data-testid="location-placement-gps-prompt">
+                    <div>@PlacementGpsPromptText</div>
+                    <div class="d-flex flex-wrap gap-2 mt-2">
+                        <button type="button"
+                                class="btn btn-sm btn-primary"
+                                @onclick="AcceptPlacementGpsAsync"
+                                disabled="@(placementSaving || placementGpsUpdating)"
+                                data-testid="location-placement-gps-accept">
+                            @if (placementGpsUpdating)
+                            {
+                                <span class="spinner-border spinner-border-sm me-1"></span>
+                            }
+                            Aktualizovat
+                        </button>
+                        <button type="button"
+                                class="btn btn-sm btn-outline-secondary"
+                                @onclick="RejectPlacementGps"
+                                disabled="@(placementSaving || placementGpsUpdating)"
+                                data-testid="location-placement-gps-reject">
+                            Ignorovat
+                        </button>
+                    </div>
+                </div>
+            }
+
             <label class="form-label mt-3">Poznámky</label>
             <DxMemo @bind-Text="@placementNotes"
                     Rows="3"
@@ -772,6 +799,10 @@ else
     private string? placementNotes;
     private string? placementError;
     private string? placementToastMessage;
+    private PhotoGpsCoordinates? placementPhotoGps;
+    private double? placementPhotoGpsDistanceMeters;
+    private bool placementGpsPromptVisible;
+    private bool placementGpsUpdating;
     // Camera-side: phone JPEGs frequently land in the 8–20 MB range, so we
     // accept generously here. Resize happens client-side in JS canvas; the
     // server still enforces its own multipart limit, but we cap the post-
@@ -780,9 +811,16 @@ else
     private const long PlacementMaxUploadFileSize = 5 * 1024 * 1024;
     private const int PlacementResizeMaxDim = 1920;
     private const double PlacementResizeQuality = 0.85;
+    private const double PlacementGpsDriftThresholdMeters = 50;
     private byte[]? placementPhotoBytes;
     private string placementPhotoUploadContentType = "image/jpeg";
     private bool placementAutoOpenHandled;
+
+    private sealed class PhotoGpsCoordinates
+    {
+        public double Lat { get; set; }
+        public double Lng { get; set; }
+    }
 
     // Toolbar filter state
     private string? searchText
@@ -922,6 +960,10 @@ else
             ? locations.FirstOrDefault(l => l.Id == placementSelectedLocationId.Value)
             : null;
 
+    private string PlacementGpsPromptText => placementPhotoGpsDistanceMeters is double distanceMeters
+        ? $"Fotka má GPS souřadnice, které se liší od aktuálních souřadnic lokace o cca {Math.Max(1, (int)Math.Round(distanceMeters))} m. Aktualizovat polohu lokace?"
+        : "Fotka má GPS souřadnice a lokace zatím nemá aktuální souřadnice. Aktualizovat polohu lokace?";
+
     private void RefreshVisibleRows()
     {
         bool Matches(LocationListDto l)
@@ -1005,6 +1047,7 @@ else
         placementPhotoBytes = null;
         placementPreviewUrl = null;
         placementNotes = null;
+        ResetPlacementGpsState();
         isPlacementVisible = true;
         Console.WriteLine($"[loc-placement] wizard.open gameId={gameId}");
     }
@@ -1018,6 +1061,7 @@ else
         placementPhotoBytes = null;
         placementPreviewUrl = null;
         placementNotes = null;
+        ResetPlacementGpsState();
         Console.WriteLine($"[loc-placement] wizard.cancel gameId={gameId}");
     }
 
@@ -1039,6 +1083,7 @@ else
         placementPhotoFile = e.File;
         placementPhotoBytes = null;
         placementPreviewUrl = null;
+        ResetPlacementGpsState();
         if (placementPhotoFile.Size > PlacementMaxIngressFileSize)
         {
             placementPhotoFile = null;
@@ -1066,6 +1111,8 @@ else
             Console.WriteLine($"[loc-placement] wizard.photo-selected.failed gameId={gameId} source={source} reason=read-failed detail={ex.Message}");
             return;
         }
+
+        await EvaluatePlacementPhotoGpsAsync(originalDataUrl);
 
         // Client-side canvas resize. Phone cameras emit 10–20 MB JPEGs that
         // exceed the server's 5 MB multipart limit; resize re-encodes as
@@ -1112,6 +1159,154 @@ else
         Console.WriteLine($"[loc-placement] wizard.photo-resized gameId={gameId} originalSize={placementPhotoFile.Size} resizedSize={resizedBytes.LongLength}");
     }
 
+    private async Task EvaluatePlacementPhotoGpsAsync(string originalDataUrl)
+    {
+        PhotoGpsCoordinates? gps;
+        try
+        {
+            gps = await JS.InvokeAsync<PhotoGpsCoordinates?>("ovcinaExif.readGpsFromDataUrl", originalDataUrl);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[loc-placement] exif read result=parse-failed gameId={gameId} detail={ex.Message}");
+            return;
+        }
+
+        if (gps is null)
+        {
+            Console.WriteLine($"[loc-placement] exif read result=no-gps gameId={gameId}");
+            return;
+        }
+
+        placementPhotoGps = gps;
+        Console.WriteLine($"[loc-placement] exif read result=found-gps gameId={gameId}");
+        Console.WriteLine($"[loc-placement] exif gps-coords lat={FormatPlacementGpsCoord(gps.Lat)} lng={FormatPlacementGpsCoord(gps.Lng)}");
+
+        var selected = SelectedPlacementLocation;
+        if (selected is null)
+        {
+            return;
+        }
+
+        if (selected.Latitude.HasValue && selected.Longitude.HasValue)
+        {
+            var distanceMeters = await JS.InvokeAsync<double>(
+                "ovcinaExif.haversineMeters",
+                (double)selected.Latitude.Value,
+                (double)selected.Longitude.Value,
+                gps.Lat,
+                gps.Lng);
+            placementPhotoGpsDistanceMeters = distanceMeters;
+            if (distanceMeters <= PlacementGpsDriftThresholdMeters)
+            {
+                return;
+            }
+        }
+
+        placementGpsPromptVisible = true;
+        Console.WriteLine(
+            $"[loc-placement] gps-prompt shown distance={FormatPlacementDistanceMeters(placementPhotoGpsDistanceMeters)}m " +
+            $"currentCoords={FormatPlacementGpsCoords(selected.Latitude, selected.Longitude)} " +
+            $"photoCoords={FormatPlacementGpsCoords(gps.Lat, gps.Lng)}");
+    }
+
+    private async Task AcceptPlacementGpsAsync()
+    {
+        if (placementPhotoGps is null || SelectedPlacementLocation is null)
+        {
+            return;
+        }
+
+        placementError = null;
+        placementGpsUpdating = true;
+        var locationId = SelectedPlacementLocation.Id;
+        var latitude = (decimal)placementPhotoGps.Lat;
+        var longitude = (decimal)placementPhotoGps.Lng;
+        Console.WriteLine($"[loc-placement] gps-update accepted locationId={locationId}");
+        Console.WriteLine($"[loc-placement] gps-patch attempt locationId={locationId} coords={FormatPlacementGpsCoords(placementPhotoGps.Lat, placementPhotoGps.Lng)}");
+        try
+        {
+            var (ok, problem) = await Api.PatchWithProblemAsync(
+                $"/api/locations/{locationId}/coordinates",
+                new LocationCoordinatesPatchDto(latitude, longitude));
+            if (!ok)
+            {
+                placementError = problem ?? "Souřadnice z fotky se nepodařilo uložit.";
+                Console.WriteLine($"[loc-placement] gps-patch result=failed locationId={locationId} detail={placementError}");
+                return;
+            }
+
+            UpdatePlacementLocationCoordinates(locationId, latitude, longitude);
+            ClearPlacementGpsPrompt();
+            Console.WriteLine($"[loc-placement] gps-patch result=ok locationId={locationId}");
+        }
+        catch (Exception ex)
+        {
+            placementError = "Souřadnice z fotky se nepodařilo uložit.";
+            Console.WriteLine($"[loc-placement] gps-patch result=failed locationId={locationId} detail={ex.Message}");
+        }
+        finally
+        {
+            placementGpsUpdating = false;
+        }
+    }
+
+    private void RejectPlacementGps()
+    {
+        var locationId = SelectedPlacementLocation?.Id;
+        Console.WriteLine($"[loc-placement] gps-update rejected locationId={locationId}");
+        ClearPlacementGpsPrompt();
+    }
+
+    private void UpdatePlacementLocationCoordinates(int locationId, decimal latitude, decimal longitude)
+    {
+        var index = locations.FindIndex(l => l.Id == locationId);
+        if (index < 0)
+        {
+            return;
+        }
+
+        locations[index] = locations[index] with
+        {
+            Latitude = latitude,
+            Longitude = longitude,
+            EffectiveLatitude = latitude,
+            EffectiveLongitude = longitude,
+            IsLocated = true,
+        };
+        RefreshVisibleRows();
+    }
+
+    private void ResetPlacementGpsState()
+    {
+        placementPhotoGps = null;
+        placementPhotoGpsDistanceMeters = null;
+        placementGpsPromptVisible = false;
+        placementGpsUpdating = false;
+    }
+
+    private void ClearPlacementGpsPrompt()
+    {
+        placementPhotoGpsDistanceMeters = null;
+        placementGpsPromptVisible = false;
+    }
+
+    private static string FormatPlacementGpsCoord(double value)
+        => value.ToString("0.000000", CultureInfo.InvariantCulture);
+
+    private static string FormatPlacementGpsCoords(decimal? latitude, decimal? longitude)
+        => latitude.HasValue && longitude.HasValue
+            ? FormatPlacementGpsCoords((double)latitude.Value, (double)longitude.Value)
+            : "null";
+
+    private static string FormatPlacementGpsCoords(double latitude, double longitude)
+        => $"{{lat:{FormatPlacementGpsCoord(latitude)},lng:{FormatPlacementGpsCoord(longitude)}}}";
+
+    private static string FormatPlacementDistanceMeters(double? distanceMeters)
+        => distanceMeters.HasValue
+            ? Math.Round(distanceMeters.Value).ToString(CultureInfo.InvariantCulture)
+            : "unknown";
+
     private async Task SubmitPlacementAsync()
     {
         placementError = null;
@@ -1123,6 +1318,11 @@ else
         if (placementPhotoFile is null || placementPhotoBytes is null)
         {
             placementError = "Nejprve vyfoťte nebo nahrajte fotku umístění.";
+            return;
+        }
+        if (placementGpsPromptVisible)
+        {
+            placementError = "Nejprve potvrďte, jestli se má poloha lokace aktualizovat podle GPS z fotky.";
             return;
         }
 
@@ -1173,8 +1373,10 @@ else
             placementToastMessage = $"Umístění lokace {status.LocationName} uloženo.";
             isPlacementVisible = false;
             placementPhotoFile = null;
+            placementPhotoBytes = null;
             placementPreviewUrl = null;
             placementNotes = null;
+            ResetPlacementGpsState();
             Console.WriteLine($"[loc-placement] wizard.submit.success gameId={gameId} locationId={locationId}");
         }
         catch (Exception ex)

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -793,7 +793,28 @@ else
     private bool isSaving;
     private bool isPlacementVisible;
     private bool placementSaving;
-    private int? placementSelectedLocationId;
+    private int? placementSelectedLocationId
+    {
+        get => placementSelectedLocationIdValue;
+        set
+        {
+            if (placementSelectedLocationIdValue == value) return;
+            placementSelectedLocationIdValue = value;
+
+            if (isPlacementVisible
+                && (placementPhotoFile is not null
+                    || placementPhotoBytes is not null
+                    || !string.IsNullOrWhiteSpace(placementPreviewUrl)))
+            {
+                placementPhotoFile = null;
+                placementPhotoBytes = null;
+                placementPreviewUrl = null;
+                placementError = "Po změně lokace vyberte fotku znovu.";
+            }
+            ResetPlacementGpsState();
+        }
+    }
+    private int? placementSelectedLocationIdValue;
     private IBrowserFile? placementPhotoFile;
     private string? placementPreviewUrl;
     private string? placementNotes;
@@ -1321,10 +1342,7 @@ else
             return;
         }
         if (placementGpsPromptVisible)
-        {
-            placementError = "Nejprve potvrďte, jestli se má poloha lokace aktualizovat podle GPS z fotky.";
-            return;
-        }
+            RejectPlacementGps();
 
         placementSaving = true;
         var locationId = SelectedPlacementLocation.Id;

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -148,14 +148,23 @@
                     </div>
                 }
             </div>
-            <label class="btn btn-outline-primary oh-placement-file-btn mt-2">
-                <i class="bi bi-camera me-1"></i>@(placementPhotoFile is null ? "Vybrat fotku" : "Vybrat jinou fotku")
-                <InputFile OnChange="HandlePlacementFileSelected"
-                           accept="image/*"
-                           capture="environment"
-                           disabled="@placementSaving"
-                           data-testid="location-placement-file" />
-            </label>
+            <div class="d-flex flex-wrap gap-2 mt-2">
+                <label class="btn btn-outline-primary oh-placement-file-btn" @onclick="LogPlacementCameraTap">
+                    <i class="bi bi-camera me-1"></i>Vyfotit
+                    <InputFile OnChange="HandlePlacementCameraFileSelected"
+                               accept="image/*"
+                               capture="environment"
+                               disabled="@placementSaving"
+                               data-testid="location-placement-camera-file" />
+                </label>
+                <label class="btn btn-outline-primary oh-placement-file-btn" @onclick="LogPlacementGalleryTap">
+                    <i class="bi bi-image me-1"></i>Z galerie
+                    <InputFile OnChange="HandlePlacementGalleryFileSelected"
+                               accept="image/*"
+                               disabled="@placementSaving"
+                               data-testid="location-placement-gallery-file" />
+                </label>
+            </div>
 
             <label class="form-label mt-3">Poznámky</label>
             <DxMemo @bind-Text="@placementNotes"
@@ -1012,7 +1021,19 @@ else
         Console.WriteLine($"[loc-placement] wizard.cancel gameId={gameId}");
     }
 
-    private async Task HandlePlacementFileSelected(InputFileChangeEventArgs e)
+    private Task HandlePlacementCameraFileSelected(InputFileChangeEventArgs e)
+        => HandlePlacementFileSelected(e, "camera");
+
+    private Task HandlePlacementGalleryFileSelected(InputFileChangeEventArgs e)
+        => HandlePlacementFileSelected(e, "gallery");
+
+    private void LogPlacementCameraTap()
+        => Console.WriteLine($"[loc-placement] gallery-tap source=camera gameId={gameId}");
+
+    private void LogPlacementGalleryTap()
+        => Console.WriteLine($"[loc-placement] gallery-tap source=gallery gameId={gameId}");
+
+    private async Task HandlePlacementFileSelected(InputFileChangeEventArgs e, string source)
     {
         placementError = null;
         placementPhotoFile = e.File;
@@ -1022,7 +1043,7 @@ else
         {
             placementPhotoFile = null;
             placementError = $"Soubor je příliš velký (max {PlacementMaxIngressFileSize / 1024 / 1024} MB).";
-            Console.WriteLine($"[loc-placement] wizard.photo-selected.failed gameId={gameId} reason=ingress-too-large size={e.File.Size}");
+            Console.WriteLine($"[loc-placement] wizard.photo-selected.failed gameId={gameId} source={source} reason=ingress-too-large size={e.File.Size}");
             return;
         }
 
@@ -1036,13 +1057,13 @@ else
             using var buffer = new MemoryStream();
             await stream.CopyToAsync(buffer);
             originalDataUrl = $"data:{contentType};base64,{Convert.ToBase64String(buffer.ToArray())}";
-            Console.WriteLine($"[loc-placement] wizard.photo-selected gameId={gameId} size={placementPhotoFile.Size}");
+            Console.WriteLine($"[loc-placement] wizard.photo-selected gameId={gameId} source={source} size={placementPhotoFile.Size}");
         }
         catch (Exception ex)
         {
             placementPhotoFile = null;
             placementError = "Fotku se nepodařilo načíst.";
-            Console.WriteLine($"[loc-placement] wizard.photo-selected.failed gameId={gameId} reason=read-failed detail={ex.Message}");
+            Console.WriteLine($"[loc-placement] wizard.photo-selected.failed gameId={gameId} source={source} reason=read-failed detail={ex.Message}");
             return;
         }
 

--- a/src/OvcinaHra.Client/wwwroot/index.html
+++ b/src/OvcinaHra.Client/wwwroot/index.html
@@ -44,7 +44,7 @@
     <script src="js/map-interop.js?v=20260411"></script>
     <script src="js/overlay-interop.js?v=20260428"></script>
     <script src="js/download-interop.js?v=20260427"></script>
-    <script src="js/image-resize-interop.js?v=20260429"></script>
+    <script src="js/image-resize-interop.js?v=20260429-410"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script>navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' });</script>
     <script>

--- a/src/OvcinaHra.Client/wwwroot/js/image-resize-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/image-resize-interop.js
@@ -50,3 +50,258 @@ window.ovcinaImageResize.fromBase64 = async function (dataUrl, maxDim, quality) 
         img.src = dataUrl;
     });
 };
+
+window.ovcinaExif = window.ovcinaExif || {};
+
+const GPS_DRIFT_THRESHOLD_M = 50;
+window.ovcinaExif.gpsDriftThresholdMeters = GPS_DRIFT_THRESHOLD_M;
+
+window.ovcinaExif.haversineMeters = function (lat1, lng1, lat2, lng2) {
+    const toRad = value => value * Math.PI / 180;
+    const earthRadiusMeters = 6371000;
+    const dLat = toRad(lat2 - lat1);
+    const dLng = toRad(lng2 - lng1);
+    const a =
+        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+        Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+        Math.sin(dLng / 2) * Math.sin(dLng / 2);
+    return earthRadiusMeters * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+};
+
+window.ovcinaExif.readGpsFromDataUrl = async function (dataUrl) {
+    if (typeof dataUrl !== "string" || dataUrl.length === 0) {
+        return null;
+    }
+
+    const buffer = dataUrlToArrayBuffer(dataUrl);
+    return readExifGps(buffer);
+};
+
+function dataUrlToArrayBuffer(dataUrl) {
+    const commaIdx = dataUrl.indexOf(",");
+    if (commaIdx < 0) {
+        throw new Error("Invalid data URL");
+    }
+
+    const metadata = dataUrl.slice(0, commaIdx);
+    const payload = dataUrl.slice(commaIdx + 1);
+    if (!/;base64/i.test(metadata)) {
+        return new TextEncoder().encode(decodeURIComponent(payload)).buffer;
+    }
+
+    const binary = atob(payload);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes.buffer;
+}
+
+function readExifGps(buffer) {
+    const view = new DataView(buffer);
+    const tiffOffset = findTiffOffset(view);
+    if (tiffOffset === null) {
+        return null;
+    }
+
+    const byteOrder = readAscii(view, tiffOffset, 2);
+    const littleEndian = byteOrder === "II";
+    if (!littleEndian && byteOrder !== "MM") {
+        return null;
+    }
+
+    if (view.getUint16(tiffOffset + 2, littleEndian) !== 42) {
+        return null;
+    }
+
+    const firstIfdOffset = view.getUint32(tiffOffset + 4, littleEndian);
+    const gpsIfdPointer = readIfdTag(view, tiffOffset, tiffOffset + firstIfdOffset, littleEndian, 0x8825);
+    if (gpsIfdPointer === null) {
+        return null;
+    }
+
+    return readGpsIfd(view, tiffOffset, tiffOffset + gpsIfdPointer, littleEndian);
+}
+
+function findTiffOffset(view) {
+    if (view.byteLength < 4 || view.getUint16(0, false) !== 0xffd8) {
+        return null;
+    }
+
+    let offset = 2;
+    while (offset + 4 < view.byteLength) {
+        if (view.getUint8(offset) !== 0xff) {
+            return null;
+        }
+
+        const marker = view.getUint8(offset + 1);
+        offset += 2;
+        if (marker === 0xda || marker === 0xd9) {
+            return null;
+        }
+
+        const segmentLength = view.getUint16(offset, false);
+        if (segmentLength < 2 || offset + segmentLength > view.byteLength) {
+            return null;
+        }
+
+        const segmentStart = offset + 2;
+        if (marker === 0xe1
+            && segmentLength >= 8
+            && readAscii(view, segmentStart, 6) === "Exif\0\0") {
+            return segmentStart + 6;
+        }
+
+        offset += segmentLength;
+    }
+
+    return null;
+}
+
+function readIfdTag(view, tiffOffset, ifdOffset, littleEndian, targetTag) {
+    if (ifdOffset < 0 || ifdOffset + 2 > view.byteLength) {
+        return null;
+    }
+
+    const entryCount = view.getUint16(ifdOffset, littleEndian);
+    for (let i = 0; i < entryCount; i++) {
+        const entryOffset = ifdOffset + 2 + i * 12;
+        if (entryOffset + 12 > view.byteLength) {
+            return null;
+        }
+
+        const tag = view.getUint16(entryOffset, littleEndian);
+        if (tag !== targetTag) {
+            continue;
+        }
+
+        const type = view.getUint16(entryOffset + 2, littleEndian);
+        const count = view.getUint32(entryOffset + 4, littleEndian);
+        return readExifValue(view, tiffOffset, entryOffset, type, count, littleEndian);
+    }
+
+    return null;
+}
+
+function readGpsIfd(view, tiffOffset, gpsIfdOffset, littleEndian) {
+    if (gpsIfdOffset < 0 || gpsIfdOffset + 2 > view.byteLength) {
+        return null;
+    }
+
+    const entryCount = view.getUint16(gpsIfdOffset, littleEndian);
+    let latRef = null;
+    let lngRef = null;
+    let latDms = null;
+    let lngDms = null;
+
+    for (let i = 0; i < entryCount; i++) {
+        const entryOffset = gpsIfdOffset + 2 + i * 12;
+        if (entryOffset + 12 > view.byteLength) {
+            return null;
+        }
+
+        const tag = view.getUint16(entryOffset, littleEndian);
+        const type = view.getUint16(entryOffset + 2, littleEndian);
+        const count = view.getUint32(entryOffset + 4, littleEndian);
+        const valueOffset = valueDataOffset(view, tiffOffset, entryOffset, type, count, littleEndian);
+        if (valueOffset === null) {
+            continue;
+        }
+
+        switch (tag) {
+            case 0x0001:
+                latRef = readAscii(view, valueOffset, count).replace(/\0/g, "").trim();
+                break;
+            case 0x0002:
+                latDms = readRationals(view, valueOffset, count, littleEndian);
+                break;
+            case 0x0003:
+                lngRef = readAscii(view, valueOffset, count).replace(/\0/g, "").trim();
+                break;
+            case 0x0004:
+                lngDms = readRationals(view, valueOffset, count, littleEndian);
+                break;
+        }
+    }
+
+    if (!latRef || !lngRef || !latDms || !lngDms || latDms.length < 3 || lngDms.length < 3) {
+        return null;
+    }
+
+    let lat = dmsToDecimal(latDms);
+    let lng = dmsToDecimal(lngDms);
+    if (latRef.toUpperCase() === "S") {
+        lat = -lat;
+    }
+    if (lngRef.toUpperCase() === "W") {
+        lng = -lng;
+    }
+
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)
+        || Math.abs(lat) > 90 || Math.abs(lng) > 180) {
+        return null;
+    }
+
+    return { lat, lng };
+}
+
+function readExifValue(view, tiffOffset, entryOffset, type, count, littleEndian) {
+    const valueOffset = valueDataOffset(view, tiffOffset, entryOffset, type, count, littleEndian);
+    if (valueOffset === null) {
+        return null;
+    }
+
+    switch (type) {
+        case 3:
+            return view.getUint16(valueOffset, littleEndian);
+        case 4:
+            return view.getUint32(valueOffset, littleEndian);
+        default:
+            return view.getUint32(entryOffset + 8, littleEndian);
+    }
+}
+
+function valueDataOffset(view, tiffOffset, entryOffset, type, count, littleEndian) {
+    const typeSize = { 1: 1, 2: 1, 3: 2, 4: 4, 5: 8, 7: 1 }[type];
+    if (!typeSize) {
+        return null;
+    }
+
+    const byteLength = typeSize * count;
+    const offset = byteLength <= 4
+        ? entryOffset + 8
+        : tiffOffset + view.getUint32(entryOffset + 8, littleEndian);
+    return offset >= 0 && offset + byteLength <= view.byteLength ? offset : null;
+}
+
+function readRationals(view, offset, count, littleEndian) {
+    const values = [];
+    for (let i = 0; i < count; i++) {
+        const itemOffset = offset + i * 8;
+        if (itemOffset + 8 > view.byteLength) {
+            return null;
+        }
+
+        const numerator = view.getUint32(itemOffset, littleEndian);
+        const denominator = view.getUint32(itemOffset + 4, littleEndian);
+        if (denominator === 0) {
+            return null;
+        }
+
+        values.push(numerator / denominator);
+    }
+    return values;
+}
+
+function dmsToDecimal(values) {
+    return values[0] + values[1] / 60 + values[2] / 3600;
+}
+
+function readAscii(view, offset, length) {
+    let value = "";
+    const end = Math.min(offset + length, view.byteLength);
+    for (let i = offset; i < end; i++) {
+        value += String.fromCharCode(view.getUint8(i));
+    }
+    return value;
+}

--- a/src/OvcinaHra.Client/wwwroot/js/image-resize-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/image-resize-interop.js
@@ -53,9 +53,6 @@ window.ovcinaImageResize.fromBase64 = async function (dataUrl, maxDim, quality) 
 
 window.ovcinaExif = window.ovcinaExif || {};
 
-const GPS_DRIFT_THRESHOLD_M = 50;
-window.ovcinaExif.gpsDriftThresholdMeters = GPS_DRIFT_THRESHOLD_M;
-
 window.ovcinaExif.haversineMeters = function (lat1, lng1, lat2, lng2) {
     const toRad = value => value * Math.PI / 180;
     const earthRadiusMeters = 6371000;


### PR DESCRIPTION
## Summary
- Adds separate `Vyfotit` and `Z galerie` choices to the mobile location-placement wizard, keeping `capture="environment"` only on the camera path.
- Reads EXIF GPS from the original photo before canvas resize, prompts when the photo GPS is missing from the location or differs by more than 50 m, and PATCHes `/api/locations/{id}/coordinates` on acceptance.
- Keeps permanent `[loc-placement]` diagnostics for source taps, EXIF outcomes, GPS prompt decisions, and GPS PATCH results.

## Verification
- `node --check src/OvcinaHra.Client/wwwroot/js/image-resize-interop.js`
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test OvcinaHra.slnx --no-build`

closes #410