### PR TITLE
feat(images): auto-resize shared image uploads

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Diagnostics;
+using System.Globalization;
 using System.Security.Claims;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Services;
@@ -191,6 +192,7 @@ public static class ImageEndpoints
                 return TypedResults.NotFound();
             }
 
+            var metadata = await ReadUploadMetadataAsync(http, ct);
             var isPlacement = string.Equals(field, "placement", StringComparison.OrdinalIgnoreCase);
             var suffix = isPlacement ? "placement" : "image";
             var ext = file.ContentType switch
@@ -376,7 +378,7 @@ public static class ImageEndpoints
             }
             LogPlacementImageExit(logger, isPlacementUpload, entityId, gameId, userId, 200, blobKey, url);
             LogImageUploadServerExit(logger, isServerTimedImageUpload, http, entityType, entityId, userId, serverTimer, 200, blobKey);
-            return TypedResults.Ok(new ImageUploadResult(blobKey, url));
+            return TypedResults.Ok(new ImageUploadResult(blobKey, url, metadata));
         }
         catch (Exception ex) when (isPlacementUpload && ex is not OperationCanceledException)
         {
@@ -409,6 +411,39 @@ public static class ImageEndpoints
             LogImageUploadServerExit(logger, isServerTimedImageUpload, http, entityType, entityId, userId, serverTimer, 500, detail: ex.Message);
             throw;
         }
+    }
+
+    private static async Task<ImageUploadMetadataDto?> ReadUploadMetadataAsync(HttpContext http, CancellationToken ct)
+    {
+        var form = await http.Request.ReadFormAsync(ct);
+        var gpsLatitude = ReadNullableDouble(form, "gpsLatitude");
+        var gpsLongitude = ReadNullableDouble(form, "gpsLongitude");
+        var capturedAt = ReadNullableString(form, "capturedAt");
+
+        if (gpsLatitude is null && gpsLongitude is null && capturedAt is null)
+            return null;
+
+        return new ImageUploadMetadataDto(gpsLatitude, gpsLongitude, capturedAt);
+    }
+
+    private static double? ReadNullableDouble(IFormCollection form, string key)
+    {
+        var value = ReadNullableString(form, key);
+        if (value is null)
+            return null;
+
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static string? ReadNullableString(IFormCollection form, string key)
+    {
+        if (!form.TryGetValue(key, out var values))
+            return null;
+
+        var value = values.ToString();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
     /// <summary>

--- a/src/OvcinaHra.Client/Components/ImagePicker.razor
+++ b/src/OvcinaHra.Client/Components/ImagePicker.razor
@@ -1,4 +1,5 @@
 @using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.JSInterop
 
 <div class="image-picker-wrap">
     <label class="image-picker-box @(currentUrl is null ? "is-empty" : "is-filled") @(isWorking ? "is-working" : "")"
@@ -49,6 +50,7 @@
 
 @code {
     [Inject] private ApiClient Api { get; set; } = null!;
+    [Inject] private IJSRuntime JS { get; set; } = null!;
 
     [Parameter, EditorRequired] public string EntityType { get; set; } = "";
     [Parameter, EditorRequired] public int EntityId { get; set; }
@@ -57,6 +59,11 @@
 
     [Parameter] public string AspectRatio { get; set; } = "1:1";
     [Parameter] public string Width { get; set; } = "200px";
+    [Parameter] public bool AutoResize { get; set; } = true;
+    [Parameter] public bool? ReadExif { get; set; }
+    [Parameter] public int ResizeMaxDimension { get; set; } = DefaultResizeMaxDimension;
+    [Parameter] public double ResizeQuality { get; set; } = DefaultResizeQuality;
+    [Parameter] public string? Surface { get; set; }
 
     private string? currentUrl;
     private string? errorMessage;
@@ -68,6 +75,19 @@
     private string? _lastEntityType;
     private int _lastEntityId;
     private string? _lastField;
+
+    private const long DefaultMaxIngressFileSize = 30 * 1024 * 1024;
+    private const long DefaultMaxUploadFileSize = 5 * 1024 * 1024;
+    private const int DefaultResizeMaxDimension = 1920;
+    private const double DefaultResizeQuality = 0.85;
+
+    private bool IsPlacementSurface =>
+        string.Equals(EntityType, "locationplacements", StringComparison.Ordinal)
+        || (string.Equals(EntityType, "locations", StringComparison.Ordinal)
+            && string.Equals(Field, "placement", StringComparison.OrdinalIgnoreCase));
+
+    private bool ShouldReadExif => ReadExif ?? IsPlacementSurface;
+    private string UploadSurface => Surface ?? (IsPlacementSurface ? "placement" : EntityType);
 
     protected override void OnParametersSet()
     {
@@ -124,19 +144,76 @@
         try
         {
             var file = e.File;
-            if (file.Size > 5 * 1024 * 1024)
+            var surface = UploadSurface;
+            if (file.Size > DefaultMaxIngressFileSize)
             {
-                errorMessage = "Soubor je příliš velký (max 5 MB).";
+                errorMessage = $"Soubor je příliš velký (max {DefaultMaxIngressFileSize / 1024 / 1024} MB).";
+                Console.WriteLine($"[image-upload] reject reason=ingress-too-large surface={surface} entity={EntityType} id={EntityId} size={file.Size}");
                 return;
             }
 
-            var query = Field is not null ? $"?field={Field}" : "";
-            Console.WriteLine($"[image-upload] start entity={EntityType} id={EntityId} field={Field ?? "image"}");
+            Console.WriteLine($"[image-upload] start surface={surface} entity={EntityType} id={EntityId} field={Field ?? "image"} originalSize={file.Size}");
+            var originalContentType = string.IsNullOrWhiteSpace(file.ContentType)
+                ? "image/jpeg"
+                : file.ContentType;
+            string originalDataUrl;
+            try
+            {
+                await using var stream = file.OpenReadStream(maxAllowedSize: DefaultMaxIngressFileSize);
+                using var buffer = new MemoryStream();
+                await stream.CopyToAsync(buffer);
+                originalDataUrl = ToDataUrl(originalContentType, buffer.ToArray());
+            }
+            catch (Exception ex)
+            {
+                errorMessage = "Obrázek se nepodařilo načíst.";
+                Console.WriteLine($"[image-upload] reject reason=read-failed surface={surface} entity={EntityType} id={EntityId} detail={ex.Message}");
+                return;
+            }
+
+            var metadata = await ReadImageMetadataAsync(originalDataUrl, surface);
+            var uploadBytes = DecodeDataUrlBytes(originalDataUrl);
+            var uploadContentType = originalContentType;
+            var uploadFilename = string.IsNullOrWhiteSpace(file.Name) ? "image" : file.Name;
+
+            if (AutoResize)
+            {
+                try
+                {
+                    var resizeTimer = System.Diagnostics.Stopwatch.StartNew();
+                    Console.WriteLine($"[image-upload] resize.start surface={surface} entity={EntityType} id={EntityId} originalSize={file.Size} maxDim={ResizeMaxDimension} quality={ResizeQuality}");
+                    var resizedDataUrl = await JS.InvokeAsync<string>(
+                        "ovcinaImageResize.fromBase64",
+                        originalDataUrl,
+                        ResizeMaxDimension,
+                        ResizeQuality);
+                    uploadBytes = DecodeDataUrlBytes(resizedDataUrl);
+                    uploadContentType = "image/jpeg";
+                    uploadFilename = Path.ChangeExtension(uploadFilename, "jpg");
+                    resizeTimer.Stop();
+                    Console.WriteLine($"[image-upload] resize.done surface={surface} entity={EntityType} id={EntityId} resizedSize={uploadBytes.LongLength} elapsedMs={resizeTimer.ElapsedMilliseconds}");
+                }
+                catch (Exception ex)
+                {
+                    errorMessage = "Obrázek se nepodařilo zmenšit.";
+                    Console.WriteLine($"[image-upload] reject reason=resize-failed surface={surface} entity={EntityType} id={EntityId} detail={ex.Message}");
+                    return;
+                }
+            }
+
+            if (uploadBytes.LongLength > DefaultMaxUploadFileSize)
+            {
+                errorMessage = $"Obrázek se nepodařilo zmenšit pod {DefaultMaxUploadFileSize / 1024 / 1024} MB. Zkuste prosím jiný snímek.";
+                Console.WriteLine($"[image-upload] reject reason=too-large-after-resize surface={surface} entity={EntityType} id={EntityId} size={uploadBytes.LongLength}");
+                return;
+            }
+
+            var query = Field is not null ? $"?field={Uri.EscapeDataString(Field)}" : "";
             using var content = new MultipartFormDataContent();
-            using var stream = file.OpenReadStream(maxAllowedSize: 5 * 1024 * 1024);
-            var fileContent = new StreamContent(stream);
-            fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(file.ContentType);
-            content.Add(fileContent, "file", file.Name);
+            using var fileContent = new ByteArrayContent(uploadBytes);
+            fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(uploadContentType);
+            content.Add(fileContent, "file", uploadFilename);
+            AddMetadataFields(content, metadata);
 
             var (ok, result, problemDetail, statusCode) = await Api.PostMultipartWithProblemAsync<ImageUploadResult>(
                 $"/api/images/{EntityType}/{EntityId}{query}", content);
@@ -150,7 +227,7 @@
             if (result is not null)
             {
                 currentUrl = result.Url;
-                Console.WriteLine($"[image-upload] success blobKey={result.BlobKey}");
+                Console.WriteLine($"[image-upload] success surface={surface} entity={EntityType} id={EntityId} blobKey={result.BlobKey}");
             }
         }
         catch (Exception ex)
@@ -184,5 +261,90 @@
         }
         catch (Exception ex) { errorMessage = ex.Message; }
         finally { isWorking = false; }
+    }
+
+    private async Task<ImagePickerUploadMetadata?> ReadImageMetadataAsync(string originalDataUrl, string surface)
+    {
+        if (!ShouldReadExif)
+        {
+            Console.WriteLine($"[image-upload] exif.read result=skipped surface={surface} entity={EntityType} id={EntityId}");
+            return null;
+        }
+
+        try
+        {
+            var jsMetadata = await JS.InvokeAsync<ImagePickerExifMetadata?>(
+                "ovcinaExif.readMetadataFromDataUrl",
+                originalDataUrl);
+            if (jsMetadata is null
+                || (jsMetadata.Gps is null && string.IsNullOrWhiteSpace(jsMetadata.CapturedAt)))
+            {
+                Console.WriteLine($"[image-upload] exif.read result=no-gps surface={surface} entity={EntityType} id={EntityId} capturedAt=false");
+                return null;
+            }
+
+            var gps = jsMetadata.Gps;
+            var capturedAt = jsMetadata.CapturedAt;
+            var hasGps = gps is not null;
+            var hasCapturedAt = !string.IsNullOrWhiteSpace(capturedAt);
+            Console.WriteLine($"[image-upload] exif.read result={(hasGps ? "found-gps" : "no-gps")} surface={surface} entity={EntityType} id={EntityId} capturedAt={hasCapturedAt.ToString().ToLowerInvariant()}");
+            return new ImagePickerUploadMetadata
+            {
+                GpsLatitude = gps?.Lat,
+                GpsLongitude = gps?.Lng,
+                CapturedAt = capturedAt
+            };
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[image-upload] exif.read result=parse-failed surface={surface} entity={EntityType} id={EntityId} detail={ex.Message}");
+            return null;
+        }
+    }
+
+    private static string ToDataUrl(string contentType, byte[] bytes)
+        => $"data:{contentType};base64,{Convert.ToBase64String(bytes)}";
+
+    private static byte[] DecodeDataUrlBytes(string dataUrl)
+    {
+        var commaIdx = dataUrl.IndexOf(',');
+        if (commaIdx < 0)
+            throw new FormatException("Invalid data URL.");
+
+        return Convert.FromBase64String(dataUrl[(commaIdx + 1)..]);
+    }
+
+    private static void AddMetadataFields(MultipartFormDataContent content, ImagePickerUploadMetadata? metadata)
+    {
+        if (metadata is null)
+            return;
+
+        if (metadata.GpsLatitude.HasValue && metadata.GpsLongitude.HasValue)
+        {
+            content.Add(new StringContent(metadata.GpsLatitude.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)), "gpsLatitude");
+            content.Add(new StringContent(metadata.GpsLongitude.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)), "gpsLongitude");
+        }
+
+        if (!string.IsNullOrWhiteSpace(metadata.CapturedAt))
+            content.Add(new StringContent(metadata.CapturedAt), "capturedAt");
+    }
+
+    private sealed class ImagePickerExifMetadata
+    {
+        public ImagePickerGpsCoordinates? Gps { get; set; }
+        public string? CapturedAt { get; set; }
+    }
+
+    private sealed class ImagePickerUploadMetadata
+    {
+        public double? GpsLatitude { get; init; }
+        public double? GpsLongitude { get; init; }
+        public string? CapturedAt { get; init; }
+    }
+
+    private sealed class ImagePickerGpsCoordinates
+    {
+        public double Lat { get; set; }
+        public double Lng { get; set; }
     }
 }

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -821,6 +821,7 @@ else
     private string? placementError;
     private string? placementToastMessage;
     private PhotoGpsCoordinates? placementPhotoGps;
+    private string? placementPhotoCapturedAt;
     private double? placementPhotoGpsDistanceMeters;
     private bool placementGpsPromptVisible;
     private bool placementGpsUpdating;
@@ -841,6 +842,12 @@ else
     {
         public double Lat { get; set; }
         public double Lng { get; set; }
+    }
+
+    private sealed class PhotoExifMetadata
+    {
+        public PhotoGpsCoordinates? Gps { get; set; }
+        public string? CapturedAt { get; set; }
     }
 
     // Toolbar filter state
@@ -1133,7 +1140,7 @@ else
             return;
         }
 
-        await EvaluatePlacementPhotoGpsAsync(originalDataUrl);
+        await EvaluatePlacementPhotoMetadataAsync(originalDataUrl);
 
         // Client-side canvas resize. Phone cameras emit 10–20 MB JPEGs that
         // exceed the server's 5 MB multipart limit; resize re-encodes as
@@ -1180,18 +1187,25 @@ else
         Console.WriteLine($"[loc-placement] wizard.photo-resized gameId={gameId} originalSize={placementPhotoFile.Size} resizedSize={resizedBytes.LongLength}");
     }
 
-    private async Task EvaluatePlacementPhotoGpsAsync(string originalDataUrl)
+    private async Task EvaluatePlacementPhotoMetadataAsync(string originalDataUrl)
     {
-        PhotoGpsCoordinates? gps;
+        PhotoExifMetadata? metadata;
         try
         {
-            gps = await JS.InvokeAsync<PhotoGpsCoordinates?>("ovcinaExif.readGpsFromDataUrl", originalDataUrl);
+            metadata = await JS.InvokeAsync<PhotoExifMetadata?>("ovcinaExif.readMetadataFromDataUrl", originalDataUrl);
         }
         catch (Exception ex)
         {
             Console.WriteLine($"[loc-placement] exif read result=parse-failed gameId={gameId} detail={ex.Message}");
+            Console.WriteLine($"[image-upload] exif.read result=parse-failed surface=placement gameId={gameId} detail={ex.Message}");
             return;
         }
+
+        var gps = metadata?.Gps;
+        placementPhotoCapturedAt = metadata?.CapturedAt;
+        Console.WriteLine(
+            $"[image-upload] exif.read result={(gps is not null ? "found-gps" : "no-gps")} " +
+            $"surface=placement gameId={gameId} capturedAt={(!string.IsNullOrWhiteSpace(placementPhotoCapturedAt)).ToString().ToLowerInvariant()}");
 
         if (gps is null)
         {
@@ -1301,6 +1315,7 @@ else
     private void ResetPlacementGpsState()
     {
         placementPhotoGps = null;
+        placementPhotoCapturedAt = null;
         placementPhotoGpsDistanceMeters = null;
         placementGpsPromptVisible = false;
         placementGpsUpdating = false;
@@ -1358,6 +1373,13 @@ else
                 string.IsNullOrWhiteSpace(placementPhotoFile.Name) ? "placement" : placementPhotoFile.Name,
                 "jpg");
             content.Add(fileContent, "file", uploadFilename);
+            if (placementPhotoGps is not null)
+            {
+                content.Add(new StringContent(placementPhotoGps.Lat.ToString(CultureInfo.InvariantCulture)), "gpsLatitude");
+                content.Add(new StringContent(placementPhotoGps.Lng.ToString(CultureInfo.InvariantCulture)), "gpsLongitude");
+            }
+            if (!string.IsNullOrWhiteSpace(placementPhotoCapturedAt))
+                content.Add(new StringContent(placementPhotoCapturedAt), "capturedAt");
 
             var (uploadOk, uploadResult, uploadProblem, uploadStatus) =
                 await Api.PostMultipartWithProblemAsync<ImageUploadResult>(

--- a/src/OvcinaHra.Client/wwwroot/index.html
+++ b/src/OvcinaHra.Client/wwwroot/index.html
@@ -44,7 +44,7 @@
     <script src="js/map-interop.js?v=20260411"></script>
     <script src="js/overlay-interop.js?v=20260428"></script>
     <script src="js/download-interop.js?v=20260427"></script>
-    <script src="js/image-resize-interop.js?v=20260429-410"></script>
+    <script src="js/image-resize-interop.js?v=20260430-463"></script>
     <script src="js/version-refresh.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script>navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' });</script>

--- a/src/OvcinaHra.Client/wwwroot/js/image-resize-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/image-resize-interop.js
@@ -66,12 +66,17 @@ window.ovcinaExif.haversineMeters = function (lat1, lng1, lat2, lng2) {
 };
 
 window.ovcinaExif.readGpsFromDataUrl = async function (dataUrl) {
+    const metadata = await window.ovcinaExif.readMetadataFromDataUrl(dataUrl);
+    return metadata && metadata.gps ? metadata.gps : null;
+};
+
+window.ovcinaExif.readMetadataFromDataUrl = async function (dataUrl) {
     if (typeof dataUrl !== "string" || dataUrl.length === 0) {
         return null;
     }
 
     const buffer = dataUrlToArrayBuffer(dataUrl);
-    return readExifGps(buffer);
+    return readExifMetadata(buffer);
 };
 
 function dataUrlToArrayBuffer(dataUrl) {
@@ -95,6 +100,11 @@ function dataUrlToArrayBuffer(dataUrl) {
 }
 
 function readExifGps(buffer) {
+    const metadata = readExifMetadata(buffer);
+    return metadata ? metadata.gps : null;
+}
+
+function readExifMetadata(buffer) {
     const view = new DataView(buffer);
     const tiffOffset = findTiffOffset(view);
     if (tiffOffset === null) {
@@ -112,12 +122,25 @@ function readExifGps(buffer) {
     }
 
     const firstIfdOffset = view.getUint32(tiffOffset + 4, littleEndian);
-    const gpsIfdPointer = readIfdTag(view, tiffOffset, tiffOffset + firstIfdOffset, littleEndian, 0x8825);
-    if (gpsIfdPointer === null) {
-        return null;
-    }
+    const ifd0Offset = tiffOffset + firstIfdOffset;
+    const gpsIfdPointer = readIfdTag(view, tiffOffset, ifd0Offset, littleEndian, 0x8825);
+    const exifIfdPointer = readIfdTag(view, tiffOffset, ifd0Offset, littleEndian, 0x8769);
 
-    return readGpsIfd(view, tiffOffset, tiffOffset + gpsIfdPointer, littleEndian);
+    const gps = gpsIfdPointer === null
+        ? null
+        : readGpsIfd(view, tiffOffset, tiffOffset + gpsIfdPointer, littleEndian);
+
+    let capturedAt = null;
+    if (exifIfdPointer !== null) {
+        const exifIfdOffset = tiffOffset + exifIfdPointer;
+        capturedAt =
+            normalizeExifDateTime(readIfdAsciiTag(view, tiffOffset, exifIfdOffset, littleEndian, 0x9003))
+            || normalizeExifDateTime(readIfdAsciiTag(view, tiffOffset, exifIfdOffset, littleEndian, 0x9004));
+    }
+    capturedAt = capturedAt
+        || normalizeExifDateTime(readIfdAsciiTag(view, tiffOffset, ifd0Offset, littleEndian, 0x0132));
+
+    return gps || capturedAt ? { gps, capturedAt } : null;
 }
 
 function findTiffOffset(view) {
@@ -156,6 +179,37 @@ function findTiffOffset(view) {
 }
 
 function readIfdTag(view, tiffOffset, ifdOffset, littleEndian, targetTag) {
+    const entryOffset = findIfdEntryOffset(view, ifdOffset, littleEndian, targetTag);
+    if (entryOffset === null) {
+        return null;
+    }
+
+    const type = view.getUint16(entryOffset + 2, littleEndian);
+    const count = view.getUint32(entryOffset + 4, littleEndian);
+    return readExifValue(view, tiffOffset, entryOffset, type, count, littleEndian);
+}
+
+function readIfdAsciiTag(view, tiffOffset, ifdOffset, littleEndian, targetTag) {
+    const entryOffset = findIfdEntryOffset(view, ifdOffset, littleEndian, targetTag);
+    if (entryOffset === null) {
+        return null;
+    }
+
+    const type = view.getUint16(entryOffset + 2, littleEndian);
+    const count = view.getUint32(entryOffset + 4, littleEndian);
+    if (type !== 2 || count <= 0) {
+        return null;
+    }
+
+    const valueOffset = valueDataOffset(view, tiffOffset, entryOffset, type, count, littleEndian);
+    if (valueOffset === null) {
+        return null;
+    }
+
+    return readAscii(view, valueOffset, count).replace(/\0/g, "").trim();
+}
+
+function findIfdEntryOffset(view, ifdOffset, littleEndian, targetTag) {
     if (ifdOffset < 0 || ifdOffset + 2 > view.byteLength) {
         return null;
     }
@@ -172,9 +226,7 @@ function readIfdTag(view, tiffOffset, ifdOffset, littleEndian, targetTag) {
             continue;
         }
 
-        const type = view.getUint16(entryOffset + 2, littleEndian);
-        const count = view.getUint32(entryOffset + 4, littleEndian);
-        return readExifValue(view, tiffOffset, entryOffset, type, count, littleEndian);
+        return entryOffset;
     }
 
     return null;
@@ -292,6 +344,20 @@ function readRationals(view, offset, count, littleEndian) {
 
 function dmsToDecimal(values) {
     return values[0] + values[1] / 60 + values[2] / 3600;
+}
+
+function normalizeExifDateTime(value) {
+    if (typeof value !== "string" || value.length === 0) {
+        return null;
+    }
+
+    const trimmed = value.replace(/\0/g, "").trim();
+    const match = /^(\d{4}):(\d{2}):(\d{2}) (\d{2}):(\d{2}):(\d{2})$/.exec(trimmed);
+    if (!match) {
+        return trimmed || null;
+    }
+
+    return `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}`;
 }
 
 function readAscii(view, offset, length) {

--- a/src/OvcinaHra.Shared/Dtos/ImageDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/ImageDtos.cs
@@ -1,4 +1,5 @@
 namespace OvcinaHra.Shared.Dtos;
 
-public record ImageUploadResult(string BlobKey, string? Url);
+public record ImageUploadResult(string BlobKey, string? Url, ImageUploadMetadataDto? Metadata = null);
+public record ImageUploadMetadataDto(double? GpsLatitude = null, double? GpsLongitude = null, string? CapturedAt = null);
 public record ImageUrlsDto(string? ImageUrl, string? PlacementUrl, string? StampUrl = null);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
@@ -52,6 +52,32 @@ public class ImageEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
     }
 
     [Fact]
+    public async Task Upload_WithMetadata_EchoesUploadMetadata()
+    {
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Foto s metadaty", LocationKind.Village, 49.5m, 17.1m));
+        var loc = await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        using var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(ValidPng);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        content.Add(fileContent, "file", "photo.png");
+        content.Add(new StringContent("49.123456"), "gpsLatitude");
+        content.Add(new StringContent("17.654321"), "gpsLongitude");
+        content.Add(new StringContent("2026-04-30T12:34:56"), "capturedAt");
+
+        var response = await Client.PostAsync($"/api/images/locations/{loc!.Id}", content);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ImageUploadResult>();
+        Assert.NotNull(result);
+        var metadata = Assert.IsType<ImageUploadMetadataDto>(result.Metadata);
+        Assert.Equal(49.123456, metadata.GpsLatitude!.Value, precision: 6);
+        Assert.Equal(17.654321, metadata.GpsLongitude!.Value, precision: 6);
+        Assert.Equal("2026-04-30T12:34:56", metadata.CapturedAt);
+    }
+
+    [Fact]
     public async Task Upload_LocationStamp_PersistsStampPathAndFullSasUrl()
     {
         var locResponse = await Client.PostAsJsonAsync("/api/locations",


### PR DESCRIPTION
## Summary
- Generalize ImagePicker to client-resize uploads before posting, with 30 MB ingress cap, 5 MB post-resize cap, and permanent [image-upload] markers.
- Keep the placement wizard flow while sharing the EXIF metadata helper so GPS and capturedAt are read before resize.
- Add optional upload metadata DTO fields and echo submitted GPS/capturedAt values without persistence changes.

## Verification
- node --check src/OvcinaHra.Client/wwwroot/js/image-resize-interop.js
- dotnet build OvcinaHra.slnx --no-restore
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter FullyQualifiedName~ImageEndpointTests

Closes #463