### PR TITLE
fix(lore): Drozd trigger overlap and active heading visibility

### DIFF
--- a/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.css
+++ b/src/OvcinaHra.Client/Components/BotConsultDrawer.razor.css
@@ -2,7 +2,7 @@
     position: fixed;
     right: 1.25rem;
     bottom: 1.25rem;
-    z-index: 1050;
+    z-index: 900;
     min-width: 3.5rem;
     height: 3.5rem;
     max-width: min(17rem, calc(100vw - 2rem));

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -231,6 +231,13 @@
     color: var(--oh-primary-light);
 }
 
+.location-tabs .dxbl-tabs-item.dxbl-active,
+.location-tabs .dxbl-tabs-item.dxbl-active:hover,
+.location-tabs .dxbl-tabs-item.dxbl-active:focus,
+.location-tabs .dxbl-tabs-item.dxbl-active * {
+    color: var(--oh-header-text) !important;
+}
+
 /* === DxPager === */
 
 .dxbl-pager .dxbl-pager-page-item.dxbl-active {


### PR DESCRIPTION
## Summary
- lower the closed Drozd FAB layer so it cannot sit above location edit dialogs and block Save/Cancel
- keep the opened Drozd drawer/backdrop on their existing dialog layers
- make the active location popup tab use high-contrast header text, fixing the active Lore heading visibility

Closes #470

## Verification
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test OvcinaHra.slnx --no-build`
- `git diff --check`
- Browser smoke at 700x460: opened location create popup with Drozd enabled, switched to Lore tab, confirmed active tab color `rgb(255, 248, 240)`, Save button wins hit-test at its center, and Drozd drawer still opens after closing the popup.
- §16: CSS-only change, no client HTTP paths touched.