### PR TITLE
Add cockpit My Roles and My Timetable

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using System.Diagnostics;
+using System.Security.Claims;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Endpoints;
@@ -23,6 +25,10 @@ public static class OrganizerRoleEndpoints
         group.MapPost("/bulk", BulkAssign);
         group.MapPut("/slots/{slotId:int}/npcs/{npcId:int}", UpsertSlotAssignment);
         group.MapDelete("/slots/{slotId:int}/npcs/{npcId:int}", DeleteSlotAssignment);
+
+        routes.MapGet("/api/organizer-roles/me", GetMine)
+            .WithTags("OrganizerRoles")
+            .RequireAuthorization();
 
         return group;
     }
@@ -90,6 +96,117 @@ public static class OrganizerRoleEndpoints
             assignments.Count);
 
         return TypedResults.Ok(new OrganizerRoleMatrixDto(gameId, slots, npcs, assignments));
+    }
+
+    private static async Task<Results<Ok<OrganizerRoleMeDto>, NotFound, UnauthorizedHttpResult>> GetMine(
+        int gameId,
+        ClaimsPrincipal user,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger(LoggerCategory);
+        if (user.Identity?.IsAuthenticated != true)
+        {
+            return TypedResults.Unauthorized();
+        }
+
+        if (!await db.Games.AnyAsync(g => g.Id == gameId, ct))
+        {
+            logger.LogInformation("[my-roles] view-load game_not_found gameId={GameId}", gameId);
+            return TypedResults.NotFound();
+        }
+
+        var userId = user.FindFirstValue("sub")
+            ?? user.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? user.Identity.Name
+            ?? "unknown";
+        var userEmail = NullIfWhiteSpace(user.FindFirstValue("email") ?? user.FindFirstValue(ClaimTypes.Email));
+
+        var slots = await db.GameTimeSlots
+            .AsNoTracking()
+            .Where(s => s.GameId == gameId)
+            .OrderBy(s => s.StartTime)
+            .Select(s => new OrganizerRoleTimeSlotDto(
+                s.Id,
+                s.StartTime,
+                (decimal)s.Duration.TotalHours,
+                s.InGameYear,
+                s.Stage))
+            .ToListAsync(ct);
+
+        var assignments = new List<OrganizerRoleMineAssignmentRow>();
+        if (userEmail is not null)
+        {
+            var normalizedEmail = userEmail.ToUpperInvariant();
+            assignments = await db.OrganizerRoleAssignments
+                .AsNoTracking()
+                .Where(a => a.GameId == gameId
+                    && a.PersonEmail != null
+                    && a.PersonEmail.ToUpper() == normalizedEmail)
+                .OrderBy(a => a.TimeSlot.StartTime)
+                .ThenBy(a => a.Npc.Name)
+                .Select(a => new OrganizerRoleMineAssignmentRow(
+                    a.GameTimeSlotId,
+                    a.NpcId,
+                    a.Npc.Name,
+                    a.Npc.Role,
+                    a.Npc.Description,
+                    a.Notes,
+                    a.PersonId,
+                    a.PersonName,
+                    a.PersonEmail))
+                .ToListAsync(ct);
+        }
+
+        var primary = PickPrimaryRole(assignments, out var pickReason);
+        logger.LogInformation(
+            "[my-roles] view-load gameId={GameId} userId={UserId} assignmentsCount={AssignmentCount}",
+            gameId,
+            userId,
+            assignments.Count);
+        logger.LogDebug(
+            "[my-roles] role-pick selected={NpcId} reason={Reason}",
+            primary?.NpcId,
+            pickReason);
+
+        var assignmentsBySlot = assignments
+            .GroupBy(a => a.GameTimeSlotId)
+            .ToDictionary(g => g.Key, g => g
+                .OrderBy(a => a.NpcName, StringComparer.CurrentCultureIgnoreCase)
+                .ThenBy(a => a.NpcId)
+                .Select(a => new OrganizerRoleMeSlotAssignmentDto(
+                    a.NpcId,
+                    a.NpcName,
+                    a.Role,
+                    a.Description,
+                    a.Notes))
+                .ToList());
+
+        var now = DateTime.UtcNow;
+        var currentSlotId = slots
+            .FirstOrDefault(s => s.StartTime <= now && s.StartTime.AddHours((double)s.DurationHours) > now)
+            ?.Id;
+        var person = assignments.FirstOrDefault();
+
+        var dto = new OrganizerRoleMeDto(
+            gameId,
+            userId,
+            userEmail,
+            person?.PersonId,
+            person?.PersonName,
+            currentSlotId,
+            primary,
+            slots.Select(s => new OrganizerRoleMeSlotDto(
+                s.Id,
+                s.StartTime,
+                s.DurationHours,
+                s.InGameYear,
+                s.Stage,
+                assignmentsBySlot.GetValueOrDefault(s.Id) ?? []))
+            .ToList());
+
+        return TypedResults.Ok(dto);
     }
 
     private static async Task<Results<Ok<BulkOrganizerRoleAssignmentResultDto>, NotFound, ProblemHttpResult>> BulkAssign(
@@ -564,6 +681,56 @@ public static class OrganizerRoleEndpoints
             a.Notes,
             a.CreatedAtUtc,
             a.UpdatedAtUtc);
+
+    private static OrganizerRoleMePrimaryRoleDto? PickPrimaryRole(
+        List<OrganizerRoleMineAssignmentRow> assignments,
+        out string reason)
+    {
+        if (assignments.Count == 0)
+        {
+            reason = "none";
+            return null;
+        }
+
+        var counts = assignments
+            .GroupBy(a => new { a.NpcId, a.NpcName, a.Role, a.Description })
+            .Select(g => new
+            {
+                g.Key.NpcId,
+                g.Key.NpcName,
+                g.Key.Role,
+                g.Key.Description,
+                Count = g.Count()
+            })
+            .ToList();
+
+        var maxCount = counts.Max(c => c.Count);
+        var candidates = counts
+            .Where(c => c.Count == maxCount)
+            .OrderBy(c => c.NpcName, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(c => c.NpcId)
+            .ToList();
+        var selected = candidates[0];
+        reason = candidates.Count > 1 ? "alphabetical" : "count";
+
+        return new OrganizerRoleMePrimaryRoleDto(
+            selected.NpcId,
+            selected.NpcName,
+            selected.Role,
+            selected.Description,
+            selected.Count);
+    }
+
+    private sealed record OrganizerRoleMineAssignmentRow(
+        int GameTimeSlotId,
+        int NpcId,
+        string NpcName,
+        NpcRole Role,
+        string? Description,
+        string? Notes,
+        int PersonId,
+        string PersonName,
+        string? PersonEmail);
 
     private static ProblemHttpResult Problem(string detail, string title, int statusCode) =>
         TypedResults.Problem(detail: detail, title: title, statusCode: statusCode);

--- a/src/OvcinaHra.Client/Components/MyRolesTimetable.razor
+++ b/src/OvcinaHra.Client/Components/MyRolesTimetable.razor
@@ -1,0 +1,187 @@
+@inject ApiClient Api
+@inject ILogger<MyRolesTimetable> Logger
+@implements IDisposable
+
+<div class="oh-home-my-tiles" aria-label="Moje role a rozvrh">
+    <section class="oh-home-my-card oh-home-my-role" aria-labelledby="oh-home-my-role-title">
+        <header class="oh-home-my-head">
+            <i class="bi bi-person-badge"></i>
+            <h2 id="oh-home-my-role-title">Moje role</h2>
+        </header>
+
+        @if (_loading)
+        {
+            <div class="oh-home-my-skel">
+                <span class="oh-home-skel-line-lg"></span>
+                <span class="oh-home-skel-line"></span>
+            </div>
+        }
+        else if (_failed)
+        {
+            <p class="oh-home-my-empty">Role se teď nepodařilo načíst.</p>
+        }
+        else if (_model?.PrimaryRole is null)
+        {
+            <p class="oh-home-my-empty">Zatím nemáš přidělenou žádnou roli.</p>
+        }
+        else
+        {
+            <div class="oh-home-my-role-main">
+                <span class="oh-home-my-role-name">@_model.PrimaryRole.NpcName</span>
+                <span class="oh-home-my-role-kind">@_model.PrimaryRole.Role.GetDisplayName()</span>
+            </div>
+            <p class="oh-home-my-role-desc">
+                @(string.IsNullOrWhiteSpace(_model.PrimaryRole.Description)
+                    ? "Popis role zatím není vyplněný."
+                    : _model.PrimaryRole.Description)
+            </p>
+        }
+    </section>
+
+    <section class="oh-home-my-card oh-home-my-timetable" aria-labelledby="oh-home-my-table-title">
+        <header class="oh-home-my-head">
+            <i class="bi bi-calendar-week"></i>
+            <h2 id="oh-home-my-table-title">Můj rozvrh</h2>
+        </header>
+
+        @if (_loading)
+        {
+            <div class="oh-home-my-slots">
+                @for (var i = 0; i < 3; i++)
+                {
+                    <div class="oh-home-my-slot oh-home-my-slot--skel">
+                        <span class="oh-home-skel-line"></span>
+                        <span class="oh-home-skel-line-lg"></span>
+                    </div>
+                }
+            </div>
+        }
+        else if (_failed)
+        {
+            <p class="oh-home-my-empty">Rozvrh se teď nepodařilo načíst.</p>
+        }
+        else if (_model?.TimeSlots.Count is null or 0)
+        {
+            <p class="oh-home-my-empty">Harmonogram zatím nemá časové sloty.</p>
+        }
+        else
+        {
+            <div class="oh-home-my-slots" role="list">
+                @foreach (var slot in _model.TimeSlots)
+                {
+                    var isCurrent = IsGameRunning && slot.SlotId == _model.CurrentSlotId;
+                    <div class="oh-home-my-slot @(isCurrent ? "oh-home-my-slot--current" : "")" role="listitem">
+                        <div class="oh-home-my-slot-top">
+                            <span class="oh-home-my-slot-time">@FormatSlotTime(slot)</span>
+                            <span class="oh-home-my-slot-stage">@slot.Stage.GetDisplayName()</span>
+                        </div>
+
+                        @if (slot.Assignments.Count == 0)
+                        {
+                            <strong class="oh-home-my-unassigned">Nepřiděleno</strong>
+                        }
+                        else
+                        {
+                            <div class="oh-home-my-slot-roles">
+                                @foreach (var assignment in slot.Assignments)
+                                {
+                                    <span>@assignment.NpcName</span>
+                                    <small>@assignment.Role.GetDisplayName()</small>
+                                }
+                            </div>
+                        }
+                    </div>
+                }
+            </div>
+        }
+    </section>
+</div>
+
+@code {
+    private CancellationTokenSource? _loadCts;
+    private OrganizerRoleMeDto? _model;
+    private int? _loadedGameId;
+    private bool _loading;
+    private bool _failed;
+
+    [Parameter] public int? GameId { get; set; }
+    [Parameter] public bool IsGameRunning { get; set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (GameId is null)
+        {
+            Reset();
+            return;
+        }
+
+        if (_loadedGameId == GameId.Value && (_model is not null || _loading))
+        {
+            LogRenderMarker();
+            return;
+        }
+
+        await LoadAsync(GameId.Value);
+    }
+
+    private async Task LoadAsync(int gameId)
+    {
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
+        _loadCts = new CancellationTokenSource();
+        var token = _loadCts.Token;
+
+        _loadedGameId = gameId;
+        _model = null;
+        _loading = true;
+        _failed = false;
+
+        try
+        {
+            _model = await Api.GetAsync<OrganizerRoleMeDto>($"/api/organizer-roles/me?gameId={gameId}", token);
+            if (token.IsCancellationRequested) return;
+
+            LogRenderMarker();
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _failed = true;
+            Logger.LogWarning(ex, "[my-roles] load failed gameId={GameId}", gameId);
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private void Reset()
+    {
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
+        _loadCts = null;
+        _loadedGameId = null;
+        _model = null;
+        _loading = false;
+        _failed = false;
+    }
+
+    private void LogRenderMarker()
+    {
+        if (_model is null) return;
+
+        var currentSlot = IsGameRunning ? _model.CurrentSlotId?.ToString() ?? "null" : "null";
+        Console.WriteLine($"[my-roles] timetable-render slots={_model.TimeSlots.Count} currentSlot={currentSlot}");
+    }
+
+    private static string FormatSlotTime(OrganizerRoleMeSlotDto slot)
+    {
+        var start = slot.StartTime.ToLocalTime();
+        var end = slot.StartTime.AddHours((double)slot.DurationHours).ToLocalTime();
+        return $"{start:d.M. HH:mm}-{end:HH:mm}";
+    }
+
+    public void Dispose() => Reset();
+}

--- a/src/OvcinaHra.Client/Components/QuickLaunchTiles.razor
+++ b/src/OvcinaHra.Client/Components/QuickLaunchTiles.razor
@@ -1,12 +1,10 @@
-@* Issue #158 — 8 square 1:1 tiles, 4×2 desktop / 2×4 tablet / 1-col
-   phone (flow handled in CSS via grid auto-fit). Each `<a href>` to
-   its catalog so Blazor enhanced nav handles routing. *@
+@* Issue #432 — keep the cockpit quick action focused on field placement. *@
 
 <section class="oh-home-qlaunch" aria-labelledby="oh-home-q-title">
     <header class="oh-home-qlaunch-head">
         <h2 id="oh-home-q-title">Rychlý přístup</h2>
     </header>
-    <div class="oh-home-qlaunch-grid">
+    <div class="oh-home-qlaunch-grid oh-home-qlaunch-grid--single">
         @foreach (var tile in Tiles)
         {
             <a class="oh-home-tile oh-home-k-@tile.Key" href="@tile.Href">
@@ -22,17 +20,6 @@
 
     private static readonly Tile[] Tiles =
     {
-        new("loc",   "Lokace",     "bi-geo-alt-fill",   "/locations"),
-        new("itm",   "Předměty",   "bi-box-seam",       "/items"),
-        new("mon",   "Příšery",    "bi-bug",            "/monsters"),
-        new("qst",   "Questy",      "bi-list-check",     "/quests"),
-        new("skl",   "Dovednosti", "bi-mortarboard",    "/skills"),
-        new("spl",   "Kouzla",     "bi-magic",          "/spells"),
-        new("stash", "Skrýše",     "bi-archive",        "/secret-stashes"),
-        new("tre",   "Poklady",    "bi-gem",            "/treasures"),
-        // Issue #383 follow-up: one-tap entry from cockpit straight into
-        // the placement wizard. Query string is parsed by /locations and
-        // auto-opens the wizard.
         new("place", "Umístění lokace", "bi-camera-fill", "/locations?placement=1"),
     };
 }

--- a/src/OvcinaHra.Client/Pages/Home.razor
+++ b/src/OvcinaHra.Client/Pages/Home.razor
@@ -58,6 +58,8 @@
                     }
                     <QuickLaunchTiles />
                 </div>
+
+                <MyRolesTimetable GameId="GameContext.SelectedGameId" IsGameRunning="_isGameRunning" />
             </div>
         }
     </Authorized>

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3402,7 +3402,7 @@
 
 /* Bottom row: recent activity + quick-launch */
 .oh-home-bottom-row{display:grid;grid-template-columns:1fr 1fr;gap:14px}
-.oh-home-act,.oh-home-qlaunch{padding:14px 18px;background:var(--oh-surface,#FAF6EC);
+.oh-home-act,.oh-home-qlaunch,.oh-home-my-card{padding:14px 18px;background:var(--oh-surface,#FAF6EC);
     border:1px solid var(--oh-border,#d8d2be);border-radius:8px}
 .oh-home-act-head h2,.oh-home-qlaunch-head h2{margin:0 0 8px;font:700 1.05rem var(--oh-font-heading)}
 .oh-home-act-row{display:flex;align-items:center;gap:10px;padding:8px 6px;border-radius:5px;
@@ -3429,12 +3429,41 @@
 
 /* Quick launch tiles */
 .oh-home-qlaunch-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
+.oh-home-qlaunch-grid.oh-home-qlaunch-grid--single{grid-template-columns:minmax(132px,180px)}
 .oh-home-tile{aspect-ratio:1/1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;
     border-radius:8px;background:var(--oh-home-tile-bg);
     border:1px solid var(--oh-border,#d8d2be);text-decoration:none;color:var(--oh-text,#2a2a2a);transition:.12s ease}
 .oh-home-tile:hover{background:var(--oh-home-tile-hover);border-color:var(--oh-home-tile-icon)}
 .oh-home-tile i{font-size:1.6rem;color:var(--oh-home-tile-icon)}
 .oh-home-tile-lbl{font:600 .8rem var(--oh-font-body)}
+
+/* My roles + timetable */
+.oh-home-my-tiles{display:grid;grid-template-columns:minmax(260px,.8fr) minmax(0,1.2fr);gap:14px;min-width:0}
+.oh-home-my-card{min-width:0}
+.oh-home-my-head{display:flex;align-items:center;gap:8px;margin-bottom:10px}
+.oh-home-my-head h2{margin:0;font:700 1.05rem var(--oh-font-heading)}
+.oh-home-my-head i{font-size:1.15rem;color:#8B1E3F}
+.oh-home-my-role-main{display:flex;align-items:baseline;gap:8px;flex-wrap:wrap;margin-bottom:8px}
+.oh-home-my-role-name{font:700 1.2rem var(--oh-font-heading);color:#2D5016}
+.oh-home-my-role-kind{padding:2px 8px;border-radius:999px;background:rgba(139,30,63,.1);
+    color:#8B1E3F;font:700 .76rem var(--oh-font-body)}
+.oh-home-my-role-desc{margin:0;color:var(--oh-text,#2a2a2a);line-height:1.45}
+.oh-home-my-empty{margin:0;color:var(--oh-text-muted,#6b6453);font-style:italic}
+.oh-home-my-skel{display:flex;flex-direction:column;gap:8px}
+.oh-home-my-slots{display:flex;gap:10px;overflow-x:auto;max-width:100%;min-width:0;
+    padding:2px 2px 6px;scroll-snap-type:x proximity}
+.oh-home-my-slot{display:flex;flex-direction:column;gap:8px;min-width:190px;max-width:230px;
+    padding:10px;border:1px solid var(--oh-border,#d8d2be);border-radius:8px;
+    background:var(--oh-surface-alt,#F2EBD8);scroll-snap-align:start}
+.oh-home-my-slot--current{border-color:#2D5016;background:rgba(45,80,22,.12);box-shadow:inset 0 0 0 2px rgba(45,80,22,.18)}
+.oh-home-my-slot-top{display:flex;align-items:flex-start;justify-content:space-between;gap:8px}
+.oh-home-my-slot-time{font:700 .86rem var(--oh-font-body);font-variant-numeric:tabular-nums}
+.oh-home-my-slot-stage{font:700 .72rem var(--oh-font-body);color:#8B1E3F}
+.oh-home-my-unassigned{color:var(--oh-text-muted,#6b6453);font-style:italic}
+.oh-home-my-slot-roles{display:flex;flex-direction:column;gap:2px}
+.oh-home-my-slot-roles span{font-weight:700}
+.oh-home-my-slot-roles small{color:var(--oh-text-muted,#6b6453)}
+.oh-home-my-slot--skel{min-height:88px}
 
 /* Drozd welcome takeover */
 .oh-home-takeover{position:fixed;inset:0;background:rgba(20,16,8,.78);display:flex;align-items:center;justify-content:center;
@@ -3468,11 +3497,13 @@
     .oh-home-stats{grid-template-columns:repeat(4,minmax(0,1fr))}
     .oh-home-running-row{grid-template-columns:1fr}
     .oh-home-bottom-row{grid-template-columns:1fr}
+    .oh-home-my-tiles{grid-template-columns:1fr}
     .oh-home-qlaunch-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
 }
 @media (max-width:600px){
     .oh-home-stats{grid-template-columns:repeat(2,minmax(0,1fr))}
     .oh-home-qlaunch-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+    .oh-home-my-slot{min-width:78vw;max-width:78vw}
 }
 
 /* ===========================================================================

--- a/src/OvcinaHra.Shared/Dtos/OrganizerRoleDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/OrganizerRoleDtos.cs
@@ -33,6 +33,38 @@ public record OrganizerRoleAssignmentDto(
     DateTime CreatedAtUtc,
     DateTime UpdatedAtUtc);
 
+public record OrganizerRoleMeDto(
+    int GameId,
+    string UserId,
+    string? UserEmail,
+    int? PersonId,
+    string? PersonName,
+    int? CurrentSlotId,
+    OrganizerRoleMePrimaryRoleDto? PrimaryRole,
+    List<OrganizerRoleMeSlotDto> TimeSlots);
+
+public record OrganizerRoleMePrimaryRoleDto(
+    int NpcId,
+    string NpcName,
+    NpcRole Role,
+    string? Description,
+    int AssignmentCount);
+
+public record OrganizerRoleMeSlotDto(
+    int SlotId,
+    DateTime StartTime,
+    decimal DurationHours,
+    int? InGameYear,
+    GameTimePhase Stage,
+    List<OrganizerRoleMeSlotAssignmentDto> Assignments);
+
+public record OrganizerRoleMeSlotAssignmentDto(
+    int NpcId,
+    string NpcName,
+    NpcRole Role,
+    string? Description,
+    string? Notes);
+
 public record UpsertOrganizerRoleAssignmentDto(
     int PersonId,
     string PersonName,

--- a/tests/OvcinaHra.Api.Tests/Endpoints/OrganizerRoleEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/OrganizerRoleEndpointTests.cs
@@ -191,6 +191,59 @@ public class OrganizerRoleEndpointTests(PostgresFixture postgres) : IntegrationT
         Assert.Contains("200", problem.Detail ?? "");
     }
 
+    [Fact]
+    public async Task GetMine_ReturnsPrimaryRoleAndTimetableForCurrentUserEmail()
+    {
+        var game = await CreateGameAsync();
+        var firstSlot = await CreateSlotAsync(game.Id, hour: 10);
+        var secondSlot = await CreateSlotAsync(game.Id, hour: 11);
+        var merchant = await CreateNpcAsync("Kupec Pavel", NpcRole.Merchant);
+        var monster = await CreateNpcAsync("Vlkodlak", NpcRole.Monster);
+        await AssignNpcAsync(game.Id, merchant.Id);
+        await AssignNpcAsync(game.Id, monster.Id);
+
+        await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{firstSlot.Id}/npcs/{merchant.Id}",
+            new UpsertOrganizerRoleAssignmentDto(501, "Test Player", "TEST@OVCINA.CZ", "stánek"));
+        await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{secondSlot.Id}/npcs/{merchant.Id}",
+            new UpsertOrganizerRoleAssignmentDto(501, "Test Player", "test@ovcina.cz"));
+        await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{firstSlot.Id}/npcs/{monster.Id}",
+            new UpsertOrganizerRoleAssignmentDto(501, "Test Player", "test@ovcina.cz"));
+
+        var mine = await LoadMineAsync(game.Id);
+
+        Assert.Equal("test@ovcina.cz", mine.UserEmail);
+        Assert.Equal(501, mine.PersonId);
+        Assert.NotNull(mine.PrimaryRole);
+        Assert.Equal(merchant.Id, mine.PrimaryRole.NpcId);
+        Assert.Equal(2, mine.PrimaryRole.AssignmentCount);
+        Assert.Equal(2, mine.TimeSlots.Count);
+        Assert.Equal(2, mine.TimeSlots.Single(s => s.SlotId == firstSlot.Id).Assignments.Count);
+        Assert.Single(mine.TimeSlots.Single(s => s.SlotId == secondSlot.Id).Assignments);
+    }
+
+    [Fact]
+    public async Task GetMine_LeavesSlotsVisibleWhenUserHasNoAssignments()
+    {
+        var game = await CreateGameAsync();
+        var slot = await CreateSlotAsync(game.Id, hour: 10);
+        var npc = await CreateNpcAsync("Kupec bez hráče", NpcRole.Merchant);
+        await AssignNpcAsync(game.Id, npc.Id);
+        await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{slot.Id}/npcs/{npc.Id}",
+            new UpsertOrganizerRoleAssignmentDto(777, "Někdo jiný", "other@example.test"));
+
+        var mine = await LoadMineAsync(game.Id);
+
+        Assert.Null(mine.PrimaryRole);
+        Assert.Null(mine.PersonId);
+        var visibleSlot = Assert.Single(mine.TimeSlots);
+        Assert.Equal(slot.Id, visibleSlot.SlotId);
+        Assert.Empty(visibleSlot.Assignments);
+    }
+
     private async Task<(GameDetailDto Game, NpcDetailDto Npc, List<GameTimeSlotDto> Slots)> CreateGameWithNpcAndSlotsAsync(int slotCount)
     {
         var game = await CreateGameAsync();
@@ -248,5 +301,12 @@ public class OrganizerRoleEndpointTests(PostgresFixture postgres) : IntegrationT
         var matrix = await Client.GetFromJsonAsync<OrganizerRoleMatrixDto>(
             $"/api/games/{gameId}/organizer-role-assignments");
         return matrix!;
+    }
+
+    private async Task<OrganizerRoleMeDto> LoadMineAsync(int gameId)
+    {
+        var response = await Client.GetAsync($"/api/organizer-roles/me?gameId={gameId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        return (await response.Content.ReadFromJsonAsync<OrganizerRoleMeDto>())!;
     }
 }


### PR DESCRIPTION
## Summary
- Simplifies `Rychlý přístup` to the single `Umístění lokace` field-placement tile.
- Adds `GET /api/organizer-roles/me?gameId=...` for the logged-in adult's primary NPC role and per-slot timetable, with `[my-roles]` diagnostics.
- Adds the cockpit `Moje role` and `Můj rozvrh` cards, including current-slot highlight while the game is running and empty `Nepřiděleno` states.

## Verification
- `dotnet build OvcinaHra.slnx`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter FullyQualifiedName~OrganizerRoleEndpointTests`
- `dotnet test OvcinaHra.slnx`
- Browser smoke via local API + Blazor client:
  - desktop assigned role: single quick-launch tile, role description visible, timetable roles visible, current slot highlighted
  - mobile empty future game: empty role state, `Nepřiděleno` slot cards, no current highlight, no page-wide horizontal overflow

Orchestrator owns merge.
