### PR TITLE
feat(api): WorldChange audit dashboard feed (closes #247) [v0.17.2]

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/WorldChangeConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/WorldChangeConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OvcinaHra.Shared.Domain.Entities;
+
+namespace OvcinaHra.Api.Data.Configurations;
+
+public class WorldChangeConfiguration : IEntityTypeConfiguration<WorldChange>
+{
+    public void Configure(EntityTypeBuilder<WorldChange> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.EntityType).IsRequired().HasMaxLength(100);
+        builder.Property(e => e.EntityName).IsRequired().HasMaxLength(300);
+        builder.Property(e => e.Operation).HasConversion<string>().HasMaxLength(32);
+        builder.Property(e => e.ActorUserId).IsRequired().HasMaxLength(200);
+        builder.Property(e => e.ActorDisplayName).IsRequired().HasMaxLength(200);
+
+        builder.HasIndex(e => e.ChangedAtUtc);
+        builder.HasIndex(e => new { e.GameId, e.ChangedAtUtc });
+        builder.HasIndex(e => new { e.EntityType, e.EntityId });
+    }
+}

--- a/src/OvcinaHra.Api/Data/WorldChangeAuditInterceptor.cs
+++ b/src/OvcinaHra.Api/Data/WorldChangeAuditInterceptor.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Security.Claims;
+using System.Transactions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -90,6 +91,14 @@ public class WorldChangeAuditInterceptor(
 
         try
         {
+            if (db.Database.CurrentTransaction is not null || Transaction.Current is not null)
+            {
+                logger.LogWarning(
+                    "[world-change-audit] interceptor.skip-active-transaction pendingCount={PendingCount}",
+                    pending.Count);
+                return await base.SavedChangesAsync(eventData, result, cancellationToken);
+            }
+
             var rows = pending
                 .Select(BuildWorldChange)
                 .Where(c => c is not null)

--- a/src/OvcinaHra.Api/Data/WorldChangeAuditInterceptor.cs
+++ b/src/OvcinaHra.Api/Data/WorldChangeAuditInterceptor.cs
@@ -1,0 +1,311 @@
+using System.Diagnostics;
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Api.Data;
+
+public class WorldChangeAuditInterceptor(
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<WorldChangeAuditInterceptor> logger) : SaveChangesInterceptor
+{
+    private static readonly HashSet<Type> AuditedEntityTypes =
+    [
+        typeof(Location),
+        typeof(OrganizerRoleAssignment),
+        typeof(TreasureQuest),
+        typeof(Item),
+        typeof(Building),
+        typeof(CraftingRecipe),
+        typeof(BuildingRecipe),
+        typeof(Game),
+        typeof(GameTimeSlot),
+        typeof(Monster),
+        typeof(PersonalQuest),
+        typeof(Quest),
+        typeof(Npc),
+        typeof(Character)
+    ];
+
+    private static readonly string[] DisplayNameProperties =
+    [
+        "Name",
+        "Title",
+        "PersonName",
+        "DisplayName"
+    ];
+
+    private List<PendingWorldChange>? _pending;
+    private bool _savingAuditRows;
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        if (_savingAuditRows || eventData.Context is not WorldDbContext db)
+            return base.SavingChangesAsync(eventData, result, cancellationToken);
+
+        try
+        {
+            _pending = db.ChangeTracker
+                .Entries()
+                .Select(CreatePending)
+                .Where(p => p is not null)
+                .Select(p => p!)
+                .ToList();
+
+            logger.LogInformation(
+                "[world-change-audit] interceptor.entry entityCount={EntityCount}",
+                _pending.Count);
+        }
+        catch (Exception ex)
+        {
+            _pending = null;
+            logger.LogWarning(ex,
+                "[world-change-audit] interceptor.capture-failed");
+        }
+
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    public override async ValueTask<int> SavedChangesAsync(
+        SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        if (_savingAuditRows || eventData.Context is not WorldDbContext db)
+            return await base.SavedChangesAsync(eventData, result, cancellationToken);
+
+        var pending = _pending;
+        _pending = null;
+
+        if (pending is null || pending.Count == 0)
+            return await base.SavedChangesAsync(eventData, result, cancellationToken);
+
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var rows = pending
+                .Select(BuildWorldChange)
+                .Where(c => c is not null)
+                .Select(c => c!)
+                .ToList();
+
+            foreach (var row in rows)
+            {
+                logger.LogInformation(
+                    "[world-change-audit] interceptor.captured entityType={EntityType} operation={Operation} entityId={EntityId} actorUserId={ActorUserId}",
+                    row.EntityType,
+                    row.Operation,
+                    row.EntityId,
+                    row.ActorUserId);
+            }
+
+            if (rows.Count > 0)
+            {
+                _savingAuditRows = true;
+                db.WorldChanges.AddRange(rows);
+                await db.SaveChangesAsync(cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            DetachPendingAuditRows(db);
+            logger.LogWarning(ex,
+                "[world-change-audit] interceptor.persist-failed pendingCount={PendingCount}",
+                pending.Count);
+        }
+        finally
+        {
+            _savingAuditRows = false;
+            stopwatch.Stop();
+            logger.LogInformation(
+                "[world-change-audit] interceptor.exit elapsedMs={ElapsedMs}",
+                stopwatch.ElapsedMilliseconds);
+        }
+
+        return await base.SavedChangesAsync(eventData, result, cancellationToken);
+    }
+
+    public override Task SaveChangesFailedAsync(
+        DbContextErrorEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        _pending = null;
+        _savingAuditRows = false;
+        return base.SaveChangesFailedAsync(eventData, cancellationToken);
+    }
+
+    private PendingWorldChange? CreatePending(EntityEntry entry)
+    {
+        if (!AuditedEntityTypes.Contains(entry.Metadata.ClrType))
+            return null;
+
+        var operation = entry.State switch
+        {
+            EntityState.Added => WorldChangeOperation.Created,
+            EntityState.Modified when HasMeaningfulModification(entry) => WorldChangeOperation.Updated,
+            EntityState.Deleted => WorldChangeOperation.Deleted,
+            _ => (WorldChangeOperation?)null
+        };
+
+        if (operation is null)
+            return null;
+
+        var useOriginal = operation == WorldChangeOperation.Deleted;
+        var actor = CurrentActor();
+        var entityId = operation == WorldChangeOperation.Created
+            ? null
+            : ReadIntProperty(entry, "Id", useOriginal);
+
+        return new PendingWorldChange(
+            entry,
+            entry.Metadata.ClrType.Name,
+            operation.Value,
+            entityId,
+            ReadGameId(entry, useOriginal),
+            ReadDisplayName(entry, useOriginal),
+            actor.UserId,
+            actor.DisplayName);
+    }
+
+    private static bool HasMeaningfulModification(EntityEntry entry)
+        => entry.Properties.Any(p => p.IsModified && !p.Metadata.IsPrimaryKey());
+
+    private WorldChange? BuildWorldChange(PendingWorldChange pending)
+    {
+        var entityId = pending.EntityId ?? ReadIntProperty(pending.Entry, "Id", useOriginal: false);
+        if (entityId is null or <= 0)
+            return null;
+
+        var capturedGameId = pending.GameId is > 0 ? pending.GameId : null;
+        var gameId = capturedGameId
+            ?? (pending.EntityType == nameof(Game) ? entityId : ReadGameId(pending.Entry, useOriginal: false));
+
+        var entityName = pending.EntityName
+            ?? ReadDisplayName(pending.Entry, useOriginal: false)
+            ?? $"{pending.EntityType} #{entityId.Value}";
+
+        return new WorldChange
+        {
+            GameId = gameId,
+            EntityType = pending.EntityType,
+            EntityId = entityId.Value,
+            EntityName = TrimToMax(entityName, 300),
+            Operation = pending.Operation,
+            ActorUserId = TrimToMax(pending.ActorUserId, 200),
+            ActorDisplayName = TrimToMax(pending.ActorDisplayName, 200),
+            ChangedAtUtc = DateTime.UtcNow
+        };
+    }
+
+    private (string UserId, string DisplayName) CurrentActor()
+    {
+        var user = httpContextAccessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+            return ("system", "System");
+
+        var userId = user.FindFirstValue("sub")
+            ?? user.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? "system";
+        var displayName = user.FindFirstValue("name")
+            ?? user.FindFirstValue(ClaimTypes.Name)
+            ?? user.Identity.Name
+            ?? userId;
+
+        return (userId, displayName);
+    }
+
+    private static int? ReadGameId(EntityEntry entry, bool useOriginal)
+    {
+        if (entry.Metadata.ClrType == typeof(Game))
+            return ReadIntProperty(entry, "Id", useOriginal);
+
+        return ReadIntProperty(entry, "GameId", useOriginal);
+    }
+
+    private static string? ReadDisplayName(EntityEntry entry, bool useOriginal)
+    {
+        foreach (var propertyName in DisplayNameProperties)
+        {
+            var value = ReadStringProperty(entry, propertyName, useOriginal);
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+        }
+
+        var startTime = ReadDateTimeProperty(entry, "StartTime", useOriginal);
+        return startTime is null ? null : $"GameTimeSlot {startTime.Value:yyyy-MM-dd HH:mm}";
+    }
+
+    private static int? ReadIntProperty(EntityEntry entry, string propertyName, bool useOriginal)
+    {
+        if (entry.Metadata.FindProperty(propertyName) is null)
+            return null;
+
+        var value = useOriginal
+            ? entry.Property(propertyName).OriginalValue
+            : entry.Property(propertyName).CurrentValue;
+
+        return value switch
+        {
+            int i => i,
+            _ => null
+        };
+    }
+
+    private static string? ReadStringProperty(EntityEntry entry, string propertyName, bool useOriginal)
+    {
+        if (entry.Metadata.FindProperty(propertyName) is null)
+            return null;
+
+        var value = useOriginal
+            ? entry.Property(propertyName).OriginalValue
+            : entry.Property(propertyName).CurrentValue;
+
+        return value as string;
+    }
+
+    private static DateTime? ReadDateTimeProperty(EntityEntry entry, string propertyName, bool useOriginal)
+    {
+        if (entry.Metadata.FindProperty(propertyName) is null)
+            return null;
+
+        var value = useOriginal
+            ? entry.Property(propertyName).OriginalValue
+            : entry.Property(propertyName).CurrentValue;
+
+        return value switch
+        {
+            DateTime dt => dt,
+            _ => null
+        };
+    }
+
+    private static string TrimToMax(string value, int maxLength)
+        => value.Length <= maxLength ? value : value[..maxLength];
+
+    private static void DetachPendingAuditRows(WorldDbContext db)
+    {
+        foreach (var entry in db.ChangeTracker.Entries<WorldChange>()
+                     .Where(e => e.State is EntityState.Added or EntityState.Modified)
+                     .ToList())
+        {
+            entry.State = EntityState.Detached;
+        }
+    }
+
+    private sealed record PendingWorldChange(
+        EntityEntry Entry,
+        string EntityType,
+        WorldChangeOperation Operation,
+        int? EntityId,
+        int? GameId,
+        string? EntityName,
+        string ActorUserId,
+        string ActorDisplayName);
+}

--- a/src/OvcinaHra.Api/Data/WorldDbContext.cs
+++ b/src/OvcinaHra.Api/Data/WorldDbContext.cs
@@ -58,6 +58,7 @@ public class WorldDbContext(DbContextOptions<WorldDbContext> options) : DbContex
     public DbSet<CharacterEvent> CharacterEvents => Set<CharacterEvent>();
     public DbSet<EventIdempotency> EventIdempotencies => Set<EventIdempotency>();
     public DbSet<WorldActivity> WorldActivities => Set<WorldActivity>();
+    public DbSet<WorldChange> WorldChanges => Set<WorldChange>();
     public DbSet<GameEvent> GameEvents => Set<GameEvent>();
     public DbSet<GameEventTimeSlot> GameEventTimeSlots => Set<GameEventTimeSlot>();
     public DbSet<GameEventLocation> GameEventLocations => Set<GameEventLocation>();

--- a/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
@@ -108,90 +108,48 @@ public static class DashboardEndpoints
         count == 0 ? "low" : count < 5 ? "low" : count < 15 ? "mid" : "high";
 
     /// <summary>
-    /// Powers RecentActivityFeed — real WorldActivity recordings first,
-    /// followed by legacy per-entity timestamp rows until every workflow
-    /// records through WorldActivity.
+    /// Powers RecentActivityFeed from the best-effort WorldChange audit log.
     /// </summary>
     private static async Task<Ok<List<DashboardActivityDto>>> GetActivity(
-        int gameId, WorldDbContext db, HttpContext http, int? limit = 10)
+        int gameId, WorldDbContext db, int? limit = 10)
     {
         var take = Math.Clamp(limit ?? 10, 1, 50);
 
-        var activityRows = await db.WorldActivities
-            .Where(a => a.GameId == gameId)
-            .OrderByDescending(a => a.TimestampUtc)
+        var changes = await db.WorldChanges
+            .AsNoTracking()
+            .Where(c => c.GameId == gameId || c.GameId == null)
+            .OrderByDescending(c => c.ChangedAtUtc)
+            .ThenByDescending(c => c.Id)
             .Take(take)
-            .Select(a => new
+            .Select(c => new
             {
-                a.Id,
-                a.LocationId,
-                a.Description,
-                a.OrganizerName,
-                a.TimestampUtc,
-                a.ActivityType,
-                LocationName = a.Location != null ? a.Location.Name : null,
-                PlacementPhotoPath = a.Location != null ? a.Location.PlacementPhotoPath : null
+                c.EntityType,
+                c.EntityId,
+                c.EntityName,
+                c.Operation,
+                c.ActorDisplayName,
+                c.ChangedAtUtc
             })
             .ToListAsync();
 
-        var activities = activityRows.Select(a => new DashboardActivityDto(
-            a.LocationId.HasValue ? "location" : "activity",
-            a.LocationId ?? a.Id,
-            a.LocationName ?? a.Description,
-            a.LocationId.HasValue && !string.IsNullOrWhiteSpace(a.PlacementPhotoPath)
-                ? ImageEndpoints.ThumbUrl(http, "locationplacements", a.LocationId.Value, "small")
-                : null,
-            ActivityVerb(a.ActivityType),
-            a.OrganizerName,
-            a.TimestampUtc)).ToList();
+        var rows = changes.Select(c => new DashboardActivityDto(
+            c.EntityType.ToLowerInvariant(),
+            c.EntityId,
+            c.EntityName,
+            null,
+            ChangeVerb(c.Operation),
+            c.ActorDisplayName,
+            c.ChangedAtUtc)).ToList();
 
-        // Per-entity slices, each ordered DESC and capped at `take` so the
-        // merged result has enough material to slice the global top-N from.
-        // Sequential awaits — single DbContext can't serve concurrent queries.
-        var characters = await db.CharacterAssignments
-            .Where(a => a.GameId == gameId)
-            .OrderByDescending(a => a.Character.UpdatedAtUtc)
-            .Take(take)
-            .Select(a => new DashboardActivityDto(
-                "character", a.CharacterId, a.Character.Name,
-                null, "upravil", "—", a.Character.UpdatedAtUtc))
-            .ToListAsync();
-
-        var events = await db.GameEvents
-            .Where(e => e.GameId == gameId)
-            .OrderByDescending(e => e.UpdatedAtUtc)
-            .Take(take)
-            .Select(e => new DashboardActivityDto(
-                "event", e.Id, e.Name,
-                null, "upravil", "—", e.UpdatedAtUtc))
-            .ToListAsync();
-
-        var npcs = await db.GameNpcs
-            .Where(gn => gn.GameId == gameId)
-            .OrderByDescending(gn => gn.Npc.UpdatedAtUtc)
-            .Take(take)
-            .Select(gn => new DashboardActivityDto(
-                "npc", gn.NpcId, gn.Npc.Name,
-                null, "upravil", "—", gn.Npc.UpdatedAtUtc))
-            .ToListAsync();
-
-        var merged = characters
-            .Concat(activities)
-            .Concat(events)
-            .Concat(npcs)
-            .OrderByDescending(x => x.OccurredUtc)
-            .Take(take)
-            .ToList();
-
-        return TypedResults.Ok(merged);
+        return TypedResults.Ok(rows);
     }
 
-    private static string ActivityVerb(WorldActivityType type) => type switch
+    private static string ChangeVerb(WorldChangeOperation operation) => operation switch
     {
-        WorldActivityType.LocationPlaced => "umístil",
-        WorldActivityType.CharacterLevelUp => "zapsal level",
-        WorldActivityType.QuestCompleted => "dokončil quest",
-        _ => "zapsal"
+        WorldChangeOperation.Created => "vytvořil",
+        WorldChangeOperation.Updated => "upravil",
+        WorldChangeOperation.Deleted => "smazal",
+        _ => "upravil"
     };
 
     /// <summary>

--- a/src/OvcinaHra.Api/Migrations/20260430061542_AddWorldChangeAudit.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260430061542_AddWorldChangeAudit.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430061542_AddWorldChangeAudit")]
+    partial class AddWorldChangeAudit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260430061542_AddWorldChangeAudit.cs
+++ b/src/OvcinaHra.Api/Migrations/20260430061542_AddWorldChangeAudit.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorldChangeAudit : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WorldChanges",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    GameId = table.Column<int>(type: "integer", nullable: true),
+                    EntityType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    EntityId = table.Column<int>(type: "integer", nullable: false),
+                    EntityName = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    Operation = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ActorUserId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    ActorDisplayName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    ChangedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorldChanges", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorldChanges_EntityType_EntityId",
+                table: "WorldChanges",
+                columns: new[] { "EntityType", "EntityId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorldChanges_GameId_ChangedAtUtc",
+                table: "WorldChanges",
+                columns: new[] { "GameId", "ChangedAtUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorldChanges_ChangedAtUtc",
+                table: "WorldChanges",
+                column: "ChangedAtUtc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WorldChanges");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Program.cs
+++ b/src/OvcinaHra.Api/Program.cs
@@ -39,8 +39,12 @@ try
     });
 
     builder.Services.AddOpenApi();
-    builder.Services.AddDbContext<WorldDbContext>(options =>
-        options.UseNpgsql(builder.Configuration.GetConnectionString("WorldDb")));
+    builder.Services.AddHttpContextAccessor();
+    builder.Services.AddScoped<WorldChangeAuditInterceptor>();
+    builder.Services.AddDbContext<WorldDbContext>((sp, options) =>
+        options
+            .UseNpgsql(builder.Configuration.GetConnectionString("WorldDb"))
+            .AddInterceptors(sp.GetRequiredService<WorldChangeAuditInterceptor>()));
     builder.Services.AddHealthChecks()
         .AddDbContextCheck<WorldDbContext>();
 

--- a/src/OvcinaHra.Client/Components/RecentActivityFeed.razor
+++ b/src/OvcinaHra.Client/Components/RecentActivityFeed.razor
@@ -1,5 +1,4 @@
-@* Issue #158 + #383 — recent organizer activity. WorldActivity rows use
-   real actor/timestamp data; older entity timestamp rows remain as fallback. *@
+@* Issue #247 — recent organizer activity from the WorldChange audit log. *@
 
 <section class="oh-home-act" aria-labelledby="oh-home-act-title">
     <header class="oh-home-act-head">
@@ -51,18 +50,38 @@
     private static string RouteFor(DashboardActivityDto r) => r.EntityType switch
     {
         "character" => $"/characters/{r.EntityId}",
-        "event"     => $"/timeline",
+        "building" => $"/buildings/{r.EntityId}",
+        "buildingrecipe" => "/buildings",
+        "craftingrecipe" => $"/recipes/{r.EntityId}",
+        "game" => "/games",
+        "gametimeslot" => "/timeline",
+        "item" => $"/items/{r.EntityId}",
         "location"  => $"/locations/{r.EntityId}",
+        "monster" => $"/monsters/{r.EntityId}",
         "npc"       => $"/npcs/{r.EntityId}",
+        "organizerroleassignment" => "/organizer-roles",
+        "personalquest" => "/personal-quests",
+        "quest" => $"/quests/{r.EntityId}",
+        "treasurequest" => "/treasures",
         _           => "/",
     };
 
     private static string IconFor(string entityType) => entityType switch
     {
         "character" => "bi-person",
-        "event"     => "bi-calendar-event",
+        "building" => "bi-house-door",
+        "buildingrecipe" => "bi-hammer",
+        "craftingrecipe" => "bi-flask",
+        "game" => "bi-controller",
+        "gametimeslot" => "bi-clock",
+        "item" => "bi-box-seam",
         "location"  => "bi-geo-alt",
+        "monster" => "bi-bug",
         "npc"       => "bi-person-badge",
+        "organizerroleassignment" => "bi-person-check",
+        "personalquest" => "bi-journal-bookmark",
+        "quest" => "bi-scroll",
+        "treasurequest" => "bi-gem",
         _           => "bi-circle",
     };
 
@@ -78,11 +97,17 @@
 
     private static string TimeAgo(DateTime utc)
     {
-        var delta = DateTime.UtcNow - utc;
+        var utcTime = utc.Kind switch
+        {
+            DateTimeKind.Local => utc.ToUniversalTime(),
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(utc, DateTimeKind.Utc),
+            _ => utc
+        };
+        var delta = DateTime.UtcNow - utcTime;
         if (delta.TotalMinutes < 1) return "před chvílí";
         if (delta.TotalMinutes < 60) return $"před {(int)delta.TotalMinutes} min";
         if (delta.TotalHours  < 24) return $"před {(int)delta.TotalHours} h";
         if (delta.TotalDays   < 30) return $"před {(int)delta.TotalDays} dny";
-        return utc.ToLocalTime().ToString("d. M.");
+        return utcTime.ToLocalTime().ToString("d. M.");
     }
 }

--- a/src/OvcinaHra.Client/Pages/Home.razor
+++ b/src/OvcinaHra.Client/Pages/Home.razor
@@ -52,10 +52,7 @@
                 }
 
                 <div class="oh-home-bottom-row">
-                    @if (_isGameRunning)
-                    {
-                        <RecentActivityPanel GameId="GameContext.SelectedGameId" IsRunning="_isGameRunning" />
-                    }
+                    <RecentActivityFeed Rows="_activity" />
                     <QuickLaunchTiles />
                 </div>
 
@@ -78,11 +75,15 @@
     private DashboardStatsDto? _stats;
     private DashboardIssuesDto? _issues;
     private List<TimelineRowDto>? _timeline;
+    private List<DashboardActivityDto>? _activity;
+    private CancellationTokenSource? _activityRefreshCts;
 
     protected override async Task OnInitializedAsync()
     {
         await GameContext.InitializeAsync();
         GameContext.OnGameChanged += HandleGameChanged;
+        _activityRefreshCts = new CancellationTokenSource();
+        _ = RefreshActivityLoopAsync(_activityRefreshCts.Token);
         await LoadCockpitAsync();
     }
 
@@ -93,7 +94,7 @@
         var gameId = GameContext.SelectedGameId;
         if (gameId is null)
         {
-            _stats = null; _issues = null; _timeline = null;
+            _stats = null; _issues = null; _timeline = null; _activity = null;
             await InvokeAsync(StateHasChanged);
             return;
         }
@@ -110,8 +111,10 @@
                 $"/api/dashboard/issues?gameId={gameId.Value}");
             var timelineTask = Api.GetListAsync<TimelineRowDto>(
                 $"/api/dashboard/timeline?gameId={gameId.Value}&take=6");
+            var activityTask = Api.GetListAsync<DashboardActivityDto>(
+                $"/api/dashboard/activity?gameId={gameId.Value}&limit=10");
 
-            await Task.WhenAll(gameTask, statsTask, issuesTask, timelineTask);
+            await Task.WhenAll(gameTask, statsTask, issuesTask, timelineTask, activityTask);
 
             var game = gameTask.Result;
             if (game is not null)
@@ -124,6 +127,7 @@
             _stats = statsTask.Result;
             _issues = issuesTask.Result;
             _timeline = timelineTask.Result;
+            _activity = activityTask.Result;
             // Drive Hra běží mode from the explicit server bool, not the
             // localised label — Copilot caught the brittle string match.
             _isGameRunning = timelineTask.Result?.Any(r => r.IsRunning) ?? false;
@@ -141,5 +145,52 @@
 
     private void OnChangeGameClick() => Nav.NavigateTo("/games");
 
-    public void Dispose() => GameContext.OnGameChanged -= HandleGameChanged;
+    private async Task RefreshActivityLoopAsync(CancellationToken cancellationToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(cancellationToken))
+            {
+                await RefreshActivityAsync(cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private async Task RefreshActivityAsync(CancellationToken cancellationToken)
+    {
+        var gameId = GameContext.SelectedGameId;
+        if (gameId is null)
+        {
+            _activity = null;
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        try
+        {
+            _activity = await Api.GetListAsync<DashboardActivityDto>(
+                $"/api/dashboard/activity?gameId={gameId.Value}&limit=10",
+                cancellationToken);
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // Keep the last visible activity list if a background refresh flakes.
+        }
+    }
+
+    public void Dispose()
+    {
+        GameContext.OnGameChanged -= HandleGameChanged;
+        _activityRefreshCts?.Cancel();
+        _activityRefreshCts?.Dispose();
+    }
 }

--- a/src/OvcinaHra.Shared/Domain/Entities/WorldChange.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/WorldChange.cs
@@ -1,0 +1,16 @@
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Shared.Domain.Entities;
+
+public class WorldChange
+{
+    public int Id { get; set; }
+    public int? GameId { get; set; }
+    public required string EntityType { get; set; }
+    public int EntityId { get; set; }
+    public required string EntityName { get; set; }
+    public WorldChangeOperation Operation { get; set; }
+    public required string ActorUserId { get; set; }
+    public required string ActorDisplayName { get; set; }
+    public DateTime ChangedAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/src/OvcinaHra.Shared/Domain/Enums/WorldChangeOperation.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/WorldChangeOperation.cs
@@ -1,0 +1,8 @@
+namespace OvcinaHra.Shared.Domain.Enums;
+
+public enum WorldChangeOperation
+{
+    Created = 1,
+    Updated = 2,
+    Deleted = 3
+}

--- a/src/OvcinaHra.Shared/Dtos/DashboardDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/DashboardDtos.cs
@@ -37,16 +37,14 @@ public record DashboardIssueDto(
 public record DashboardIssuesDto(IReadOnlyList<DashboardIssueDto> Issues);
 
 /// <summary>
-/// One row in the RecentActivityFeed. WorldActivity rows are real organizer
-/// recordings; legacy rows still come from entity timestamps until more
-/// activity types are wired through the same table.
+/// One row in the RecentActivityFeed, backed by the WorldChange audit log.
 /// </summary>
 public record DashboardActivityDto(
     string EntityType,
     int EntityId,
     string EntityName,
     string? ThumbnailUrl,
-    string Verb,        /* vytvořil | upravil | smazal — currently always "upravil" */
+    string Verb,        /* vytvořil | upravil | smazal */
     string ActorName,
     DateTime OccurredUtc);
 

--- a/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
@@ -309,6 +309,34 @@ public class DashboardEndpointsTests(PostgresFixture postgres)
     }
 
     [Fact]
+    public async Task WorldChangeInterceptor_ExplicitTransaction_SkipsAuditWithoutBlockingUserData()
+    {
+        await ClearWorldChangesAsync();
+
+        int locationId;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            await using var tx = await db.Database.BeginTransactionAsync();
+            var location = new Location
+            {
+                Name = "Transakční paseka",
+                LocationKind = LocationKind.Wilderness
+            };
+            db.Locations.Add(location);
+            await db.SaveChangesAsync();
+            locationId = location.Id;
+            await tx.CommitAsync();
+        }
+
+        using var assertScope = Factory.Services.CreateScope();
+        var assertDb = assertScope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        Assert.True(await assertDb.Locations.AnyAsync(l => l.Id == locationId));
+        Assert.False(await assertDb.WorldChanges.AnyAsync(c =>
+            c.EntityType == nameof(Location) && c.EntityId == locationId));
+    }
+
+    [Fact]
     public async Task Timeline_PastSlot_IsExcluded()
     {
         var game = await CreateGameAsync();

--- a/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
@@ -24,6 +24,13 @@ public class DashboardEndpointsTests(PostgresFixture postgres)
         return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
     }
 
+    private async Task ClearWorldChangesAsync()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        await db.WorldChanges.ExecuteDeleteAsync();
+    }
+
     [Fact]
     public async Task Stats_EmptyGame_ReturnsAllZeros()
     {
@@ -180,6 +187,7 @@ public class DashboardEndpointsTests(PostgresFixture postgres)
     public async Task Activity_NoEdits_ReturnsEmpty()
     {
         var game = await CreateGameAsync();
+        await ClearWorldChangesAsync();
 
         var rows = await Client.GetFromJsonAsync<List<DashboardActivityDto>>(
             $"/api/dashboard/activity?gameId={game.Id}");
@@ -189,48 +197,115 @@ public class DashboardEndpointsTests(PostgresFixture postgres)
     }
 
     [Fact]
-    public async Task Activity_WorldActivityLocationPlacement_ReturnsActorLocationAndThumbnail()
+    public async Task Activity_WorldChanges_ReturnsNewestScopedRows()
     {
         var game = await CreateGameAsync();
-        int locationId;
+        var otherGame = await CreateGameAsync();
+        await ClearWorldChangesAsync();
+
+        var now = DateTime.UtcNow;
         using (var scope = Factory.Services.CreateScope())
         {
             var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
-            var location = new Location
-            {
-                Name = "Starý brod",
-                LocationKind = LocationKind.Village,
-                PlacementPhotoPath = "locationplacements/1/image.png"
-            };
-            db.Locations.Add(location);
+            db.WorldChanges.AddRange(
+                new WorldChange
+                {
+                    GameId = game.Id,
+                    EntityType = nameof(Location),
+                    EntityId = 10,
+                    EntityName = "Starý brod",
+                    Operation = WorldChangeOperation.Updated,
+                    ActorUserId = "test-user",
+                    ActorDisplayName = "Test Organizátor",
+                    ChangedAtUtc = now
+                },
+                new WorldChange
+                {
+                    GameId = null,
+                    EntityType = nameof(Item),
+                    EntityId = 20,
+                    EntityName = "Hojivý lektvar",
+                    Operation = WorldChangeOperation.Created,
+                    ActorUserId = "system",
+                    ActorDisplayName = "System",
+                    ChangedAtUtc = now.AddMinutes(1)
+                },
+                new WorldChange
+                {
+                    GameId = otherGame.Id,
+                    EntityType = nameof(Npc),
+                    EntityId = 30,
+                    EntityName = "Cizí NPC",
+                    Operation = WorldChangeOperation.Deleted,
+                    ActorUserId = "other",
+                    ActorDisplayName = "Other",
+                    ChangedAtUtc = now.AddMinutes(2)
+                });
             await db.SaveChangesAsync();
-            location.PlacementPhotoPath = $"locationplacements/{location.Id}/image.png";
-            db.GameLocations.Add(new GameLocation { GameId = game.Id, LocationId = location.Id });
-            db.WorldActivities.Add(new WorldActivity
-            {
-                GameId = game.Id,
-                TimestampUtc = DateTime.UtcNow.AddMinutes(-1),
-                OrganizerUserId = "test-user",
-                OrganizerName = "Test Organizátor",
-                ActivityType = WorldActivityType.LocationPlaced,
-                Description = $"Umístěna lokace: {location.Name}",
-                LocationId = location.Id,
-                DataJson = "{}"
-            });
-            await db.SaveChangesAsync();
-            locationId = location.Id;
         }
 
         var rows = await Client.GetFromJsonAsync<List<DashboardActivityDto>>(
             $"/api/dashboard/activity?gameId={game.Id}");
 
-        var row = Assert.Single(rows!);
-        Assert.Equal("location", row.EntityType);
-        Assert.Equal(locationId, row.EntityId);
-        Assert.Equal("Starý brod", row.EntityName);
-        Assert.Equal("Test Organizátor", row.ActorName);
-        Assert.Equal("umístil", row.Verb);
-        Assert.Contains($"/api/images/locationplacements/{locationId}/thumb", row.ThumbnailUrl!);
+        Assert.NotNull(rows);
+        Assert.Collection(rows,
+            row =>
+            {
+                Assert.Equal("item", row.EntityType);
+                Assert.Equal(20, row.EntityId);
+                Assert.Equal("Hojivý lektvar", row.EntityName);
+                Assert.Equal("System", row.ActorName);
+                Assert.Equal("vytvořil", row.Verb);
+                Assert.Null(row.ThumbnailUrl);
+            },
+            row =>
+            {
+                Assert.Equal("location", row.EntityType);
+                Assert.Equal(10, row.EntityId);
+                Assert.Equal("Starý brod", row.EntityName);
+                Assert.Equal("Test Organizátor", row.ActorName);
+                Assert.Equal("upravil", row.Verb);
+            });
+    }
+
+    [Fact]
+    public async Task WorldChangeInterceptor_ApiCreateGame_RecordsAuthenticatedActor()
+    {
+        var game = await CreateGameAsync();
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var row = await db.WorldChanges.SingleAsync(c =>
+            c.EntityType == nameof(Game) && c.EntityId == game.Id);
+
+        Assert.Equal(game.Id, row.GameId);
+        Assert.Equal("Cockpit", row.EntityName);
+        Assert.Equal(WorldChangeOperation.Created, row.Operation);
+        Assert.Equal("test-user", row.ActorUserId);
+        Assert.Equal("Test Organizátor", row.ActorDisplayName);
+    }
+
+    [Fact]
+    public async Task WorldChangeInterceptor_BackgroundSave_UsesSystemActor()
+    {
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            db.Locations.Add(new Location
+            {
+                Name = "Bez kontextu",
+                LocationKind = LocationKind.Wilderness
+            });
+            await db.SaveChangesAsync();
+        }
+
+        using var assertScope = Factory.Services.CreateScope();
+        var assertDb = assertScope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var row = await assertDb.WorldChanges.SingleAsync(c => c.EntityType == nameof(Location));
+
+        Assert.Equal(WorldChangeOperation.Created, row.Operation);
+        Assert.Equal("system", row.ActorUserId);
+        Assert.Equal("System", row.ActorDisplayName);
     }
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
+++ b/tests/OvcinaHra.Api.Tests/Fixtures/ApiWebApplicationFactory.cs
@@ -48,8 +48,10 @@ public class ApiWebApplicationFactory : WebApplicationFactory<Program>
             if (descriptor != null)
                 services.Remove(descriptor);
 
-            services.AddDbContext<WorldDbContext>(options =>
-                options.UseNpgsql(_connectionString));
+            services.AddDbContext<WorldDbContext>((sp, options) =>
+                options
+                    .UseNpgsql(_connectionString)
+                    .AddInterceptors(sp.GetRequiredService<WorldChangeAuditInterceptor>()));
 
             // Replace blob storage with in-memory stub for tests
             var blobDescriptor = services.SingleOrDefault(


### PR DESCRIPTION
Closes #247

## Summary
- Add WorldChange audit entity, EF migration, and best-effort SaveChanges interceptor for the approved whitelist.
- Switch /api/dashboard/activity to WorldChange rows and wire RecentActivityFeed into Home with periodic refresh and local-time display.
- Add integration coverage for activity feed filtering plus authenticated/system actor audit capture.
- Transaction review follow-up: verified explicit API transactions exist in audited areas; interceptor now skips audit persistence while an EF/ambient transaction is active so audit failure cannot roll back user data.

## Verification
- git grep -n "BeginTransactionAsync\|UseTransaction\|TransactionScope" -- "src/OvcinaHra.Api/" (found explicit transactions; patched with no-enlistment skip path)
- dotnet build OvcinaHra.slnx --no-restore
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter FullyQualifiedName~DashboardEndpointsTests
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build
- dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include <changed C# files>

Note: full-solution dotnet format --verify-no-changes still reports pre-existing unrelated whitespace in files such as SpellSchool.cs and BuildingEndpoints.cs; this PR leaves those untouched.
