### PR TITLE
feat(map): done-locations green check overlay

### DIFF
--- a/src/OvcinaHra.Api/Services/MapDataService.cs
+++ b/src/OvcinaHra.Api/Services/MapDataService.cs
@@ -34,6 +34,7 @@ public sealed class MapDataService(
                 gl.Location.Name,
                 gl.Location.LocationKind,
                 gl.Location.Region,
+                gl.Location.PlacementPhotoPath,
                 Lat = gl.Location.Coordinates!.Latitude,
                 Lon = gl.Location.Coordinates!.Longitude,
                 gl.Location.ImagePath,
@@ -141,6 +142,7 @@ public sealed class MapDataService(
             (double)r.Lat, (double)r.Lon,
             r.LocationKind,
             r.Region,
+            !string.IsNullOrWhiteSpace(r.PlacementPhotoPath),
             // Kingdom not stored on Location/GameLocation today. Return null
             // so the cockpit's kingdom-tint chip stays inert until a follow-up
             // adds the relationship.

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -72,6 +72,12 @@
                                        @onchange="SetRegionLabelsAsync" />
                                 <span>Zobrazit oblasti</span>
                             </label>
+                            <label class="oh-map-region-toggle oh-map-done-toggle @(_showDoneLocations ? "is-active" : "")">
+                                <input type="checkbox"
+                                       checked="@_showDoneLocations"
+                                       @onchange="SetDoneLocationsAsync" />
+                                <span>Hotové lokace</span>
+                            </label>
                         </div>
                         <div class="oh-map-style-toolbar">
                             <button class="oh-map-style-btn @(_activeStyle == "tourist" ? "is-active" : "")"
@@ -234,6 +240,7 @@
     // continue to deserialize via the record's default value.
     private const string LayerStateKey = "oh-map-layers-v2";
     private const string RegionLabelStateKey = "oh-map-region-labels-v1";
+    private const string DoneLocationStateKey = "oh-map-done-locations-v1";
     private const string TreasurePhaseAll = "all";
     private const string TreasurePhaseStart = "start";
     private const string TreasurePhaseEarly = "early";
@@ -258,6 +265,7 @@
     private bool _organizerOverlayVisible = true;
     private bool _isOrganizer;
     private bool _showRegionsOnMap;
+    private bool _showDoneLocations;
     // Per-LocationKind hide set. Empty (default) = all kinds visible.
     // Persists alongside the layer-visibility flags.
     private HashSet<LocationKind> _hiddenKinds = new();
@@ -363,6 +371,7 @@
             await HydrateLayerStateAsync();
         }
         await HydrateRegionLabelStateAsync();
+        await HydrateDoneLocationStateAsync();
         // Apply URL-derived style now that the basemap is ready (default
         // is "tourist", so we only need to switch when URL asked for
         // something else). Calling switchStyle directly here — going
@@ -433,6 +442,25 @@
         catch { /* localStorage unavailable — session-only toggle */ }
     }
 
+    private async Task HydrateDoneLocationStateAsync()
+    {
+        try
+        {
+            var raw = await JS.InvokeAsync<string?>("localStorage.getItem", DoneLocationStateKey);
+            _showDoneLocations = raw is "1" || string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase);
+        }
+        catch { /* localStorage unavailable — keep default off */ }
+    }
+
+    private async Task PersistDoneLocationStateAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("localStorage.setItem", DoneLocationStateKey, _showDoneLocations ? "true" : "false");
+        }
+        catch { /* localStorage unavailable — session-only toggle */ }
+    }
+
     private async Task ReloadDataAndRenderAsync()
     {
         var gameId = GameContext.SelectedGameId;
@@ -475,6 +503,7 @@
 
         var locationLabelCount = 0;
         var regionLabelCount = 0;
+        var doneLocationCount = 0;
         if (_locationsVisible)
         {
             foreach (var l in _data.Locations.OrderBy(l => l.EffectiveKind == LocationKind.Hobbit ? 1 : 0))
@@ -487,14 +516,21 @@
                 var totalCount = l.TreasureCounts?.Total ?? 0;
                 locationLabelCount++;
                 if (_showRegionsOnMap && !string.IsNullOrWhiteSpace(l.Region)) regionLabelCount++;
+                if (l.IsPlacementDone) doneLocationCount++;
                 Console.WriteLine($"[treasure-map] count-pin render locationId={l.Id} totalCount={totalCount} filteredCount={filteredCount} phase={TreasurePhaseLogName(_treasurePhaseFilter)}");
+                if (_showDoneLocations && l.IsPlacementDone)
+                {
+                    Console.WriteLine($"[map-done] pin-render locationId={l.Id} done=true");
+                }
                 await JS.InvokeVoidAsync("ovcinaMap.addLocationPin",
                     l.Id, l.Lat, l.Lon, l.EffectiveName, l.EffectiveKind.ToString(),
                     filteredCount, TreasurePhaseUiName(_treasurePhaseFilter),
-                    l.Region, _showRegionsOnMap);
+                    l.Region, _showRegionsOnMap,
+                    l.IsPlacementDone, _showDoneLocations);
             }
         }
         Console.WriteLine($"[map-region-toggle] render labelCount={locationLabelCount} withRegion={_showRegionsOnMap.ToString().ToLowerInvariant()} regionLabelCount={regionLabelCount}");
+        Console.WriteLine($"[map-done] render visible={_showDoneLocations.ToString().ToLowerInvariant()} doneCount={doneLocationCount}");
         if (_stashesVisible)
         {
             foreach (var s in _data.Stashes)
@@ -524,6 +560,17 @@
         _showRegionsOnMap = enabled;
         Console.WriteLine($"[map-region-toggle] state-changed enabled={enabled.ToString().ToLowerInvariant()}");
         await PersistRegionLabelStateAsync();
+        await PaintPinsAsync();
+    }
+
+    private async Task SetDoneLocationsAsync(ChangeEventArgs e)
+    {
+        var enabled = e.Value is bool value && value;
+        if (_showDoneLocations == enabled) return;
+
+        _showDoneLocations = enabled;
+        Console.WriteLine($"[map-done] toggle changed enabled={enabled.ToString().ToLowerInvariant()}");
+        await PersistDoneLocationStateAsync();
         await PaintPinsAsync();
     }
 

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3841,6 +3841,9 @@
 .oh-map-region-toggle input{width:13px;height:13px;margin:0;accent-color:#2D5016}
 .oh-map-region-toggle:hover{background:rgba(45,80,22,.08);color:#2D5016}
 .oh-map-region-toggle.is-active{background:#2D5016;color:#fff}
+.oh-map-done-toggle input{accent-color:#1F8F3A}
+.oh-map-done-toggle:hover{background:rgba(31,143,58,.08);color:#1F8F3A}
+.oh-map-done-toggle.is-active{background:#1F8F3A;color:#fff}
 @media (max-width: 900px){
     .oh-map-treasure-filter{top:48px;right:8px;max-width:calc(100% - 16px)}
 }
@@ -3892,6 +3895,10 @@
     border-radius:99px;padding:0 4px;font:700 .65rem var(--oh-font-body);
     border:1.5px solid var(--oh-border,#d8d2be);min-width:14px;text-align:center;
     box-shadow:0 1px 2px rgba(0,0,0,.18);z-index:3}
+.oh-map-pin-done{position:absolute;top:-5px;right:-6px;z-index:4;width:17px;height:17px;
+    border-radius:50%;background:#fff;color:#1F8F3A;font-size:16px;line-height:1;
+    box-shadow:0 1px 3px rgba(0,0,0,.3)}
+.oh-map-pin.oh-map-pin-has-count .oh-map-pin-done{top:11px;right:-7px}
 /* Ctrl/Meta held over the map → crosshair cursor (visual hint that
    Ctrl+Click places an ungeocoded location and Ctrl+Shift+Click opens
    the relocation picker). Class toggled by map-interop.js keydown/keyup. */

--- a/src/OvcinaHra.Client/wwwroot/js/map-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/map-interop.js
@@ -1223,7 +1223,7 @@ window.ovcinaMap._kindIconFor = function (kindRaw) {
     return this._kindIcon[k] || 'bi-geo-alt-fill';
 };
 
-window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind, treasureCount, treasurePhase, region, showRegion) {
+window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind, treasureCount, treasurePhase, region, showRegion, isPlacementDone, showDone) {
     if (!this._map) {
         if (this._pinDiag()) console.warn('[pin-diag] addLocationPin called but no map — id=' + id);
         return;
@@ -1258,8 +1258,10 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind, treasureCo
     count = Math.max(0, Math.trunc(count));
     var phaseText = treasurePhase || '';
     var regionText = showRegion && region ? String(region).trim() : '';
+    var showDoneBadge = !!showDone && !!isPlacementDone;
     var kindKey = (kind || 'wilderness').toLowerCase();
     pin.setAttribute('data-kind', kindKey);
+    if (count > 0) pin.classList.add('oh-map-pin-has-count');
     // Issue #273 — graduated label-visibility-by-zoom. Each pin advertises
     // its minzoom; the zoomend handler in init() flips `oh-pin-label-on`
     // when map.getZoom() >= this value. Initial state set inline below
@@ -1270,6 +1272,7 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind, treasureCo
     var markerTitle = name || '';
     if (regionText) markerTitle += (markerTitle ? ' · ' : '') + regionText;
     if (count > 0) markerTitle += (markerTitle ? ' · ' : '') + count + ' pokladů' + (phaseText ? ' (' + phaseText + ')' : '');
+    if (showDoneBadge) markerTitle += (markerTitle ? ' · ' : '') + 'Hotová lokace';
     wrapper.title = markerTitle;
     // Issue #257 — tear-drop pin chrome. The bubble (oh-map-pin-bg) carries
     // the per-kind background and the downward triangle tail (::after); the
@@ -1292,6 +1295,13 @@ window.ovcinaMap.addLocationPin = function (id, lat, lon, name, kind, treasureCo
         countBadge.textContent = String(count);
         countBadge.title = count + ' pokladů' + (phaseText ? ' (' + phaseText + ')' : '');
         pin.appendChild(countBadge);
+    }
+    if (showDoneBadge) {
+        var doneBadge = document.createElement('i');
+        doneBadge.className = 'oh-map-pin-done bi bi-check-circle-fill';
+        doneBadge.title = 'Hotová lokace';
+        doneBadge.setAttribute('aria-hidden', 'true');
+        pin.appendChild(doneBadge);
     }
     if (name) {
         var label = document.createElement('div');

--- a/src/OvcinaHra.Shared/Dtos/MapDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/MapDtos.cs
@@ -29,6 +29,7 @@ public record MapLocationDto(
     double Lon,
     LocationKind Kind,
     string? Region,
+    bool IsPlacementDone,
     int? KingdomId,
     string? KingdomName,
     string? ThumbnailUrl,

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/MapDoneOverlaySmokeTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/MapDoneOverlaySmokeTests.cs
@@ -1,0 +1,52 @@
+namespace OvcinaHra.Api.Tests.ClientSmoke;
+
+public class MapDoneOverlaySmokeTests
+{
+    [Fact]
+    public void MapPage_WiresDoneLocationOverlay()
+    {
+        var root = FindRepoRoot();
+        var mapPage = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Pages",
+            "Map",
+            "MapPage.razor"));
+        var mapInterop = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "wwwroot",
+            "js",
+            "map-interop.js"));
+        var theme = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "wwwroot",
+            "css",
+            "ovcinahra-theme.css"));
+
+        Assert.Contains("Hotové lokace", mapPage);
+        Assert.Contains("DoneLocationStateKey", mapPage);
+        Assert.Contains("[map-done] toggle changed", mapPage);
+        Assert.Contains("l.IsPlacementDone", mapPage);
+        Assert.Contains("showDoneBadge", mapInterop);
+        Assert.Contains("bi-check-circle-fill", mapInterop);
+        Assert.Contains("oh-map-pin-done", mapInterop);
+        Assert.Contains("oh-map-pin-has-count", mapInterop);
+        Assert.Contains(".oh-map-done-toggle", theme);
+        Assert.Contains(".oh-map-pin-done", theme);
+        Assert.Contains(".oh-map-pin.oh-map-pin-has-count .oh-map-pin-done", theme);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "OvcinaHra.slnx")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not find repository root.");
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/MapEndpointsTests.cs
@@ -51,6 +51,7 @@ public class MapEndpointsTests(PostgresFixture postgres)
                 Name = "Hradec",
                 LocationKind = LocationKind.Wilderness,
                 Region = "Severní les",
+                PlacementPhotoPath = "locations/1/placement.jpg",
                 Coordinates = new GpsCoordinates(49.5m, 17.1m),
             };
             var withoutGps = new Location
@@ -73,6 +74,7 @@ public class MapEndpointsTests(PostgresFixture postgres)
         var single = Assert.Single(data.Locations);
         Assert.Equal("Hradec", single.Name);
         Assert.Equal("Severní les", single.Region);
+        Assert.True(single.IsPlacementDone);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- adds `IsPlacementDone` to `/api/map/data`, derived from `Location.PlacementPhotoPath`
- adds a persisted `/map` toolbar toggle labeled `Hotové lokace`
- renders a green `bi-check-circle-fill` badge on done location pins when the toggle is enabled
- keeps treasure counts and region labels composable with the done badge

Closes #460

## Phase 0 decisions
- Done means: placement photo present
- Toggle label: `Hotové lokace`
- Visual: green Bootstrap check badge on the pin
- Animation: none
- Server data: boolean `IsPlacementDone`, no raw blob key in map DTO
- Composition: count badge + region label + done badge can stack

## Verification
- dotnet build OvcinaHra.slnx --nologo
- dotnet test OvcinaHra.slnx --nologo --no-build

## Visual smoke
- Open `/map` for game 30.
- Toggle `Hotové lokace` ON: locations with placement photos show a green check badge.
- Toggle OFF: check badges disappear.
- Combine with treasure phase chips and `Zobrazit oblasti`: count badge, region label, and check badge should all remain readable.
- Console should show `[map-done]` toggle/render markers.
