### PR TITLE
feat(api): server-side timing markers across critical endpoints

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ExportEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ExportEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
@@ -24,6 +25,7 @@ public static class ExportEndpoints
         int gameId,
         string? style,
         IExplorerMapExportService exporter,
+        HttpContext http,
         ILoggerFactory loggerFactory,
         CancellationToken ct) =>
         DownloadMapPdf(
@@ -33,7 +35,7 @@ public static class ExportEndpoints
             MapExportPageFormat.A4Portrait,
             organizerOnly: false,
             exporter,
-            null,
+            http,
             loggerFactory,
             ct);
 
@@ -59,6 +61,7 @@ public static class ExportEndpoints
         int gameId,
         string? style,
         IExplorerMapExportService exporter,
+        HttpContext http,
         ILoggerFactory loggerFactory,
         CancellationToken ct) =>
         DownloadMapPdf(
@@ -68,7 +71,7 @@ public static class ExportEndpoints
             MapExportPageFormat.A3Portrait,
             organizerOnly: false,
             exporter,
-            null,
+            http,
             loggerFactory,
             ct);
 
@@ -79,11 +82,20 @@ public static class ExportEndpoints
         MapExportPageFormat pageFormat,
         bool organizerOnly,
         IExplorerMapExportService exporter,
-        HttpContext? http,
+        HttpContext http,
         ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.ExportEndpoints");
+        var timer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[export-server] entry method={Method} path={Path} gameId={GameId} kind={Kind} pageFormat={PageFormat} styleRaw={StyleRaw}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId,
+            kind,
+            pageFormat,
+            style);
         logger.LogInformation(
             "[map-export-pr3] export endpoint entry gameId={GameId} kind={Kind} pageFormat={PageFormat} styleRaw={StyleRaw}",
             gameId,
@@ -92,10 +104,29 @@ public static class ExportEndpoints
             style);
 
         if (!TryParseStyle(style, out var parsedStyle))
-            return TypedResults.BadRequest(ValidationProblem("Neznámý podklad mapy."));
-
-        if (organizerOnly && (http?.User is null || !IsOrganizer(http.User)))
         {
+            timer.Stop();
+            logger.LogInformation(
+                "[export-server] exit method={Method} path={Path} gameId={GameId} kind={Kind} status=bad-request elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                kind,
+                timer.ElapsedMilliseconds,
+                "unknown-style");
+            return TypedResults.BadRequest(ValidationProblem("Neznámý podklad mapy."));
+        }
+
+        if (organizerOnly && !IsOrganizer(http.User))
+        {
+            timer.Stop();
+            logger.LogInformation(
+                "[export-server] exit method={Method} path={Path} gameId={GameId} kind={Kind} status=forbidden elapsedMs={ElapsedMs}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                kind,
+                timer.ElapsedMilliseconds);
             logger.LogWarning(
                 "[map-export-pr3] export auth-gate denial gameId={GameId} kind={Kind}",
                 gameId,
@@ -109,6 +140,16 @@ public static class ExportEndpoints
         try
         {
             var pdf = await exporter.RenderMapAsync(gameId, parsedStyle, kind, pageFormat, ct);
+            timer.Stop();
+            logger.LogInformation(
+                "[export-server] exit method={Method} path={Path} gameId={GameId} kind={Kind} status=file fileName={FileName} bytes={ByteCount} elapsedMs={ElapsedMs}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                kind,
+                pdf.FileName,
+                pdf.Bytes.Length,
+                timer.ElapsedMilliseconds);
             logger.LogInformation(
                 "[map-export-pr3] export endpoint exit gameId={GameId} kind={Kind} status=file fileName={FileName} bytes={ByteCount}",
                 gameId,
@@ -122,6 +163,14 @@ public static class ExportEndpoints
         }
         catch (KeyNotFoundException)
         {
+            timer.Stop();
+            logger.LogInformation(
+                "[export-server] exit method={Method} path={Path} gameId={GameId} kind={Kind} status=not-found elapsedMs={ElapsedMs}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                kind,
+                timer.ElapsedMilliseconds);
             logger.LogInformation(
                 "[map-export-pr3] export endpoint exit gameId={GameId} kind={Kind} status=not-found",
                 gameId,
@@ -130,18 +179,61 @@ public static class ExportEndpoints
         }
         catch (MapExportProblemException ex)
         {
+            timer.Stop();
+            logger.LogInformation(
+                "[export-server] exit method={Method} path={Path} gameId={GameId} kind={Kind} status=bad-request elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                kind,
+                timer.ElapsedMilliseconds,
+                ex.Detail);
             return TypedResults.BadRequest(ValidationProblem(ex.Title, ex.Detail));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            timer.Stop();
+            logger.LogError(
+                ex,
+                "[export-server] exception method={Method} path={Path} gameId={GameId} kind={Kind} elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                kind,
+                timer.ElapsedMilliseconds,
+                ex.Message);
+            throw;
         }
     }
 
     private static async Task<Results<FileContentHttpResult, NotFound, BadRequest<ProblemDetails>>> DownloadMagicBookPdf(
         int gameId,
         IMagicBookExportService exporter,
+        HttpContext http,
+        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.ExportEndpoints");
+        var timer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[export-server] entry method={Method} path={Path} gameId={GameId} kind={Kind}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId,
+            "MagicBook");
         try
         {
             var pdf = await exporter.RenderMagicBookAsync(gameId, ct);
+            timer.Stop();
+            logger.LogInformation(
+                "[export-server] exit method={Method} path={Path} gameId={GameId} kind={Kind} status=file fileName={FileName} bytes={ByteCount} elapsedMs={ElapsedMs}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                "MagicBook",
+                pdf.FileName,
+                pdf.Bytes.Length,
+                timer.ElapsedMilliseconds);
             return TypedResults.File(
                 pdf.Bytes,
                 contentType: "application/pdf",
@@ -149,11 +241,42 @@ public static class ExportEndpoints
         }
         catch (KeyNotFoundException)
         {
+            timer.Stop();
+            logger.LogInformation(
+                "[export-server] exit method={Method} path={Path} gameId={GameId} kind={Kind} status=not-found elapsedMs={ElapsedMs}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                "MagicBook",
+                timer.ElapsedMilliseconds);
             return TypedResults.NotFound();
         }
         catch (MagicBookExportProblemException ex)
         {
+            timer.Stop();
+            logger.LogInformation(
+                "[export-server] exit method={Method} path={Path} gameId={GameId} kind={Kind} status=bad-request elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                "MagicBook",
+                timer.ElapsedMilliseconds,
+                ex.Detail);
             return TypedResults.BadRequest(ValidationProblem(ex.Title, ex.Detail));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            timer.Stop();
+            logger.LogError(
+                ex,
+                "[export-server] exception method={Method} path={Path} gameId={GameId} kind={Kind} elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                "MagicBook",
+                timer.ElapsedMilliseconds,
+                ex.Message);
+            throw;
         }
     }
 

--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -16,6 +16,8 @@ public static class ImageEndpoints
     // Location.Id. They write Location.StampImagePath / PlacementPhotoPath but
     // keep independent thumbnail cache keys from the main location image.
     private static readonly HashSet<string> ValidEntityTypes = ["locations", "locationstamps", "locationplacements", "items", "monsters", "secretstashes", "npcs", "buildings", "characters", "kingdoms", "spells", "quests"];
+    private static readonly HashSet<string> ServerTimedImageUploadEntityTypes =
+        new(StringComparer.Ordinal) { "locations", "locationstamps", "items", "npcs", "kingdoms" };
     private static readonly HashSet<string> AllowedContentTypes = ["image/jpeg", "image/png", "image/webp"];
     private const long MaxFileSize = 5 * 1024 * 1024; // 5 MB
     private const int LocationStampMinimumPixels = 200;
@@ -122,8 +124,23 @@ public static class ImageEndpoints
         var isLegacyLocationPlacement = string.Equals(entityType, "locations", StringComparison.Ordinal)
             && string.Equals(field, "placement", StringComparison.OrdinalIgnoreCase);
         var isPlacementUpload = isLocationPlacement || isLegacyLocationPlacement;
+        var isServerTimedImageUpload = !isPlacementUpload && ServerTimedImageUploadEntityTypes.Contains(entityType);
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.ImageEndpoints");
         var userId = GetUserId(http.User);
+        var serverTimer = Stopwatch.StartNew();
+        if (isServerTimedImageUpload)
+        {
+            logger.LogInformation(
+                "[image-upload-server] image.upload.entry method={Method} path={Path} entityType={EntityType} entityId={EntityId} userId={UserId} size={Size} contentType={ContentType} field={Field}",
+                http.Request.Method,
+                http.Request.Path,
+                entityType,
+                entityId,
+                userId,
+                file.Length,
+                file.ContentType,
+                field);
+        }
         if (isPlacementUpload)
         {
             logger.LogInformation(
@@ -149,24 +166,28 @@ public static class ImageEndpoints
             if (!ValidEntityTypes.Contains(entityType))
             {
                 LogPlacementImageExit(logger, isPlacementUpload, entityId, gameId, userId, 400, detail: $"invalid-entity-type:{entityType}");
+                LogImageUploadServerExit(logger, isServerTimedImageUpload, http, entityType, entityId, userId, serverTimer, 400, detail: $"invalid-entity-type:{entityType}");
                 return TypedResults.BadRequest(ImageValidationProblem($"Neplatný typ entity '{entityType}'."));
             }
 
             if (file.Length > MaxFileSize)
             {
                 LogPlacementImageExit(logger, isPlacementUpload, entityId, gameId, userId, 400, detail: "file-too-large");
+                LogImageUploadServerExit(logger, isServerTimedImageUpload, http, entityType, entityId, userId, serverTimer, 400, detail: "file-too-large");
                 return TypedResults.BadRequest(ImageValidationProblem($"Soubor je příliš velký. Maximální velikost je {MaxFileSize / (1024 * 1024)} MB."));
             }
 
             if (!AllowedContentTypes.Contains(file.ContentType))
             {
                 LogPlacementImageExit(logger, isPlacementUpload, entityId, gameId, userId, 400, detail: $"invalid-content-type:{file.ContentType}");
+                LogImageUploadServerExit(logger, isServerTimedImageUpload, http, entityType, entityId, userId, serverTimer, 400, detail: $"invalid-content-type:{file.ContentType}");
                 return TypedResults.BadRequest(ImageValidationProblem($"Neplatný typ souboru '{file.ContentType}'. Povolené typy: {string.Join(", ", AllowedContentTypes)}."));
             }
 
             if (!await EntityExists(db, entityType, entityId))
             {
                 LogPlacementImageExit(logger, isPlacementUpload, entityId, gameId, userId, 404, detail: "entity-not-found");
+                LogImageUploadServerExit(logger, isServerTimedImageUpload, http, entityType, entityId, userId, serverTimer, 404, detail: "entity-not-found");
                 return TypedResults.NotFound();
             }
 
@@ -188,6 +209,7 @@ public static class ImageEndpoints
                 if (validationProblem is not null)
                 {
                     LogPlacementImageExit(logger, isPlacementUpload, entityId, gameId, userId, 400, blobKey, detail: "stamp-validation-failed");
+                    LogImageUploadServerExit(logger, isServerTimedImageUpload, http, entityType, entityId, userId, serverTimer, 400, blobKey, detail: "stamp-validation-failed");
                     return TypedResults.BadRequest(validationProblem);
                 }
             }
@@ -198,6 +220,14 @@ public static class ImageEndpoints
             {
                 logger.LogInformation(
                     "[loc-placement-server] image.upload.blob-write.attempt locationId={LocationId} blobKey={BlobKey}",
+                    entityId,
+                    blobKey);
+            }
+            if (isServerTimedImageUpload)
+            {
+                logger.LogInformation(
+                    "[image-upload-server] image.upload.blob-write.attempt entityType={EntityType} entityId={EntityId} blobKey={BlobKey}",
+                    entityType,
                     entityId,
                     blobKey);
             }
@@ -214,6 +244,15 @@ public static class ImageEndpoints
                         blobKey,
                         blobWriteTimer.ElapsedMilliseconds);
                 }
+                if (isServerTimedImageUpload)
+                {
+                    logger.LogInformation(
+                        "[image-upload-server] image.upload.blob-write.ok entityType={EntityType} entityId={EntityId} blobKey={BlobKey} elapsedMs={ElapsedMs}",
+                        entityType,
+                        entityId,
+                        blobKey,
+                        blobWriteTimer.ElapsedMilliseconds);
+                }
             }
             catch (Exception ex) when (isPlacementUpload && ex is not OperationCanceledException)
             {
@@ -221,6 +260,18 @@ public static class ImageEndpoints
                 logger.LogError(
                     ex,
                     "[loc-placement-server] image.upload.blob-write.failed locationId={LocationId} blobKey={BlobKey} detail={Detail}",
+                    entityId,
+                    blobKey,
+                    ex.Message);
+                throw;
+            }
+            catch (Exception ex) when (isServerTimedImageUpload && ex is not OperationCanceledException)
+            {
+                blobWriteTimer.Stop();
+                logger.LogError(
+                    ex,
+                    "[image-upload-server] image.upload.blob-write.failed entityType={EntityType} entityId={EntityId} blobKey={BlobKey} detail={Detail}",
+                    entityType,
                     entityId,
                     blobKey,
                     ex.Message);
@@ -263,6 +314,15 @@ public static class ImageEndpoints
                     entityId,
                     "PlacementPhotoPath");
             }
+            if (isServerTimedImageUpload)
+            {
+                logger.LogInformation(
+                    "[image-upload-server] image.upload.db-update.attempt entityType={EntityType} entityId={EntityId} field={Field} blobKey={BlobKey}",
+                    entityType,
+                    entityId,
+                    isPlacement ? "PlacementPhotoPath" : "ImagePath",
+                    blobKey);
+            }
             int rowsAffected;
             try
             {
@@ -274,12 +334,30 @@ public static class ImageEndpoints
                         entityId,
                         rowsAffected);
                 }
+                if (isServerTimedImageUpload)
+                {
+                    logger.LogInformation(
+                        "[image-upload-server] image.upload.db-update.ok entityType={EntityType} entityId={EntityId} rowsAffected={RowsAffected}",
+                        entityType,
+                        entityId,
+                        rowsAffected);
+                }
             }
             catch (Exception ex) when (isPlacementUpload && ex is not OperationCanceledException)
             {
                 logger.LogError(
                     ex,
                     "[loc-placement-server] image.upload.db-update.failed locationId={LocationId} detail={Detail}",
+                    entityId,
+                    ex.Message);
+                throw;
+            }
+            catch (Exception ex) when (isServerTimedImageUpload && ex is not OperationCanceledException)
+            {
+                logger.LogError(
+                    ex,
+                    "[image-upload-server] image.upload.db-update.failed entityType={EntityType} entityId={EntityId} detail={Detail}",
+                    entityType,
                     entityId,
                     ex.Message);
                 throw;
@@ -297,6 +375,7 @@ public static class ImageEndpoints
                     url);
             }
             LogPlacementImageExit(logger, isPlacementUpload, entityId, gameId, userId, 200, blobKey, url);
+            LogImageUploadServerExit(logger, isServerTimedImageUpload, http, entityType, entityId, userId, serverTimer, 200, blobKey);
             return TypedResults.Ok(new ImageUploadResult(blobKey, url));
         }
         catch (Exception ex) when (isPlacementUpload && ex is not OperationCanceledException)
@@ -315,6 +394,19 @@ public static class ImageEndpoints
                 entityId,
                 ex.Message);
             LogPlacementImageExit(logger, isPlacementUpload, entityId, gameId, userId, 500, detail: ex.Message);
+            throw;
+        }
+        catch (Exception ex) when (isServerTimedImageUpload && ex is not OperationCanceledException)
+        {
+            logger.LogError(
+                ex,
+                "[image-upload-server] image.upload.exception method={Method} path={Path} entityType={EntityType} entityId={EntityId} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                entityType,
+                entityId,
+                ex.Message);
+            LogImageUploadServerExit(logger, isServerTimedImageUpload, http, entityType, entityId, userId, serverTimer, 500, detail: ex.Message);
             throw;
         }
     }
@@ -673,6 +765,34 @@ public static class ImageEndpoints
             status,
             imageBlobKey,
             imageBlobUrl,
+            detail);
+    }
+
+    private static void LogImageUploadServerExit(
+        ILogger logger,
+        bool isServerTimedImageUpload,
+        HttpContext http,
+        string entityType,
+        int entityId,
+        string userId,
+        Stopwatch serverTimer,
+        int status,
+        string? imageBlobKey = null,
+        string? detail = null)
+    {
+        if (!isServerTimedImageUpload) return;
+
+        serverTimer.Stop();
+        logger.LogInformation(
+            "[image-upload-server] image.upload.exit method={Method} path={Path} entityType={EntityType} entityId={EntityId} userId={UserId} status={Status} imageBlobKey={ImageBlobKey} elapsedMs={ElapsedMs} detail={Detail}",
+            http.Request.Method,
+            http.Request.Path,
+            entityType,
+            entityId,
+            userId,
+            status,
+            imageBlobKey,
+            serverTimer.ElapsedMilliseconds,
             detail);
     }
 

--- a/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
+using System.Diagnostics;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Dtos;
@@ -96,80 +97,145 @@ public static class OrganizerRoleEndpoints
         BulkOrganizerRoleAssignmentDto dto,
         WorldDbContext db,
         ILoggerFactory loggerFactory,
+        HttpContext http,
         CancellationToken ct)
     {
         var logger = loggerFactory.CreateLogger(LoggerCategory);
-        var validation = await ValidateAssignmentTargetAsync(
+        var serverTimer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[organizer-roles-server] entry method={Method} path={Path} route=bulk-assign gameId={GameId} npcId={NpcId} personId={PersonId}",
+            http.Request.Method,
+            http.Request.Path,
             gameId,
             dto.NpcId,
-            dto.PersonId,
-            dto.PersonName,
-            dto.PersonEmail,
-            dto.Notes,
-            db,
-            ct);
-        if (validation is not null) return validation;
+            dto.PersonId);
 
-        var slotIds = await db.GameTimeSlots
-            .Where(s => s.GameId == gameId)
-            .OrderBy(s => s.StartTime)
-            .Select(s => s.Id)
-            .ToListAsync(ct);
-
-        if (slotIds.Count == 0)
+        void LogServerExit(string status, int? createdCount = null, int? updatedCount = null, string? detail = null)
         {
-            return Problem(
-                "Nejdřív vytvořte časové bloky v harmonogramu.",
-                "Hra nemá časové sloty",
-                StatusCodes.Status400BadRequest);
+            serverTimer.Stop();
+            logger.LogInformation(
+                "[organizer-roles-server] exit method={Method} path={Path} route=bulk-assign gameId={GameId} npcId={NpcId} personId={PersonId} status={Status} created={CreatedCount} updated={UpdatedCount} elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                dto.NpcId,
+                dto.PersonId,
+                status,
+                createdCount,
+                updatedCount,
+                serverTimer.ElapsedMilliseconds,
+                detail);
         }
 
-        var existing = await db.OrganizerRoleAssignments
-            .Where(a => a.GameId == gameId && a.NpcId == dto.NpcId && slotIds.Contains(a.GameTimeSlotId))
-            .ToDictionaryAsync(a => a.GameTimeSlotId, ct);
-
-        var now = DateTime.UtcNow;
-        var created = 0;
-        var updated = 0;
-        foreach (var slotId in slotIds)
+        try
         {
-            if (existing.TryGetValue(slotId, out var assignment))
+            var validation = await ValidateAssignmentTargetAsync(
+                gameId,
+                dto.NpcId,
+                dto.PersonId,
+                dto.PersonName,
+                dto.PersonEmail,
+                dto.Notes,
+                db,
+                ct);
+            if (validation is not null)
             {
-                assignment.PersonId = dto.PersonId;
-                assignment.PersonName = dto.PersonName.Trim();
-                assignment.PersonEmail = NullIfWhiteSpace(dto.PersonEmail);
-                assignment.Notes = NullIfWhiteSpace(dto.Notes);
-                assignment.UpdatedAtUtc = now;
-                updated++;
-                continue;
+                LogServerExit("validation");
+                return validation;
             }
 
-            db.OrganizerRoleAssignments.Add(new OrganizerRoleAssignment
+            var slotIds = await db.GameTimeSlots
+                .Where(s => s.GameId == gameId)
+                .OrderBy(s => s.StartTime)
+                .Select(s => s.Id)
+                .ToListAsync(ct);
+
+            if (slotIds.Count == 0)
             {
-                GameId = gameId,
-                GameTimeSlotId = slotId,
-                NpcId = dto.NpcId,
-                PersonId = dto.PersonId,
-                PersonName = dto.PersonName.Trim(),
-                PersonEmail = NullIfWhiteSpace(dto.PersonEmail),
-                Notes = NullIfWhiteSpace(dto.Notes),
-                CreatedAtUtc = now,
-                UpdatedAtUtc = now
-            });
-            created++;
+                LogServerExit("validation", detail: "no-slots");
+                return Problem(
+                    "Nejdřív vytvořte časové bloky v harmonogramu.",
+                    "Hra nemá časové sloty",
+                    StatusCodes.Status400BadRequest);
+            }
+
+            var existing = await db.OrganizerRoleAssignments
+                .Where(a => a.GameId == gameId && a.NpcId == dto.NpcId && slotIds.Contains(a.GameTimeSlotId))
+                .ToDictionaryAsync(a => a.GameTimeSlotId, ct);
+
+            var now = DateTime.UtcNow;
+            var created = 0;
+            var updated = 0;
+            foreach (var slotId in slotIds)
+            {
+                if (existing.TryGetValue(slotId, out var assignment))
+                {
+                    assignment.PersonId = dto.PersonId;
+                    assignment.PersonName = dto.PersonName.Trim();
+                    assignment.PersonEmail = NullIfWhiteSpace(dto.PersonEmail);
+                    assignment.Notes = NullIfWhiteSpace(dto.Notes);
+                    assignment.UpdatedAtUtc = now;
+                    updated++;
+                    continue;
+                }
+
+                db.OrganizerRoleAssignments.Add(new OrganizerRoleAssignment
+                {
+                    GameId = gameId,
+                    GameTimeSlotId = slotId,
+                    NpcId = dto.NpcId,
+                    PersonId = dto.PersonId,
+                    PersonName = dto.PersonName.Trim(),
+                    PersonEmail = NullIfWhiteSpace(dto.PersonEmail),
+                    Notes = NullIfWhiteSpace(dto.Notes),
+                    CreatedAtUtc = now,
+                    UpdatedAtUtc = now
+                });
+                created++;
+            }
+
+            logger.LogInformation(
+                "[organizer-roles-server] db-write.attempt route=bulk-assign gameId={GameId} npcId={NpcId} created={CreatedCount} updated={UpdatedCount}",
+                gameId,
+                dto.NpcId,
+                created,
+                updated);
+            var dbTimer = Stopwatch.StartNew();
+            await db.SaveChangesAsync(ct);
+            dbTimer.Stop();
+            logger.LogInformation(
+                "[organizer-roles-server] db-write.ok route=bulk-assign gameId={GameId} npcId={NpcId} elapsedMs={ElapsedMs}",
+                gameId,
+                dto.NpcId,
+                dbTimer.ElapsedMilliseconds);
+
+            var assignments = await LoadAssignmentsForNpcAsync(gameId, dto.NpcId, db, ct);
+            logger.LogInformation(
+                "[organizer-roles] bulk assigned gameId={GameId} npcId={NpcId} personId={PersonId} created={CreatedCount} updated={UpdatedCount}",
+                gameId,
+                dto.NpcId,
+                dto.PersonId,
+                created,
+                updated);
+
+            LogServerExit("ok", created, updated);
+            return TypedResults.Ok(new BulkOrganizerRoleAssignmentResultDto(created, updated, assignments));
         }
-
-        await db.SaveChangesAsync(ct);
-        var assignments = await LoadAssignmentsForNpcAsync(gameId, dto.NpcId, db, ct);
-        logger.LogInformation(
-            "[organizer-roles] bulk assigned gameId={GameId} npcId={NpcId} personId={PersonId} created={CreatedCount} updated={UpdatedCount}",
-            gameId,
-            dto.NpcId,
-            dto.PersonId,
-            created,
-            updated);
-
-        return TypedResults.Ok(new BulkOrganizerRoleAssignmentResultDto(created, updated, assignments));
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(
+                ex,
+                "[organizer-roles-server] exception method={Method} path={Path} route=bulk-assign gameId={GameId} npcId={NpcId} personId={PersonId} elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                dto.NpcId,
+                dto.PersonId,
+                serverTimer.ElapsedMilliseconds,
+                ex.Message);
+            LogServerExit("exception", detail: ex.Message);
+            throw;
+        }
     }
 
     private static async Task<Results<Ok<OrganizerRoleAssignmentDto>, NotFound, ProblemHttpResult>> UpsertSlotAssignment(
@@ -179,59 +245,127 @@ public static class OrganizerRoleEndpoints
         UpsertOrganizerRoleAssignmentDto dto,
         WorldDbContext db,
         ILoggerFactory loggerFactory,
+        HttpContext http,
         CancellationToken ct)
     {
         var logger = loggerFactory.CreateLogger(LoggerCategory);
-        var validation = await ValidateAssignmentTargetAsync(
-            gameId,
-            npcId,
-            dto.PersonId,
-            dto.PersonName,
-            dto.PersonEmail,
-            dto.Notes,
-            db,
-            ct,
-            slotId);
-        if (validation is not null) return validation;
-
-        var existing = await db.OrganizerRoleAssignments
-            .SingleOrDefaultAsync(a => a.GameId == gameId && a.GameTimeSlotId == slotId && a.NpcId == npcId, ct);
-
-        var now = DateTime.UtcNow;
-        if (existing is null)
-        {
-            existing = new OrganizerRoleAssignment
-            {
-                GameId = gameId,
-                GameTimeSlotId = slotId,
-                NpcId = npcId,
-                PersonId = dto.PersonId,
-                PersonName = dto.PersonName.Trim(),
-                PersonEmail = NullIfWhiteSpace(dto.PersonEmail),
-                Notes = NullIfWhiteSpace(dto.Notes),
-                CreatedAtUtc = now,
-                UpdatedAtUtc = now
-            };
-            db.OrganizerRoleAssignments.Add(existing);
-        }
-        else
-        {
-            existing.PersonId = dto.PersonId;
-            existing.PersonName = dto.PersonName.Trim();
-            existing.PersonEmail = NullIfWhiteSpace(dto.PersonEmail);
-            existing.Notes = NullIfWhiteSpace(dto.Notes);
-            existing.UpdatedAtUtc = now;
-        }
-
-        await db.SaveChangesAsync(ct);
+        var serverTimer = Stopwatch.StartNew();
         logger.LogInformation(
-            "[organizer-roles] slot assigned gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId}",
+            "[organizer-roles-server] entry method={Method} path={Path} route=slot-assign gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId}",
+            http.Request.Method,
+            http.Request.Path,
             gameId,
             slotId,
             npcId,
             dto.PersonId);
 
-        return TypedResults.Ok(ToDto(existing));
+        void LogServerExit(string status, string? operation = null, string? detail = null)
+        {
+            serverTimer.Stop();
+            logger.LogInformation(
+                "[organizer-roles-server] exit method={Method} path={Path} route=slot-assign gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId} operation={Operation} status={Status} elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                slotId,
+                npcId,
+                dto.PersonId,
+                operation,
+                status,
+                serverTimer.ElapsedMilliseconds,
+                detail);
+        }
+
+        try
+        {
+            var validation = await ValidateAssignmentTargetAsync(
+                gameId,
+                npcId,
+                dto.PersonId,
+                dto.PersonName,
+                dto.PersonEmail,
+                dto.Notes,
+                db,
+                ct,
+                slotId);
+            if (validation is not null)
+            {
+                LogServerExit("validation");
+                return validation;
+            }
+
+            var existing = await db.OrganizerRoleAssignments
+                .SingleOrDefaultAsync(a => a.GameId == gameId && a.GameTimeSlotId == slotId && a.NpcId == npcId, ct);
+
+            var operation = existing is null ? "create" : "update";
+            var now = DateTime.UtcNow;
+            if (existing is null)
+            {
+                existing = new OrganizerRoleAssignment
+                {
+                    GameId = gameId,
+                    GameTimeSlotId = slotId,
+                    NpcId = npcId,
+                    PersonId = dto.PersonId,
+                    PersonName = dto.PersonName.Trim(),
+                    PersonEmail = NullIfWhiteSpace(dto.PersonEmail),
+                    Notes = NullIfWhiteSpace(dto.Notes),
+                    CreatedAtUtc = now,
+                    UpdatedAtUtc = now
+                };
+                db.OrganizerRoleAssignments.Add(existing);
+            }
+            else
+            {
+                existing.PersonId = dto.PersonId;
+                existing.PersonName = dto.PersonName.Trim();
+                existing.PersonEmail = NullIfWhiteSpace(dto.PersonEmail);
+                existing.Notes = NullIfWhiteSpace(dto.Notes);
+                existing.UpdatedAtUtc = now;
+            }
+
+            logger.LogInformation(
+                "[organizer-roles-server] db-write.attempt route=slot-assign gameId={GameId} slotId={SlotId} npcId={NpcId} operation={Operation}",
+                gameId,
+                slotId,
+                npcId,
+                operation);
+            var dbTimer = Stopwatch.StartNew();
+            await db.SaveChangesAsync(ct);
+            dbTimer.Stop();
+            logger.LogInformation(
+                "[organizer-roles-server] db-write.ok route=slot-assign gameId={GameId} slotId={SlotId} npcId={NpcId} operation={Operation} elapsedMs={ElapsedMs}",
+                gameId,
+                slotId,
+                npcId,
+                operation,
+                dbTimer.ElapsedMilliseconds);
+            logger.LogInformation(
+                "[organizer-roles] slot assigned gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId}",
+                gameId,
+                slotId,
+                npcId,
+                dto.PersonId);
+
+            LogServerExit("ok", operation);
+            return TypedResults.Ok(ToDto(existing));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(
+                ex,
+                "[organizer-roles-server] exception method={Method} path={Path} route=slot-assign gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId} elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                slotId,
+                npcId,
+                dto.PersonId,
+                serverTimer.ElapsedMilliseconds,
+                ex.Message);
+            LogServerExit("exception", detail: ex.Message);
+            throw;
+        }
     }
 
     private static async Task<Results<NoContent, NotFound>> DeleteSlotAssignment(
@@ -240,23 +374,88 @@ public static class OrganizerRoleEndpoints
         int npcId,
         WorldDbContext db,
         ILoggerFactory loggerFactory,
+        HttpContext http,
         CancellationToken ct)
     {
-        var assignment = await db.OrganizerRoleAssignments
-            .SingleOrDefaultAsync(a => a.GameId == gameId && a.GameTimeSlotId == slotId && a.NpcId == npcId, ct);
-        if (assignment is null) return TypedResults.NotFound();
-
-        db.OrganizerRoleAssignments.Remove(assignment);
-        await db.SaveChangesAsync(ct);
-
-        loggerFactory.CreateLogger(LoggerCategory).LogInformation(
-            "[organizer-roles] slot unassigned gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId}",
+        var logger = loggerFactory.CreateLogger(LoggerCategory);
+        var serverTimer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[organizer-roles-server] entry method={Method} path={Path} route=slot-remove gameId={GameId} slotId={SlotId} npcId={NpcId}",
+            http.Request.Method,
+            http.Request.Path,
             gameId,
             slotId,
-            npcId,
-            assignment.PersonId);
+            npcId);
 
-        return TypedResults.NoContent();
+        void LogServerExit(string status, int? personId = null, string? detail = null)
+        {
+            serverTimer.Stop();
+            logger.LogInformation(
+                "[organizer-roles-server] exit method={Method} path={Path} route=slot-remove gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId} status={Status} elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                slotId,
+                npcId,
+                personId,
+                status,
+                serverTimer.ElapsedMilliseconds,
+                detail);
+        }
+
+        try
+        {
+            var assignment = await db.OrganizerRoleAssignments
+                .SingleOrDefaultAsync(a => a.GameId == gameId && a.GameTimeSlotId == slotId && a.NpcId == npcId, ct);
+            if (assignment is null)
+            {
+                LogServerExit("not-found");
+                return TypedResults.NotFound();
+            }
+
+            db.OrganizerRoleAssignments.Remove(assignment);
+            logger.LogInformation(
+                "[organizer-roles-server] db-write.attempt route=slot-remove gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId}",
+                gameId,
+                slotId,
+                npcId,
+                assignment.PersonId);
+            var dbTimer = Stopwatch.StartNew();
+            await db.SaveChangesAsync(ct);
+            dbTimer.Stop();
+            logger.LogInformation(
+                "[organizer-roles-server] db-write.ok route=slot-remove gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId} elapsedMs={ElapsedMs}",
+                gameId,
+                slotId,
+                npcId,
+                assignment.PersonId,
+                dbTimer.ElapsedMilliseconds);
+
+            logger.LogInformation(
+                "[organizer-roles] slot unassigned gameId={GameId} slotId={SlotId} npcId={NpcId} personId={PersonId}",
+                gameId,
+                slotId,
+                npcId,
+                assignment.PersonId);
+
+            LogServerExit("no-content", assignment.PersonId);
+            return TypedResults.NoContent();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(
+                ex,
+                "[organizer-roles-server] exception method={Method} path={Path} route=slot-remove gameId={GameId} slotId={SlotId} npcId={NpcId} elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                slotId,
+                npcId,
+                serverTimer.ElapsedMilliseconds,
+                ex.Message);
+            LogServerExit("exception", detail: ex.Message);
+            throw;
+        }
     }
 
     private static async Task<ProblemHttpResult?> ValidateAssignmentTargetAsync(

--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
@@ -282,9 +283,11 @@ public static class TreasurePlanningEndpoints
     private static async Task<Results<Created<TreasureQuestDetailDto>, ValidationProblem>> AssignTreasure(
         AssignTreasureDto dto,
         WorldDbContext db,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        HttpContext http)
     {
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
+        var serverTimer = Stopwatch.StartNew();
         var poolAssignments = dto.PoolItems?
             .GroupBy(p => p.TreasureItemId)
             .Select(g => new PoolItemAssignDto(g.Key, g.Sum(p => p.Count)))
@@ -305,6 +308,31 @@ public static class TreasurePlanningEndpoints
             poolUnits = poolAssignments.Sum(p => p.Count),
             unlimitedCount
         });
+        logger.LogInformation(
+            "[treasure-alloc-server] entry method={Method} path={Path} gameId={GameId} targetLocationId={LocationId} targetSecretStashId={SecretStashId} kind={Kind} poolRows={PoolRows} poolUnits={PoolUnits} unlimitedRows={UnlimitedRows}",
+            http.Request.Method,
+            http.Request.Path,
+            dto.GameId,
+            dto.LocationId,
+            dto.SecretStashId,
+            isComposite ? "composite" : "single",
+            poolCount,
+            poolAssignments.Sum(p => p.Count),
+            unlimitedCount);
+
+        void LogAssignExit(string status, string? detail = null, int? questId = null)
+        {
+            serverTimer.Stop();
+            logger.LogInformation(
+                "[treasure-alloc-server] exit method={Method} path={Path} gameId={GameId} status={Status} questId={QuestId} elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                dto.GameId,
+                status,
+                questId,
+                serverTimer.ElapsedMilliseconds,
+                detail);
+        }
 
         // Validate XOR
         if ((dto.LocationId is null) == (dto.SecretStashId is null))
@@ -316,6 +344,7 @@ public static class TreasurePlanningEndpoints
                 dto.LocationId,
                 dto.SecretStashId
             });
+            LogAssignExit("validation", "location-stash-xor");
             return TypedResults.ValidationProblem(new Dictionary<string, string[]>
             {
                 ["LocationId"] = ["Musí být vyplněna buď lokace, nebo tajná skrýš (ne obojí)."]
@@ -331,6 +360,7 @@ public static class TreasurePlanningEndpoints
                 poolAssignmentRows = poolAssignments.Count,
                 legacyPoolRows = legacyPoolItemIds.Count
             });
+            LogAssignExit("validation", "mixed-pool-contracts");
             return TypedResults.ValidationProblem(new Dictionary<string, string[]>
             {
                 ["PoolItems"] = ["Použijte buď položky s počtem, nebo starý seznam položek — ne obojí."]
@@ -355,6 +385,7 @@ public static class TreasurePlanningEndpoints
                     dto.GameId,
                     missing
                 });
+                LogAssignExit("validation", "pool-item-missing");
                 return TypedResults.ValidationProblem(new Dictionary<string, string[]>
                 {
                     ["PoolItems"] = ["Některé položky už nejsou v zásobníku."]
@@ -374,6 +405,7 @@ public static class TreasurePlanningEndpoints
                         requested = assignment.Count,
                         available = poolItem.Count
                     });
+                    LogAssignExit("validation", "pool-count-out-of-range");
                     return TypedResults.ValidationProblem(new Dictionary<string, string[]>
                     {
                         ["PoolItems"] = [$"Počet pro {poolItem.Item.Name} musí být mezi 1 a {poolItem.Count}."]
@@ -390,6 +422,7 @@ public static class TreasurePlanningEndpoints
                         requested = assignment.Count,
                         available = poolItem.Count
                     });
+                    LogAssignExit("validation", "unique-partial-count");
                     return TypedResults.ValidationProblem(new Dictionary<string, string[]>
                     {
                         ["PoolItems"] = [$"{poolItem.Item.Name} je unikátní předmět a musí se přiřadit celý."]
@@ -438,7 +471,17 @@ public static class TreasurePlanningEndpoints
                 SecretStashId = targetSecretStashId,
                 poolUnits = poolAssignments.Sum(p => p.Count)
             });
+            logger.LogInformation(
+                "[treasure-alloc-server] db-write.attempt route=assign phase=create-quest gameId={GameId}",
+                dto.GameId);
+            var createQuestSaveTimer = Stopwatch.StartNew();
             await db.SaveChangesAsync(); // get the ID
+            createQuestSaveTimer.Stop();
+            logger.LogInformation(
+                "[treasure-alloc-server] db-write.ok route=assign phase=create-quest gameId={GameId} questId={QuestId} elapsedMs={ElapsedMs}",
+                dto.GameId,
+                quest.Id,
+                createQuestSaveTimer.ElapsedMilliseconds);
 
             // Assign legacy pool items by moving the whole row.
             if (dto.TreasureItemIds is { Count: > 0 })
@@ -499,7 +542,18 @@ public static class TreasurePlanningEndpoints
                 poolUnits = poolAssignments.Sum(p => p.Count),
                 unlimitedCount
             });
+            logger.LogInformation(
+                "[treasure-alloc-server] db-write.attempt route=assign phase=attach-items gameId={GameId} questId={QuestId}",
+                dto.GameId,
+                quest.Id);
+            var attachItemsSaveTimer = Stopwatch.StartNew();
             await db.SaveChangesAsync();
+            attachItemsSaveTimer.Stop();
+            logger.LogInformation(
+                "[treasure-alloc-server] db-write.ok route=assign phase=attach-items gameId={GameId} questId={QuestId} elapsedMs={ElapsedMs}",
+                dto.GameId,
+                quest.Id,
+                attachItemsSaveTimer.ElapsedMilliseconds);
 
             // Reload with includes for response
             var loaded = await db.TreasureQuests
@@ -514,6 +568,7 @@ public static class TreasurePlanningEndpoints
                 dto.GameId,
                 itemCount = loaded.TreasureItems.Sum(ti => ti.Count)
             });
+            LogAssignExit("created", questId: quest.Id);
 
             return TypedResults.Created($"/api/treasure-quests/{quest.Id}",
                 new TreasureQuestDetailDto(
@@ -531,6 +586,15 @@ public static class TreasurePlanningEndpoints
                 poolCount,
                 unlimitedCount
             }, ex);
+            serverTimer.Stop();
+            logger.LogError(
+                ex,
+                "[treasure-alloc-server] exception method={Method} path={Path} gameId={GameId} elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                dto.GameId,
+                serverTimer.ElapsedMilliseconds,
+                ex.Message);
             throw;
         }
     }
@@ -606,9 +670,30 @@ public static class TreasurePlanningEndpoints
         int id,
         AdjustTreasureItemCountDto dto,
         WorldDbContext db,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        HttpContext http)
     {
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
+        var serverTimer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[treasure-alloc-server] entry method={Method} path={Path} route=count-adjust treasureItemId={TreasureItemId} delta={Delta} source={Source}",
+            http.Request.Method,
+            http.Request.Path,
+            id,
+            dto.Delta,
+            dto.Source);
+        void LogCountAdjustExit(string status, string? detail = null)
+        {
+            serverTimer.Stop();
+            logger.LogInformation(
+                "[treasure-alloc-server] exit method={Method} path={Path} route=count-adjust treasureItemId={TreasureItemId} status={Status} elapsedMs={ElapsedMs} detail={Detail}",
+                http.Request.Method,
+                http.Request.Path,
+                id,
+                status,
+                serverTimer.ElapsedMilliseconds,
+                detail);
+        }
         LogTreasureAlloc(logger, LogLevel.Information, "count-adjust-entry", new
         {
             treasureItemId = id,
@@ -622,6 +707,7 @@ public static class TreasurePlanningEndpoints
 
         if (item is null)
         {
+            LogCountAdjustExit("not-found");
             return TypedResults.NotFound();
         }
 
@@ -632,6 +718,7 @@ public static class TreasurePlanningEndpoints
                 reason = "zero-delta",
                 treasureItemId = id
             });
+            LogCountAdjustExit("validation", "zero-delta");
             return TypedResults.ValidationProblem(new Dictionary<string, string[]>
             {
                 ["Delta"] = ["Změna počtu nesmí být nula."]
@@ -645,6 +732,7 @@ public static class TreasurePlanningEndpoints
                 reason = "pool-row-not-target",
                 treasureItemId = id
             });
+            LogCountAdjustExit("validation", "pool-row-not-target");
             return TypedResults.ValidationProblem(new Dictionary<string, string[]>
             {
                 ["TreasureItemId"] = ["Počet lze upravovat jen u již umístěného pokladu."]
@@ -659,6 +747,7 @@ public static class TreasurePlanningEndpoints
                 treasureItemId = id,
                 item.ItemId
             });
+            LogCountAdjustExit("validation", "unique-item");
             return TypedResults.ValidationProblem(new Dictionary<string, string[]>
             {
                 ["TreasureItemId"] = ["Unikátní předmět nelze upravovat po kusech."]
@@ -677,6 +766,7 @@ public static class TreasurePlanningEndpoints
                     item.Count,
                     dto.Delta
                 });
+                LogCountAdjustExit("validation", "below-one");
                 return TypedResults.ValidationProblem(new Dictionary<string, string[]>
                 {
                     ["Delta"] = ["Počet pokladu nesmí klesnout pod 1."]
@@ -703,6 +793,7 @@ public static class TreasurePlanningEndpoints
                     requested = dto.Delta,
                     available
                 });
+                LogCountAdjustExit("validation", "not-enough-pool");
                 return TypedResults.ValidationProblem(new Dictionary<string, string[]>
                 {
                     ["Delta"] = [$"V zásobníku je už jen {available} kusů."]
@@ -732,7 +823,20 @@ public static class TreasurePlanningEndpoints
             item.Count,
             dto.Source
         });
+        logger.LogInformation(
+            "[treasure-alloc-server] db-write.attempt route=count-adjust treasureItemId={TreasureItemId} gameId={GameId} delta={Delta}",
+            id,
+            item.GameId,
+            dto.Delta);
+        var saveTimer = Stopwatch.StartNew();
         await db.SaveChangesAsync();
+        saveTimer.Stop();
+        logger.LogInformation(
+            "[treasure-alloc-server] db-write.ok route=count-adjust treasureItemId={TreasureItemId} gameId={GameId} delta={Delta} elapsedMs={ElapsedMs}",
+            id,
+            item.GameId,
+            dto.Delta,
+            saveTimer.ElapsedMilliseconds);
 
         LogTreasureAlloc(logger, LogLevel.Information, "count-adjust-success", new
         {
@@ -741,6 +845,7 @@ public static class TreasurePlanningEndpoints
             item.GameId,
             item.Count
         });
+        LogCountAdjustExit("ok");
 
         return TypedResults.Ok(new TreasureItemDto(item.Id, item.ItemId, item.Item.Name, item.Count, item.TreasureQuestId));
     }
@@ -815,12 +920,40 @@ public static class TreasurePlanningEndpoints
     /// or a fresh pool row is created. Items where allocations already exceed
     /// stock are skipped and listed in <see cref="RefillPoolResponse.OverAllocated"/>.
     /// </summary>
-    private static async Task<Ok<RefillPoolResponse>> RefillPool(int gameId, bool? dryRun, WorldDbContext db)
+    private static async Task<Ok<RefillPoolResponse>> RefillPool(
+        int gameId,
+        bool? dryRun,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory,
+        HttpContext http)
     {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
+        var serverTimer = Stopwatch.StartNew();
         // Optional preview mode — compute the same response shape without
         // persisting. UI fetches a preview before showing the confirm popup
         // so the user reviews exactly what will be added before committing.
         var preview = dryRun == true;
+        logger.LogInformation(
+            "[treasure-alloc-server] entry method={Method} path={Path} route=refill-pool gameId={GameId} preview={Preview}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId,
+            preview);
+
+        void LogRefillExit(string status, int added, int overAllocated)
+        {
+            serverTimer.Stop();
+            logger.LogInformation(
+                "[treasure-alloc-server] exit method={Method} path={Path} route=refill-pool gameId={GameId} preview={Preview} status={Status} itemsAdded={ItemsAdded} overAllocated={OverAllocated} elapsedMs={ElapsedMs}",
+                http.Request.Method,
+                http.Request.Path,
+                gameId,
+                preview,
+                status,
+                added,
+                overAllocated,
+                serverTimer.ElapsedMilliseconds);
+        }
 
         // Wrap the read-then-write in SERIALIZABLE so two concurrent refills
         // can't both compute `remaining` from the same allocation snapshot
@@ -841,6 +974,7 @@ public static class TreasurePlanningEndpoints
         if (gameItems.Count == 0)
         {
             await tx.CommitAsync();
+            LogRefillExit("no-items", 0, 0);
             return TypedResults.Ok(new RefillPoolResponse(0,
                 Array.Empty<RefillPoolItemDto>(), Array.Empty<RefillPoolOverAllocationDto>()));
         }
@@ -939,11 +1073,24 @@ public static class TreasurePlanningEndpoints
         if (preview)
         {
             await tx.RollbackAsync();
+            LogRefillExit("preview", added.Sum(a => a.Added), overAllocated.Count);
         }
         else
         {
+            logger.LogInformation(
+                "[treasure-alloc-server] db-write.attempt route=refill-pool gameId={GameId} itemRows={ItemRows}",
+                gameId,
+                added.Count);
+            var saveTimer = Stopwatch.StartNew();
             await db.SaveChangesAsync();
             await tx.CommitAsync();
+            saveTimer.Stop();
+            logger.LogInformation(
+                "[treasure-alloc-server] db-write.ok route=refill-pool gameId={GameId} itemRows={ItemRows} elapsedMs={ElapsedMs}",
+                gameId,
+                added.Count,
+                saveTimer.ElapsedMilliseconds);
+            LogRefillExit("ok", added.Sum(a => a.Added), overAllocated.Count);
         }
 
         return TypedResults.Ok(new RefillPoolResponse(


### PR DESCRIPTION
## Summary
- Add [export-server] entry/exit/exception timing around PDF export endpoints.
- Add [treasure-alloc-server] timing around treasure planning write flows.
- Add [image-upload-server] timing for non-placement uploads: locations, locationstamps, items, npcs, kingdoms.
- Add [organizer-roles-server] timing around bulk assign, slot assign, and slot remove.

Closes #419.

## Verification
- dotnet build OvcinaHra.slnx --no-restore
- dotnet test OvcinaHra.slnx --no-build
- Static marker inventory/no-spam check: new server markers are not in image GET/Delete, organizer matrix GET, or treasure pool Add/Remove sections.