### PR TITLE
fix(lore): make Zeptej se Drozda visible

### DIFF
--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor
@@ -17,7 +17,7 @@
     @if (_open)
     {
         <div class="oh-bot-backdrop" @onclick="Close"></div>
-        <section class="oh-bot-drawer @PersonaClass" aria-label="Zeptat se Drozda">
+        <section class="oh-bot-drawer @PersonaClass" aria-label="Zeptej se Drozda">
             <header class="oh-bot-header">
                 <div>
                     <div class="oh-bot-title">
@@ -29,7 +29,7 @@
                                  aria-hidden="true"
                                  @onerror="HideDrozdIcon" />
                         }
-                        <h2>Zeptat se Drozda</h2>
+                        <h2>Zeptej se Drozda</h2>
                     </div>
                     <div class="oh-bot-personas" role="tablist" aria-label="Drozdova odbornost">
                         <button type="button"

--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor
@@ -7,10 +7,11 @@
 {
     <button type="button"
             class="oh-bot-fab @PersonaClass"
-            title="Zeptat se Drozda"
-            aria-label="Zeptat se Drozda"
+            title="Zeptej se Drozda"
+            aria-label="Zeptej se Drozda"
             @onclick="Open">
         <i class="bi bi-chat-dots-fill" aria-hidden="true"></i>
+        <span>Zeptej se Drozda</span>
     </button>
 
     @if (_open)

--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.css
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.css
@@ -3,18 +3,29 @@
     right: 1.25rem;
     bottom: 1.25rem;
     z-index: 1050;
-    width: 3.5rem;
+    min-width: 3.5rem;
     height: 3.5rem;
+    max-width: min(17rem, calc(100vw - 2rem));
     border: 0;
-    border-radius: 50%;
+    border-radius: 999px;
     background: var(--oh-primary);
     color: var(--oh-header-text);
     box-shadow: 0 0.4rem 1rem rgba(44, 24, 16, 0.28);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.35rem;
+    gap: 0.55rem;
+    padding: 0 1.1rem;
+    font: 700 0.95rem var(--oh-font-body);
     transition: transform var(--oh-transition), box-shadow var(--oh-transition);
+}
+
+.oh-bot-fab i {
+    font-size: 1.25rem;
+}
+
+.oh-bot-fab span {
+    white-space: nowrap;
 }
 
 .oh-bot-fab:hover,
@@ -301,6 +312,10 @@
     .oh-bot-fab {
         right: 1rem;
         bottom: 1rem;
+        height: 3.25rem;
+        max-width: calc(100vw - 2rem);
+        padding: 0 0.95rem;
+        font-size: 0.88rem;
     }
 
     .oh-bot-input {

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/BotConsultDrawerSmokeTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/BotConsultDrawerSmokeTests.cs
@@ -39,7 +39,7 @@ public class BotConsultDrawerSmokeTests
         Assert.Contains("rulemaster", drawer);
         Assert.Contains("loremaster", drawer);
         Assert.Contains("aria-label=\"Zeptej se Drozda\"", drawer);
-        Assert.Contains("<span>Zeptej se Drozda</span>", drawer);
+        Assert.Matches("<span>\\s*Zeptej se Drozda\\s*</span>", drawer);
         Assert.Contains("img/drozd/drozd-idle.svg", drawer);
         Assert.Contains("@onerror=\"HideDrozdIcon\"", drawer);
         Assert.Contains("@ref=\"_draftInput\"", drawer);
@@ -56,7 +56,7 @@ public class BotConsultDrawerSmokeTests
         Assert.Contains("--oh-color-forest-deep", css);
         Assert.Contains("--oh-color-azanulinbar", css);
         Assert.Contains(".oh-bot-title-drozd", css);
-        Assert.Contains("border-radius: 999px;", css);
+        Assert.Contains("border-radius: 999px", css);
         Assert.Contains(".oh-bot-fab span", css);
         Assert.Contains("@media (max-width: 767.98px)", css);
         Assert.Contains("height: 100dvh;", css);

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/BotConsultDrawerSmokeTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/BotConsultDrawerSmokeTests.cs
@@ -38,7 +38,8 @@ public class BotConsultDrawerSmokeTests
         Assert.Contains("oh-bot-last-persona", drawer);
         Assert.Contains("rulemaster", drawer);
         Assert.Contains("loremaster", drawer);
-        Assert.Contains("Zeptat se Drozda", drawer);
+        Assert.Contains("aria-label=\"Zeptej se Drozda\"", drawer);
+        Assert.Contains("<span>Zeptej se Drozda</span>", drawer);
         Assert.Contains("img/drozd/drozd-idle.svg", drawer);
         Assert.Contains("@onerror=\"HideDrozdIcon\"", drawer);
         Assert.Contains("@ref=\"_draftInput\"", drawer);
@@ -55,6 +56,8 @@ public class BotConsultDrawerSmokeTests
         Assert.Contains("--oh-color-forest-deep", css);
         Assert.Contains("--oh-color-azanulinbar", css);
         Assert.Contains(".oh-bot-title-drozd", css);
+        Assert.Contains("border-radius: 999px;", css);
+        Assert.Contains(".oh-bot-fab span", css);
         Assert.Contains("@media (max-width: 767.98px)", css);
         Assert.Contains("height: 100dvh;", css);
 


### PR DESCRIPTION
## Summary
- makes the Drozd consult entry point visibly read `Zeptej se Drozda` instead of rendering as an icon-only floating button
- restyles the FAB as a compact pill so the Lore self-service entry point is discoverable
- updates the existing BotConsultDrawer smoke test to guard the visible label and pill styling

Closes #433

## Verification
- dotnet build OvcinaHra.slnx --nologo
- dotnet test OvcinaHra.slnx --nologo --no-build

## Visual smoke
- Open a Lore section, confirm the bottom-right Drozd pill is visible as `Zeptej se Drozda`.
- Click it and confirm the BotConsultDrawer opens.
- Confirm the Lore tab and message input still render normally.
