### PR TITLE
#412 Keep exports reachable in game nav

### DIFF
--- a/src/OvcinaHra.Client/Layout/MainLayout.razor.css
+++ b/src/OvcinaHra.Client/Layout/MainLayout.razor.css
@@ -12,6 +12,9 @@ main {
 
 .sidebar {
     background: var(--oh-sidebar);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
 }
 
 .top-row {

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor.css
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor.css
@@ -408,6 +408,10 @@
         position: static;
     }
 
+    .oh-nav ::deep .oh-nav-item {
+        height: 44px;
+    }
+
     /* Reserve safe-area inset for iOS home-bar so the very last item
        isn't tucked under the system gesture region. */
     .oh-nav-foot {


### PR DESCRIPTION
## Summary
- make the sidebar a real flex column so the existing nav-list overflow can scroll the long `Tato hra` menu instead of pushing Exports out of the sticky viewport
- keep mobile nav items at a 44px touch target while preserving desktop density

## Verification
- `dotnet build OvcinaHra.slnx`
- `dotnet test OvcinaHra.slnx --no-build`
- Playwright smoke: desktop and mobile toggled `Tato hra`, scrolled/clicked `Exporty`, returned and confirmed `Katalog` list still reachable

Closes #412