### PR TITLE
#385 Rebuild stale-client force reload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,7 @@ jobs:
           build-args: |
             DEVEXPRESS_NUGET_SOURCE=${{ secrets.DEVEXPRESS_NUGET_SOURCE }}
             DEVEXPRESS_LICENSE_CONTENT=${{ secrets.DEVEXPRESS_LICENSE_CONTENT }}
+            GIT_SHA=${{ github.sha }}
 
       - name: Azure Login
         uses: azure/login@v2

--- a/src/OvcinaHra.Client/Components/VersionDriftBanner.razor
+++ b/src/OvcinaHra.Client/Components/VersionDriftBanner.razor
@@ -1,9 +1,13 @@
 @* Persistent strip rendered at the top of MainLayout when the server's
    /api/version commit no longer matches what we recorded at app boot.
    Click "Obnovit" → hard browser refresh through NavigationManager.Refresh. *@
+@using System.Globalization
+@using System.Text.Json.Serialization
+@using Microsoft.JSInterop
 @implements IDisposable
 @inject VersionDriftService Drift
 @inject NavigationManager Nav
+@inject IJSRuntime JS
 
 @if (Drift.IsDrifted)
 {
@@ -26,7 +30,10 @@
 @code {
     private bool _started;
     private bool reloading;
+    private bool _autoReloadAttempted;
     private string? _lastLoggedRenderState;
+    private static readonly TimeSpan AutoReloadCooldown = TimeSpan.FromSeconds(60);
+    private const string AutoReloadStorageKey = "last-force-reload-utc";
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -35,6 +42,7 @@
             _started = true;
             Drift.StateChanged += OnStateChanged;
             await Drift.StartAsync();
+            await TryBootAutoReloadAsync();
         }
 
         LogRenderState();
@@ -43,17 +51,112 @@
     private void OnStateChanged()
     {
         Console.WriteLine($"[version-refresh] banner state changed drifted={Drift.IsDrifted} baseline={Drift.BaselineCommit ?? "(null)"} latest={Drift.LatestCommit ?? "(null)"}");
-        _ = InvokeAsync(StateHasChanged);
+        _ = InvokeAsync(async () =>
+        {
+            await TryBootAutoReloadAsync();
+            StateHasChanged();
+        });
     }
 
-    private Task ReloadAsync()
+    private async Task ReloadAsync()
     {
-        if (reloading) return Task.CompletedTask;
+        if (reloading) return;
         reloading = true;
         Console.WriteLine($"[version-refresh] refresh clicked url={Nav.Uri} baseline={Drift.BaselineCommit ?? "(null)"} latest={Drift.LatestCommit ?? "(null)"}");
+        await UnregisterServiceWorkersAsync();
         Console.WriteLine("[version-refresh] reload requested method=NavigationManager.Refresh forceReload=True");
         Nav.Refresh(forceReload: true);
-        return Task.CompletedTask;
+    }
+
+    private async Task TryBootAutoReloadAsync()
+    {
+        if (!Drift.IsDrifted
+            || Drift.DriftReason != VersionDriftReason.Boot
+            || reloading
+            || _autoReloadAttempted)
+        {
+            return;
+        }
+
+        _autoReloadAttempted = true;
+        var now = DateTimeOffset.UtcNow;
+        var lastReload = await ReadLastAutoReloadUtcAsync();
+        var elapsed = lastReload is null ? (TimeSpan?)null : now - lastReload.Value;
+        var withinCooldown = elapsed is not null && elapsed < AutoReloadCooldown;
+        var elapsedLabel = elapsed is null ? "(none)" : $"{Math.Max(0, (int)elapsed.Value.TotalSeconds)}s";
+        Console.WriteLine($"[version-refresh] cooldown check lastReload={lastReload?.ToString("O", CultureInfo.InvariantCulture) ?? "(null)"} elapsed={elapsedLabel} within=60s result={withinCooldown}");
+
+        if (withinCooldown)
+        {
+            Console.WriteLine("[version-refresh] cooldown hit — skipping auto-reload");
+            return;
+        }
+
+        await WriteLastAutoReloadUtcAsync(now);
+        reloading = true;
+        StateHasChanged();
+
+        Console.WriteLine($"[version-refresh] auto-reload triggered drifted=true reason=boot baseline={Drift.BaselineCommit ?? "(null)"} latest={Drift.LatestCommit ?? "(null)"} route={Nav.Uri}");
+        await UnregisterServiceWorkersAsync();
+        Console.WriteLine("[version-refresh] reload requested method=NavigationManager.Refresh forceReload=True");
+        Nav.Refresh(forceReload: true);
+    }
+
+    private async Task<DateTimeOffset?> ReadLastAutoReloadUtcAsync()
+    {
+        try
+        {
+            var raw = await JS.InvokeAsync<string?>("sessionStorage.getItem", AutoReloadStorageKey);
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+
+            if (DateTimeOffset.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+            {
+                return parsed.ToUniversalTime();
+            }
+
+            Console.WriteLine($"[version-refresh] cooldown read invalid value={raw}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[version-refresh] cooldown read failed detail={SanitizeForLog(ex.Message)}");
+        }
+
+        return null;
+    }
+
+    private async Task WriteLastAutoReloadUtcAsync(DateTimeOffset value)
+    {
+        try
+        {
+            await JS.InvokeVoidAsync(
+                "sessionStorage.setItem",
+                AutoReloadStorageKey,
+                value.ToString("O", CultureInfo.InvariantCulture));
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[version-refresh] cooldown write failed detail={SanitizeForLog(ex.Message)}");
+        }
+    }
+
+    private async Task UnregisterServiceWorkersAsync()
+    {
+        try
+        {
+            var result = await JS.InvokeAsync<ServiceWorkerUnregisterResult>("ovcinaSw.unregisterAll");
+            Console.WriteLine($"[version-refresh] sw unregister attempted count={result.Count}");
+            Console.WriteLine($"[version-refresh] sw unregister result count={result.Count} successful={result.Successful} failed={result.Failed}");
+
+            if (result.Failed > 0)
+            {
+                Console.WriteLine($"[version-refresh] sw unregister failed detail={SanitizeForLog(result.Detail)}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("[version-refresh] sw unregister attempted count=unknown");
+            Console.WriteLine($"[version-refresh] sw unregister failed detail={SanitizeForLog(ex.Message)}");
+        }
     }
 
     private void LogRenderState()
@@ -64,6 +167,18 @@
         _lastLoggedRenderState = renderState;
         Console.WriteLine($"[version-refresh] banner render drifted={Drift.IsDrifted} baseline={Drift.BaselineCommit ?? "(null)"} latest={Drift.LatestCommit ?? "(null)"}");
     }
+
+    private static string SanitizeForLog(string? detail) =>
+        string.IsNullOrWhiteSpace(detail)
+            ? "(none)"
+            : detail.ReplaceLineEndings(" ");
+
+    private sealed record ServiceWorkerUnregisterResult(
+        [property: JsonPropertyName("supported")] bool Supported,
+        [property: JsonPropertyName("count")] int Count,
+        [property: JsonPropertyName("successful")] int Successful,
+        [property: JsonPropertyName("failed")] int Failed,
+        [property: JsonPropertyName("detail")] string? Detail);
 
     public void Dispose() => Drift.StateChanged -= OnStateChanged;
 }

--- a/src/OvcinaHra.Client/Dockerfile
+++ b/src/OvcinaHra.Client/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG DEVEXPRESS_NUGET_SOURCE
 ARG DEVEXPRESS_LICENSE_CONTENT
+ARG GIT_SHA=unknown
 WORKDIR /src
 
 COPY ["global.json", "."]
@@ -22,7 +23,7 @@ RUN if [ -n "${DEVEXPRESS_NUGET_SOURCE}" ]; then \
 
 COPY src/ src/
 
-RUN dotnet publish src/OvcinaHra.Client/OvcinaHra.Client.csproj -c Release -o /app/publish --no-restore
+RUN dotnet publish src/OvcinaHra.Client/OvcinaHra.Client.csproj -c Release -o /app/publish --no-restore /p:SourceRevisionId=${GIT_SHA}
 
 # IMPORTANT: do NOT modify /app/publish/wwwroot/appsettings.json after this point.
 # `dotnet publish` has already emitted service-worker-assets.js with SHA-256

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -1,4 +1,3 @@
-@using System.Reflection
 @using Microsoft.JSInterop
 @inject GameContextService GameContext
 @inject IJSRuntime JS
@@ -239,10 +238,7 @@
 
     private const string NavModeStorageKey = "oh-nav-mode";
 
-    private static string AppVersion =>
-        typeof(NavMenu).Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-            ?.InformationalVersion.Split('+')[0] ?? "dev";
+    private static string AppVersion => ClientBuildInfo.DisplayVersion;
 
     private string mode = "hra";  // "hra" | "katalog"
 

--- a/src/OvcinaHra.Client/Services/ClientBuildInfo.cs
+++ b/src/OvcinaHra.Client/Services/ClientBuildInfo.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+
+namespace OvcinaHra.Client.Services;
+
+/// <summary>
+/// Identity of the WebAssembly bundle currently executing in the browser.
+/// Production Docker builds stamp <c>SourceRevisionId</c> into
+/// <see cref="AssemblyInformationalVersionAttribute"/> so boot-time version
+/// checks can compare the loaded client against the deployed API commit.
+/// </summary>
+public static class ClientBuildInfo
+{
+    private const string UnknownCommit = "unknown";
+
+    private static readonly string InformationalVersion =
+        typeof(ClientBuildInfo).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion ?? "dev";
+
+    public static string DisplayVersion => InformationalVersion.Split('+')[0];
+
+    public static string RawInformationalVersion => InformationalVersion;
+
+    public static string? Commit
+    {
+        get
+        {
+            var separator = InformationalVersion.IndexOf('+', StringComparison.Ordinal);
+            if (separator < 0 || separator == InformationalVersion.Length - 1)
+                return null;
+
+            var commit = InformationalVersion[(separator + 1)..].Trim();
+            return string.IsNullOrWhiteSpace(commit)
+                || string.Equals(commit, UnknownCommit, StringComparison.OrdinalIgnoreCase)
+                    ? null
+                    : commit;
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Services/VersionDriftService.cs
+++ b/src/OvcinaHra.Client/Services/VersionDriftService.cs
@@ -1,6 +1,13 @@
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace OvcinaHra.Client.Services;
+
+public enum VersionDriftReason
+{
+    Boot,
+    Poll
+}
 
 /// <summary>
 /// Polls <c>GET /api/version</c> every <see cref="PollInterval"/> and raises
@@ -28,6 +35,7 @@ public sealed class VersionDriftService : IDisposable
     public bool IsDrifted { get; private set; }
     public string? BaselineCommit { get; private set; }
     public string? LatestCommit { get; private set; }
+    public VersionDriftReason? DriftReason { get; private set; }
 
     public VersionDriftService(ApiClient api, ILogger<VersionDriftService> logger)
     {
@@ -50,10 +58,43 @@ public sealed class VersionDriftService : IDisposable
         if (_started) return;
         _started = true;
 
-        BaselineCommit = await FetchCommitAsync();   // may be null on transient failure
-        LatestCommit = BaselineCommit;
-        Console.WriteLine($"[version-refresh] baseline captured commit={BaselineCommit ?? "(null)"}");
+        var clientCommit = ClientBuildInfo.Commit;
+        Console.WriteLine($"[version-refresh] boot identity commit={clientCommit ?? "(null)"} displayVersion={ClientBuildInfo.DisplayVersion} informational={ClientBuildInfo.RawInformationalVersion}");
 
+        var latest = await FetchCommitAsync();
+        if (clientCommit is not null)
+        {
+            BaselineCommit = clientCommit;
+            LatestCommit = latest;
+            Console.WriteLine($"[version-refresh] baseline captured source=client commit={BaselineCommit}");
+
+            if (latest is null)
+            {
+                Console.WriteLine($"[version-refresh] boot compare skipped reason=latest-null baseline={BaselineCommit}");
+                StartPollLoop();
+                return;
+            }
+
+            if (!CommitEquals(latest, clientCommit))
+            {
+                MarkDrift(VersionDriftReason.Boot, latest);
+                return;
+            }
+
+            Console.WriteLine($"[version-refresh] boot compare drifted=false baseline={BaselineCommit} latest={latest}");
+            StartPollLoop();
+            return;
+        }
+
+        BaselineCommit = latest;
+        LatestCommit = latest;
+        Console.WriteLine($"[version-refresh] baseline captured source=server-fallback commit={BaselineCommit ?? "(null)"}");
+
+        StartPollLoop();
+    }
+
+    private void StartPollLoop()
+    {
         _cts = new CancellationTokenSource();
         _ = PollLoopAsync(_cts.Token);
     }
@@ -79,12 +120,9 @@ public sealed class VersionDriftService : IDisposable
                     continue;
                 }
 
-                if (current == BaselineCommit) continue;
+                if (CommitEquals(current, BaselineCommit)) continue;
 
-                LatestCommit = current;
-                IsDrifted = true;
-                Console.WriteLine($"[version-refresh] drift detected baseline={BaselineCommit} latest={LatestCommit}");
-                StateChanged?.Invoke();
+                MarkDrift(VersionDriftReason.Poll, current);
                 // Stop polling — drift is sticky until the user reloads.
                 break;
             }
@@ -101,11 +139,22 @@ public sealed class VersionDriftService : IDisposable
         }
     }
 
+    private void MarkDrift(VersionDriftReason reason, string latest)
+    {
+        LatestCommit = latest;
+        DriftReason = reason;
+        IsDrifted = true;
+        Console.WriteLine($"[version-refresh] drift detected baseline={BaselineCommit ?? "(null)"} latest={LatestCommit} reason={reason.ToString().ToLowerInvariant()}");
+        StateChanged?.Invoke();
+    }
+
     private async Task<string?> FetchCommitAsync()
     {
         try
         {
+            var stopwatch = Stopwatch.StartNew();
             var info = await _api.GetAsync<VersionInfo>("/api/version");
+            stopwatch.Stop();
             if (info is null)
             {
                 _logger.LogDebug("[version-refresh] /api/version returned null payload");
@@ -115,7 +164,10 @@ public sealed class VersionDriftService : IDisposable
             _logger.LogDebug("[version-refresh] /api/version read commit={Commit} startedUtc={StartedUtc:O}",
                 info.Commit,
                 info.StartedUtc);
-            return info.Commit;
+
+            var commit = NormalizeCommit(info.Commit);
+            Console.WriteLine($"[version-refresh] /api/version fetch.ok latest={commit ?? "(null)"} elapsedMs={stopwatch.ElapsedMilliseconds}");
+            return commit;
         }
         catch (Exception ex)
         {
@@ -125,6 +177,20 @@ public sealed class VersionDriftService : IDisposable
             return null;
         }
     }
+
+    private static string? NormalizeCommit(string? commit)
+    {
+        if (string.IsNullOrWhiteSpace(commit)
+            || string.Equals(commit, "unknown", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return commit.Trim();
+    }
+
+    private static bool CommitEquals(string? left, string? right) =>
+        string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
 
     private sealed record VersionInfo(string Commit, DateTimeOffset StartedUtc);
 

--- a/src/OvcinaHra.Client/wwwroot/index.html
+++ b/src/OvcinaHra.Client/wwwroot/index.html
@@ -45,6 +45,7 @@
     <script src="js/overlay-interop.js?v=20260428"></script>
     <script src="js/download-interop.js?v=20260427"></script>
     <script src="js/image-resize-interop.js?v=20260429"></script>
+    <script src="js/version-refresh.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script>navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' });</script>
     <script>

--- a/src/OvcinaHra.Client/wwwroot/js/version-refresh.js
+++ b/src/OvcinaHra.Client/wwwroot/js/version-refresh.js
@@ -1,0 +1,48 @@
+window.ovcinaSw = {
+    unregisterAll: async () => {
+        if (!("serviceWorker" in navigator)) {
+            return {
+                supported: false,
+                count: 0,
+                successful: 0,
+                failed: 0,
+                detail: "serviceWorker not supported"
+            };
+        }
+
+        let registrations;
+        try {
+            registrations = await navigator.serviceWorker.getRegistrations();
+        } catch (error) {
+            return {
+                supported: true,
+                count: 0,
+                successful: 0,
+                failed: 1,
+                detail: error?.message ?? String(error)
+            };
+        }
+
+        let successful = 0;
+        const errors = [];
+        await Promise.all(registrations.map(async (registration, index) => {
+            try {
+                if (await registration.unregister()) {
+                    successful += 1;
+                } else {
+                    errors.push(`registration ${index} returned false`);
+                }
+            } catch (error) {
+                errors.push(error?.message ?? String(error));
+            }
+        }));
+
+        return {
+            supported: true,
+            count: registrations.length,
+            successful: successful,
+            failed: registrations.length - successful,
+            detail: errors.join("; ")
+        };
+    }
+};


### PR DESCRIPTION
## Summary
- rebuilds PR #409 from scratch on latest `origin/main` after auto-bump churn made the original branch dirty
- stamps the deployed client image with `GIT_SHA` via `/p:SourceRevisionId`, then compares loaded client commit vs `/api/version` on boot
- auto-reloads boot-time stale clients after SW unregister, guarded by `sessionStorage["last-force-reload-utc"]` 60s cooldown
- keeps expanded permanent `[version-refresh]` markers for boot identity, version fetch, drift, cooldown, SW unregister, and reload request

## Verification
- `gh pr diff 409 --repo timurlain/ovcinahra > /tmp/pr409-original.diff`
- `dotnet build OvcinaHra.slnx`
- `dotnet test OvcinaHra.slnx --no-build`
- Browser smoke with client `SourceRevisionId=client-old` and API `GIT_SHA=server-new`: marker chain showed boot identity, `/api/version fetch.ok`, drift detect, cooldown check, auto reload, SW unregister result, reload request, and second-load cooldown hit with banner still visible.

Supersedes #409.
Fixes #385