### PR TITLE
feat(treasures): phase toggle + thumbnail images on cards

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -301,6 +301,7 @@ public static class TreasurePlanningEndpoints
             dto.LocationId,
             dto.SecretStashId,
             kind = isComposite ? "composite" : "single",
+            phase = dto.Difficulty.ToString(),
             poolCount,
             poolUnits = poolAssignments.Sum(p => p.Count),
             unlimitedCount

--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -44,20 +44,30 @@ public static class TreasurePlanningEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<TreasurePoolItemDto>>> GetPool(int gameId, WorldDbContext db)
+    private static async Task<Ok<List<TreasurePoolItemDto>>> GetPool(int gameId, WorldDbContext db, HttpContext http)
     {
-        var items = await db.TreasureItems
+        var rows = await db.TreasureItems
             .Where(ti => ti.GameId == gameId
                 && ti.TreasureQuestId == null
                 && ti.Item.ItemType != ItemType.Money)
             .Include(ti => ti.Item)
             .OrderBy(ti => ti.Item.ItemType).ThenBy(ti => ti.Item.Name)
-            .Select(ti => new TreasurePoolItemDto(ti.Id, ti.ItemId, ti.Item.Name, ti.Item.ItemType, ti.Count, ti.GameId, ti.Item.IsUnique))
             .ToListAsync();
+        var items = rows
+            .Select(ti => new TreasurePoolItemDto(
+                ti.Id,
+                ti.ItemId,
+                ti.Item.Name,
+                ti.Item.ItemType,
+                ti.Count,
+                ti.GameId,
+                ti.Item.IsUnique,
+                ItemThumbnailUrl(http, ti.ItemId, ti.Item.ImagePath)))
+            .ToList();
         return TypedResults.Ok(items);
     }
 
-    private static async Task<Results<Created<TreasurePoolItemDto>, ValidationProblem>> AddToPool(CreateTreasurePoolItemDto dto, WorldDbContext db)
+    private static async Task<Results<Created<TreasurePoolItemDto>, ValidationProblem>> AddToPool(CreateTreasurePoolItemDto dto, WorldDbContext db, HttpContext http)
     {
         var gameItem = await db.GameItems
             .Include(gi => gi.Item)
@@ -100,7 +110,15 @@ public static class TreasurePlanningEndpoints
         await db.SaveChangesAsync();
 
         return TypedResults.Created($"/api/treasure-planning/pool/{dto.GameId}",
-            new TreasurePoolItemDto(ti.Id, ti.ItemId, gameItem.Item.Name, gameItem.Item.ItemType, ti.Count, ti.GameId, gameItem.Item.IsUnique));
+            new TreasurePoolItemDto(
+                ti.Id,
+                ti.ItemId,
+                gameItem.Item.Name,
+                gameItem.Item.ItemType,
+                ti.Count,
+                ti.GameId,
+                gameItem.Item.IsUnique,
+                ItemThumbnailUrl(http, ti.ItemId, gameItem.Item.ImagePath)));
     }
 
     private static async Task<Results<NoContent, NotFound, ValidationProblem>> RemoveFromPool(int id, WorldDbContext db)
@@ -165,7 +183,8 @@ public static class TreasurePlanningEndpoints
     private static async Task<Ok<List<TreasurePlanningLocationDto>>> GetLocationCards(
         int gameId,
         WorldDbContext db,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        HttpContext http)
     {
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
         var assignedLocationIds = await db.GameLocations
@@ -210,6 +229,7 @@ public static class TreasurePlanningEndpoints
         var quests = await db.TreasureQuests
             .Where(tq => tq.GameId == gameId)
             .Include(tq => tq.TreasureItems)
+            .ThenInclude(ti => ti.Item)
             .ToListAsync();
 
         var result = parentLocations.Select(loc =>
@@ -233,6 +253,20 @@ public static class TreasurePlanningEndpoints
                 var sQuests = quests.Where(q => q.SecretStashId == gs.SecretStashId).ToList();
                 return new StashSummaryDto(gs.SecretStashId, gs.SecretStash.Name, sQuests.SelectMany(q => q.TreasureItems).Sum(ti => ti.Count));
             }).ToList();
+            var assignedTreasures = allQuests
+                .OrderBy(q => q.Difficulty)
+                .ThenBy(q => q.Title)
+                .SelectMany(q => q.TreasureItems
+                    .OrderBy(ti => ti.Item.Name)
+                    .Select(ti => new TreasurePlanningAssignedTreasureDto(
+                        q.Id,
+                        q.Title,
+                        q.Difficulty,
+                        ti.ItemId,
+                        ti.Item.Name,
+                        ti.Count,
+                        ItemThumbnailUrl(http, ti.ItemId, ti.Item.ImagePath))))
+                .ToList();
 
             return new TreasurePlanningLocationDto(
                 loc.Id, loc.Name, loc.LocationKind,
@@ -247,7 +281,8 @@ public static class TreasurePlanningEndpoints
                 Latitude: loc.Coordinates?.Latitude,
                 Longitude: loc.Coordinates?.Longitude,
                 EffectiveLatitude: loc.Coordinates?.Latitude,
-                EffectiveLongitude: loc.Coordinates?.Longitude);
+                EffectiveLongitude: loc.Coordinates?.Longitude,
+                AssignedTreasures: assignedTreasures);
         }).ToList();
 
         return TypedResults.Ok(result);
@@ -282,7 +317,8 @@ public static class TreasurePlanningEndpoints
     private static async Task<Results<Created<TreasureQuestDetailDto>, ValidationProblem>> AssignTreasure(
         AssignTreasureDto dto,
         WorldDbContext db,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        HttpContext http)
     {
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
         var poolAssignments = dto.PoolItems?
@@ -520,7 +556,7 @@ public static class TreasurePlanningEndpoints
                 new TreasureQuestDetailDto(
                     loaded.Id, loaded.Title, loaded.Clue, loaded.Difficulty,
                     loaded.LocationId, loaded.Location?.Name, loaded.SecretStashId, loaded.SecretStash?.Name, loaded.GameId,
-                    loaded.TreasureItems.Select(ti => new TreasureItemDto(ti.Id, ti.ItemId, ti.Item.Name, ti.Count, ti.TreasureQuestId)).ToList()));
+                    loaded.TreasureItems.Select(ti => ToTreasureItemDto(http, ti)).ToList()));
         }
         catch (Exception ex)
         {
@@ -607,7 +643,8 @@ public static class TreasurePlanningEndpoints
         int id,
         AdjustTreasureItemCountDto dto,
         WorldDbContext db,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        HttpContext http)
     {
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
         LogTreasureAlloc(logger, LogLevel.Information, "count-adjust-entry", new
@@ -743,7 +780,7 @@ public static class TreasurePlanningEndpoints
             item.Count
         });
 
-        return TypedResults.Ok(new TreasureItemDto(item.Id, item.ItemId, item.Item.Name, item.Count, item.TreasureQuestId));
+        return TypedResults.Ok(ToTreasureItemDto(http, item));
     }
 
     private static void AssignPoolItemToQuest(TreasureItem poolItem, int count, int questId, WorldDbContext db)
@@ -783,6 +820,15 @@ public static class TreasurePlanningEndpoints
 
         poolRow.Count += count;
     }
+
+    private static TreasureItemDto ToTreasureItemDto(HttpContext http, TreasureItem item) =>
+        new(item.Id, item.ItemId, item.Item.Name, item.Count, item.TreasureQuestId,
+            ItemThumbnailUrl(http, item.ItemId, item.Item.ImagePath));
+
+    private static string? ItemThumbnailUrl(HttpContext http, int itemId, string? imagePath) =>
+        string.IsNullOrWhiteSpace(imagePath)
+            ? null
+            : ImageEndpoints.ThumbUrl(http, "items", itemId, "small");
 
     private static void LogTreasureAlloc(ILogger logger, LogLevel level, string eventName, object payload, Exception? exception = null)
     {

--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -51,19 +51,29 @@ public static class TreasurePlanningEndpoints
             .Where(ti => ti.GameId == gameId
                 && ti.TreasureQuestId == null
                 && ti.Item.ItemType != ItemType.Money)
-            .Include(ti => ti.Item)
             .OrderBy(ti => ti.Item.ItemType).ThenBy(ti => ti.Item.Name)
+            .Select(ti => new
+            {
+                ti.Id,
+                ti.ItemId,
+                ItemName = ti.Item.Name,
+                ti.Item.ItemType,
+                ti.Count,
+                ti.GameId,
+                ti.Item.IsUnique,
+                ti.Item.ImagePath
+            })
             .ToListAsync();
         var items = rows
             .Select(ti => new TreasurePoolItemDto(
                 ti.Id,
                 ti.ItemId,
-                ti.Item.Name,
-                ti.Item.ItemType,
+                ti.ItemName,
+                ti.ItemType,
                 ti.Count,
                 ti.GameId,
-                ti.Item.IsUnique,
-                ItemThumbnailUrl(http, ti.ItemId, ti.Item.ImagePath)))
+                ti.IsUnique,
+                ItemThumbnailUrl(http, ti.ItemId, ti.ImagePath)))
             .ToList();
         return TypedResults.Ok(items);
     }
@@ -254,12 +264,13 @@ public static class TreasurePlanningEndpoints
                 var sQuests = quests.Where(q => q.SecretStashId == gs.SecretStashId).ToList();
                 return new StashSummaryDto(gs.SecretStashId, gs.SecretStash.Name, sQuests.SelectMany(q => q.TreasureItems).Sum(ti => ti.Count));
             }).ToList();
-            var assignedTreasures = allQuests
+            var allAssignedTreasures = allQuests
                 .OrderBy(q => q.Difficulty)
                 .ThenBy(q => q.Title)
                 .SelectMany(q => q.TreasureItems
                     .OrderBy(ti => ti.Item.Name)
                     .Select(ti => new TreasurePlanningAssignedTreasureDto(
+                        ti.Id,
                         q.Id,
                         q.Title,
                         q.Difficulty,
@@ -267,7 +278,18 @@ public static class TreasurePlanningEndpoints
                         ti.Item.Name,
                         ti.Count,
                         ItemThumbnailUrl(http, ti.ItemId, ti.Item.ImagePath))))
+                .GroupBy(ti => new { ti.QuestId, ti.Difficulty, ti.ItemId, ti.ItemName, ti.ItemThumbnailUrl })
+                .Select(g => new TreasurePlanningAssignedTreasureDto(
+                    g.Min(ti => ti.TreasureItemId),
+                    g.Key.QuestId,
+                    g.First().QuestTitle,
+                    g.Key.Difficulty,
+                    g.Key.ItemId,
+                    g.Key.ItemName,
+                    g.Sum(ti => ti.Count),
+                    g.Key.ItemThumbnailUrl))
                 .ToList();
+            var assignedTreasures = allAssignedTreasures.Take(4).ToList();
 
             return new TreasurePlanningLocationDto(
                 loc.Id, loc.Name, loc.LocationKind,
@@ -283,7 +305,8 @@ public static class TreasurePlanningEndpoints
                 Longitude: loc.Coordinates?.Longitude,
                 EffectiveLatitude: loc.Coordinates?.Latitude,
                 EffectiveLongitude: loc.Coordinates?.Longitude,
-                AssignedTreasures: assignedTreasures);
+                AssignedTreasures: assignedTreasures,
+                AssignedTreasureCount: allAssignedTreasures.Count);
         }).ToList();
 
         return TypedResults.Ok(result);

--- a/src/OvcinaHra.Api/Endpoints/TreasureQuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasureQuestEndpoints.cs
@@ -34,7 +34,7 @@ public static class TreasureQuestEndpoints
         return TypedResults.Ok(tqs);
     }
 
-    private static async Task<Results<Ok<TreasureQuestDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
+    private static async Task<Results<Ok<TreasureQuestDetailDto>, NotFound>> GetById(int id, WorldDbContext db, HttpContext http)
     {
         var t = await db.TreasureQuests
             .Include(t => t.Location)
@@ -46,8 +46,14 @@ public static class TreasureQuestEndpoints
         return TypedResults.Ok(new TreasureQuestDetailDto(
             t.Id, t.Title, t.Clue, t.Difficulty,
             t.LocationId, t.Location?.Name, t.SecretStashId, t.SecretStash?.Name, t.GameId,
-            t.TreasureItems.Select(ti => new TreasureItemDto(ti.Id, ti.ItemId, ti.Item.Name, ti.Count, ti.TreasureQuestId)).ToList()));
+            t.TreasureItems.Select(ti => ToTreasureItemDto(http, ti)).ToList()));
     }
+
+    private static TreasureItemDto ToTreasureItemDto(HttpContext http, TreasureItem item) =>
+        new(item.Id, item.ItemId, item.Item.Name, item.Count, item.TreasureQuestId,
+            string.IsNullOrWhiteSpace(item.Item.ImagePath)
+                ? null
+                : ImageEndpoints.ThumbUrl(http, "items", item.ItemId, "small"));
 
     private static async Task<Results<Created<TreasureQuestListDto>, ValidationProblem>> Create(CreateTreasureQuestDto dto, WorldDbContext db)
     {

--- a/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
+++ b/src/OvcinaHra.Client/Components/TreasureAssignForm.razor
@@ -64,7 +64,9 @@
                 @foreach (var p in SelectedPool)
                 {
                     <div class="oh-tp-chosen-row">
-                        <i class="bi bi-check-circle text-success"></i>
+                        <TreasureItemThumbnail ItemId="@p.ItemId"
+                                               ItemName="@p.ItemName"
+                                               ThumbnailUrl="@p.ItemThumbnailUrl" />
                         <span class="flex-grow-1">@p.ItemName</span>
                         <span class="oh-tp-focus-quest-meta">
                             @(p.IsUnique ? $"×{p.Count}" : $"×1 z {p.Count}")

--- a/src/OvcinaHra.Client/Components/TreasureItemThumbnail.razor
+++ b/src/OvcinaHra.Client/Components/TreasureItemThumbnail.razor
@@ -1,0 +1,51 @@
+@if (!string.IsNullOrWhiteSpace(ThumbnailUrl) && !imageFailed)
+{
+    <img class="@ImageCssClass"
+         src="@ThumbnailUrl"
+         alt="@ItemName"
+         draggable="false"
+         @onload="HandleImageLoaded"
+         @onerror="HandleImageFailed" />
+}
+else
+{
+    <div class="@FallbackCssClass" aria-hidden="true">
+        <i class="bi @FallbackIcon"></i>
+    </div>
+}
+
+@code {
+    [Parameter, EditorRequired] public int ItemId { get; set; }
+    [Parameter, EditorRequired] public string ItemName { get; set; } = "";
+    [Parameter] public string? ThumbnailUrl { get; set; }
+    [Parameter] public string ImageCssClass { get; set; } = "oh-tp-item-thumb-img";
+    [Parameter] public string FallbackCssClass { get; set; } = "oh-tp-item-thumb oh-tp-item-thumb--placeholder";
+    [Parameter] public string FallbackIcon { get; set; } = "bi-gem";
+
+    private bool imageFailed;
+    private bool loadLogged;
+    private string? lastThumbnailUrl;
+    private int lastItemId;
+
+    protected override void OnParametersSet()
+    {
+        if (lastItemId == ItemId && lastThumbnailUrl == ThumbnailUrl) return;
+        lastItemId = ItemId;
+        lastThumbnailUrl = ThumbnailUrl;
+        imageFailed = false;
+        loadLogged = false;
+    }
+
+    private void HandleImageLoaded()
+    {
+        if (loadLogged) return;
+        loadLogged = true;
+        Console.WriteLine($"[treasure-alloc] thumbnail-load itemId={ItemId} status=ok");
+    }
+
+    private void HandleImageFailed()
+    {
+        imageFailed = true;
+        Console.WriteLine($"[treasure-alloc] thumbnail-load itemId={ItemId} status=failed");
+    }
+}

--- a/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
+++ b/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
@@ -31,7 +31,7 @@
             <div class="oh-tp-card-treasures">
                 @foreach (var item in assignedTreasures.Take(4))
                 {
-                    <div class="oh-tp-card-treasure" @key="@($"{item.QuestId}-{item.ItemId}")">
+                    <div class="oh-tp-card-treasure" @key="@item.TreasureItemId">
                         <TreasureItemThumbnail ItemId="@item.ItemId"
                                                ItemName="@item.ItemName"
                                                ThumbnailUrl="@item.ItemThumbnailUrl" />
@@ -39,9 +39,9 @@
                         <span class="oh-tp-card-treasure-count">×@item.Count</span>
                     </div>
                 }
-                @if (assignedTreasures.Count > 4)
+                @if (AssignedTreasureCount > 4)
                 {
-                    <div class="oh-tp-card-treasure-more">+@(assignedTreasures.Count - 4) dalších</div>
+                    <div class="oh-tp-card-treasure-more">+@(AssignedTreasureCount - 4) dalších</div>
                 }
             </div>
         }
@@ -77,6 +77,10 @@
 
     private string CssClass =>
         $"oh-tp-card {(IsFocused ? "is-focused" : "")} {(HasSelectedPool ? "has-pending" : "")}".Trim();
+
+    private int AssignedTreasureCount => Location.AssignedTreasureCount > 0
+        ? Location.AssignedTreasureCount
+        : Location.AssignedTreasures?.Count ?? 0;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
+++ b/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
@@ -26,6 +26,25 @@
                 }
             </div>
         }
+        @if (Location.AssignedTreasures is { Count: > 0 } assignedTreasures)
+        {
+            <div class="oh-tp-card-treasures">
+                @foreach (var item in assignedTreasures.Take(4))
+                {
+                    <div class="oh-tp-card-treasure" @key="@($"{item.QuestId}-{item.ItemId}")">
+                        <TreasureItemThumbnail ItemId="@item.ItemId"
+                                               ItemName="@item.ItemName"
+                                               ThumbnailUrl="@item.ItemThumbnailUrl" />
+                        <span class="oh-tp-card-treasure-name">@item.ItemName</span>
+                        <span class="oh-tp-card-treasure-count">×@item.Count</span>
+                    </div>
+                }
+                @if (assignedTreasures.Count > 4)
+                {
+                    <div class="oh-tp-card-treasure-more">+@(assignedTreasures.Count - 4) dalších</div>
+                }
+            </div>
+        }
         @if (HasSelectedPool)
         {
             <div class="oh-tp-card-cta">

--- a/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
+++ b/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
@@ -14,18 +14,11 @@
      @onfocus="() => isNameFlyoutOpen = true"
      @onblur="() => isNameFlyoutOpen = false"
      @onclick="OnClickInternal">
-    @if (!imageFailed)
-    {
-        <img class="oh-tp-pool-tile-img"
-             src="@($"/api/images/items/{Item.ItemId}/thumb?size=small")"
-             alt="@Item.ItemName"
-             @onerror="() => imageFailed = true"
-             draggable="false" />
-    }
-    else
-    {
-        <div class="oh-tp-pool-tile-fallback"><i class="bi bi-gem"></i></div>
-    }
+    <TreasureItemThumbnail ItemId="@Item.ItemId"
+                           ItemName="@Item.ItemName"
+                           ThumbnailUrl="@Item.ItemThumbnailUrl"
+                           ImageCssClass="oh-tp-pool-tile-img"
+                           FallbackCssClass="oh-tp-pool-tile-fallback" />
     @if (!Item.IsUnique)
     {
         <div class="oh-tp-pool-tile-badge">× @Item.Count</div>
@@ -95,8 +88,6 @@
     [Parameter] public EventCallback<TreasurePoolItemDto> OnRemove { get; set; }
 
     private ElementReference elementRef;
-    private bool imageFailed;
-    private int _imageStateForItemId = -1;
     private int _wiredForPoolItemId = -1;
 
     private bool isRemoveVisible;
@@ -104,17 +95,6 @@
     private bool removing;
     private string tileTargetId => $"oh-tp-pool-tile-{Item.Id}";
     private string TileLabel => Item.IsUnique ? Item.ItemName : $"{Item.ItemName} × {Item.Count}";
-
-    protected override void OnParametersSet()
-    {
-        // Reset image-failure state only when the underlying catalog item changes
-        // (image URL is keyed by Item.ItemId, not the pool entry's Id).
-        if (_imageStateForItemId != Item.ItemId)
-        {
-            _imageStateForItemId = Item.ItemId;
-            imageFailed = false;
-        }
-    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -242,6 +242,20 @@ else
 
             @* RIGHT: assignment panel *@
             <div class="oh-tp-assign-panel">
+                <div class="oh-tp-placement-phase">
+                    <span class="oh-tp-placement-phase-lbl">Fáze umístění</span>
+                    <div class="oh-tl-seg" role="group" aria-label="Fáze, do které se ukládají nové poklady">
+                        @foreach (var phase in placementPhaseOptions)
+                        {
+                            <button type="button"
+                                    class="oh-tl-seg-btn @(lastUsedDifficulty == phase.Value ? "on" : "")"
+                                    data-stage="@phase.StageKey"
+                                    @onclick="() => SetPlacementPhase(phase.Value)">
+                                @phase.Label
+                            </button>
+                        }
+                    </div>
+                </div>
                 @if (focusedLocationId is null)
                 {
                     @* --- Default: pool grid --- *@
@@ -1313,6 +1327,37 @@ else
         Console.WriteLine($"[treasure-alloc] {json}");
     }
 
+    private void SetPlacementPhase(GameTimePhase next)
+    {
+        if (lastUsedDifficulty == next) return;
+        var previous = PlacementPhaseUiName(lastUsedDifficulty);
+        lastUsedDifficulty = next;
+        var current = PlacementPhaseUiName(next);
+        Console.WriteLine($"[treasure-alloc] phase-toggle changed from={previous} to={current}");
+        LogTreasureAlloc("phase-toggle", new
+        {
+            from = previous,
+            to = current,
+            phase = next.ToString(),
+            gameId
+        });
+    }
+
+    private static string PlacementPhaseUiName(GameTimePhase phase) => phase switch
+    {
+        GameTimePhase.Start => "Start",
+        GameTimePhase.Lategame or GameTimePhase.EndGame => "Konec",
+        _ => "Hra"
+    };
+
+    private static void LogAssignRequestPhase(GameTimePhase phase, string source, int? locationId, int? secretStashId = null)
+    {
+        Console.WriteLine(
+            $"[treasure-alloc] assign request includes phase={PlacementPhaseUiName(phase)} " +
+            $"source={source} locationId={locationId?.ToString() ?? "null"} " +
+            $"stashId={secretStashId?.ToString() ?? "null"}");
+    }
+
     private void CollapseQuickAllocationStepper()
     {
         if (quickAllocation is null) return;
@@ -1432,12 +1477,19 @@ else
 
     // ===== Stage metadata =====
     private record StageInfo(string Key, string SoftKey, GameTimePhase Value, string Label);
+    private record PlacementPhaseOption(string StageKey, GameTimePhase Value, string Label);
     private static readonly List<StageInfo> stageKeys =
     [
         new("start", "start",    GameTimePhase.Start,    "Start"),
         new("early", "early",    GameTimePhase.Early,    "Rozvoj hry"),
         new("mid",   "midgame",  GameTimePhase.Midgame,  "Střed hry"),
         new("late",  "lategame", GameTimePhase.Lategame, "Závěr hry"),
+    ];
+    private static readonly List<PlacementPhaseOption> placementPhaseOptions =
+    [
+        new("start", GameTimePhase.Start, "Start"),
+        new("mid", GameTimePhase.Midgame, "Hra"),
+        new("end", GameTimePhase.Lategame, "Konec"),
     ];
 
     private static readonly List<EnumItem<GameTimePhase>> difficultyValues = Enum.GetValues<GameTimePhase>()
@@ -1906,12 +1958,14 @@ else
             source,
             target = "location",
             locationId,
+            phase = PlacementPhaseUiName(dto.Difficulty),
             dto.Title,
             poolRows = assignments.Count,
             poolUnits = assignments.Sum(a => a.Count),
             unlimitedRows = unlimitedAssignments.Count,
             unlimitedUnits = unlimitedAssignments.Sum(a => a.Count)
         });
+        LogAssignRequestPhase(dto.Difficulty, source, locationId);
 
         var result = await Api.PostWithProblemAsync<AssignTreasureDto, TreasureQuestDetailDto>("/api/treasure-planning/assign", dto);
         if (!result.Ok || result.Value is null)
@@ -1967,12 +2021,14 @@ else
             source,
             target = "location",
             locationId,
+            phase = PlacementPhaseUiName(dto.Difficulty),
             poolItemId = item.Id,
             item.ItemId,
             kind = item.IsUnique ? "unique" : "non-unique",
             availableCount = item.Count,
             committedCount = count
         });
+        LogAssignRequestPhase(dto.Difficulty, source, locationId);
 
         var result = await Api.PostWithProblemAsync<AssignTreasureDto, TreasureQuestDetailDto>("/api/treasure-planning/assign", dto);
         if (!result.Ok || result.Value is null)
@@ -2075,8 +2131,10 @@ else
             dto.SecretStashId,
             poolCount = (dto.PoolItems?.Count ?? 0) + (dto.TreasureItemIds?.Count ?? 0),
             poolUnits = dto.PoolItems?.Sum(p => p.Count) ?? 0,
-            unlimitedCount = dto.UnlimitedItems?.Count ?? 0
+            unlimitedCount = dto.UnlimitedItems?.Count ?? 0,
+            phase = PlacementPhaseUiName(dto.Difficulty)
         });
+        LogAssignRequestPhase(dto.Difficulty, "form-save", dto.LocationId, dto.SecretStashId);
         var result = await Api.PostWithProblemAsync<AssignTreasureDto, TreasureQuestDetailDto>("/api/treasure-planning/assign", dto);
         if (!result.Ok)
         {
@@ -2185,6 +2243,7 @@ else
             var result = await Api.PostWithProblemAsync<AssignTreasureDto, TreasureQuestDetailDto>(
                 "/api/treasure-planning/assign",
                 dto);
+            LogAssignRequestPhase(dto.Difficulty, "gros-dialog", locationId);
             if (!result.Ok || result.Value is null)
             {
                 grosError = result.ProblemDetail ?? "Vytvoření pokladu z grošů se nepodařilo.";

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -248,7 +248,7 @@ else
                         @foreach (var phase in placementPhaseOptions)
                         {
                             <button type="button"
-                                    class="oh-tl-seg-btn @(lastUsedDifficulty == phase.Value ? "on" : "")"
+                                    class="oh-tl-seg-btn @(placementPhase == phase.Value ? "on" : "")"
                                     data-stage="@phase.StageKey"
                                     @onclick="() => SetPlacementPhase(phase.Value)">
                                 @phase.Label
@@ -1339,8 +1339,9 @@ else
 
     private void SetPlacementPhase(GameTimePhase next)
     {
-        if (lastUsedDifficulty == next) return;
-        var previous = PlacementPhaseUiName(lastUsedDifficulty);
+        if (placementPhase == next && lastUsedDifficulty == next) return;
+        var previous = PlacementPhaseUiName(placementPhase);
+        placementPhase = next;
         lastUsedDifficulty = next;
         var current = PlacementPhaseUiName(next);
         Console.WriteLine($"[treasure-alloc] phase-toggle changed from={previous} to={current}");
@@ -1358,6 +1359,13 @@ else
         GameTimePhase.Start => "Start",
         GameTimePhase.Lategame or GameTimePhase.EndGame => "Konec",
         _ => "Hra"
+    };
+
+    private static GameTimePhase PlacementPhaseBucket(GameTimePhase phase) => phase switch
+    {
+        GameTimePhase.Start => GameTimePhase.Start,
+        GameTimePhase.Lategame or GameTimePhase.EndGame => GameTimePhase.Lategame,
+        _ => GameTimePhase.Midgame
     };
 
     private static void LogAssignRequestPhase(GameTimePhase phase, string source, int? locationId, int? secretStashId = null)
@@ -1425,6 +1433,7 @@ else
     private OvcinaHra.Shared.Domain.Enums.LocationKind? treasuresKindFilter;
     private string? treasuresRegionFilter;
     private GameTimePhase lastUsedDifficulty = GameTimePhase.Start;
+    private GameTimePhase placementPhase = GameTimePhase.Start;
 
     // ===== Game context =====
     private int gameId => GameContext.SelectedGameId ?? 1;
@@ -1955,7 +1964,7 @@ else
         var unlimitedAssignments = BuildCompositeBundleUnlimitedAssignments();
         var dto = new AssignTreasureDto(
             Title: EffectiveCompositeBundleTitle,
-            Difficulty: lastUsedDifficulty,
+            Difficulty: placementPhase,
             GameId: gameId,
             LocationId: locationId,
             PoolItems: assignments,
@@ -1994,6 +2003,7 @@ else
         }
 
         lastUsedDifficulty = dto.Difficulty;
+        placementPhase = PlacementPhaseBucket(dto.Difficulty);
         var completedBundleId = compositeBundleClientId;
         var completedUnits = CompositeBundleUnitCount;
         ClearCompositeBundle();
@@ -2021,7 +2031,7 @@ else
         var count = item.IsUnique ? item.Count : 1;
         var dto = new AssignTreasureDto(
             Title: item.ItemName,
-            Difficulty: lastUsedDifficulty,
+            Difficulty: placementPhase,
             GameId: gameId,
             LocationId: locationId,
             PoolItems: [new PoolItemAssignDto(item.Id, count)]);
@@ -2050,6 +2060,7 @@ else
         }
 
         lastUsedDifficulty = dto.Difficulty;
+        placementPhase = PlacementPhaseBucket(dto.Difficulty);
         selectedPool.RemoveAll(p => p.Id == item.Id);
         focusedLocationId = locationId;
         focusTab = "prehled";
@@ -2153,6 +2164,7 @@ else
         }
 
         lastUsedDifficulty = dto.Difficulty;
+        placementPhase = PlacementPhaseBucket(dto.Difficulty);
         selectedPool.Clear();
         markersPlaced = false;
         await LoadAllAsync();
@@ -2245,7 +2257,7 @@ else
             var count = Math.Max(1, grosCount);
             var dto = new AssignTreasureDto(
                 Title: $"Groše × {count}",
-                Difficulty: lastUsedDifficulty,
+                Difficulty: placementPhase,
                 GameId: gameId,
                 LocationId: locationId,
                 UnlimitedItems: [new UnlimitedItemAssignDto(grosItem.ItemId, count)]);
@@ -2261,6 +2273,7 @@ else
             }
 
             lastUsedDifficulty = dto.Difficulty;
+            placementPhase = PlacementPhaseBucket(dto.Difficulty);
             isGrosDialogVisible = false;
             markersPlaced = false;
             await LoadAllAsync();

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -348,6 +348,9 @@ else
                                         @foreach (var line in GetCompositeBundleDisplayLines())
                                         {
                                             <div class="oh-tp-bundle-line" @key="line.ItemId">
+                                                <TreasureItemThumbnail ItemId="@line.ItemId"
+                                                                       ItemName="@line.ItemName"
+                                                                       ThumbnailUrl="@line.ItemThumbnailUrl" />
                                                 <span class="oh-tp-bundle-line-name">@line.ItemName</span>
                                                 <button type="button"
                                                         class="oh-tp-stepper-btn"
@@ -712,7 +715,14 @@ else
                         @foreach (var item in editQuestItems)
                         {
                             <tr>
-                                <td>@item.ItemName</td>
+                                <td>
+                                    <div class="oh-tp-edit-item">
+                                        <TreasureItemThumbnail ItemId="@item.ItemId"
+                                                               ItemName="@item.ItemName"
+                                                               ThumbnailUrl="@item.ItemThumbnailUrl" />
+                                        <span>@item.ItemName</span>
+                                    </div>
+                                </td>
                                 <td>@item.Count</td>
                                 <td>
                                     <button class="btn btn-sm btn-link text-danger p-0"
@@ -940,9 +950,9 @@ else
     private string? wiredCompositeBundlePayload;
     private readonly List<CompositeBundleLine> compositeBundleItems = [];
 
-    private sealed record CompositeBundleLine(int PoolItemId, int ItemId, string ItemName, bool IsUnique, int Count);
-    private sealed record CompositeBundleDisplayLine(int ItemId, string ItemName, int Count);
-    private sealed record CompositeBundleChoice(int PoolItemId, int ItemId, string ItemName, string Label, int Available, bool IsUnique);
+    private sealed record CompositeBundleLine(int PoolItemId, int ItemId, string ItemName, bool IsUnique, int Count, string? ItemThumbnailUrl);
+    private sealed record CompositeBundleDisplayLine(int ItemId, string ItemName, int Count, string? ItemThumbnailUrl);
+    private sealed record CompositeBundleChoice(int PoolItemId, int ItemId, string ItemName, string Label, int Available, bool IsUnique, string? ItemThumbnailUrl);
 
     private int CompositeBundleCurrencyCount => Math.Max(0, compositeBundleCurrencyCount ?? 0);
     private bool HasCompositeBundleCurrency => CompositeBundleCurrencyCount > 0;
@@ -976,16 +986,16 @@ else
             {
                 var available = p.Count - GetCompositeBundleReservedCount(p.Id);
                 var label = p.IsUnique ? p.ItemName : $"{p.ItemName} (zbývá {available})";
-                return new CompositeBundleChoice(p.Id, p.ItemId, p.ItemName, label, available, p.IsUnique);
+                return new CompositeBundleChoice(p.Id, p.ItemId, p.ItemName, label, available, p.IsUnique, p.ItemThumbnailUrl);
             })
             .Where(c => c.Available > 0)
             .OrderBy(c => c.ItemName);
 
     private IEnumerable<CompositeBundleDisplayLine> GetCompositeBundleDisplayLines() =>
         compositeBundleItems
-            .GroupBy(i => new { i.ItemId, i.ItemName })
+            .GroupBy(i => new { i.ItemId, i.ItemName, i.ItemThumbnailUrl })
             .OrderBy(g => g.Key.ItemName)
-            .Select(g => new CompositeBundleDisplayLine(g.Key.ItemId, g.Key.ItemName, g.Sum(i => i.Count)));
+            .Select(g => new CompositeBundleDisplayLine(g.Key.ItemId, g.Key.ItemName, g.Sum(i => i.Count), g.Key.ItemThumbnailUrl));
 
     private IEnumerable<string> GetCompositeBundleSummaryParts()
     {
@@ -1056,7 +1066,7 @@ else
         }
         else
         {
-            compositeBundleItems.Add(new CompositeBundleLine(poolItem.Id, poolItem.ItemId, poolItem.ItemName, poolItem.IsUnique, count));
+            compositeBundleItems.Add(new CompositeBundleLine(poolItem.Id, poolItem.ItemId, poolItem.ItemName, poolItem.IsUnique, count, poolItem.ItemThumbnailUrl));
         }
         selectedPool.Clear();
         selectedCompositeBundle = true;
@@ -1132,7 +1142,7 @@ else
             }
             else
             {
-                compositeBundleItems.Add(new CompositeBundleLine(poolItem.Id, poolItem.ItemId, poolItem.ItemName, poolItem.IsUnique, 1));
+                compositeBundleItems.Add(new CompositeBundleLine(poolItem.Id, poolItem.ItemId, poolItem.ItemName, poolItem.IsUnique, 1, poolItem.ItemThumbnailUrl));
             }
         }
         if (!HasCompositeBundle)

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2492,6 +2492,12 @@
 
 /* Assignment panel ----------------------------------------- */
 .oh-tp-assign-panel{display:flex;flex-direction:column;background:var(--oh-surface);border:1px solid var(--oh-card-border,var(--oh-border));border-radius:var(--oh-radius);box-shadow:var(--oh-shadow);overflow:hidden;min-height:520px}
+.oh-tp-placement-phase{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:10px 14px;border-bottom:1px solid var(--oh-border);background:linear-gradient(135deg,var(--oh-primary-surface),#fff8ec)}
+.oh-tp-placement-phase-lbl{font:800 .82rem var(--oh-font-body);color:var(--oh-primary);white-space:nowrap}
+.oh-tp-placement-phase .oh-tl-seg{background:rgba(255,255,255,.72)}
+.oh-tp-placement-phase .oh-tl-seg-btn[data-stage="start"].on{background:var(--oh-stage-start)}
+.oh-tp-placement-phase .oh-tl-seg-btn[data-stage="mid"].on{background:var(--oh-stage-midgame)}
+.oh-tp-placement-phase .oh-tl-seg-btn[data-stage="end"].on{background:var(--oh-stage-lategame)}
 .oh-tp-assign-hdr{display:flex;align-items:center;gap:10px;padding:12px 14px;border-bottom:1px solid var(--oh-border);background:var(--oh-surface-alt)}
 .oh-tp-assign-hdr h5{margin:0;font:700 1rem var(--oh-font-heading);color:var(--oh-primary);flex:1}
 .oh-tp-assign-hdr .oh-tp-close{background:none;border:none;font-size:1.1rem;cursor:pointer;color:var(--oh-text-secondary);padding:2px 6px;line-height:1}

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2537,6 +2537,9 @@
 .oh-tp-bundle-line{display:flex;align-items:center;gap:7px;padding:5px 7px;border:1px solid rgba(45,80,22,.18);border-radius:7px;background:rgba(255,255,255,.72)}
 .oh-tp-bundle-line-name{flex:1;font-weight:700;font-size:.82rem;color:var(--oh-text)}
 .oh-tp-bundle-line .remove{background:none;border:none;color:var(--oh-error);padding:0 2px}
+.oh-tp-item-thumb-img,.oh-tp-item-thumb{width:34px;height:34px;border-radius:6px;flex:0 0 34px;border:1px solid rgba(45,80,22,.2)}
+.oh-tp-item-thumb-img{object-fit:cover;background:var(--oh-surface-alt)}
+.oh-tp-item-thumb{display:inline-flex;align-items:center;justify-content:center;background:var(--oh-primary-surface);color:var(--oh-primary-light);font-size:.95rem}
 .oh-tp-bundle-money{display:grid;grid-template-columns:minmax(5.5rem,1fr) 42px minmax(7rem,9rem) 42px;gap:8px;align-items:center;padding:7px;border:1px solid rgba(45,80,22,.2);border-radius:7px;background:rgba(255,255,255,.8)}
 .oh-tp-bundle-money-name{font-weight:800;font-size:.86rem;color:var(--oh-text)}
 .oh-tp-bundle-money-btn{width:42px;height:42px;display:inline-flex;align-items:center;justify-content:center;border:1px solid #2D5016;border-radius:8px;background:#fff;color:#2D5016;padding:0}
@@ -2563,6 +2566,7 @@
 .oh-tp-focus-quest:hover{border-color:var(--oh-primary-light)}
 .oh-tp-focus-quest-title{flex:1;font:600 .875rem var(--oh-font-body);color:var(--oh-text)}
 .oh-tp-focus-quest-meta{font-size:.75rem;color:var(--oh-text-secondary);font-family:var(--oh-font-mono)}
+.oh-tp-edit-item{display:flex;align-items:center;gap:8px}
 .oh-tp-focus-stash-hdr{font:600 .75rem var(--oh-font-body);color:var(--oh-text-secondary);text-transform:uppercase;letter-spacing:.06em;margin:10px 0 6px}
 .oh-tp-focus-group-hdr{display:flex;align-items:center;gap:6px;font:700 .875rem var(--oh-font-heading);color:var(--oh-primary);margin:10px 0 6px}
 .oh-tp-focus-group-hdr .sw{width:10px;height:10px;border-radius:2px}
@@ -3295,6 +3299,12 @@
 .oh-tp-card-name{font-weight:600;color:var(--oh-text,#2a2a2a);font-size:.95rem}
 .oh-tp-card-name-count{color:var(--oh-text-secondary,#666);font-family:'JetBrains Mono',monospace;font-size:.82rem}
 .oh-tp-card-stash{font-size:.75rem;color:var(--oh-text-secondary,#666);display:flex;align-items:center;gap:.3rem}
+.oh-tp-card-treasures{display:flex;flex-direction:column;gap:4px;margin-top:.2rem}
+.oh-tp-card-treasure{display:flex;align-items:center;gap:6px;min-width:0;padding:3px 4px;border:1px solid rgba(45,80,22,.12);border-radius:7px;background:rgba(255,255,255,.55)}
+.oh-tp-card-treasure .oh-tp-item-thumb-img,.oh-tp-card-treasure .oh-tp-item-thumb{width:32px;height:32px;flex-basis:32px}
+.oh-tp-card-treasure-name{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font:700 .78rem var(--oh-font-body);color:var(--oh-text,#2a2a2a)}
+.oh-tp-card-treasure-count{font:800 .75rem 'JetBrains Mono',monospace;color:#2D5016}
+.oh-tp-card-treasure-more{font:.72rem 'JetBrains Mono',monospace;color:var(--oh-text-secondary,#666);padding-left:2px}
 .oh-tp-card-actions{display:flex;margin-top:.2rem}
 .oh-tp-card-gros{display:inline-flex;align-items:center;gap:.3rem;border:1px solid var(--oh-border,#D9CFB6);border-radius:999px;background:#fff8ec;color:#2D5016;padding:.2rem .55rem;font:700 .75rem var(--oh-font-body);cursor:pointer}
 .oh-tp-card-gros:hover{background:#F2EBD8;border-color:#B8A87A}

--- a/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
@@ -25,7 +25,7 @@ public record UpdateTreasureQuestDto(
     string Title, string? Clue, GameTimePhase Difficulty,
     int? LocationId, int? SecretStashId);
 
-public record TreasureItemDto(int Id, int ItemId, string ItemName, int Count, int? TreasureQuestId);
+public record TreasureItemDto(int Id, int ItemId, string ItemName, int Count, int? TreasureQuestId, string? ItemThumbnailUrl = null);
 public record AddTreasureItemDto(int ItemId, int Count = 1);
 
 public record PendingTreasureQuestDto(
@@ -46,7 +46,7 @@ public record VerifyTreasureQuestDto(
 
 // --- Treasure Pool DTOs ---
 
-public record TreasurePoolItemDto(int Id, int ItemId, string ItemName, ItemType ItemType, int Count, int GameId, bool IsUnique)
+public record TreasurePoolItemDto(int Id, int ItemId, string ItemName, ItemType ItemType, int Count, int GameId, bool IsUnique, string? ItemThumbnailUrl = null)
 {
     [JsonIgnore]
     public string ItemTypeDisplay => ItemType.GetDisplayName();
@@ -64,7 +64,17 @@ public record TreasurePlanningLocationDto(
     decimal? Latitude = null,
     decimal? Longitude = null,
     decimal? EffectiveLatitude = null,
-    decimal? EffectiveLongitude = null);
+    decimal? EffectiveLongitude = null,
+    List<TreasurePlanningAssignedTreasureDto>? AssignedTreasures = null);
+
+public record TreasurePlanningAssignedTreasureDto(
+    int QuestId,
+    string QuestTitle,
+    GameTimePhase Difficulty,
+    int ItemId,
+    string ItemName,
+    int Count,
+    string? ItemThumbnailUrl = null);
 
 public record StashSummaryDto(int Id, string Name, int ItemCount);
 

--- a/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
@@ -65,9 +65,11 @@ public record TreasurePlanningLocationDto(
     decimal? Longitude = null,
     decimal? EffectiveLatitude = null,
     decimal? EffectiveLongitude = null,
-    List<TreasurePlanningAssignedTreasureDto>? AssignedTreasures = null);
+    List<TreasurePlanningAssignedTreasureDto>? AssignedTreasures = null,
+    int AssignedTreasureCount = 0);
 
 public record TreasurePlanningAssignedTreasureDto(
+    int TreasureItemId,
     int QuestId,
     string QuestTitle,
     GameTimePhase Difficulty,

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
@@ -33,6 +35,16 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
             new CreateItemDto(name, itemType));
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<ItemDetailDto>())!;
+    }
+
+    private async Task SetItemImagePathAsync(int itemId, string imagePath)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var item = await db.Items.FindAsync(itemId);
+        Assert.NotNull(item);
+        item!.ImagePath = imagePath;
+        await db.SaveChangesAsync();
     }
 
     private async Task AssignItemToGameAsync(int gameId, int itemId, int? stockCount = null, bool isFindable = false)
@@ -71,6 +83,33 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
             new CreateTreasurePoolItemDto(itemId, gameId, count));
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<TreasurePoolItemDto>())!;
+    }
+
+    [Fact]
+    public async Task GetPool_ReturnsAbsoluteThumbnailUrlOnlyWhenItemHasImagePath()
+    {
+        var game = await CreateGameAsync();
+        var illustrated = await CreateItemAsync("Ilustrovaný klíč");
+        var plain = await CreateItemAsync("Obyčejný kámen");
+        await SetItemImagePathAsync(illustrated.Id, $"items/{illustrated.Id}/klic.webp");
+        await AssignItemToGameAsync(game.Id, illustrated.Id);
+        await AssignItemToGameAsync(game.Id, plain.Id);
+        await AddPoolItemAsync(game.Id, illustrated.Id);
+        await AddPoolItemAsync(game.Id, plain.Id);
+
+        var pool = await Client.GetFromJsonAsync<List<TreasurePoolItemDto>>(
+            $"/api/treasure-planning/pool/{game.Id}");
+
+        Assert.NotNull(pool);
+        var illustratedRow = Assert.Single(pool!, p => p.ItemId == illustrated.Id);
+        var plainRow = Assert.Single(pool!, p => p.ItemId == plain.Id);
+        Assert.NotNull(illustratedRow.ItemThumbnailUrl);
+        Assert.True(
+            Uri.TryCreate(illustratedRow.ItemThumbnailUrl, UriKind.Absolute, out var thumbnailUri),
+            $"Expected absolute thumbnail URL, got '{illustratedRow.ItemThumbnailUrl}'.");
+        Assert.Equal($"/api/images/items/{illustrated.Id}/thumb", thumbnailUri!.AbsolutePath);
+        Assert.Equal("?size=small", thumbnailUri.Query);
+        Assert.Null(plainRow.ItemThumbnailUrl);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds a write-mode `Fáze umístění` selector on `/treasures` using the map vocabulary: `Start`, `Hra`, `Konec`.
- Sends the selected phase through quick drag/drop, click fallback, composite bundle, manual assignment, and groše creation flows.
- Supplies item thumbnail URLs from the API and renders thumbnails on pool tiles, selected/balíček rows, location cards, and edit item rows.
- Keeps `[treasure-alloc]` diagnostics for phase changes, assignment phase, and thumbnail load success/failure.

## Verification
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test OvcinaHra.slnx --no-build` (575 API + 8 E2E passed)

closes #426
closes #427