### PR TITLE
fix(api): polish stamp LLM reviewer NITs (closes #457) [v0.16.57]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/StampLlmEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/StampLlmEndpoints.cs
@@ -42,13 +42,21 @@ public static class StampLlmEndpoints
                 statusCode: StatusCodes.Status403Forbidden);
         }
 
+        if (!verifier.IsConfigured)
+            return AnthropicConfigurationMissing(logger);
+
         var location = await db.Locations
             .Where(l => l.Id == request.LocationId)
             .Select(l => new { l.Id, l.Name, l.StampImagePath })
             .FirstOrDefaultAsync(ct);
 
         if (location is null)
-            return BadRequest("Lokalita neexistuje", $"Lokalita s ID {request.LocationId} neexistuje.");
+        {
+            return TypedResults.Problem(
+                title: "Lokalita neexistuje",
+                detail: $"Lokalita s ID {request.LocationId} neexistuje.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
 
         if (string.IsNullOrWhiteSpace(location.StampImagePath))
         {
@@ -102,19 +110,42 @@ public static class StampLlmEndpoints
         catch (StampLlmRateLimitedException ex)
         {
             await AuditFailureAsync(db, request, organizer, location.Id, ex, ct);
+            logger.LogWarning(
+                ex,
+                "[stamp-llm-server] endpoint rate-limited locationId={LocationId} rawResponse={RawResponse}",
+                location.Id,
+                ex.RawResponse);
             return TypedResults.Problem(
                 title: "LLM ověření je dočasně omezené",
-                detail: $"Anthropic API vrátilo rate limit: {ex.RawResponse}",
+                detail: "LLM ověření je dočasně omezené, použij ruční výběr.",
                 statusCode: StatusCodes.Status429TooManyRequests);
+        }
+        catch (StampLlmConfigurationException)
+        {
+            return AnthropicConfigurationMissing(logger);
         }
         catch (StampLlmProviderException ex)
         {
             await AuditFailureAsync(db, request, organizer, location.Id, ex, ct);
+            logger.LogError(
+                ex,
+                "[stamp-llm-server] endpoint provider-error locationId={LocationId} rawResponse={RawResponse}",
+                location.Id,
+                ex.RawResponse);
             return TypedResults.Problem(
                 title: "LLM ověření selhalo",
-                detail: $"Anthropic API selhalo: {ex.RawResponse}. Použij ruční výběr.",
+                detail: "LLM ověření selhalo, použij ruční výběr.",
                 statusCode: StatusCodes.Status502BadGateway);
         }
+    }
+
+    private static ProblemHttpResult AnthropicConfigurationMissing(ILogger logger)
+    {
+        logger.LogWarning("[stamp-llm-server] config-missing graceful-503");
+        return TypedResults.Problem(
+            title: "LLM ověření není v tomto prostředí nakonfigurované",
+            detail: "Nastavte proměnnou prostředí Anthropic__ApiKey pro zapnutí LLM ověřování razítek.",
+            statusCode: StatusCodes.Status503ServiceUnavailable);
     }
 
     private static ProblemHttpResult BadRequest(string title, string detail)

--- a/src/OvcinaHra.Api/Services/StampLlmVerifyService.cs
+++ b/src/OvcinaHra.Api/Services/StampLlmVerifyService.cs
@@ -8,6 +8,7 @@ namespace OvcinaHra.Api.Services;
 
 public interface IStampLlmVerifyService
 {
+    bool IsConfigured { get; }
     Task<StampLlmVerifyResult> VerifyAsync(StampLlmVerifyJob job, CancellationToken ct = default);
 }
 
@@ -174,8 +175,10 @@ public sealed class StampLlmVerifyService : IStampLlmVerifyService, IDisposable
     private readonly ILogger<StampLlmVerifyService> _logger;
     private readonly string _model;
     private readonly int _maxTokens;
-    private readonly HttpClient _httpClient;
-    private readonly AnthropicClient _client;
+    private readonly HttpClient? _httpClient;
+    private readonly AnthropicClient? _client;
+
+    public bool IsConfigured { get; }
 
     public StampLlmVerifyService(
         IConfiguration config,
@@ -185,20 +188,28 @@ public sealed class StampLlmVerifyService : IStampLlmVerifyService, IDisposable
         _blobStorage = blobStorage;
         _logger = logger;
 
-        var apiKey = config["Anthropic:ApiKey"];
-        if (string.IsNullOrWhiteSpace(apiKey))
-            throw new InvalidOperationException("Configuration key Anthropic:ApiKey is required.");
-
         _model = config["Anthropic:Model"] ?? DefaultModel;
         _maxTokens = config.GetValue("Anthropic:MaxTokens", DefaultMaxTokens);
         var timeoutSeconds = config.GetValue("Anthropic:TimeoutSeconds", DefaultTimeoutSeconds);
 
+        var apiKey = config["Anthropic:ApiKey"];
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            IsConfigured = false;
+            _logger.LogWarning("[stamp-llm-server] config-missing graceful-503");
+            return;
+        }
+
+        IsConfigured = true;
         _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(timeoutSeconds) };
         _client = new AnthropicClient(new APIAuthentication(apiKey), _httpClient);
     }
 
     public async Task<StampLlmVerifyResult> VerifyAsync(StampLlmVerifyJob job, CancellationToken ct = default)
     {
+        if (!IsConfigured || _client is null)
+            throw new StampLlmConfigurationException();
+
         var referenceBytes = await _blobStorage.DownloadAsync(job.ReferenceBlobKey, ct);
         if (referenceBytes is null || referenceBytes.Length == 0)
         {
@@ -340,8 +351,8 @@ public sealed class StampLlmVerifyService : IStampLlmVerifyService, IDisposable
 
     public void Dispose()
     {
-        _client.Dispose();
-        _httpClient.Dispose();
+        _client?.Dispose();
+        _httpClient?.Dispose();
     }
 
     private static ParsedStampLlmResponse ParseResponse(string raw)
@@ -380,6 +391,9 @@ public class StampLlmValidationException(string title, string detail) : Exceptio
     public string Title { get; } = title;
     public string Detail { get; } = detail;
 }
+
+public sealed class StampLlmConfigurationException()
+    : Exception("Configuration key Anthropic:ApiKey is required.");
 
 public class StampLlmProviderException(
     string message,

--- a/tests/OvcinaHra.Api.Tests/Endpoints/StampLlmEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/StampLlmEndpointTests.cs
@@ -110,6 +110,20 @@ public class StampLlmEndpointTests(PostgresFixture postgres) : IntegrationTestBa
     }
 
     [Fact]
+    public async Task VerifyLlm_UnknownLocation_Returns404BeforeValidatingImage()
+    {
+        var fake = new FakeStampLlmVerifyService(_ => throw new InvalidOperationException("Verifier must not run."));
+        await using var resources = await CreateClientWithFakeAsync(fake);
+
+        var response = await resources.Client.PostAsJsonAsync("/api/stamps/verify-llm",
+            new VerifyStampLlmRequest(999999, "not-base64"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await AssertProblemDetailsAsync(response, "Lokalita neexistuje", "999999");
+        Assert.Empty(fake.Jobs);
+    }
+
+    [Fact]
     public async Task VerifyLlm_LocationWithoutStamp_ReturnsCzechProblemDetails()
     {
         var fake = new FakeStampLlmVerifyService(_ => throw new InvalidOperationException("Verifier must not run."));
@@ -130,7 +144,7 @@ public class StampLlmEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         var fake = new FakeStampLlmVerifyService(_ => throw new StampLlmProviderException(
             "provider failed",
             432,
-            "upstream boom"));
+            "upstream boom with token sk-ant-test"));
         await using var resources = await CreateClientWithFakeAsync(fake);
         var locationId = await SeedLocationAsync(resources.Factory);
 
@@ -138,7 +152,12 @@ public class StampLlmEndpointTests(PostgresFixture postgres) : IntegrationTestBa
             new VerifyStampLlmRequest(locationId, ToDataUrl(ReadTestData("sample-stamp-captured-good.jpg"), "image/jpeg")));
 
         Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
-        await AssertProblemDetailsAsync(response, "LLM ověření selhalo", "upstream boom");
+        var problem = await AssertProblemDetailsAsync(
+            response,
+            "LLM ověření selhalo",
+            "použij ruční výběr");
+        Assert.DoesNotContain("upstream boom", problem.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sk-ant", problem.Detail, StringComparison.OrdinalIgnoreCase);
 
         using var scope = resources.Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
@@ -146,7 +165,7 @@ public class StampLlmEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         Assert.False(audit.Match);
         Assert.Equal(0, audit.Confidence);
         Assert.Equal(432, audit.LatencyMs);
-        Assert.Equal("upstream boom", audit.RawResponse);
+        Assert.Equal("upstream boom with token sk-ant-test", audit.RawResponse);
     }
 
     [Fact]
@@ -163,13 +182,33 @@ public class StampLlmEndpointTests(PostgresFixture postgres) : IntegrationTestBa
             new VerifyStampLlmRequest(locationId, ToDataUrl(ReadTestData("sample-stamp-captured-good.jpg"), "image/jpeg")));
 
         Assert.Equal((HttpStatusCode)429, response.StatusCode);
-        await AssertProblemDetailsAsync(response, "LLM ověření je dočasně omezené", "too many requests");
+        var problem = await AssertProblemDetailsAsync(response, "LLM ověření je dočasně omezené", "ruční výběr");
+        Assert.DoesNotContain("too many requests", problem.Detail, StringComparison.OrdinalIgnoreCase);
 
         using var scope = resources.Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
         var audit = await db.StampLlmVerifications.SingleAsync();
         Assert.False(audit.Match);
         Assert.Equal(211, audit.LatencyMs);
+    }
+
+    [Fact]
+    public async Task VerifyLlm_MissingAnthropicConfiguration_Returns503()
+    {
+        var fake = new FakeStampLlmVerifyService(
+            _ => throw new InvalidOperationException("Verifier must not run."),
+            isConfigured: false);
+        await using var resources = await CreateClientWithFakeAsync(fake);
+
+        var response = await resources.Client.PostAsJsonAsync("/api/stamps/verify-llm",
+            new VerifyStampLlmRequest(999999, "not-base64"));
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        await AssertProblemDetailsAsync(
+            response,
+            "LLM ověření není v tomto prostředí nakonfigurované",
+            "Anthropic__ApiKey");
+        Assert.Empty(fake.Jobs);
     }
 
     private async Task<TestResources> CreateClientWithFakeAsync(FakeStampLlmVerifyService fake)
@@ -209,7 +248,7 @@ public class StampLlmEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         return location.Id;
     }
 
-    private static async Task AssertProblemDetailsAsync(
+    private static async Task<ProblemDetails> AssertProblemDetailsAsync(
         HttpResponseMessage response,
         string expectedTitle,
         string expectedDetailFragment)
@@ -218,6 +257,7 @@ public class StampLlmEndpointTests(PostgresFixture postgres) : IntegrationTestBa
         Assert.NotNull(problem);
         Assert.Equal(expectedTitle, problem!.Title);
         Assert.Contains(expectedDetailFragment, problem.Detail, StringComparison.OrdinalIgnoreCase);
+        return problem;
     }
 
     private static byte[] ReadTestData(string fileName)
@@ -226,9 +266,12 @@ public class StampLlmEndpointTests(PostgresFixture postgres) : IntegrationTestBa
     private static string ToDataUrl(byte[] bytes, string mediaType)
         => $"data:{mediaType};base64,{Convert.ToBase64String(bytes)}";
 
-    private sealed class FakeStampLlmVerifyService(Func<StampLlmVerifyJob, StampLlmVerifyResult> verify)
+    private sealed class FakeStampLlmVerifyService(
+        Func<StampLlmVerifyJob, StampLlmVerifyResult> verify,
+        bool isConfigured = true)
         : IStampLlmVerifyService
     {
+        public bool IsConfigured { get; } = isConfigured;
         public List<StampLlmVerifyJob> Jobs { get; } = [];
 
         public Task<StampLlmVerifyResult> VerifyAsync(StampLlmVerifyJob job, CancellationToken ct = default)


### PR DESCRIPTION
## Summary
- Returns Czech 404 ProblemDetails for unknown `locationId` before validating the captured image payload.
- Stops leaking raw Anthropic upstream errors to clients; raw details stay in server logs and audit rows.
- Makes missing `Anthropic__ApiKey` a graceful Czech 503 instead of a constructor-time 500.

## Verification
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter FullyQualifiedName~StampLlmEndpointTests` — passed, 8 tests.
- `dotnet build OvcinaHra.slnx` — passed.
- `dotnet test OvcinaHra.slnx` — passed: API tests 612, E2E tests 8.

Closes #457.
