### PR TITLE
feat(games): entity ↔ game associations + remove-from-game UI

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -48,6 +48,10 @@ public static class GameEndpoints
         group.MapGet("/{gameId:int}/buildings", GetGameBuildings);
         group.MapPost("/{gameId:int}/buildings/{buildingId:int}", AddBuildingToGame);
         group.MapDelete("/{gameId:int}/buildings/{buildingId:int}", RemoveBuildingFromGame);
+        group.MapGet("/{gameId:int}/creatures", GetGameCreatures);
+        group.MapPost("/{gameId:int}/creatures/{monsterId:int}", AddCreatureToGame);
+        group.MapDelete("/{gameId:int}/creatures/{monsterId:int}", RemoveCreatureFromGame);
+        group.MapDelete("/{gameId:int}/quests/{questId:int}", RemoveQuestFromGame);
 
         return group;
     }
@@ -221,6 +225,216 @@ public static class GameEndpoints
             http.Request.Path,
             gameId,
             buildingId,
+            status,
+            timer.ElapsedMilliseconds,
+            detail);
+    }
+
+    private static async Task<Results<Ok<List<GameMonsterDto>>, NotFound>> GetGameCreatures(
+        int gameId,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.GameEndpoints");
+        var timer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[monster-game-server] entry method={Method} path={Path} gameId={GameId}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId);
+
+        if (!await db.Games.AnyAsync(g => g.Id == gameId))
+        {
+            LogMonsterGameExit(logger, http, gameId, null, timer, 404, "game-not-found");
+            return TypedResults.NotFound();
+        }
+
+        var monsters = await db.GameMonsters
+            .Where(gm => gm.GameId == gameId)
+            .OrderBy(gm => gm.Monster.Name)
+            .Select(gm => new GameMonsterDto(gm.GameId, gm.MonsterId, gm.Monster.Name))
+            .ToListAsync();
+
+        LogMonsterGameExit(logger, http, gameId, null, timer, 200, detail: $"count={monsters.Count}");
+        return TypedResults.Ok(monsters);
+    }
+
+    private static async Task<Results<Created, Ok, NotFound>> AddCreatureToGame(
+        int gameId,
+        int monsterId,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.GameEndpoints");
+        var timer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[monster-game-server] entry method={Method} path={Path} gameId={GameId} monsterId={MonsterId}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId,
+            monsterId);
+
+        if (!await db.Games.AnyAsync(g => g.Id == gameId))
+        {
+            LogMonsterGameExit(logger, http, gameId, monsterId, timer, 404, "game-not-found");
+            return TypedResults.NotFound();
+        }
+
+        if (!await db.Monsters.AnyAsync(m => m.Id == monsterId))
+        {
+            LogMonsterGameExit(logger, http, gameId, monsterId, timer, 404, "monster-not-found");
+            return TypedResults.NotFound();
+        }
+
+        if (await db.GameMonsters.AnyAsync(gm => gm.GameId == gameId && gm.MonsterId == monsterId))
+        {
+            LogMonsterGameExit(logger, http, gameId, monsterId, timer, 200, "already-linked");
+            return TypedResults.Ok();
+        }
+
+        db.GameMonsters.Add(new GameMonster { GameId = gameId, MonsterId = monsterId });
+        logger.LogInformation(
+            "[monster-game-server] db-write.attempt gameId={GameId} monsterId={MonsterId}",
+            gameId,
+            monsterId);
+        var dbTimer = Stopwatch.StartNew();
+        var rowsAffected = await db.SaveChangesAsync();
+        dbTimer.Stop();
+        logger.LogInformation(
+            "[monster-game-server] db-write.ok gameId={GameId} monsterId={MonsterId} rowsAffected={RowsAffected} elapsedMs={ElapsedMs}",
+            gameId,
+            monsterId,
+            rowsAffected,
+            dbTimer.ElapsedMilliseconds);
+
+        LogMonsterGameExit(logger, http, gameId, monsterId, timer, 201, "created");
+        return TypedResults.Created($"/api/games/{gameId}/creatures/{monsterId}");
+    }
+
+    private static async Task<Results<NoContent, NotFound>> RemoveCreatureFromGame(
+        int gameId,
+        int monsterId,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.GameEndpoints");
+        var timer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[monster-game-server] entry method={Method} path={Path} gameId={GameId} monsterId={MonsterId}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId,
+            monsterId);
+
+        var link = await db.GameMonsters.FindAsync(gameId, monsterId);
+        if (link is null)
+        {
+            LogMonsterGameExit(logger, http, gameId, monsterId, timer, 404, "link-not-found");
+            return TypedResults.NotFound();
+        }
+
+        db.GameMonsters.Remove(link);
+        logger.LogInformation(
+            "[monster-game-server] db-write.attempt gameId={GameId} monsterId={MonsterId}",
+            gameId,
+            monsterId);
+        var dbTimer = Stopwatch.StartNew();
+        var rowsAffected = await db.SaveChangesAsync();
+        dbTimer.Stop();
+        logger.LogInformation(
+            "[monster-game-server] db-write.ok gameId={GameId} monsterId={MonsterId} rowsAffected={RowsAffected} elapsedMs={ElapsedMs}",
+            gameId,
+            monsterId,
+            rowsAffected,
+            dbTimer.ElapsedMilliseconds);
+
+        LogMonsterGameExit(logger, http, gameId, monsterId, timer, 204, "removed");
+        return TypedResults.NoContent();
+    }
+
+    private static void LogMonsterGameExit(
+        ILogger logger,
+        HttpContext http,
+        int gameId,
+        int? monsterId,
+        Stopwatch timer,
+        int status,
+        string? detail = null)
+    {
+        timer.Stop();
+        logger.LogInformation(
+            "[monster-game-server] exit method={Method} path={Path} gameId={GameId} monsterId={MonsterId} status={Status} elapsedMs={ElapsedMs} detail={Detail}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId,
+            monsterId,
+            status,
+            timer.ElapsedMilliseconds,
+            detail);
+    }
+
+    private static async Task<Results<NoContent, NotFound>> RemoveQuestFromGame(
+        int gameId,
+        int questId,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.GameEndpoints");
+        var timer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[quest-game-server] entry method={Method} path={Path} gameId={GameId} questId={QuestId}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId,
+            questId);
+
+        var quest = await db.Quests.FirstOrDefaultAsync(q => q.Id == questId && q.GameId == gameId);
+        if (quest is null)
+        {
+            LogQuestGameExit(logger, http, gameId, questId, timer, 404, "quest-not-in-game");
+            return TypedResults.NotFound();
+        }
+
+        quest.GameId = null;
+        quest.TimeSlotId = null;
+        logger.LogInformation(
+            "[quest-game-server] db-write.attempt gameId={GameId} questId={QuestId}",
+            gameId,
+            questId);
+        var dbTimer = Stopwatch.StartNew();
+        var rowsAffected = await db.SaveChangesAsync();
+        dbTimer.Stop();
+        logger.LogInformation(
+            "[quest-game-server] db-write.ok gameId={GameId} questId={QuestId} rowsAffected={RowsAffected} elapsedMs={ElapsedMs}",
+            gameId,
+            questId,
+            rowsAffected,
+            dbTimer.ElapsedMilliseconds);
+
+        LogQuestGameExit(logger, http, gameId, questId, timer, 204, "removed");
+        return TypedResults.NoContent();
+    }
+
+    private static void LogQuestGameExit(
+        ILogger logger,
+        HttpContext http,
+        int gameId,
+        int questId,
+        Stopwatch timer,
+        int status,
+        string? detail = null)
+    {
+        timer.Stop();
+        logger.LogInformation(
+            "[quest-game-server] exit method={Method} path={Path} gameId={GameId} questId={QuestId} status={Status} elapsedMs={ElapsedMs} detail={Detail}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId,
+            questId,
             status,
             timer.ElapsedMilliseconds,
             detail);

--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -45,8 +45,185 @@ public static class GameEndpoints
         group.MapDelete("/{gameId:int}/skills/{gameSkillId:int}", DeleteGameSkill);
         group.MapPost("/{gameId:int}/quests/bulk", BulkAddQuests);
         group.MapDelete("/{gameId:int}/locations/{locationId:int}", RemoveLocationFromGame);
+        group.MapGet("/{gameId:int}/buildings", GetGameBuildings);
+        group.MapPost("/{gameId:int}/buildings/{buildingId:int}", AddBuildingToGame);
+        group.MapDelete("/{gameId:int}/buildings/{buildingId:int}", RemoveBuildingFromGame);
 
         return group;
+    }
+
+    private static async Task<Results<Ok<List<BuildingListDto>>, NotFound>> GetGameBuildings(
+        int gameId,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.GameEndpoints");
+        var timer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[building-game-server] entry method={Method} path={Path} gameId={GameId}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId);
+
+        if (!await db.Games.AnyAsync(g => g.Id == gameId))
+        {
+            LogBuildingGameExit(logger, http, gameId, null, timer, 404, "game-not-found");
+            return TypedResults.NotFound();
+        }
+
+        var rows = await db.GameBuildings
+            .Where(gb => gb.GameId == gameId)
+            .OrderBy(gb => gb.Building.Name)
+            .Select(gb => new
+            {
+                gb.Building.Id,
+                gb.Building.Name,
+                gb.Building.Description,
+                gb.Building.Notes,
+                gb.Building.LocationId,
+                LocationName = gb.Building.Location != null ? gb.Building.Location.Name : null,
+                gb.Building.IsPrebuilt,
+                gb.Building.ImagePath,
+                gb.Building.CostMoney,
+                gb.Building.Effect,
+                CraftingRecipesCount = gb.Building.CraftingRequirements.Count,
+                GamesCount = gb.Building.GameBuildings.Count
+            })
+            .ToListAsync();
+
+        var buildings = rows.Select(r => new BuildingListDto(
+            r.Id,
+            r.Name,
+            r.Description,
+            r.Notes,
+            r.LocationId,
+            r.LocationName,
+            r.IsPrebuilt,
+            ImageEndpoints.ThumbUrl(http, "buildings", r.Id, "card"),
+            CostMoney: r.CostMoney,
+            Effect: r.Effect,
+            CraftingRecipesCount: r.CraftingRecipesCount,
+            GamesCount: r.GamesCount)).ToList();
+
+        LogBuildingGameExit(logger, http, gameId, null, timer, 200, detail: $"count={buildings.Count}");
+        return TypedResults.Ok(buildings);
+    }
+
+    private static async Task<Results<Created, Ok, NotFound>> AddBuildingToGame(
+        int gameId,
+        int buildingId,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.GameEndpoints");
+        var timer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[building-game-server] entry method={Method} path={Path} gameId={GameId} buildingId={BuildingId}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId,
+            buildingId);
+
+        if (!await db.Games.AnyAsync(g => g.Id == gameId))
+        {
+            LogBuildingGameExit(logger, http, gameId, buildingId, timer, 404, "game-not-found");
+            return TypedResults.NotFound();
+        }
+
+        if (!await db.Buildings.AnyAsync(b => b.Id == buildingId))
+        {
+            LogBuildingGameExit(logger, http, gameId, buildingId, timer, 404, "building-not-found");
+            return TypedResults.NotFound();
+        }
+
+        if (await db.GameBuildings.AnyAsync(gb => gb.GameId == gameId && gb.BuildingId == buildingId))
+        {
+            LogBuildingGameExit(logger, http, gameId, buildingId, timer, 200, "already-linked");
+            return TypedResults.Ok();
+        }
+
+        db.GameBuildings.Add(new GameBuilding { GameId = gameId, BuildingId = buildingId });
+        logger.LogInformation(
+            "[building-game-server] db-write.attempt gameId={GameId} buildingId={BuildingId}",
+            gameId,
+            buildingId);
+        var dbTimer = Stopwatch.StartNew();
+        var rowsAffected = await db.SaveChangesAsync();
+        dbTimer.Stop();
+        logger.LogInformation(
+            "[building-game-server] db-write.ok gameId={GameId} buildingId={BuildingId} rowsAffected={RowsAffected} elapsedMs={ElapsedMs}",
+            gameId,
+            buildingId,
+            rowsAffected,
+            dbTimer.ElapsedMilliseconds);
+
+        LogBuildingGameExit(logger, http, gameId, buildingId, timer, 201, "created");
+        return TypedResults.Created($"/api/games/{gameId}/buildings/{buildingId}");
+    }
+
+    private static async Task<Results<NoContent, NotFound>> RemoveBuildingFromGame(
+        int gameId,
+        int buildingId,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.GameEndpoints");
+        var timer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[building-game-server] entry method={Method} path={Path} gameId={GameId} buildingId={BuildingId}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId,
+            buildingId);
+
+        var link = await db.GameBuildings.FindAsync(gameId, buildingId);
+        if (link is null)
+        {
+            LogBuildingGameExit(logger, http, gameId, buildingId, timer, 404, "link-not-found");
+            return TypedResults.NotFound();
+        }
+
+        db.GameBuildings.Remove(link);
+        logger.LogInformation(
+            "[building-game-server] db-write.attempt gameId={GameId} buildingId={BuildingId}",
+            gameId,
+            buildingId);
+        var dbTimer = Stopwatch.StartNew();
+        var rowsAffected = await db.SaveChangesAsync();
+        dbTimer.Stop();
+        logger.LogInformation(
+            "[building-game-server] db-write.ok gameId={GameId} buildingId={BuildingId} rowsAffected={RowsAffected} elapsedMs={ElapsedMs}",
+            gameId,
+            buildingId,
+            rowsAffected,
+            dbTimer.ElapsedMilliseconds);
+
+        LogBuildingGameExit(logger, http, gameId, buildingId, timer, 204, "removed");
+        return TypedResults.NoContent();
+    }
+
+    private static void LogBuildingGameExit(
+        ILogger logger,
+        HttpContext http,
+        int gameId,
+        int? buildingId,
+        Stopwatch timer,
+        int status,
+        string? detail = null)
+    {
+        timer.Stop();
+        logger.LogInformation(
+            "[building-game-server] exit method={Method} path={Path} gameId={GameId} buildingId={BuildingId} status={Status} elapsedMs={ElapsedMs} detail={Detail}",
+            http.Request.Method,
+            http.Request.Path,
+            gameId,
+            buildingId,
+            status,
+            timer.ElapsedMilliseconds,
+            detail);
     }
 
     private static async Task<Results<Ok<BulkAddQuestsResponse>, NotFound>> BulkAddQuests(

--- a/src/OvcinaHra.Client/Components/MonsterRow.razor
+++ b/src/OvcinaHra.Client/Components/MonsterRow.razor
@@ -44,6 +44,10 @@
         <button type="button" title="Upravit" @onclick="HandleEdit"><i class="bi bi-pencil"></i></button>
         <button type="button" title="Přidat kořist" @onclick="HandleAddLoot"><i class="bi bi-plus-square"></i></button>
         <button type="button" title="Zkoušet (Soubojová karta)" @onclick="HandleBattle"><i class="bi bi-play-fill"></i></button>
+        @if (!Catalog)
+        {
+            <button type="button" title="Odebrat ze hry" @onclick="HandleRemoveFromGame"><i class="bi bi-x-circle"></i></button>
+        }
         <button type="button" class="oh-mon-danger" title="Smazat" @onclick="HandleDelete"><i class="bi bi-trash"></i></button>
     </div>
 
@@ -57,7 +61,7 @@
             else
             {
                 <button type="button" class="oh-mon-assign" @onclick="HandleAssign">
-                    <i class="bi bi-plus-lg"></i> Přiřadit ke hře
+                    <i class="bi bi-plus-lg"></i> Přidat do hry
                 </button>
             }
         </div>
@@ -74,6 +78,7 @@
     [Parameter] public EventCallback OnBattle { get; set; }
     [Parameter] public EventCallback OnDelete { get; set; }
     [Parameter] public EventCallback OnAssign { get; set; }
+    [Parameter] public EventCallback OnRemoveFromGame { get; set; }
 
     private bool imageFailed;
     private string? _lastImageUrl;
@@ -93,6 +98,7 @@
     private Task HandleBattle() => OnBattle.HasDelegate ? OnBattle.InvokeAsync() : Task.CompletedTask;
     private Task HandleDelete() => OnDelete.HasDelegate ? OnDelete.InvokeAsync() : Task.CompletedTask;
     private Task HandleAssign() => OnAssign.HasDelegate ? OnAssign.InvokeAsync() : Task.CompletedTask;
+    private Task HandleRemoveFromGame() => OnRemoveFromGame.HasDelegate ? OnRemoveFromGame.InvokeAsync() : Task.CompletedTask;
 
     public static string MonsterTypeIcon(MonsterType t) => t switch
     {

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
@@ -1,19 +1,25 @@
 @page "/buildings"
 @attribute [Authorize]
 @inject ApiClient Api
+@inject GameContextService GameContext
 @inject NavigationManager Nav
 @inject IJSRuntime JS
 
-@* Issue #208 — single-catalog Buildings list with 3-mode toggle:
-   Galerie (5:7 tiles, default) ↔ Karty (horizontal card-rows) ↔ Seznam
-   (DxGrid). The legacy per-game / catalog mode toggle is gone — the
-   building catalog is global per the design brief, and the per-game
-   construction-recipe editor lives at /recipes (BuildingRecipe entity,
-   issue #142, untouched). View choice persists in localStorage. *@
+@* Buildings have two independent modes:
+   - data scope: Jen tato hra ↔ Katalog (query parameter, like Items)
+   - visual view: Galerie ↔ Karty ↔ Seznam (localStorage, issue #208)
+   Keep them separate so the catalog/game distinction stays visible without
+   losing the richer building presentation modes. *@
 
 <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
-    <h1 class="mb-0">Stavby</h1>
+    <h1 class="mb-0">@(Catalog ? "Katalog staveb" : "Stavby")</h1>
     <div class="d-flex gap-2 align-items-center">
+        <div class="d-flex gap-2">
+            <button class="btn btn-sm @(Catalog ? "btn-outline-primary" : "btn-primary")"
+                    @onclick='() => Nav.NavigateTo("/buildings")'>Jen tato hra</button>
+            <button class="btn btn-sm @(Catalog ? "btn-primary" : "btn-outline-primary")"
+                    @onclick='() => Nav.NavigateTo("/buildings?catalog=true")'>Katalog</button>
+        </div>
         <div class="oh-segmented" role="tablist" aria-label="Zobrazení">
             <button type="button"
                     class="oh-segmented-btn @(view == "galerie" ? "oh-segmented-btn--on" : "")"
@@ -58,11 +64,18 @@
 {
     <p class="text-muted">Načítám…</p>
 }
+else if (!Catalog && GameContext.SelectedGameId is null)
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-controller fs-1 d-block mb-2"></i>
+        <p>Vyber hru v levém panelu.</p>
+    </div>
+}
 else if (filtered.Count == 0)
 {
     <div class="text-center text-muted py-5">
         <i class="bi bi-house fs-1 d-block mb-2"></i>
-        <p>Žádné stavby zatím nejsou.</p>
+        <p>@(Catalog ? "Žádné stavby zatím nejsou." : "Tato hra nemá přiřazené žádné stavby.")</p>
         <button class="btn btn-outline-primary" type="button"
                 @onclick="ClearFilters">Zrušit filtry</button>
     </div>
@@ -72,8 +85,33 @@ else if (view == "galerie")
     <div class="oh-bld-gallery">
         @foreach (var b in filtered)
         {
-            <BuildingTile @key="b.Id" Building="@b"
-                          OnClick="@(_ => Nav.NavigateTo($"/buildings/{b.Id}"))" />
+            <div class="oh-bld-action-card" @key="b.Id">
+                <BuildingTile Building="@b"
+                              OnClick="@(_ => Nav.NavigateTo($"/buildings/{b.Id}"))" />
+                @if (Catalog)
+                {
+                    @if (assignedBuildingIds.Contains(b.Id))
+                    {
+                        <span class="btn btn-sm btn-outline-secondary disabled"><i class="bi bi-check2"></i> V této hře</span>
+                    }
+                    else
+                    {
+                        <button type="button" class="btn btn-sm btn-outline-primary"
+                                disabled="@(GameContext.SelectedGameId is null || isAssociationBusy)"
+                                @onclick="() => AddBuildingToGameAsync(b)">
+                            <i class="bi bi-plus-circle"></i> Přidat do hry
+                        </button>
+                    }
+                }
+                else
+                {
+                    <button type="button" class="btn btn-sm btn-outline-danger"
+                            disabled="@isAssociationBusy"
+                            @onclick="() => RequestRemoveFromGame(b)">
+                        <i class="bi bi-x-circle"></i> Odebrat ze hry
+                    </button>
+                }
+            </div>
         }
     </div>
 }
@@ -82,17 +120,42 @@ else if (view == "karty")
     <div class="oh-bld-cardrow-wrap">
         @foreach (var b in filtered)
         {
-            <BuildingCardRow @key="b.Id" Building="@b"
-                             OnClick="@(_ => Nav.NavigateTo($"/buildings/{b.Id}"))" />
+            <div class="oh-bld-action-row" @key="b.Id">
+                <BuildingCardRow Building="@b"
+                                 OnClick="@(_ => Nav.NavigateTo($"/buildings/{b.Id}"))" />
+                @if (Catalog)
+                {
+                    @if (assignedBuildingIds.Contains(b.Id))
+                    {
+                        <span class="btn btn-sm btn-outline-secondary disabled align-self-center"><i class="bi bi-check2"></i> V této hře</span>
+                    }
+                    else
+                    {
+                        <button type="button" class="btn btn-sm btn-outline-primary align-self-center"
+                                disabled="@(GameContext.SelectedGameId is null || isAssociationBusy)"
+                                @onclick="() => AddBuildingToGameAsync(b)">
+                            <i class="bi bi-plus-circle"></i> Přidat do hry
+                        </button>
+                    }
+                }
+                else
+                {
+                    <button type="button" class="btn btn-sm btn-outline-danger align-self-center"
+                            disabled="@isAssociationBusy"
+                            @onclick="() => RequestRemoveFromGame(b)">
+                        <i class="bi bi-x-circle"></i> Odebrat ze hry
+                    </button>
+                }
+            </div>
         }
     </div>
 }
 else
 {
-    @* Seznam mode — LayoutKey bumped to grid-layout-buildings-v2 because
-       column schema changed (image, recipe pair, counts).
+    @* Seznam mode — LayoutKey bumped to grid-layout-buildings-v3 because
+       the action column was added for Přidat/Odebrat ze hry.
        Memory rule: feedback_ovcinagrid_layoutkey_bump. *@
-    <OvcinaGrid Data="@filtered" KeyFieldName="Id" LayoutKey="grid-layout-buildings-v2"
+    <OvcinaGrid Data="@filtered" KeyFieldName="Id" LayoutKey="grid-layout-buildings-v3"
                 RowClick="@(e => Nav.NavigateTo($"/buildings/{((BuildingListDto)e.Grid.GetDataItem(e.VisibleIndex)).Id}"))">
         <Columns>
             <DxGridDataColumn Caption="" Width="60px" AllowSort="false" AllowGroup="false">
@@ -143,8 +206,43 @@ else
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="Description" Caption="Popis" MinWidth="240" Visible="false" />
             <DxGridDataColumn FieldName="Notes" Caption="Poznámky" MinWidth="240" Visible="false" />
+            <DxGridDataColumn Caption="" Width="160px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var b = (BuildingListDto)context.DataItem; }
+                    @if (Catalog)
+                    {
+                        @if (assignedBuildingIds.Contains(b.Id))
+                        {
+                            <span class="btn btn-sm btn-outline-secondary disabled"><i class="bi bi-check2"></i> V této hře</span>
+                        }
+                        else
+                        {
+                            <button type="button" class="btn btn-sm btn-outline-primary"
+                                    disabled="@(GameContext.SelectedGameId is null || isAssociationBusy)"
+                                    @onclick:stopPropagation="true"
+                                    @onclick="() => AddBuildingToGameAsync(b)">
+                                <i class="bi bi-plus-circle"></i> Přidat
+                            </button>
+                        }
+                    }
+                    else
+                    {
+                        <button type="button" class="btn btn-sm btn-outline-danger"
+                                disabled="@isAssociationBusy"
+                                @onclick:stopPropagation="true"
+                                @onclick="() => RequestRemoveFromGame(b)">
+                            <i class="bi bi-x-circle"></i> Odebrat
+                        </button>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
         </Columns>
     </OvcinaGrid>
+}
+
+@if (associationError is not null)
+{
+    <div class="alert alert-danger mt-3">@associationError</div>
 }
 
 @* "+ Nová stavba" minimal create modal. After create, nav to /buildings/{id}
@@ -171,8 +269,29 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+<DxPopup @bind-Visible="@isRemoveFromGameVisible" HeaderText="Odebrat stavbu z této hry?" Width="440px">
+    <BodyContentTemplate Context="removeCtx">
+        <p>Opravdu chceš odebrat stavbu <strong>@pendingRemoveBuilding?.Name</strong> z aktuální hry? Katalogová stavba zůstane zachovaná.</p>
+        @if (associationError is not null)
+        {
+            <div class="alert alert-danger">@associationError</div>
+        }
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" type="button" @onclick="() => isRemoveFromGameVisible = false" disabled="@isAssociationBusy">Zrušit</button>
+            <button class="btn btn-danger" type="button" @onclick="ConfirmRemoveFromGameAsync" disabled="@isAssociationBusy">
+                @if (isAssociationBusy) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Odebrat
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @code {
+    [SupplyParameterFromQuery]
+    public bool Catalog { get; set; }
+
     private List<BuildingListDto> buildings = [];
+    private HashSet<int> assignedBuildingIds = [];
     private bool loading = true;
 
     private string view = "galerie"; // galerie | karty | seznam — persisted
@@ -185,6 +304,11 @@ else
     private bool isCreating;
     private string? createError;
     private string createName = "";
+    private bool _previousCatalog;
+    private bool isAssociationBusy;
+    private bool isRemoveFromGameVisible;
+    private BuildingListDto? pendingRemoveBuilding;
+    private string? associationError;
 
     private List<BuildingListDto> filtered =>
         buildings.Where(b =>
@@ -199,6 +323,8 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        await GameContext.InitializeAsync();
+        _previousCatalog = Catalog;
         try
         {
             view = await JS.InvokeAsync<string>("localStorage.getItem", "oh-building-view") ?? "galerie";
@@ -208,12 +334,36 @@ else
         await LoadAsync();
     }
 
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Catalog != _previousCatalog)
+        {
+            _previousCatalog = Catalog;
+            await LoadAsync();
+        }
+    }
+
     private async Task LoadAsync()
     {
         loading = true;
+        associationError = null;
         try
         {
-            buildings = await Api.GetListAsync<BuildingListDto>("/api/buildings");
+            if (!Catalog && GameContext.SelectedGameId is int gameId)
+            {
+                buildings = await Api.GetListAsync<BuildingListDto>($"/api/games/{gameId}/buildings");
+                assignedBuildingIds = buildings.Select(b => b.Id).ToHashSet();
+            }
+            else
+            {
+                buildings = await Api.GetListAsync<BuildingListDto>("/api/buildings");
+                assignedBuildingIds = [];
+                if (Catalog && GameContext.SelectedGameId is int catalogGameId)
+                {
+                    var linked = await Api.GetListAsync<BuildingListDto>($"/api/games/{catalogGameId}/buildings");
+                    assignedBuildingIds = linked.Select(b => b.Id).ToHashSet();
+                }
+            }
         }
         finally { loading = false; }
     }
@@ -264,5 +414,61 @@ else
         onlyWithImage = false;
         onlyWithRecipes = false;
         onlyWithEffect = false;
+    }
+
+    private async Task AddBuildingToGameAsync(BuildingListDto building)
+    {
+        if (GameContext.SelectedGameId is not int gameId) return;
+        associationError = null;
+        isAssociationBusy = true;
+        try
+        {
+            var (ok, _, problem) = await Api.PostWithProblemAsync<object, object>(
+                $"/api/games/{gameId}/buildings/{building.Id}",
+                new { });
+            if (!ok)
+            {
+                associationError = problem ?? "Přidání stavby do hry se nezdařilo.";
+                return;
+            }
+
+            assignedBuildingIds.Add(building.Id);
+            if (!Catalog)
+            {
+                await LoadAsync();
+            }
+        }
+        catch (Exception ex) { associationError = ex.Message; }
+        finally { isAssociationBusy = false; }
+    }
+
+    private void RequestRemoveFromGame(BuildingListDto building)
+    {
+        pendingRemoveBuilding = building;
+        associationError = null;
+        isRemoveFromGameVisible = true;
+    }
+
+    private async Task ConfirmRemoveFromGameAsync()
+    {
+        if (pendingRemoveBuilding is null || GameContext.SelectedGameId is not int gameId) return;
+        associationError = null;
+        isAssociationBusy = true;
+        try
+        {
+            var (ok, problem) = await Api.DeleteWithProblemAsync($"/api/games/{gameId}/buildings/{pendingRemoveBuilding.Id}");
+            if (!ok)
+            {
+                associationError = problem ?? "Odebrání stavby ze hry se nezdařilo.";
+                return;
+            }
+
+            assignedBuildingIds.Remove(pendingRemoveBuilding.Id);
+            buildings.RemoveAll(b => b.Id == pendingRemoveBuilding.Id);
+            pendingRemoveBuilding = null;
+            isRemoveFromGameVisible = false;
+        }
+        catch (Exception ex) { associationError = ex.Message; }
+        finally { isAssociationBusy = false; }
     }
 }

--- a/src/OvcinaHra.Client/Pages/Games/GameQuests.razor
+++ b/src/OvcinaHra.Client/Pages/Games/GameQuests.razor
@@ -67,9 +67,9 @@ else if (filtered.Count == 0)
 }
 else
 {
-    @* LayoutKey bumped to grid-layout-game-quests-v2 — column schema added
-       state, image, counts. Memory rule: feedback_ovcinagrid_layoutkey_bump. *@
-    <OvcinaGrid Data="@filtered" KeyFieldName="Id" LayoutKey="grid-layout-game-quests-v2"
+    @* LayoutKey bumped to grid-layout-game-quests-v3 — action column added
+       for Odebrat ze hry. Memory rule: feedback_ovcinagrid_layoutkey_bump. *@
+    <OvcinaGrid Data="@filtered" KeyFieldName="Id" LayoutKey="grid-layout-game-quests-v3"
                 RowClick="@(e => Nav.NavigateTo($"/quests/{((QuestListDto)e.Grid.GetDataItem(e.VisibleIndex)).Id}"))">
         <Columns>
             <DxGridDataColumn Caption="" Width="60px" AllowSort="false" AllowGroup="false">
@@ -120,6 +120,17 @@ else
                 </CellDisplayTemplate>
             </DxGridDataColumn>
             <DxGridDataColumn FieldName="ChainOrder" Caption="Pořadí" Width="90px" Visible="false" />
+            <DxGridDataColumn Caption="" Width="140px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{ var q = (QuestListDto)context.DataItem; }
+                    <button type="button" class="btn btn-sm btn-outline-danger"
+                            disabled="@isRemovingFromGame"
+                            @onclick:stopPropagation="true"
+                            @onclick="() => RequestRemoveFromGame(q)">
+                        <i class="bi bi-x-circle"></i> Odebrat
+                    </button>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
         </Columns>
     </OvcinaGrid>
 }
@@ -257,6 +268,23 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+<DxPopup @bind-Visible="@isRemoveFromGameVisible" HeaderText="Odebrat quest z této hry?" Width="440px">
+    <BodyContentTemplate Context="removeCtx">
+        <p>Opravdu chceš odebrat quest <strong>@pendingRemoveQuest?.Name</strong> z této hry? Quest zůstane zachovaný v katalogu.</p>
+        @if (removeError is not null)
+        {
+            <div class="alert alert-danger">@removeError</div>
+        }
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" type="button" @onclick="() => isRemoveFromGameVisible = false" disabled="@isRemovingFromGame">Zrušit</button>
+            <button class="btn btn-danger" type="button" @onclick="ConfirmRemoveFromGameAsync" disabled="@isRemovingFromGame">
+                @if (isRemovingFromGame) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Odebrat
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @code {
     [Parameter] public int GameId { get; set; }
 
@@ -264,6 +292,10 @@ else
     private List<QuestListDto> quests = [];
     private List<QuestCatalogDto>? catalog;
     private bool loading = true;
+    private bool isRemoveFromGameVisible;
+    private bool isRemovingFromGame;
+    private QuestListDto? pendingRemoveQuest;
+    private string? removeError;
 
     private string stateFilter = "all"; // all | inactive | active | done
     private List<QuestType> selectedQuestTypes = [];
@@ -458,6 +490,36 @@ else
         }
         catch (Exception ex) { bulkError = ex.Message; }
         finally { isBulkAdding = false; }
+    }
+
+    private void RequestRemoveFromGame(QuestListDto quest)
+    {
+        pendingRemoveQuest = quest;
+        removeError = null;
+        isRemoveFromGameVisible = true;
+    }
+
+    private async Task ConfirmRemoveFromGameAsync()
+    {
+        if (pendingRemoveQuest is null) return;
+        removeError = null;
+        isRemovingFromGame = true;
+        try
+        {
+            var (ok, problem) = await Api.DeleteWithProblemAsync($"/api/games/{GameId}/quests/{pendingRemoveQuest.Id}");
+            if (!ok)
+            {
+                removeError = problem ?? "Odebrání questu ze hry se nezdařilo.";
+                return;
+            }
+
+            quests.RemoveAll(q => q.Id == pendingRemoveQuest.Id);
+            pendingRemoveQuest = null;
+            isRemoveFromGameVisible = false;
+            await LoadCatalogIfNeededAsync();
+        }
+        catch (Exception ex) { removeError = ex.Message; }
+        finally { isRemovingFromGame = false; }
     }
 
     private async Task OpenBlankCreateModal()

--- a/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
+++ b/src/OvcinaHra.Client/Pages/Monsters/MonsterList.razor
@@ -124,7 +124,8 @@ else
                             OnAddLoot="@(() => OpenEditModal(captured))"
                             OnBattle="@(() => Nav.NavigateTo($"/monsters/{captured.Id}"))"
                             OnDelete="@(() => RequestDeleteFromRow(captured))"
-                            OnAssign="@(() => AssignMonsterAsync(captured.Id))" />
+                            OnAssign="@(() => AssignMonsterAsync(captured.Id))"
+                            OnRemoveFromGame="@(() => RequestRemoveFromGame(captured))" />
             }
         </div>
     }
@@ -315,15 +316,34 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+<DxPopup @bind-Visible="@isRemoveFromGameVisible" HeaderText="Odebrat příšeru z této hry?" Width="440px">
+    <BodyContentTemplate Context="removeCtx">
+        <p>Opravdu chceš odebrat příšeru <strong>@pendingRemoveMonster?.Name</strong> z aktuální hry? Katalogový záznam zůstane zachovaný.</p>
+        @if (error is not null)
+        {
+            <div class="alert alert-danger">@error</div>
+        }
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" @onclick="() => isRemoveFromGameVisible = false" disabled="@isAssociationBusy">Zrušit</button>
+            <button class="btn btn-danger" @onclick="ConfirmRemoveFromGameAsync" disabled="@isAssociationBusy">
+                @if (isAssociationBusy) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Odebrat
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @code {
     [SupplyParameterFromQuery]
     public bool Catalog { get; set; }
 
     private List<MonsterListDto> monsters = [];
     private bool loading = true, isModalVisible, isDeleteVisible, isSaving, drozdFailed, confusedFailed;
+    private bool isRemoveFromGameVisible, isAssociationBusy;
     private string modalTitle = "", name = "";
     private string? error, abilities, aiBehavior, rewardNotes, notes;
     private int? editingId;
+    private MonsterListDto? pendingRemoveMonster;
     private MonsterType monsterType = MonsterType.Beast;
     private MonsterCategory category = MonsterCategory.Tier1;
     private int attack = 1, defense = 1, health = 5;
@@ -414,10 +434,11 @@ else
     {
         loading = true;
         var allMonsters = await Api.GetListAsync<MonsterListDto>("/api/monsters");
+        assignedMonsterIds = [];
 
         if (!Catalog && GameContext.SelectedGameId is int gid)
         {
-            var gameMonsters = await Api.GetListAsync<GameMonsterDto>($"/api/monsters/by-game/{gid}");
+            var gameMonsters = await Api.GetListAsync<GameMonsterDto>($"/api/games/{gid}/creatures");
             assignedMonsterIds = gameMonsters.Select(gm => gm.MonsterId).ToHashSet();
             monsters = allMonsters.Where(m => assignedMonsterIds.Contains(m.Id)).ToList();
         }
@@ -426,7 +447,7 @@ else
             monsters = allMonsters;
             if (Catalog && GameContext.SelectedGameId is int catalogGid)
             {
-                var gameMonsters = await Api.GetListAsync<GameMonsterDto>($"/api/monsters/by-game/{catalogGid}");
+                var gameMonsters = await Api.GetListAsync<GameMonsterDto>($"/api/games/{catalogGid}/creatures");
                 assignedMonsterIds = gameMonsters.Select(gm => gm.MonsterId).ToHashSet();
             }
         }
@@ -440,12 +461,47 @@ else
         if (GameContext.SelectedGameId is null) return;
         try
         {
-            await Api.PostAsync<CreateGameMonsterDto, GameMonsterDto>("/api/monsters/game-monster",
-                new CreateGameMonsterDto(GameContext.SelectedGameId.Value, monsterId));
+            var (ok, _, problem) = await Api.PostWithProblemAsync<object, object>(
+                $"/api/games/{GameContext.SelectedGameId.Value}/creatures/{monsterId}",
+                new { });
+            if (!ok)
+            {
+                error = problem ?? "Přiřazení příšery ke hře se nezdařilo.";
+                return;
+            }
             assignedMonsterIds.Add(monsterId);
             StateHasChanged();
         }
         catch (Exception ex) { error = ex.Message; StateHasChanged(); }
+    }
+
+    private void RequestRemoveFromGame(MonsterListDto monster)
+    {
+        pendingRemoveMonster = monster;
+        error = null;
+        isRemoveFromGameVisible = true;
+    }
+
+    private async Task ConfirmRemoveFromGameAsync()
+    {
+        if (pendingRemoveMonster is null || GameContext.SelectedGameId is not int gameId) return;
+        error = null;
+        isAssociationBusy = true;
+        try
+        {
+            var (ok, problem) = await Api.DeleteWithProblemAsync($"/api/games/{gameId}/creatures/{pendingRemoveMonster.Id}");
+            if (!ok)
+            {
+                error = problem ?? "Odebrání příšery ze hry se nezdařilo.";
+                return;
+            }
+
+            isRemoveFromGameVisible = false;
+            pendingRemoveMonster = null;
+            await LoadAsync();
+        }
+        catch (Exception ex) { error = ex.Message; }
+        finally { isAssociationBusy = false; }
     }
 
     private void OpenEditModal(MonsterListDto? m)

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3990,6 +3990,7 @@ body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label{display:block}
 
 /* — Galerie tile (5:7 portrait) — */
 .oh-bld-gallery{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:18px}
+.oh-bld-action-card{display:flex;flex-direction:column;gap:8px}
 .oh-bld-tile{position:relative;display:flex;flex-direction:column;
     background:#FFF8F0;border:1px solid #d8d2be;border-radius:10px;overflow:hidden;
     cursor:pointer;text-align:left;padding:0;transition:.18s ease;font-family:inherit}
@@ -4022,6 +4023,7 @@ body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label{display:block}
 
 /* — Karty mode (horizontal card-rows) — */
 .oh-bld-cardrow-wrap{display:flex;flex-direction:column;gap:10px}
+.oh-bld-action-row{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:10px;align-items:stretch}
 .oh-bld-cardrow{display:grid;grid-template-columns:86px 1fr auto;gap:14px;align-items:center;
     background:#FFF8F0;border:1px solid #ead9b8;border-radius:10px;overflow:hidden;
     cursor:pointer;text-align:left;padding:10px;transition:.15s ease;font-family:inherit;

--- a/tests/OvcinaHra.Api.Tests/Endpoints/BuildingEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/BuildingEndpointTests.cs
@@ -245,6 +245,60 @@ public class BuildingEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
+    [Fact]
+    public async Task NestedAddToGame_NewLink_ReturnsCreatedAndByGameReflects()
+    {
+        var game = await CreateGameAsync();
+        var createResp = await Client.PostAsJsonAsync("/api/buildings", new CreateBuildingDto("Tržiště"));
+        var created = await createResp.Content.ReadFromJsonAsync<BuildingDetailDto>();
+
+        var response = await Client.PostAsync($"/api/games/{game.Id}/buildings/{created!.Id}", null);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var buildings = await Client.GetFromJsonAsync<List<BuildingListDto>>($"/api/buildings/by-game/{game.Id}");
+        Assert.Contains(buildings!, b => b.Id == created.Id);
+    }
+
+    [Fact]
+    public async Task NestedAddToGame_Duplicate_ReturnsOkWithoutDuplicate()
+    {
+        var game = await CreateGameAsync();
+        var createResp = await Client.PostAsJsonAsync("/api/buildings", new CreateBuildingDto("Sýpka"));
+        var created = await createResp.Content.ReadFromJsonAsync<BuildingDetailDto>();
+
+        await Client.PostAsync($"/api/games/{game.Id}/buildings/{created!.Id}", null);
+        var duplicate = await Client.PostAsync($"/api/games/{game.Id}/buildings/{created.Id}", null);
+
+        Assert.Equal(HttpStatusCode.OK, duplicate.StatusCode);
+        var buildings = await Client.GetFromJsonAsync<List<BuildingListDto>>($"/api/games/{game.Id}/buildings");
+        Assert.Single(buildings!, b => b.Id == created.Id);
+    }
+
+    [Fact]
+    public async Task NestedRemoveFromGame_RemovesLinkButKeepsCatalogRecord()
+    {
+        var game = await CreateGameAsync();
+        var createResp = await Client.PostAsJsonAsync("/api/buildings", new CreateBuildingDto("Stáje"));
+        var created = await createResp.Content.ReadFromJsonAsync<BuildingDetailDto>();
+        await Client.PostAsync($"/api/games/{game.Id}/buildings/{created!.Id}", null);
+
+        var response = await Client.DeleteAsync($"/api/games/{game.Id}/buildings/{created.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var byGame = await Client.GetFromJsonAsync<List<BuildingListDto>>($"/api/buildings/by-game/{game.Id}");
+        Assert.DoesNotContain(byGame!, b => b.Id == created.Id);
+        var catalog = await Client.GetFromJsonAsync<BuildingDetailDto>($"/api/buildings/{created.Id}");
+        Assert.Equal("Stáje", catalog!.Name);
+    }
+
+    [Fact]
+    public async Task NestedRemoveFromGame_NotAssigned_ReturnsNotFound()
+    {
+        var game = await CreateGameAsync();
+        var response = await Client.DeleteAsync($"/api/games/{game.Id}/buildings/9999");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
     // ── Location ────────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MonsterEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MonsterEndpointTests.cs
@@ -169,6 +169,57 @@ public class MonsterEndpointTests(PostgresFixture postgres) : IntegrationTestBas
     }
 
     [Fact]
+    public async Task NestedCreatureAdd_NewLink_ReturnsCreatedAndByGameReflects()
+    {
+        var game = await CreateGameAsync();
+        var monster = await CreateMonsterAsync("Hlídač brány");
+
+        var response = await Client.PostAsync($"/api/games/{game.Id}/creatures/{monster.Id}", null);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var byGame = await Client.GetFromJsonAsync<List<GameMonsterDto>>($"/api/games/{game.Id}/creatures");
+        Assert.Contains(byGame!, m => m.MonsterId == monster.Id);
+    }
+
+    [Fact]
+    public async Task NestedCreatureAdd_Duplicate_ReturnsOkWithoutDuplicate()
+    {
+        var game = await CreateGameAsync();
+        var monster = await CreateMonsterAsync("Hlídač skladu");
+
+        await Client.PostAsync($"/api/games/{game.Id}/creatures/{monster.Id}", null);
+        var duplicate = await Client.PostAsync($"/api/games/{game.Id}/creatures/{monster.Id}", null);
+
+        Assert.Equal(HttpStatusCode.OK, duplicate.StatusCode);
+        var byGame = await Client.GetFromJsonAsync<List<GameMonsterDto>>($"/api/games/{game.Id}/creatures");
+        Assert.Single(byGame!, m => m.MonsterId == monster.Id);
+    }
+
+    [Fact]
+    public async Task NestedCreatureRemove_RemovesLinkButKeepsCatalogRecord()
+    {
+        var game = await CreateGameAsync();
+        var monster = await CreateMonsterAsync("Hlídač mostu");
+        await Client.PostAsync($"/api/games/{game.Id}/creatures/{monster.Id}", null);
+
+        var response = await Client.DeleteAsync($"/api/games/{game.Id}/creatures/{monster.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var byGame = await Client.GetFromJsonAsync<List<GameMonsterDto>>($"/api/games/{game.Id}/creatures");
+        Assert.DoesNotContain(byGame!, m => m.MonsterId == monster.Id);
+        var catalog = await Client.GetFromJsonAsync<MonsterDetailDto>($"/api/monsters/{monster.Id}");
+        Assert.Equal("Hlídač mostu", catalog!.Name);
+    }
+
+    [Fact]
+    public async Task NestedCreatureRemove_NotAssigned_ReturnsNotFound()
+    {
+        var game = await CreateGameAsync();
+        var response = await Client.DeleteAsync($"/api/games/{game.Id}/creatures/9999");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
     public async Task AddTag_ReturnsOk()
     {
         var createMonsterResponse = await Client.PostAsJsonAsync("/api/monsters",
@@ -486,5 +537,21 @@ public class MonsterEndpointTests(PostgresFixture postgres) : IntegrationTestBas
         var created = await response.Content.ReadFromJsonAsync<MonsterDetailDto>();
         Assert.NotNull(created);
         Assert.Equal("Unikátní bestie", created!.Name);
+    }
+
+    private async Task<GameDetailDto> CreateGameAsync()
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Test Hra", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    private async Task<MonsterDetailDto> CreateMonsterAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/monsters",
+            new CreateMonsterDto(name, MonsterCategory.Tier2, MonsterType.Beast, 4, 2, 10));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<MonsterDetailDto>())!;
     }
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/QuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/QuestEndpointTests.cs
@@ -239,6 +239,39 @@ public class QuestEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
     }
 
     [Fact]
+    public async Task NestedRemoveQuestFromGame_SoftUnassignsAndKeepsQuest()
+    {
+        var game = await CreateGameAsync();
+        var createResponse = await Client.PostAsJsonAsync("/api/quests",
+            new CreateQuestDto("Odebratelný quest", QuestType.General, game.Id));
+        var created = await createResponse.Content.ReadFromJsonAsync<QuestListDto>();
+
+        var response = await Client.DeleteAsync($"/api/games/{game.Id}/quests/{created!.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var byGame = await Client.GetFromJsonAsync<List<QuestListDto>>($"/api/quests/by-game/{game.Id}");
+        Assert.DoesNotContain(byGame!, q => q.Id == created.Id);
+        var catalogQuest = await Client.GetFromJsonAsync<QuestDetailDto>($"/api/quests/{created.Id}");
+        Assert.Null(catalogQuest!.GameId);
+    }
+
+    [Fact]
+    public async Task NestedRemoveQuestFromGame_WhenQuestBelongsToOtherGame_ReturnsNotFound()
+    {
+        var game = await CreateGameAsync(1);
+        var otherGame = await CreateGameAsync(2);
+        var createResponse = await Client.PostAsJsonAsync("/api/quests",
+            new CreateQuestDto("Cizí quest", QuestType.General, otherGame.Id));
+        var created = await createResponse.Content.ReadFromJsonAsync<QuestListDto>();
+
+        var response = await Client.DeleteAsync($"/api/games/{game.Id}/quests/{created!.Id}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var unchanged = await Client.GetFromJsonAsync<QuestDetailDto>($"/api/quests/{created.Id}");
+        Assert.Equal(otherGame.Id, unchanged!.GameId);
+    }
+
+    [Fact]
     public async Task AddTag_ReturnsOk()
     {
         var gameResponse = await Client.PostAsJsonAsync("/api/games",


### PR DESCRIPTION
## Summary
- add nested game/building association endpoints with idempotent add/remove semantics and server timing markers
- split buildings UI into game/catalog scopes with add/remove actions across views
- add creature association endpoints/UI remove flow and quest soft-unassign remove-from-game flow

## Verification
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test OvcinaHra.slnx --no-build`
- `git diff --check origin/main..HEAD`

Closes #416 #417 #420