### PR TITLE
feat(treasures+locations): phase canon, resource treasure and stamp polish

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -171,7 +171,7 @@ public static class LocationEndpoints
         return earthKm * c;
     }
 
-    private static async Task<Results<Ok<LocationDetailDto>, NotFound>> GetById(int id, WorldDbContext db)
+    private static async Task<Results<Ok<LocationDetailDto>, NotFound>> GetById(int id, WorldDbContext db, HttpContext http)
     {
         var loc = await db.Locations
             .Include(l => l.Variants)
@@ -187,7 +187,8 @@ public static class LocationEndpoints
             loc.Id, loc.Name, loc.Description, loc.Details, loc.GamePotential, loc.Prompt, loc.Region, loc.LocationKind,
             latitude, longitude,
             loc.ImagePath, loc.PlacementPhotoPath, loc.StampImagePath, loc.NpcInfo, loc.SetupNotes,
-            loc.ParentLocationId, variants));
+            loc.ParentLocationId, variants,
+            StampImageUrl: string.IsNullOrWhiteSpace(loc.StampImagePath) ? null : ImageEndpoints.ThumbUrl(http, "locationstamps", loc.Id, "small")));
     }
 
     private static async Task<Results<Ok<List<LocationQuestSummaryDto>>, NotFound>> GetQuests(

--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -50,7 +50,8 @@ public static class TreasurePlanningEndpoints
         var rows = await db.TreasureItems
             .Where(ti => ti.GameId == gameId
                 && ti.TreasureQuestId == null
-                && ti.Item.ItemType != ItemType.Money)
+                && ti.Item.ItemType != ItemType.Money
+                && ti.Item.ItemType != ItemType.Resource)
             .OrderBy(ti => ti.Item.ItemType).ThenBy(ti => ti.Item.Name)
             .Select(ti => new
             {
@@ -90,11 +91,14 @@ public static class TreasurePlanningEndpoints
                 ["ItemId"] = ["Předmět není přiřazen k této hře."]
             });
         }
-        if (gameItem.Item.ItemType == ItemType.Money)
+        if (IsTreasureShortcutItemType(gameItem.Item.ItemType))
         {
+            var message = gameItem.Item.ItemType == ItemType.Money
+                ? "Peníze se do zásobníku nepřidávají. Použijte vytvoření pokladu z grošů na lokaci."
+                : "Suroviny se do zásobníku nepřidávají. Použijte vytvoření pokladu ze suroviny na lokaci.";
             return TypedResults.ValidationProblem(new Dictionary<string, string[]>
             {
-                ["ItemId"] = ["Peníze se do zásobníku nepřidávají. Použijte vytvoření pokladu z grošů na lokaci."]
+                ["ItemId"] = [message]
             });
         }
 
@@ -151,7 +155,11 @@ public static class TreasurePlanningEndpoints
     private static async Task<Ok<List<UnlimitedItemDto>>> GetUnlimitedItems(int gameId, WorldDbContext db)
     {
         var items = await db.GameItems
-            .Where(gi => gi.GameId == gameId && gi.IsFindable && gi.StockCount == null)
+            .Where(gi => gi.GameId == gameId
+                && gi.IsFindable
+                && (gi.StockCount == null
+                    || gi.Item.ItemType == ItemType.Money
+                    || gi.Item.ItemType == ItemType.Resource))
             .Include(gi => gi.Item)
             .OrderBy(gi => gi.Item.ItemType).ThenBy(gi => gi.Item.Name)
             .Select(gi => new UnlimitedItemDto(gi.ItemId, gi.Item.Name, gi.Item.ItemType))
@@ -166,7 +174,8 @@ public static class TreasurePlanningEndpoints
             .Where(gi => gi.GameId == gameId
                 && gi.IsFindable
                 && gi.StockCount != null
-                && gi.Item.ItemType != ItemType.Money)
+                && gi.Item.ItemType != ItemType.Money
+                && gi.Item.ItemType != ItemType.Resource)
             .Include(gi => gi.Item)
             .ToListAsync();
 
@@ -317,7 +326,8 @@ public static class TreasurePlanningEndpoints
         var poolRemaining = await db.TreasureItems
             .Where(ti => ti.GameId == gameId
                 && ti.TreasureQuestId == null
-                && ti.Item.ItemType != ItemType.Money)
+                && ti.Item.ItemType != ItemType.Money
+                && ti.Item.ItemType != ItemType.Resource)
             .SumAsync(ti => ti.Count);
 
         var quests = await db.TreasureQuests
@@ -506,7 +516,7 @@ public static class TreasurePlanningEndpoints
             }
         }
 
-        await LogGrosTreasureCreateIfNeededAsync(
+        await LogShortcutTreasureCreateIfNeededAsync(
             db,
             logger,
             dto,
@@ -692,7 +702,7 @@ public static class TreasurePlanningEndpoints
         return new DefaultStashPick(selected.SecretStashId, reason);
     }
 
-    private static async Task LogGrosTreasureCreateIfNeededAsync(
+    private static async Task LogShortcutTreasureCreateIfNeededAsync(
         WorldDbContext db,
         ILogger logger,
         AssignTreasureDto dto,
@@ -708,21 +718,23 @@ public static class TreasurePlanningEndpoints
         var itemsById = await db.Items
             .Where(i => itemIds.Contains(i.Id))
             .ToDictionaryAsync(i => i.Id);
-        var gros = unlimitedItems.FirstOrDefault(ui =>
-            itemsById.TryGetValue(ui.ItemId, out var item)
-            && item.ItemType == ItemType.Money);
-
-        if (gros is null)
+        foreach (var unlimitedItem in unlimitedItems)
         {
-            return;
+            if (!itemsById.TryGetValue(unlimitedItem.ItemId, out var item) || !IsTreasureShortcutItemType(item.ItemType))
+            {
+                continue;
+            }
+
+            LogTreasureAlloc(logger, LogLevel.Information,
+                item.ItemType == ItemType.Money ? "gros-treasure-create" : "surovina-treasure-create",
+                new
+                {
+                    locationId = sourceLocationId,
+                    stashId = targetSecretStashId,
+                    itemId = unlimitedItem.ItemId,
+                    count = unlimitedItem.Count
+                });
         }
-
-        LogTreasureAlloc(logger, LogLevel.Information, "gros-treasure-create", new
-        {
-            locationId = sourceLocationId,
-            stashId = targetSecretStashId,
-            count = gros.Count
-        });
     }
 
     private static async Task<Results<Ok<TreasureItemDto>, ValidationProblem, NotFound>> AdjustTreasureItemCount(
@@ -956,6 +968,9 @@ public static class TreasurePlanningEndpoints
             ? null
             : ImageEndpoints.ThumbUrl(http, "items", itemId, "small");
 
+    private static bool IsTreasureShortcutItemType(ItemType itemType) =>
+        itemType is ItemType.Money or ItemType.Resource;
+
     private static void LogTreasureAlloc(ILogger logger, LogLevel level, string eventName, object payload, Exception? exception = null)
     {
         var json = JsonSerializer.Serialize(new { Event = eventName, Payload = payload }, TreasureAllocLogJsonOptions);
@@ -1035,7 +1050,8 @@ public static class TreasurePlanningEndpoints
             .Where(gi => gi.GameId == gameId
                 && gi.IsFindable
                 && gi.StockCount != null
-                && gi.Item.ItemType != ItemType.Money)
+                && gi.Item.ItemType != ItemType.Money
+                && gi.Item.ItemType != ItemType.Resource)
             .Include(gi => gi.Item)
             .ToListAsync();
 

--- a/src/OvcinaHra.Api/Services/MapDataService.cs
+++ b/src/OvcinaHra.Api/Services/MapDataService.cs
@@ -182,8 +182,9 @@ public sealed class MapDataService(
 
         private int Total { get; set; }
         private int Start { get; set; }
-        private int Mid { get; set; }
-        private int End { get; set; }
+        private int Early { get; set; }
+        private int Midgame { get; set; }
+        private int Lategame { get; set; }
 
         public void Add(GameTimePhase phase, int count)
         {
@@ -196,16 +197,18 @@ public sealed class MapDataService(
                     Start += count;
                     break;
                 case GameTimePhase.Early:
+                    Early += count;
+                    break;
                 case GameTimePhase.Midgame:
-                    Mid += count;
+                    Midgame += count;
                     break;
                 case GameTimePhase.Lategame:
                 case GameTimePhase.EndGame:
-                    End += count;
+                    Lategame += count;
                     break;
             }
         }
 
-        public TreasureCountByPhaseDto ToDto() => new(Total, Start, Mid, End);
+        public TreasureCountByPhaseDto ToDto() => new(Total, Start, Early, Midgame, Lategame);
     }
 }

--- a/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
+++ b/src/OvcinaHra.Client/Components/TreasureLocationTargetCard.razor
@@ -60,6 +60,13 @@
                 @onkeydown:stopPropagation="true">
             <i class="bi bi-coin"></i> Vytvoř poklad z grošů
         </button>
+        <button type="button"
+                class="oh-tp-card-resource"
+                @onclick="HandleResourceClick"
+                @onclick:stopPropagation="true"
+                @onkeydown:stopPropagation="true">
+            <i class="bi bi-gem"></i> Vytvoř poklad ze suroviny
+        </button>
     </div>
 </div>
 
@@ -69,6 +76,7 @@
     [Parameter] public bool HasSelectedPool { get; set; }
     [Parameter] public EventCallback<int> OnClick { get; set; }
     [Parameter] public EventCallback<int> OnCreateGrosTreasure { get; set; }
+    [Parameter] public EventCallback<int> OnCreateResourceTreasure { get; set; }
     [Parameter] public EventCallback<PiePayloadEventArgs> OnDrop { get; set; }
 
     private ElementReference elementRef;
@@ -99,6 +107,8 @@
     private Task HandleClick() => OnClick.InvokeAsync(Location.LocationId);
 
     private Task HandleGrosClick() => OnCreateGrosTreasure.InvokeAsync(Location.LocationId);
+
+    private Task HandleResourceClick() => OnCreateResourceTreasure.InvokeAsync(Location.LocationId);
 
     [JSInvokable]
     public Task OnTreasurePoolDropped(int locationId, string payload) =>

--- a/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
+++ b/src/OvcinaHra.Client/Components/TreasurePoolTile.razor
@@ -4,7 +4,7 @@
 
 <div @ref="elementRef"
      id="@tileTargetId"
-     class="oh-tp-pool-tile @(Selected ? "selected" : "") @(Item.IsUnique ? "is-unique" : "is-aggregate")"
+     class="oh-tp-pool-tile @(Selected ? "selected" : "") @(Item.IsUnique ? "is-unique" : "is-aggregate") @(HasThumbnail ? "has-image" : "no-image")"
      role="button"
      tabindex="0"
      aria-label="@TileLabel"
@@ -93,6 +93,7 @@
     private bool isRemoveVisible;
     private bool isNameFlyoutOpen;
     private bool removing;
+    private bool HasThumbnail => !string.IsNullOrWhiteSpace(Item.ItemThumbnailUrl);
     private string tileTargetId => $"oh-tp-pool-tile-{Item.Id}";
     private string TileLabel => Item.IsUnique ? Item.ItemName : $"{Item.ItemName} × {Item.Count}";
 

--- a/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationDetail.razor
@@ -61,6 +61,12 @@ else
                     </div>
                 }
             </div>
+            @if (!string.IsNullOrWhiteSpace(stampImageUrl))
+            {
+                <div class="oh-lc-title-stamp" title="Razítko lokace" aria-label="Razítko lokace">
+                    <img src="@stampImageUrl" alt="Razítko lokace @loc.Name" />
+                </div>
+            }
             <div class="oh-lc-title-actions">
                 @if (activeTab == "upravit")
                 {
@@ -480,6 +486,7 @@ else
     // without re-fetching the catalog on every render.
     private List<LocationListDto> allLocations = [];
     private string? mainImageUrl;
+    private string? stampImageUrl;
 
     private string activeTab = "karta";
     private bool loading = true, isSaving, isDeleteVisible, isRemoveFromGameVisible;
@@ -592,7 +599,10 @@ else
                 detail.ParentLocationId,
                 detail.Description, detail.Details, detail.GamePotential,
                 detail.NpcInfo, detail.SetupNotes,
-                stashes, quests, locationTreasureQuests);
+                stashes, quests, locationTreasureQuests,
+                StampImagePath: detail.StampImagePath,
+                StampImageUrl: detail.StampImageUrl);
+            stampImageUrl = detail.StampImageUrl;
 
             PopulateFormFromDto(detail);
 

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -229,14 +229,16 @@
     private const string LayerStateKey = "oh-map-layers-v2";
     private const string TreasurePhaseAll = "all";
     private const string TreasurePhaseStart = "start";
-    private const string TreasurePhaseMid = "mid";
-    private const string TreasurePhaseEnd = "end";
+    private const string TreasurePhaseEarly = "early";
+    private const string TreasurePhaseMidgame = "midgame";
+    private const string TreasurePhaseLategame = "lategame";
     private static readonly IReadOnlyList<TreasureMapPhaseOption> TreasureMapPhaseOptions =
     [
         new(TreasurePhaseAll, "Vše", "all"),
         new(TreasurePhaseStart, "Start", "start"),
-        new(TreasurePhaseMid, "Hra", "mid"),
-        new(TreasurePhaseEnd, "Konec", "end"),
+        new(TreasurePhaseEarly, "Rozvoj hry", "early"),
+        new(TreasurePhaseMidgame, "Střed hry", "midgame"),
+        new(TreasurePhaseLategame, "Závěr hry", "lategame"),
     ];
 
     private MapView? _mapView;
@@ -486,24 +488,27 @@
             : phase switch
             {
                 TreasurePhaseStart => location.TreasureCounts.Start,
-                TreasurePhaseMid => location.TreasureCounts.Mid,
-                TreasurePhaseEnd => location.TreasureCounts.End,
+                TreasurePhaseEarly => location.TreasureCounts.Early,
+                TreasurePhaseMidgame => location.TreasureCounts.Midgame,
+                TreasurePhaseLategame => location.TreasureCounts.Lategame,
                 _ => location.TreasureCounts.Total,
             };
 
     private static string TreasurePhaseLogName(string phase) => phase switch
     {
         TreasurePhaseStart => "Start",
-        TreasurePhaseMid => "Mid",
-        TreasurePhaseEnd => "End",
+        TreasurePhaseEarly => "Early",
+        TreasurePhaseMidgame => "Midgame",
+        TreasurePhaseLategame => "Lategame",
         _ => "All",
     };
 
     private static string TreasurePhaseUiName(string phase) => phase switch
     {
         TreasurePhaseStart => "Start",
-        TreasurePhaseMid => "Hra",
-        TreasurePhaseEnd => "Konec",
+        TreasurePhaseEarly => "Rozvoj hry",
+        TreasurePhaseMidgame => "Střed hry",
+        TreasurePhaseLategame => "Závěr hry",
         _ => "Vše",
     };
 

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -207,10 +207,11 @@ else
                                             var isFocused = focusedLocationId == loc.LocationId;
                                              <TreasureLocationTargetCard Location="loc"
                                                                          IsFocused="isFocused"
-                                                                         HasSelectedPool="@HasPendingAllocation"
-                                                                         OnClick="HandleLocationTargetClick"
-                                                                         OnCreateGrosTreasure="OpenGrosTreasureDialog"
-                                                                         OnDrop="HandlePieDrop" />
+                                                                          HasSelectedPool="@HasPendingAllocation"
+                                                                          OnClick="HandleLocationTargetClick"
+                                                                          OnCreateGrosTreasure="OpenGrosTreasureDialog"
+                                                                          OnCreateResourceTreasure="OpenResourceTreasureDialog"
+                                                                          OnDrop="HandlePieDrop" />
                                         }
                                     </div>
                                 </div>
@@ -647,6 +648,38 @@ else
             <button class="btn btn-secondary" type="button" @onclick="CloseGrosDialog" disabled="@grosSaving">Zrušit</button>
             <button class="btn btn-primary" type="button" @onclick="CreateGrosTreasureAsync" disabled="@(grosSaving || grosLocationId is null)">
                 @if (grosSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vytvořit
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@* ================== CREATE RESOURCE TREASURE POPUP ================== *@
+<DxPopup @bind-Visible="@isResourceDialogVisible" HeaderText="Vytvoř poklad ze suroviny" Width="440px">
+    <BodyContentTemplate Context="popupContext">
+        <DxFormLayout>
+            <DxFormLayoutItem Caption="Lokace" ColSpanMd="12">
+                <div class="oh-tp-gros-location">@ResourceDialogLocationName</div>
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Surovina" ColSpanMd="12">
+                <DxComboBox Data="@ResourceItems"
+                            @bind-Value="@resourceItemId"
+                            TextFieldName="ItemName"
+                            ValueFieldName="ItemId"
+                            NullText="Vyberte surovinu…" />
+            </DxFormLayoutItem>
+            <DxFormLayoutItem Caption="Počet" ColSpanMd="12">
+                <DxSpinEdit @bind-Value="@resourceCount" MinValue="1" MaxValue="9999" />
+            </DxFormLayoutItem>
+        </DxFormLayout>
+        @if (resourceError is not null)
+        {
+            <div class="alert alert-danger mt-2">@resourceError</div>
+        }
+        <div class="d-flex gap-2 mt-3 justify-content-end">
+            <button class="btn btn-secondary" type="button" @onclick="CloseResourceDialog" disabled="@resourceSaving">Zrušit</button>
+            <button class="btn btn-primary" type="button" @onclick="CreateResourceTreasureAsync" disabled="@(resourceSaving || resourceLocationId is null || resourceItemId is null)">
+                @if (resourceSaving) { <span class="spinner-border spinner-border-sm me-1"></span> }
                 Vytvořit
             </button>
         </div>
@@ -1344,8 +1377,8 @@ else
         placementPhase = next;
         lastUsedDifficulty = next;
         var current = PlacementPhaseUiName(next);
-        Console.WriteLine($"[treasure-alloc] phase-toggle changed from={previous} to={current}");
-        LogTreasureAlloc("phase-toggle", new
+        Console.WriteLine($"[treasure-alloc] phase-changed from={previous} to={current}");
+        LogTreasureAlloc("phase-changed", new
         {
             from = previous,
             to = current,
@@ -1357,15 +1390,19 @@ else
     private static string PlacementPhaseUiName(GameTimePhase phase) => phase switch
     {
         GameTimePhase.Start => "Start",
-        GameTimePhase.Lategame or GameTimePhase.EndGame => "Konec",
-        _ => "Hra"
+        GameTimePhase.Early => "Rozvoj hry",
+        GameTimePhase.Midgame => "Střed hry",
+        GameTimePhase.Lategame or GameTimePhase.EndGame => "Závěr hry",
+        _ => phase.GetDisplayName()
     };
 
     private static GameTimePhase PlacementPhaseBucket(GameTimePhase phase) => phase switch
     {
         GameTimePhase.Start => GameTimePhase.Start,
+        GameTimePhase.Early => GameTimePhase.Early,
+        GameTimePhase.Midgame => GameTimePhase.Midgame,
         GameTimePhase.Lategame or GameTimePhase.EndGame => GameTimePhase.Lategame,
-        _ => GameTimePhase.Midgame
+        _ => phase
     };
 
     private static void LogAssignRequestPhase(GameTimePhase phase, string source, int? locationId, int? secretStashId = null)
@@ -1478,6 +1515,23 @@ else
             ? locationCards.FirstOrDefault(l => l.LocationId == id)?.LocationName ?? $"Lokace #{id}"
             : "";
 
+    // ===== Surovina treasure popup =====
+    private bool isResourceDialogVisible;
+    private bool resourceSaving;
+    private int? resourceLocationId;
+    private int? resourceItemId;
+    private int resourceCount = 1;
+    private string? resourceError;
+    private List<UnlimitedItemDto> ResourceItems =>
+        unlimitedItems
+            .Where(i => i.ItemType == ItemType.Resource)
+            .OrderBy(i => i.ItemName, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+    private string ResourceDialogLocationName =>
+        resourceLocationId is int id
+            ? locationCards.FirstOrDefault(l => l.LocationId == id)?.LocationName ?? $"Lokace #{id}"
+            : "";
+
     // ===== Edit-quest popup =====
     private bool isEditQuestVisible, isDeleteQuestVisible, editSaving;
     private int? editQuestId;
@@ -1507,8 +1561,9 @@ else
     private static readonly List<PlacementPhaseOption> placementPhaseOptions =
     [
         new("start", GameTimePhase.Start, "Start"),
-        new("mid", GameTimePhase.Midgame, "Hra"),
-        new("end", GameTimePhase.Lategame, "Konec"),
+        new("early", GameTimePhase.Early, "Rozvoj hry"),
+        new("mid", GameTimePhase.Midgame, "Střed hry"),
+        new("late", GameTimePhase.Lategame, "Závěr hry"),
     ];
 
     private static readonly List<EnumItem<GameTimePhase>> difficultyValues = Enum.GetValues<GameTimePhase>()
@@ -2289,6 +2344,91 @@ else
         finally
         {
             grosSaving = false;
+        }
+    }
+
+    // ===== Surovina treasure popup =====
+    private void OpenResourceTreasureDialog(int locationId)
+    {
+        resourceLocationId = locationId;
+        resourceCount = 1;
+        resourceError = null;
+        var resources = ResourceItems;
+        resourceItemId = resources.Any(i => i.ItemId == resourceItemId)
+            ? resourceItemId
+            : resources.FirstOrDefault()?.ItemId;
+        isResourceDialogVisible = true;
+        Console.WriteLine($"[treasure-alloc] surovina-dialog open locationId={locationId}");
+        LogTreasureAlloc("surovina-dialog open", new { locationId });
+    }
+
+    private void CloseResourceDialog()
+    {
+        if (resourceSaving) return;
+        isResourceDialogVisible = false;
+        resourceError = null;
+    }
+
+    private UnlimitedItemDto? FindResourceItem()
+    {
+        var resources = ResourceItems;
+        return resources.FirstOrDefault(i => i.ItemId == resourceItemId)
+            ?? resources.FirstOrDefault();
+    }
+
+    private async Task CreateResourceTreasureAsync()
+    {
+        if (resourceLocationId is not int locationId || resourceSaving) return;
+        resourceError = null;
+        var resourceItem = FindResourceItem();
+        if (resourceItem is null)
+        {
+            LogTreasureAlloc("surovina-item-not-found", new { gameId });
+            resourceError = "Hra nemá nastavenu surovinu. Přidejte položku typu Surovina do herního inventáře.";
+            return;
+        }
+
+        resourceSaving = true;
+        try
+        {
+            var count = Math.Max(1, resourceCount);
+            var dto = new AssignTreasureDto(
+                Title: $"{resourceItem.ItemName} × {count}",
+                Difficulty: placementPhase,
+                GameId: gameId,
+                LocationId: locationId,
+                UnlimitedItems: [new UnlimitedItemAssignDto(resourceItem.ItemId, count)]);
+
+            var result = await Api.PostWithProblemAsync<AssignTreasureDto, TreasureQuestDetailDto>(
+                "/api/treasure-planning/assign",
+                dto);
+            LogAssignRequestPhase(dto.Difficulty, "surovina-dialog", locationId);
+            if (!result.Ok || result.Value is null)
+            {
+                resourceError = result.ProblemDetail ?? "Vytvoření pokladu ze suroviny se nepodařilo.";
+                return;
+            }
+
+            lastUsedDifficulty = dto.Difficulty;
+            placementPhase = PlacementPhaseBucket(dto.Difficulty);
+            isResourceDialogVisible = false;
+            markersPlaced = false;
+            await LoadAllAsync();
+            await PlaceMarkersIfReadyAsync();
+            Console.WriteLine(
+                $"[treasure-alloc] surovina-treasure-create locationId={locationId} stashId={result.Value.SecretStashId?.ToString() ?? "null"} itemId={resourceItem.ItemId} count={count}");
+            LogTreasureAlloc("surovina-treasure-create", new
+            {
+                locationId,
+                stashId = result.Value.SecretStashId,
+                itemId = resourceItem.ItemId,
+                count
+            });
+            StateHasChanged();
+        }
+        finally
+        {
+            resourceSaving = false;
         }
     }
 

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -795,7 +795,23 @@
     font-weight: 700;
     color: var(--oh-text);
 }
+.oh-lc-title-stamp {
+    width: 64px;
+    height: 64px;
+    flex: 0 0 64px;
+    margin-left: auto;
+    border: 1px solid rgba(107, 90, 58, .28);
+    border-radius: 6px;
+    background: #fff8ec;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px;
+    box-shadow: 0 2px 8px rgba(58, 46, 30, .12);
+}
+.oh-lc-title-stamp img { width: 100%; height: 100%; object-fit: contain; display: block; }
 .oh-lc-title-actions { margin-left: auto; display: flex; gap: 8px; align-items: center; }
+.oh-lc-title-stamp + .oh-lc-title-actions { margin-left: 0; }
 
 .oh-lc-tabs {
     display: flex;
@@ -2496,8 +2512,9 @@
 .oh-tp-placement-phase-lbl{font:800 .82rem var(--oh-font-body);color:var(--oh-primary);white-space:nowrap}
 .oh-tp-placement-phase .oh-tl-seg{background:rgba(255,255,255,.72)}
 .oh-tp-placement-phase .oh-tl-seg-btn[data-stage="start"].on{background:var(--oh-stage-start)}
+.oh-tp-placement-phase .oh-tl-seg-btn[data-stage="early"].on{background:var(--oh-stage-early);color:#3a2612}
 .oh-tp-placement-phase .oh-tl-seg-btn[data-stage="mid"].on{background:var(--oh-stage-midgame)}
-.oh-tp-placement-phase .oh-tl-seg-btn[data-stage="end"].on{background:var(--oh-stage-lategame)}
+.oh-tp-placement-phase .oh-tl-seg-btn[data-stage="late"].on{background:var(--oh-stage-lategame)}
 .oh-tp-assign-hdr{display:flex;align-items:center;gap:10px;padding:12px 14px;border-bottom:1px solid var(--oh-border);background:var(--oh-surface-alt)}
 .oh-tp-assign-hdr h5{margin:0;font:700 1rem var(--oh-font-heading);color:var(--oh-primary);flex:1}
 .oh-tp-assign-hdr .oh-tp-close{background:none;border:none;font-size:1.1rem;cursor:pointer;color:var(--oh-text-secondary);padding:2px 6px;line-height:1}
@@ -2511,14 +2528,16 @@
 /* Pool grid (5:7 MTG tiles) -------------------------------- */
 .oh-tp-pool-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(110px,1fr));gap:8px}
 .oh-tp-pool-grid.oh-tp-pool-compact{grid-template-columns:repeat(auto-fill,minmax(84px,1fr))}
-.oh-tp-pool-tile{position:relative;aspect-ratio:5/7;border-radius:8px;border:1px solid var(--oh-card-border,var(--oh-border));background:var(--oh-surface-alt);cursor:grab;user-select:none;overflow:hidden;box-shadow:var(--oh-shadow);transition:transform .15s,box-shadow .15s}
+.oh-tp-pool-tile{position:relative;aspect-ratio:5/7;border-radius:8px;border:1px solid var(--oh-card-border,var(--oh-border));background:#fff8ec;cursor:grab;user-select:none;overflow:hidden;box-shadow:var(--oh-shadow);transition:transform .15s,box-shadow .15s}
 .oh-tp-pool-tile:hover{transform:translateY(-2px);box-shadow:0 6px 14px rgba(45,80,22,.25);z-index:3}
 .oh-tp-pool-tile:active{cursor:grabbing}
 .oh-tp-pool-tile.selected{border-color:var(--oh-primary);box-shadow:0 0 0 2px var(--oh-primary-light) inset,var(--oh-shadow-lg)}
 .oh-tp-pool-tile-dragging{opacity:.5;transform:rotate(-3deg) scale(.98)}
-.oh-tp-pool-tile-img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
-.oh-tp-pool-tile-fallback{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:1.5rem;color:var(--oh-primary-light);background:var(--oh-surface-alt)}
-.oh-tp-pool-tile-name{position:absolute;left:4px;right:4px;bottom:4px;font:600 .75rem var(--oh-font-body);color:#fff;text-shadow:0 1px 3px rgba(0,0,0,.8);line-height:1.15;max-height:2.3em;overflow:hidden}
+.oh-tp-pool-tile-img{position:absolute;inset:0;width:100%;height:100%;object-fit:contain;padding:6px;background:#fff8ec}
+.oh-tp-pool-tile-fallback{position:absolute;left:50%;bottom:9px;z-index:1;width:34px;height:34px;transform:translateX(-50%);display:flex;align-items:center;justify-content:center;border-radius:50%;font-size:1.1rem;color:var(--oh-primary-light);background:rgba(45,80,22,.12);border:1px solid rgba(45,80,22,.2)}
+.oh-tp-pool-tile-name{position:absolute;left:4px;right:4px;bottom:4px;z-index:2;padding:2px 4px;border-radius:5px;background:rgba(255,248,236,.84);font:700 .75rem var(--oh-font-body);color:#1f1a14;text-shadow:0 1px 0 rgba(255,255,255,.95),0 0 4px rgba(255,255,255,.85);line-height:1.15;max-height:2.45em;overflow:hidden}
+.oh-tp-pool-tile.no-image .oh-tp-pool-tile-name{top:10px;bottom:50px;display:flex;align-items:center;justify-content:center;text-align:center;padding:8px;font-size:1.05rem;line-height:1.18;max-height:none;background:transparent}
+.oh-tp-pool-tile.no-image .oh-tp-pool-tile-badge{top:5px;right:5px}
 .oh-tp-pool-tile-badge{position:absolute;top:4px;right:4px;z-index:3;background:rgba(45,80,22,.92);color:#fff;border-radius:99px;padding:2px 7px;font:700 .75rem var(--oh-font-mono);letter-spacing:0;text-align:center;white-space:nowrap;max-width:calc(100% - 32px);overflow:hidden;text-overflow:ellipsis}
 /* Remove affordance — sits at top-left so it doesn't collide with the count
    badge. Always visible but low-opacity; hover bumps to full opacity. Sized
@@ -2538,7 +2557,7 @@
 .oh-tp-bundle-line-name{flex:1;font-weight:700;font-size:.82rem;color:var(--oh-text)}
 .oh-tp-bundle-line .remove{background:none;border:none;color:var(--oh-error);padding:0 2px}
 .oh-tp-item-thumb-img,.oh-tp-item-thumb{width:34px;height:34px;border-radius:6px;flex:0 0 34px;border:1px solid rgba(45,80,22,.2)}
-.oh-tp-item-thumb-img{object-fit:cover;background:var(--oh-surface-alt)}
+.oh-tp-item-thumb-img{object-fit:contain;background:#fff8ec}
 .oh-tp-item-thumb{display:inline-flex;align-items:center;justify-content:center;background:var(--oh-primary-surface);color:var(--oh-primary-light);font-size:.95rem}
 .oh-tp-bundle-money{display:grid;grid-template-columns:minmax(5.5rem,1fr) 42px minmax(7rem,9rem) 42px;gap:8px;align-items:center;padding:7px;border:1px solid rgba(45,80,22,.2);border-radius:7px;background:rgba(255,255,255,.8)}
 .oh-tp-bundle-money-name{font-weight:800;font-size:.86rem;color:var(--oh-text)}
@@ -3305,9 +3324,9 @@
 .oh-tp-card-treasure-name{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font:700 .78rem var(--oh-font-body);color:var(--oh-text,#2a2a2a)}
 .oh-tp-card-treasure-count{font:800 .75rem 'JetBrains Mono',monospace;color:#2D5016}
 .oh-tp-card-treasure-more{font:.72rem 'JetBrains Mono',monospace;color:var(--oh-text-secondary,#666);padding-left:2px}
-.oh-tp-card-actions{display:flex;margin-top:.2rem}
-.oh-tp-card-gros{display:inline-flex;align-items:center;gap:.3rem;border:1px solid var(--oh-border,#D9CFB6);border-radius:999px;background:#fff8ec;color:#2D5016;padding:.2rem .55rem;font:700 .75rem var(--oh-font-body);cursor:pointer}
-.oh-tp-card-gros:hover{background:#F2EBD8;border-color:#B8A87A}
+.oh-tp-card-actions{display:flex;flex-wrap:wrap;gap:.35rem;margin-top:.2rem}
+.oh-tp-card-gros,.oh-tp-card-resource{display:inline-flex;align-items:center;gap:.3rem;border:1px solid var(--oh-border,#D9CFB6);border-radius:999px;background:#fff8ec;color:#2D5016;padding:.2rem .55rem;font:700 .75rem var(--oh-font-body);cursor:pointer}
+.oh-tp-card-gros:hover,.oh-tp-card-resource:hover{background:#F2EBD8;border-color:#B8A87A}
 .oh-tp-card-cta{margin-top:.2rem;display:inline-flex;align-items:center;gap:.3rem;color:#2D5016;font-weight:600;font-size:.78rem}
 .oh-tp-location-total{font-family:'JetBrains Mono',monospace;font-size:.85rem;color:var(--oh-text-secondary,#666);margin-left:.35rem}
 .oh-tp-stash-summary{display:flex;flex-wrap:wrap;gap:.35rem;margin:.45rem 0 .7rem}
@@ -3814,8 +3833,9 @@
 .oh-map-treasure-chip.is-active{background:var(--c,#2D5016);color:#fff}
 .oh-map-treasure-chip[data-stage="all"]{--c:#2D5016}
 .oh-map-treasure-chip[data-stage="start"]{--c:var(--oh-stage-start)}
-.oh-map-treasure-chip[data-stage="mid"]{--c:var(--oh-stage-midgame)}
-.oh-map-treasure-chip[data-stage="end"]{--c:var(--oh-stage-endgame)}
+.oh-map-treasure-chip[data-stage="early"]{--c:var(--oh-stage-early);color:#3a2612}
+.oh-map-treasure-chip[data-stage="midgame"]{--c:var(--oh-stage-midgame)}
+.oh-map-treasure-chip[data-stage="lategame"]{--c:var(--oh-stage-lategame)}
 @media (max-width: 900px){
     .oh-map-treasure-filter{top:48px;right:8px;max-width:calc(100% - 16px)}
 }

--- a/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/LocationDtos.cs
@@ -103,7 +103,8 @@ public record LocationDetailDto(
     string? NpcInfo,
     string? SetupNotes,
     int? ParentLocationId,
-    List<LocationVariantDto> Variants);
+    List<LocationVariantDto> Variants,
+    string? StampImageUrl = null);
 
 public record LocationVariantDto(int Id, string Name, LocationKind LocationKind);
 

--- a/src/OvcinaHra.Shared/Dtos/MapDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MapDtos.cs
@@ -48,7 +48,7 @@ public record MapLocationDto(
     public string EffectiveKindDisplay => EffectiveKind.GetDisplayName();
 }
 
-public record TreasureCountByPhaseDto(int Total, int Start, int Mid, int End);
+public record TreasureCountByPhaseDto(int Total, int Start, int Early, int Midgame, int Lategame);
 
 /// <summary>
 /// One stash pin. Always sits at <see cref="Lat"/>/<see cref="Lon"/> of

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
@@ -168,7 +168,7 @@ public class MapEndpointsTests(PostgresFixture postgres)
     }
 
     [Fact]
-    public async Task Data_LocationPinsIncludeTreasureItemCountsByCollapsedPhase()
+    public async Task Data_LocationPinsIncludeTreasureItemCountsByCanonicalPhase()
     {
         var game = await CreateGameAsync();
         int parentId, emptyId;
@@ -278,8 +278,9 @@ public class MapEndpointsTests(PostgresFixture postgres)
         Assert.NotNull(parentPin.TreasureCounts);
         Assert.Equal(20, parentPin.TreasureCounts.Total);
         Assert.Equal(2, parentPin.TreasureCounts.Start);
-        Assert.Equal(7, parentPin.TreasureCounts.Mid);
-        Assert.Equal(11, parentPin.TreasureCounts.End);
+        Assert.Equal(3, parentPin.TreasureCounts.Early);
+        Assert.Equal(4, parentPin.TreasureCounts.Midgame);
+        Assert.Equal(11, parentPin.TreasureCounts.Lategame);
 
         var emptyPin = Assert.Single(data.Locations, l => l.Id == emptyId);
         Assert.NotNull(emptyPin.TreasureCounts);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
@@ -296,27 +296,34 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
     }
 
     [Fact]
-    public async Task MoneyItems_CannotBeAddedToPoolButRemainUnlimitedCurrencyOptions()
+    public async Task MoneyAndResourceItems_CannotBeAddedToPoolButRemainUnlimitedOptions()
     {
         var game = await CreateGameAsync();
         var bronze = await CreateItemAsync("Bronz", ItemType.Money);
         var currency = await CreateItemAsync("Peníze", ItemType.Money);
+        var wood = await CreateItemAsync("Dřevo", ItemType.Resource);
         await AssignItemToGameAsync(game.Id, bronze.Id, stockCount: 50, isFindable: true);
         await AssignItemToGameAsync(game.Id, currency.Id, isFindable: true);
+        await AssignItemToGameAsync(game.Id, wood.Id, stockCount: 50, isFindable: true);
 
         var addResponse = await Client.PostAsJsonAsync("/api/treasure-planning/pool",
             new CreateTreasurePoolItemDto(bronze.Id, game.Id, 10));
         Assert.Equal(HttpStatusCode.BadRequest, addResponse.StatusCode);
+        var addResourceResponse = await Client.PostAsJsonAsync("/api/treasure-planning/pool",
+            new CreateTreasurePoolItemDto(wood.Id, game.Id, 10));
+        Assert.Equal(HttpStatusCode.BadRequest, addResourceResponse.StatusCode);
 
         var available = await Client.GetFromJsonAsync<List<AvailablePoolItemDto>>(
             $"/api/treasure-planning/available-items/{game.Id}");
         Assert.NotNull(available);
         Assert.DoesNotContain(available!, i => i.ItemId == bronze.Id);
+        Assert.DoesNotContain(available!, i => i.ItemId == wood.Id);
 
         var pool = await Client.GetFromJsonAsync<List<TreasurePoolItemDto>>(
             $"/api/treasure-planning/pool/{game.Id}");
         Assert.NotNull(pool);
         Assert.DoesNotContain(pool!, i => i.ItemId == bronze.Id);
+        Assert.DoesNotContain(pool!, i => i.ItemId == wood.Id);
 
         var unlimited = await Client.GetFromJsonAsync<List<UnlimitedItemDto>>(
             $"/api/treasure-planning/unlimited/{game.Id}");
@@ -324,6 +331,34 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
         var currencyOption = Assert.Single(unlimited!, i => i.ItemId == currency.Id);
         Assert.Equal(ItemType.Money, currencyOption.ItemType);
         Assert.Equal("Peníze", currencyOption.ItemName);
+        var resourceOption = Assert.Single(unlimited!, i => i.ItemId == wood.Id);
+        Assert.Equal(ItemType.Resource, resourceOption.ItemType);
+        Assert.Equal("Dřevo", resourceOption.ItemName);
+    }
+
+    [Fact]
+    public async Task AssignTreasure_WithResourceShortcut_DefaultsToLowestCountStash()
+    {
+        var game = await CreateGameAsync();
+        var location = await CreateLocationAsync();
+        await AssignLocationToGameAsync(game.Id, location.Id);
+        var stash = await CreateSecretStashAsync("Sklad u dubu");
+        await AssignStashToGameAsync(game.Id, stash.Id, location.Id);
+        var wood = await CreateItemAsync("Dřevo", ItemType.Resource);
+        await AssignItemToGameAsync(game.Id, wood.Id, stockCount: 50, isFindable: true);
+
+        var response = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto("Dřevo × 3", GameTimePhase.Midgame, game.Id,
+                LocationId: location.Id,
+                UnlimitedItems: [new UnlimitedItemAssignDto(wood.Id, 3)]));
+        response.EnsureSuccessStatusCode();
+        var quest = (await response.Content.ReadFromJsonAsync<TreasureQuestDetailDto>())!;
+
+        Assert.Null(quest.LocationId);
+        Assert.Equal(stash.Id, quest.SecretStashId);
+        var item = Assert.Single(quest.Items);
+        Assert.Equal(wood.Id, item.ItemId);
+        Assert.Equal(3, item.Count);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Canonicalized treasure phase selectors/counts to Start / Rozvoj hry / Střed hry / Závěr hry and preserved the selected phase through allocation flows.
- Improved treasure tile image scaling, empty tile layout, and thumbnail previews.
- Added "Vytvoř poklad ze suroviny" as a resource shortcut parallel to groše, with pool exclusions and diagnostic markers.
- Shows the location stamp thumbnail in the location detail header.

## Verification
- dotnet build OvcinaHra.slnx
- dotnet test OvcinaHra.slnx --no-build

closes #438
closes #439
closes #440
closes #446