### PR TITLE
fix(ui): buildings gallery + recipe ingredience enter + groše rename (closes #469 #471 #472) [v0.17.3]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/BuildingRecipeEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/BuildingRecipeEndpoints.cs
@@ -312,7 +312,7 @@ public static class BuildingRecipeEndpoints
 
     /// <summary>
     /// Compact recipe summary for the BuildingList by-game grid column.
-    /// Format: "3× ingrediencí · 50 zlaťáků · 1 dovednost · 2 budovy".
+    /// Format: "3× ingrediencí · 2 groše · 1 dovednost · 2 budovy".
     /// Returns null when the recipe is empty (no ingredients, no money,
     /// no skills, no prereqs) so the column shows "—" instead of noise.
     /// </summary>
@@ -321,8 +321,8 @@ public static class BuildingRecipeEndpoints
         var parts = new List<string>();
         if (r.Ingredients.Count > 0)
             parts.Add($"{r.Ingredients.Sum(i => i.Quantity)}× ingrediencí");
-        if (r.MoneyCost is > 0)
-            parts.Add($"{r.MoneyCost} zlaťáků");
+        if (r.MoneyCost is int moneyCost and > 0)
+            parts.Add($"{moneyCost} {PluralCz(moneyCost, "groš", "groše", "grošů")}");
         if (r.SkillRequirements.Count > 0)
             parts.Add($"{r.SkillRequirements.Count} {PluralCz(r.SkillRequirements.Count, "dovednost", "dovednosti", "dovedností")}");
         if (r.PrerequisiteBuildings.Count > 0)

--- a/src/OvcinaHra.Client/Components/BuildingTile.razor
+++ b/src/OvcinaHra.Client/Components/BuildingTile.razor
@@ -5,12 +5,12 @@
    when no image. State-flag `_imageFailed` reset on URL change so a
    reused tile (filtered list) tries the new image. *@
 
-<button type="button" class="oh-bld-tile @(string.IsNullOrEmpty(Building.ImageUrl) || _imageFailed ? "oh-bld-tile--placeholder" : "")"
+<button type="button" class="oh-bld-tile @(string.IsNullOrEmpty(EffectiveImageUrl) || _imageFailed ? "oh-bld-tile--placeholder" : "")"
         @key="Building.Id" @onclick="HandleClick">
     <div class="oh-bld-tile-art">
-        @if (!string.IsNullOrEmpty(Building.ImageUrl) && !_imageFailed)
+        @if (!string.IsNullOrEmpty(EffectiveImageUrl) && !_imageFailed)
         {
-            <img src="@Building.ImageUrl" alt="@Building.Name" @onerror="() => _imageFailed = true" />
+            <img src="@EffectiveImageUrl" alt="@Building.Name" @onerror="() => _imageFailed = true" />
             <div class="oh-bld-tile-fade"></div>
             <div class="oh-bld-tile-name-on-img">@Building.Name</div>
         }
@@ -55,16 +55,18 @@
 
 @code {
     [Parameter, EditorRequired] public BuildingListDto Building { get; set; } = null!;
+    [Parameter] public string? ImageUrl { get; set; }
     [Parameter] public EventCallback<BuildingListDto> OnClick { get; set; }
 
     private bool _imageFailed;
     private string? _lastImageUrl;
+    private string? EffectiveImageUrl => ImageUrl ?? Building.ImageUrl;
 
     protected override void OnParametersSet()
     {
-        if (_lastImageUrl != Building.ImageUrl)
+        if (_lastImageUrl != EffectiveImageUrl)
         {
-            _lastImageUrl = Building.ImageUrl;
+            _lastImageUrl = EffectiveImageUrl;
             _imageFailed = false;
         }
     }

--- a/src/OvcinaHra.Client/Components/RecipeIngredientPicker.razor
+++ b/src/OvcinaHra.Client/Components/RecipeIngredientPicker.razor
@@ -4,18 +4,18 @@
 
 @using OvcinaHra.Shared.Dtos
 
-<div class="mb-2">
+<div class="mb-2 oh-recipe-ingredient-picker">
     <strong class="small">Ingredience:</strong>
     @if (Ingredients.Count > 0)
     {
-        <table class="table table-sm mb-1">
+        <table class="table table-sm mb-1 oh-recipe-ingredient-table">
             <tbody>
                 @foreach (var ing in Ingredients)
                 {
                     <tr>
                         <td>@ing.ItemName</td>
-                        <td style="width:60px">×@ing.Quantity</td>
-                        <td style="width:40px">
+                        <td class="oh-recipe-ingredient-qty">×@ing.Quantity</td>
+                        <td class="oh-recipe-ingredient-remove">
                             <button class="btn btn-sm btn-link text-danger p-0"
                                     title="Odebrat ingredienci"
                                     aria-label="@($"Odebrat ingredienci {ing.ItemName}")"
@@ -32,13 +32,13 @@
     {
         <p class="text-muted small mb-1">Žádné ingredience.</p>
     }
-    <div class="d-flex gap-2 align-items-end">
-        <div style="flex:1">
+    <div class="oh-recipe-ingredient-add" @onkeyup="HandleAddKeyUp">
+        <div>
             <DxComboBox Data="@AvailableItems" @bind-Value="@_newItemId"
                         TextFieldName="Name" ValueFieldName="Id"
                         NullText="(přidat ingredienci)" SearchMode="ListSearchMode.AutoSearch" />
         </div>
-        <div style="width:70px">
+        <div>
             <DxSpinEdit @bind-Value="@_newQuantity" MinValue="1" />
         </div>
         <button class="btn btn-sm btn-outline-primary" style="height:34px"
@@ -81,5 +81,11 @@
         _newItemId = null;
         _newQuantity = 1;
         await OnAdd.InvokeAsync((id, qty));
+    }
+
+    private async Task HandleAddKeyUp(KeyboardEventArgs args)
+    {
+        if (args.Key is "Enter" or "NumpadEnter")
+            await AddAsync();
     }
 }

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingDetail.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingDetail.razor
@@ -61,10 +61,10 @@ else
     {
         <div class="oh-bld-karta">
             <div class="oh-bld-karta-hero">
-                <div class="oh-bld-karta-img-wrap @(string.IsNullOrEmpty(building.ImageUrl) ? "oh-bld-karta-img-wrap--placeholder" : "")">
-                    @if (!string.IsNullOrEmpty(building.ImageUrl))
+                <div class="oh-bld-karta-img-wrap @(string.IsNullOrEmpty(DetailImageUrl) ? "oh-bld-karta-img-wrap--placeholder" : "")">
+                    @if (!string.IsNullOrEmpty(DetailImageUrl))
                     {
-                        <img src="@building.ImageUrl" alt="@building.Name" class="oh-bld-karta-img" />
+                        <img src="@DetailImageUrl" alt="@building.Name" class="oh-bld-karta-img" />
                     }
                     else
                     {
@@ -197,7 +197,7 @@ else
                     @if (recipe is not null)
                     {
                         <div class="mb-2">
-                            <strong class="small">Cena v zlaťácích:</strong>
+                            <strong class="small">Cena v groších:</strong>
                             <div class="d-flex gap-2 align-items-end mt-1">
                                 <div style="width:140px">
                                     <DxSpinEdit @bind-Value="@recipeMoneyCost" MinValue="0" NullText="(žádná)"
@@ -319,6 +319,8 @@ else
     private BuildingDetailDto? building;
     private bool loading = true;
     private string? error;
+    private string? fullImageUrl;
+    private string? DetailImageUrl => fullImageUrl ?? building?.ImageUrl;
 
     private string activeTab = "karta";
 
@@ -388,6 +390,7 @@ else
     {
         loading = true;
         error = null;
+        fullImageUrl = null;
         try
         {
             building = await Api.GetAsync<BuildingDetailDto>($"/api/buildings/{Id}");
@@ -397,12 +400,27 @@ else
                 return;
             }
             ResetEditModel();
+            await LoadFullImageUrlAsync();
             await LoadLocationsAsync();
             await LoadRecipePickerDataAsync();
             await LoadRecipeAsync();
         }
         catch (Exception ex) { error = ex.Message; }
         finally { loading = false; }
+    }
+
+    private async Task LoadFullImageUrlAsync()
+    {
+        if (building is null || string.IsNullOrWhiteSpace(building.ImagePath)) return;
+        try
+        {
+            var urls = await Api.GetAsync<ImageUrlsDto>($"/api/images/buildings/{building.Id}");
+            fullImageUrl = urls?.ImageUrl ?? building.ImageUrl;
+        }
+        catch
+        {
+            fullImageUrl = building.ImageUrl;
+        }
     }
 
     private async Task LoadRecipePickerDataAsync()

--- a/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
+++ b/src/OvcinaHra.Client/Pages/Buildings/BuildingList.razor
@@ -87,6 +87,7 @@ else if (view == "galerie")
         {
             <div class="oh-bld-action-card" @key="b.Id">
                 <BuildingTile Building="@b"
+                              ImageUrl="@GetGalleryImageUrl(b)"
                               OnClick="@(_ => Nav.NavigateTo($"/buildings/{b.Id}"))" />
                 @if (Catalog)
                 {
@@ -309,6 +310,9 @@ else
     private bool isRemoveFromGameVisible;
     private BuildingListDto? pendingRemoveBuilding;
     private string? associationError;
+    private readonly Dictionary<int, string?> galleryImageUrls = [];
+    private readonly HashSet<int> galleryImageUrlAttempts = [];
+    private int galleryImageLoadVersion;
 
     private List<BuildingListDto> filtered =>
         buildings.Where(b =>
@@ -364,6 +368,11 @@ else
                     assignedBuildingIds = linked.Select(b => b.Id).ToHashSet();
                 }
             }
+            galleryImageUrls.Clear();
+            galleryImageUrlAttempts.Clear();
+            galleryImageLoadVersion++;
+            if (view == "galerie")
+                QueueGalleryImageUrlLoad();
         }
         finally { loading = false; }
     }
@@ -374,6 +383,59 @@ else
         view = newView;
         try { await JS.InvokeVoidAsync("localStorage.setItem", "oh-building-view", view); }
         catch { /* localStorage unavailable — ignore */ }
+        if (view == "galerie")
+        {
+            QueueGalleryImageUrlLoad();
+            StateHasChanged();
+        }
+    }
+
+    private string? GetGalleryImageUrl(BuildingListDto building) =>
+        galleryImageUrls.TryGetValue(building.Id, out var url) ? url ?? building.ImageUrl : building.ImageUrl;
+
+    private void QueueGalleryImageUrlLoad()
+    {
+        var version = galleryImageLoadVersion;
+        _ = InvokeAsync(async () =>
+        {
+            await LoadGalleryImageUrlsAsync(version);
+            if (version == galleryImageLoadVersion)
+                StateHasChanged();
+        });
+    }
+
+    private async Task LoadGalleryImageUrlsAsync(int version)
+    {
+        var targets = buildings
+            .Where(b => !string.IsNullOrWhiteSpace(b.ImagePath) && !galleryImageUrlAttempts.Contains(b.Id))
+            .ToList();
+        if (targets.Count == 0) return;
+
+        foreach (var building in targets)
+            galleryImageUrlAttempts.Add(building.Id);
+
+        using var throttle = new System.Threading.SemaphoreSlim(6);
+        var loaded = await Task.WhenAll(targets.Select(async building =>
+        {
+            await throttle.WaitAsync();
+            try
+            {
+                var urls = await Api.GetAsync<ImageUrlsDto>($"/api/images/buildings/{building.Id}");
+                return (building.Id, ImageUrl: urls?.ImageUrl ?? building.ImageUrl);
+            }
+            catch
+            {
+                return (building.Id, ImageUrl: building.ImageUrl);
+            }
+            finally
+            {
+                throttle.Release();
+            }
+        }));
+        if (version != galleryImageLoadVersion) return;
+
+        foreach (var (id, imageUrl) in loaded)
+            galleryImageUrls[id] = imageUrl;
     }
 
     private void OpenCreateModal()

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -4059,7 +4059,7 @@ body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label.oh-map-pin-label-with-re
 .oh-bld-tile:hover{border-color:#2D5016;box-shadow:0 6px 14px rgba(45,80,22,.18);transform:translateY(-2px)}
 .oh-bld-tile:focus-visible{outline:3px solid #2D5016;outline-offset:2px}
 .oh-bld-tile-art{position:relative;aspect-ratio:5/7;background:#f5f0e1;overflow:hidden}
-.oh-bld-tile-art img{width:100%;height:100%;object-fit:cover;display:block}
+.oh-bld-tile-art img{width:100%;height:100%;object-fit:contain;display:block}
 .oh-bld-tile-fade{position:absolute;left:0;right:0;bottom:0;height:50%;
     background:linear-gradient(180deg,rgba(0,0,0,0) 0%,rgba(20,12,4,.8) 100%);
     pointer-events:none}
@@ -4121,7 +4121,7 @@ body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label.oh-map-pin-label-with-re
 .oh-bld-karta-hero{display:grid;grid-template-columns:60fr 40fr;gap:24px;align-items:start;margin-bottom:18px}
 @media (max-width:880px){.oh-bld-karta-hero{grid-template-columns:1fr}}
 .oh-bld-karta-img-wrap{display:flex;justify-content:center}
-.oh-bld-karta-img{width:100%;max-width:380px;aspect-ratio:5/7;object-fit:cover;
+.oh-bld-karta-img{width:100%;max-width:380px;aspect-ratio:5/7;object-fit:contain;
     border-radius:6px;border:1px solid #d8d2be;background:#f5f0e1;display:block}
 .oh-bld-karta-img--placeholder{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px;
     background:repeating-linear-gradient(45deg,#FFF8F0 0 8px,#f4ead2 8px 9px);color:#7a5520}
@@ -4149,6 +4149,18 @@ body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label.oh-map-pin-label-with-re
     border:1px solid rgba(178,98,35,.3);font:500 .825rem/1.3 var(--oh-font-body,inherit)}
 .oh-bld-delete-blocked i{color:#B26223}
 .oh-bld-delete-blocked strong{color:#3a2e1a}
+
+/* — Shared recipe ingredient picker — */
+.oh-recipe-ingredient-picker{max-width:min(100%,640px)}
+.oh-recipe-ingredient-table{width:100%;table-layout:fixed}
+.oh-recipe-ingredient-table td:first-child{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.oh-recipe-ingredient-qty{width:72px;text-align:right;white-space:nowrap;font-variant-numeric:tabular-nums}
+.oh-recipe-ingredient-remove{width:40px;text-align:center}
+.oh-recipe-ingredient-add{display:grid;grid-template-columns:minmax(0,1fr) 72px 34px;gap:8px;align-items:end}
+@media (max-width:520px){
+    .oh-recipe-ingredient-picker{max-width:100%}
+    .oh-recipe-ingredient-add{grid-template-columns:minmax(0,1fr) 66px 34px}
+}
 
 /* ======================================================================
    Issue #214 — QuestWaypointEditor (Trasa tab in QuestDetail). Ordered

--- a/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/BuildingDtos.cs
@@ -5,7 +5,7 @@ public record BuildingListDto(
     int? LocationId, string? LocationName, bool IsPrebuilt,
     string? ImagePath = null, string? ImageUrl = null,
     // Issue #142 — per-game construction recipe summary. Populated by the
-    // by-game endpoint with a compact "3× ingrediencí · 50 zlaťáků · 1 dovednost"
+    // by-game endpoint with a compact "3× ingrediencí · 50 grošů · 1 dovednost"
     // string for display in the grid; catalog endpoint leaves null.
     string? RecipeSummary = null,
     // Issue #208 — building's own "build recipe" pair (cost → effect). Null

--- a/tests/OvcinaHra.Api.Tests/Endpoints/BuildingPhase1Tests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/BuildingPhase1Tests.cs
@@ -82,7 +82,7 @@ public class BuildingPhase1Tests(PostgresFixture postgres) : IntegrationTestBase
             new CreateBuildingDto(
                 "Sklepení",
                 CostMoney: 50,
-                Effect: "Skladovací kapacita pro 10 zlaťáků."));
+                Effect: "Skladovací kapacita pro 10 grošů."));
         var created = (await createResponse.Content.ReadFromJsonAsync<BuildingDetailDto>())!;
 
         var clearDto = new UpdateBuildingDto(

--- a/tests/OvcinaHra.Api.Tests/Endpoints/BuildingRecipeEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/BuildingRecipeEndpointTests.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Mvc;
+using OvcinaHra.Api.Endpoints;
 using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
 
@@ -347,5 +349,16 @@ public class BuildingRecipeEndpointTests(PostgresFixture postgres) : Integration
         Assert.Contains("75", withRow.RecipeSummary);
         Assert.Contains("4", withRow.RecipeSummary);
         Assert.Null(noRow.RecipeSummary);
+    }
+
+    [Theory]
+    [InlineData(1, "1 groš")]
+    [InlineData(2, "2 groše")]
+    [InlineData(5, "5 grošů")]
+    public void BuildRecipeSummary_DeclinesCurrency(int moneyCost, string expected)
+    {
+        var summary = BuildingRecipeEndpoints.BuildRecipeSummary(new BuildingRecipe { MoneyCost = moneyCost });
+
+        Assert.Equal(expected, summary);
     }
 }


### PR DESCRIPTION
## Summary
- Fix Buildings Galerie/detail images to use full image SAS URLs on the large surfaces, with `object-fit: contain` to avoid center-cropping.
- Add Enter-to-add behavior to the shared recipe ingredient picker and constrain its width so quantities stay near ingredient names on wide panels.
- Rename remaining `zlaťák*` UI/API summary text to `groš*` and update the related test fixture text.

## Verification
- `dotnet build OvcinaHra.slnx`
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test OvcinaHra.slnx --no-build` — 620 API + 8 E2E passed
- `git grep -n -i -E "zlaťák|zlaťáci|zlaťáky|zlatak|zlataci|zlataky" -- src tests` — no hits
- `git diff --check`

## Smoke notes
- #469 source check: Buildings Galerie and detail card now resolve `/api/images/buildings/{id}` full `ImageUrlsDto.ImageUrl`; thumbnails remain on compact list/card surfaces.
- #471 source check: shared `RecipeIngredientPicker` handles Enter/NumpadEnter on the add row, using the same add path as the plus button.
- #472 source check: remaining source/test currency hits swept to groš/groše/grošů forms.