### PR TITLE
feat(map): toggle region labels

### DIFF
--- a/src/OvcinaHra.Api/Services/MapDataService.cs
+++ b/src/OvcinaHra.Api/Services/MapDataService.cs
@@ -33,6 +33,7 @@ public sealed class MapDataService(
                 gl.LocationId,
                 gl.Location.Name,
                 gl.Location.LocationKind,
+                gl.Location.Region,
                 Lat = gl.Location.Coordinates!.Latitude,
                 Lon = gl.Location.Coordinates!.Longitude,
                 gl.Location.ImagePath,
@@ -139,6 +140,7 @@ public sealed class MapDataService(
             r.LocationId, r.Name,
             (double)r.Lat, (double)r.Lon,
             r.LocationKind,
+            r.Region,
             // Kingdom not stored on Location/GameLocation today. Return null
             // so the cockpit's kingdom-tint chip stays inert until a follow-up
             // adds the relationship.

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -66,6 +66,12 @@
                                     @phase.Label
                                 </button>
                             }
+                            <label class="oh-map-region-toggle @(_showRegionsOnMap ? "is-active" : "")">
+                                <input type="checkbox"
+                                       checked="@_showRegionsOnMap"
+                                       @onchange="SetRegionLabelsAsync" />
+                                <span>Zobrazit oblasti</span>
+                            </label>
                         </div>
                         <div class="oh-map-style-toolbar">
                             <button class="oh-map-style-btn @(_activeStyle == "tourist" ? "is-active" : "")"
@@ -227,6 +233,7 @@
     // also persists HiddenKinds). Old v1 entries without HiddenKinds
     // continue to deserialize via the record's default value.
     private const string LayerStateKey = "oh-map-layers-v2";
+    private const string RegionLabelStateKey = "oh-map-region-labels-v1";
     private const string TreasurePhaseAll = "all";
     private const string TreasurePhaseStart = "start";
     private const string TreasurePhaseEarly = "early";
@@ -250,6 +257,7 @@
     private bool _overlaysVisible = true;
     private bool _organizerOverlayVisible = true;
     private bool _isOrganizer;
+    private bool _showRegionsOnMap;
     // Per-LocationKind hide set. Empty (default) = all kinds visible.
     // Persists alongside the layer-visibility flags.
     private HashSet<LocationKind> _hiddenKinds = new();
@@ -354,6 +362,7 @@
         {
             await HydrateLayerStateAsync();
         }
+        await HydrateRegionLabelStateAsync();
         // Apply URL-derived style now that the basemap is ready (default
         // is "tourist", so we only need to switch when URL asked for
         // something else). Calling switchStyle directly here — going
@@ -405,6 +414,25 @@
         catch { /* same fallback */ }
     }
 
+    private async Task HydrateRegionLabelStateAsync()
+    {
+        try
+        {
+            var raw = await JS.InvokeAsync<string?>("localStorage.getItem", RegionLabelStateKey);
+            _showRegionsOnMap = raw is "1" || string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase);
+        }
+        catch { /* localStorage unavailable — keep default off */ }
+    }
+
+    private async Task PersistRegionLabelStateAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("localStorage.setItem", RegionLabelStateKey, _showRegionsOnMap ? "true" : "false");
+        }
+        catch { /* localStorage unavailable — session-only toggle */ }
+    }
+
     private async Task ReloadDataAndRenderAsync()
     {
         var gameId = GameContext.SelectedGameId;
@@ -445,6 +473,8 @@
         if (_data is null) { Console.WriteLine("[map-diag] PaintPinsAsync exit — _data is null"); return; }
         Console.WriteLine($"[map-diag] PaintPinsAsync data — Locations={_data.Locations.Count}, Stashes={_data.Stashes.Count}");
 
+        var locationLabelCount = 0;
+        var regionLabelCount = 0;
         if (_locationsVisible)
         {
             foreach (var l in _data.Locations.OrderBy(l => l.EffectiveKind == LocationKind.Hobbit ? 1 : 0))
@@ -455,12 +485,16 @@
                 if (_hiddenKinds.Contains(l.EffectiveKind)) continue;
                 var filteredCount = GetTreasureCount(l, _treasurePhaseFilter);
                 var totalCount = l.TreasureCounts?.Total ?? 0;
+                locationLabelCount++;
+                if (_showRegionsOnMap && !string.IsNullOrWhiteSpace(l.Region)) regionLabelCount++;
                 Console.WriteLine($"[treasure-map] count-pin render locationId={l.Id} totalCount={totalCount} filteredCount={filteredCount} phase={TreasurePhaseLogName(_treasurePhaseFilter)}");
                 await JS.InvokeVoidAsync("ovcinaMap.addLocationPin",
                     l.Id, l.Lat, l.Lon, l.EffectiveName, l.EffectiveKind.ToString(),
-                    filteredCount, TreasurePhaseUiName(_treasurePhaseFilter));
+                    filteredCount, TreasurePhaseUiName(_treasurePhaseFilter),
+                    l.Region, _showRegionsOnMap);
             }
         }
+        Console.WriteLine($"[map-region-toggle] render labelCount={locationLabelCount} withRegion={_showRegionsOnMap.ToString().ToLowerInvariant()} regionLabelCount={regionLabelCount}");
         if (_stashesVisible)
         {
             foreach (var s in _data.Stashes)
@@ -479,6 +513,17 @@
         var previous = _treasurePhaseFilter;
         _treasurePhaseFilter = phase;
         Console.WriteLine($"[treasure-map] phase-filter changed from={TreasurePhaseLogName(previous)} to={TreasurePhaseLogName(phase)}");
+        await PaintPinsAsync();
+    }
+
+    private async Task SetRegionLabelsAsync(ChangeEventArgs e)
+    {
+        var enabled = e.Value is bool value && value;
+        if (_showRegionsOnMap == enabled) return;
+
+        _showRegionsOnMap = enabled;
+        Console.WriteLine($"[map-region-toggle] state-changed enabled={enabled.ToString().ToLowerInvariant()}");
+        await PersistRegionLabelStateAsync();
         await PaintPinsAsync();
     }
 

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3835,6 +3835,12 @@
 .oh-map-treasure-chip[data-stage="early"]{--c:var(--oh-stage-early);color:#3a2612}
 .oh-map-treasure-chip[data-stage="midgame"]{--c:var(--oh-stage-midgame)}
 .oh-map-treasure-chip[data-stage="lategame"]{--c:var(--oh-stage-lategame)}
+.oh-map-region-toggle{display:flex;align-items:center;gap:5px;margin-left:4px;padding:3px 9px;
+    border-radius:99px;color:var(--oh-text,#2a2a2a);font:600 .72rem var(--oh-font-body);
+    cursor:pointer;user-select:none}
+.oh-map-region-toggle input{width:13px;height:13px;margin:0;accent-color:#2D5016}
+.oh-map-region-toggle:hover{background:rgba(45,80,22,.08);color:#2D5016}
+.oh-map-region-toggle.is-active{background:#2D5016;color:#fff}
 @media (max-width: 900px){
     .oh-map-treasure-filter{top:48px;right:8px;max-width:calc(100% - 16px)}
 }
@@ -3903,11 +3909,17 @@
     font:600 .72rem var(--oh-font-body,sans-serif);color:#1a1a2e;
     text-shadow:0 0 3px #fff,0 0 3px #fff,0 0 3px #fff,0 0 3px #fff;
     pointer-events:none;user-select:none;z-index:1}
+.oh-map-pin-label-with-region{flex-direction:column;align-items:center;gap:1px;text-align:center;line-height:1.08}
+.oh-map-pin-label-name{display:block;white-space:nowrap}
+.oh-map-pin-label-region{display:block;white-space:nowrap;font-size:.62rem;font-weight:600;color:#5f5a50;
+    text-shadow:0 0 3px #fff,0 0 3px #fff,0 0 3px #fff}
 .oh-map-pin.oh-pin-label-on .oh-map-pin-label{display:block}
+.oh-map-pin.oh-pin-label-on .oh-map-pin-label.oh-map-pin-label-with-region{display:flex}
 /* Print mode (#259) overrides the zoom gate for the labeled-print body
    class so every parent label paints regardless of map zoom — physical
    handouts can't pinch-zoom. */
 body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label{display:block}
+body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label.oh-map-pin-label-with-region{display:flex}
 
 /* Issue #273 — zoom indicator next to the Scale control. MapLibre's
    own .maplibregl-ctrl styling supplies the rounded-rect chrome; we

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -1223,7 +1223,7 @@ window.ovcinaMap._kindIconFor = function (kindRaw) {
     return this._kindIcon[k] || 'bi-geo-alt-fill';
 };
 
-window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind, treasureCount, treasurePhase) {
+window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind, treasureCount, treasurePhase, region, showRegion) {
     if (!this._map) {
         if (this._pinDiag()) console.warn('[pin-diag] addLocationPin called but no map — id=' + id);
         return;
@@ -1257,6 +1257,7 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind, treasureCo
     if (!isFinite(count)) count = 0;
     count = Math.max(0, Math.trunc(count));
     var phaseText = treasurePhase || '';
+    var regionText = showRegion && region ? String(region).trim() : '';
     var kindKey = (kind || 'wilderness').toLowerCase();
     pin.setAttribute('data-kind', kindKey);
     // Issue #273 — graduated label-visibility-by-zoom. Each pin advertises
@@ -1266,7 +1267,10 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind, treasureCo
     var minZoom = this._kindMinZoomFor(kindKey);
     pin.setAttribute('data-minzoom', String(minZoom));
     if (this._map.getZoom() >= minZoom) pin.classList.add('oh-pin-label-on');
-    wrapper.title = (name || '') + (count > 0 ? ' · ' + count + ' pokladů' + (phaseText ? ' (' + phaseText + ')' : '') : '');
+    var markerTitle = name || '';
+    if (regionText) markerTitle += (markerTitle ? ' · ' : '') + regionText;
+    if (count > 0) markerTitle += (markerTitle ? ' · ' : '') + count + ' pokladů' + (phaseText ? ' (' + phaseText + ')' : '');
+    wrapper.title = markerTitle;
     // Issue #257 — tear-drop pin chrome. The bubble (oh-map-pin-bg) carries
     // the per-kind background and the downward triangle tail (::after); the
     // glyph (Bootstrap-Icons bi-*) sits inside. Anchor moves to 'bottom' so
@@ -1291,8 +1295,17 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind, treasureCo
     }
     if (name) {
         var label = document.createElement('div');
-        label.className = 'oh-map-pin-label';
-        label.textContent = name;
+        label.className = 'oh-map-pin-label' + (regionText ? ' oh-map-pin-label-with-region' : '');
+        var nameLine = document.createElement('span');
+        nameLine.className = 'oh-map-pin-label-name';
+        nameLine.textContent = name;
+        label.appendChild(nameLine);
+        if (regionText) {
+            var regionLine = document.createElement('span');
+            regionLine.className = 'oh-map-pin-label-region';
+            regionLine.textContent = regionText;
+            label.appendChild(regionLine);
+        }
         pin.appendChild(label);
     }
     wrapper.appendChild(pin);

--- a/src/OvcinaHra.Shared/Dtos/MapDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MapDtos.cs
@@ -28,6 +28,7 @@ public record MapLocationDto(
     double Lat,
     double Lon,
     LocationKind Kind,
+    string? Region,
     int? KingdomId,
     string? KingdomName,
     string? ThumbnailUrl,

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
@@ -50,6 +50,7 @@ public class MapEndpointsTests(PostgresFixture postgres)
             {
                 Name = "Hradec",
                 LocationKind = LocationKind.Wilderness,
+                Region = "Severní les",
                 Coordinates = new GpsCoordinates(49.5m, 17.1m),
             };
             var withoutGps = new Location
@@ -71,6 +72,7 @@ public class MapEndpointsTests(PostgresFixture postgres)
         Assert.NotNull(data);
         var single = Assert.Single(data.Locations);
         Assert.Equal("Hradec", single.Name);
+        Assert.Equal("Severní les", single.Region);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- adds a /map toolbar toggle "Zobrazit oblasti" with localStorage persistence
- carries Location.Region in /api/map/data and renders it as a smaller second line under location labels when enabled
- keeps treasure count badges and EffectiveName/EffectiveKind pin rendering on the existing path

Closes #452

## Verification
- dotnet build OvcinaHra.slnx --nologo
- dotnet test OvcinaHra.slnx --nologo --no-build

## Visual smoke
- Open /map for game 30.
- Toggle "Zobrazit oblasti" ON: region names should appear under location labels, while count badges remain visible.
- Toggle OFF: labels return to the original single-line names.
- Confirm Hobbit parent labels still use the propagated Hobbit name.
