### PR TITLE
feat(map): handdraw smoothing + layers control

### DIFF
--- a/src/OvcinaHra.Client/Components/MapLayerRail.razor
+++ b/src/OvcinaHra.Client/Components/MapLayerRail.razor
@@ -1,81 +1,120 @@
 @using OvcinaHra.Shared.Domain.Enums
 @using OvcinaHra.Shared.Extensions
 
-@* Issue #207 — left rail with map layers. Lokace expands to per-kind
-   sub-chips so the user can hide individual LocationKinds. Layer +
-   per-kind state hydrates from / saves to localStorage via MapPage. *@
+@* Issue #465 — compact Vrstvy dropdown. It keeps the existing layer state
+   callbacks owned by MapPage while moving overlay toggles off the map face. *@
 
-<aside class="oh-map-layer-rail" aria-label="Vrstvy mapy">
-    <h2 class="oh-map-layer-title">Vrstvy</h2>
-    <label class="oh-map-layer-row">
-        <input type="checkbox" checked="@LocationsVisible"
-               @onchange="@(e => OnVisibilityChange.InvokeAsync(("loc", (bool)e.Value!)))" />
-        <span class="oh-map-layer-dot oh-map-layer-loc"></span>
-        <span class="oh-map-layer-lbl">Lokace</span>
-        <span class="oh-map-layer-num text-muted">@LocationsCount</span>
-    </label>
+<div class="oh-map-layers-control" aria-label="Vrstvy mapy">
+    <button id="@_buttonId"
+            type="button"
+            class="oh-map-layers-button @(_open ? "is-active" : "")"
+            aria-expanded="@_open.ToString().ToLowerInvariant()"
+            aria-controls="@_panelId"
+            aria-label="Vrstvy mapy"
+            @onclick="ToggleOpen"
+            @onclick:stopPropagation="true"
+            @onmouseenter="ShowTooltip"
+            @onmouseleave="HideTooltip"
+            @onfocus="ShowTooltip"
+            @onblur="HideTooltip">
+        <i class="bi bi-layers"></i>
+        <span>Vrstvy</span>
+    </button>
 
-    @* Per-kind sub-chips — only when the master Lokace layer is on. *@
-    @if (LocationsVisible)
+    <DxFlyout @bind-IsOpen="@_tooltipOpen"
+              PositionTarget="@($"#{_buttonId}")"
+              Position="FlyoutPosition.Bottom"
+              BodyText="Zobrazit vrstvy mapy"
+              HeaderVisible="false"
+              CloseOnOutsideClick="false"
+              Width="190px" />
+
+    @if (_open)
     {
-        <ul class="oh-map-kind-list">
-            @foreach (var kind in KindOrder)
+        <div id="@_panelId" class="oh-map-layers-panel" role="group" aria-label="Vrstvy mapy"
+             @onclick:stopPropagation="true">
+            <h2 class="oh-map-layer-title">Vrstvy</h2>
+            <label class="oh-map-layer-row">
+                <input type="checkbox" checked="@LocationsVisible"
+                       @onchange="@(e => ToggleVisibilityAsync("Lokace", "loc", (bool)e.Value!))" />
+                <span class="oh-map-layer-dot oh-map-layer-loc"></span>
+                <span class="oh-map-layer-lbl">Lokace</span>
+                <span class="oh-map-layer-num text-muted">@LocationsCount</span>
+            </label>
+
+            @if (LocationsVisible)
             {
-                var isHidden = HiddenKinds.Contains(kind);
-                var count = LocationsByKind?.GetValueOrDefault(kind) ?? 0;
-                var dataKind = kind.ToString().ToLowerInvariant();
-                <li>
-                    <button type="button"
-                            class="oh-map-kind-row @(isHidden ? "is-hidden" : "")"
-                            aria-pressed="@(isHidden ? "false" : "true")"
-                            title="@(isHidden ? "Zobrazit" : "Skrýt") — @kind.GetDisplayName()"
-                            @onclick="@(() => OnKindToggle.InvokeAsync(kind))">
-                        <span class="oh-map-kind-dot" data-kind="@dataKind"></span>
-                        <span class="oh-map-kind-lbl">@kind.GetDisplayName()</span>
-                        <span class="oh-map-kind-num">@count</span>
-                    </button>
-                </li>
+                <ul class="oh-map-kind-list">
+                    @foreach (var kind in KindOrder)
+                    {
+                        var isHidden = HiddenKinds.Contains(kind);
+                        var count = LocationsByKind?.GetValueOrDefault(kind) ?? 0;
+                        var dataKind = kind.ToString().ToLowerInvariant();
+                        <li>
+                            <button type="button"
+                                    class="oh-map-kind-row @(isHidden ? "is-hidden" : "")"
+                                    aria-pressed="@(isHidden ? "false" : "true")"
+                                    title="@(isHidden ? "Zobrazit" : "Skrýt") — @kind.GetDisplayName()"
+                                    @onclick="@(() => OnKindToggle.InvokeAsync(kind))">
+                                <span class="oh-map-kind-dot" data-kind="@dataKind"></span>
+                                <span class="oh-map-kind-lbl">@kind.GetDisplayName()</span>
+                                <span class="oh-map-kind-num">@count</span>
+                            </button>
+                        </li>
+                    }
+                </ul>
             }
-        </ul>
+
+            <label class="oh-map-layer-row">
+                <input type="checkbox" checked="@StashesVisible"
+                       @onchange="@(e => ToggleVisibilityAsync("Skrýše", "stash", (bool)e.Value!))" />
+                <span class="oh-map-layer-dot oh-map-layer-stash"></span>
+                <span class="oh-map-layer-lbl">Skrýše &amp; Poklady</span>
+                <span class="oh-map-layer-num text-muted">@StashesCount</span>
+            </label>
+
+            <label class="oh-map-layer-row">
+                <input type="checkbox" checked="@ShowRegionsOnMap"
+                       @onchange="@(e => ToggleRegionLabelsAsync((bool)e.Value!))" />
+                <span class="oh-map-layer-dot oh-map-layer-region"></span>
+                <span class="oh-map-layer-lbl">Zobrazit oblasti</span>
+            </label>
+
+            <label class="oh-map-layer-row">
+                <input type="checkbox" checked="@ShowDoneLocations"
+                       @onchange="@(e => ToggleDoneLocationsAsync((bool)e.Value!))" />
+                <span class="oh-map-layer-dot oh-map-layer-done"></span>
+                <span class="oh-map-layer-lbl">Hotové lokace</span>
+            </label>
+
+            <label class="oh-map-layer-row">
+                <input type="checkbox" checked="@OverlaysVisible"
+                       @onchange="@(e => ToggleOverlayAsync((bool)e.Value!))" />
+                <span class="oh-map-layer-dot oh-map-layer-overlay"></span>
+                <span class="oh-map-layer-lbl">Překryv hráčů</span>
+            </label>
+
+            @if (OrganizerOverlayEnabled)
+            {
+                <label class="oh-map-layer-row">
+                    <input type="checkbox" checked="@OrganizerOverlayVisible"
+                           @onchange="@(e => ToggleOrganizerOverlayAsync((bool)e.Value!))" />
+                    <span class="oh-map-layer-dot oh-map-layer-organizer-overlay"></span>
+                    <span class="oh-map-layer-lbl">Překryv organizátorů</span>
+                </label>
+            }
+
+            <p class="oh-map-layer-hint text-muted small">
+                <i class="bi bi-cursor"></i>
+                <strong>Ctrl + klik</strong> na mapu umístí dosud neumístěnou lokaci.
+            </p>
+            <p class="oh-map-layer-hint text-muted small">
+                <i class="bi bi-arrows-move"></i>
+                <strong>Ctrl + Shift + klik</strong> přesune libovolnou lokaci sem.
+            </p>
+        </div>
     }
-
-    <label class="oh-map-layer-row">
-        <input type="checkbox" checked="@StashesVisible"
-               @onchange="@(e => OnVisibilityChange.InvokeAsync(("stash", (bool)e.Value!)))" />
-        <span class="oh-map-layer-dot oh-map-layer-stash"></span>
-        <span class="oh-map-layer-lbl">Skrýše &amp; Poklady</span>
-        <span class="oh-map-layer-num text-muted">@StashesCount</span>
-    </label>
-
-    <label class="oh-map-layer-row">
-        <input type="checkbox" checked="@OverlaysVisible"
-               @onchange="@(e => OnOverlayVisibilityChange.InvokeAsync((bool)e.Value!))" />
-        <span class="oh-map-layer-dot oh-map-layer-overlay"></span>
-        <span class="oh-map-layer-lbl">Překryv hráčů</span>
-    </label>
-
-    @if (OrganizerOverlayEnabled)
-    {
-        <label class="oh-map-layer-row">
-            <input type="checkbox" checked="@OrganizerOverlayVisible"
-                   @onchange="@(e => OnOrganizerOverlayVisibilityChange.InvokeAsync((bool)e.Value!))" />
-            <span class="oh-map-layer-dot oh-map-layer-organizer-overlay"></span>
-            <span class="oh-map-layer-lbl">Překryv organizátorů</span>
-        </label>
-    }
-
-    <p class="oh-map-layer-hint text-muted small fst-italic">
-        Setkání questů přibydou, jakmile budou mít body na mapě.
-    </p>
-    <p class="oh-map-layer-hint text-muted small">
-        <i class="bi bi-cursor"></i>
-        <strong>Ctrl + klik</strong> na mapu umístí dosud neumístěnou lokaci.
-    </p>
-    <p class="oh-map-layer-hint text-muted small">
-        <i class="bi bi-arrows-move"></i>
-        <strong>Ctrl + Shift + klik</strong> přesune libovolnou lokaci sem.
-    </p>
-</aside>
+</div>
 
 @code {
     [Parameter] public bool LocationsVisible { get; set; } = true;
@@ -83,16 +122,24 @@
     [Parameter] public bool OverlaysVisible { get; set; } = true;
     [Parameter] public bool OrganizerOverlayEnabled { get; set; }
     [Parameter] public bool OrganizerOverlayVisible { get; set; } = true;
+    [Parameter] public bool ShowRegionsOnMap { get; set; }
+    [Parameter] public bool ShowDoneLocations { get; set; }
     [Parameter] public int LocationsCount { get; set; }
     [Parameter] public int StashesCount { get; set; }
     [Parameter] public EventCallback<(string Layer, bool Visible)> OnVisibilityChange { get; set; }
     [Parameter] public EventCallback<bool> OnOverlayVisibilityChange { get; set; }
     [Parameter] public EventCallback<bool> OnOrganizerOverlayVisibilityChange { get; set; }
+    [Parameter] public EventCallback<bool> OnRegionLabelsChange { get; set; }
+    [Parameter] public EventCallback<bool> OnDoneLocationsChange { get; set; }
     [Parameter] public IReadOnlyDictionary<LocationKind, int>? LocationsByKind { get; set; }
     [Parameter] public HashSet<LocationKind> HiddenKinds { get; set; } = new();
     [Parameter] public EventCallback<LocationKind> OnKindToggle { get; set; }
 
-    // Display order — common kinds on top, rare ones at the bottom.
+    private readonly string _buttonId = $"oh-map-layers-btn-{Guid.NewGuid():N}";
+    private readonly string _panelId = $"oh-map-layers-panel-{Guid.NewGuid():N}";
+    private bool _open;
+    private bool _tooltipOpen;
+
     private static readonly LocationKind[] KindOrder =
     [
         LocationKind.Village,
@@ -103,4 +150,50 @@
         LocationKind.Dungeon,
         LocationKind.PointOfInterest,
     ];
+
+    private void ToggleOpen()
+    {
+        _open = !_open;
+        _tooltipOpen = false;
+        Console.WriteLine($"[map-layers] layers-control {(_open ? "opened" : "closed")}");
+    }
+
+    private void ShowTooltip()
+    {
+        if (!_open)
+            _tooltipOpen = true;
+    }
+
+    private void HideTooltip()
+        => _tooltipOpen = false;
+
+    private async Task ToggleVisibilityAsync(string name, string layer, bool visible)
+    {
+        Console.WriteLine($"[map-layers] layer-toggle changed name={name} enabled={visible.ToString().ToLowerInvariant()}");
+        await OnVisibilityChange.InvokeAsync((layer, visible));
+    }
+
+    private async Task ToggleOverlayAsync(bool visible)
+    {
+        Console.WriteLine($"[map-layers] layer-toggle changed name=Překryv hráčů enabled={visible.ToString().ToLowerInvariant()}");
+        await OnOverlayVisibilityChange.InvokeAsync(visible);
+    }
+
+    private async Task ToggleOrganizerOverlayAsync(bool visible)
+    {
+        Console.WriteLine($"[map-layers] layer-toggle changed name=Překryv organizátorů enabled={visible.ToString().ToLowerInvariant()}");
+        await OnOrganizerOverlayVisibilityChange.InvokeAsync(visible);
+    }
+
+    private async Task ToggleRegionLabelsAsync(bool visible)
+    {
+        Console.WriteLine($"[map-layers] layer-toggle changed name=Oblasti enabled={visible.ToString().ToLowerInvariant()}");
+        await OnRegionLabelsChange.InvokeAsync(visible);
+    }
+
+    private async Task ToggleDoneLocationsAsync(bool visible)
+    {
+        Console.WriteLine($"[map-layers] layer-toggle changed name=Hotové enabled={visible.ToString().ToLowerInvariant()}");
+        await OnDoneLocationsChange.InvokeAsync(visible);
+    }
 }

--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -478,8 +478,21 @@
                 new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
             if (shape is null) return;
             Console.WriteLine($"[map-diag] MapView.OnShapeComplete parsed id={shape.Id} type={shape.GetType().Name}");
-            _stagedShapes.Add(shape);
-            _createdShapeIds.Add(shape.Id);
+            var existingIndex = _stagedShapes.FindIndex(s => s.Id == shape.Id);
+            if (existingIndex >= 0)
+            {
+                _stagedShapes[existingIndex] = shape;
+                if (_selectedShape?.Id == shape.Id)
+                {
+                    _selectedShape = shape;
+                }
+                Console.WriteLine($"[map-handdraw] shape-replaced id={shape.Id}");
+            }
+            else
+            {
+                _stagedShapes.Add(shape);
+                _createdShapeIds.Add(shape.Id);
+            }
             Console.WriteLine($"[map-diag] MapView.OnShapeComplete staged={_stagedShapes.Count} created={_createdShapeIds.Count}");
             await InvokeAsync(StateHasChanged);
             await JS.InvokeVoidAsync("ovcinaOverlay.render", _elementId, _stagedShapes);

--- a/src/OvcinaHra.Client/Pages/Map/MapPage.razor
+++ b/src/OvcinaHra.Client/Pages/Map/MapPage.razor
@@ -27,34 +27,26 @@
                             LocationsCount="@(_data?.Locations.Count ?? 0)"
                             StashesCount="@(_data?.Stashes.Count ?? 0)" />
 
-                <div class="oh-map-shell @(_railOpen ? "is-rail-open" : "")">
-                    @* Issue #216 — phone-only hamburger toggle. CSS hides
-                       the button >900px and hides the rail <900px until
-                       this flag flips. Backdrop closes the rail on tap. *@
-                    <button type="button" class="oh-map-rail-toggle"
-                            @onclick="() => _railOpen = !_railOpen"
-                            aria-label="Vrstvy mapy" title="Vrstvy mapy">
-                        <i class="bi @(_railOpen ? "bi-x-lg" : "bi-list")"></i>
-                    </button>
-                    @if (_railOpen)
-                    {
-                        <div class="oh-map-rail-backdrop" @onclick="() => _railOpen = false"></div>
-                    }
-                    <MapLayerRail LocationsVisible="@_locationsVisible"
-                                   StashesVisible="@_stashesVisible"
-                                   OverlaysVisible="@_overlaysVisible"
-                                   OrganizerOverlayEnabled="@_isOrganizer"
-                                   OrganizerOverlayVisible="@_organizerOverlayVisible"
-                                   LocationsCount="@(_data?.Locations.Count ?? 0)"
-                                   StashesCount="@(_data?.Stashes.Count ?? 0)"
-                                   LocationsByKind="@_locationsByKind"
-                                   HiddenKinds="@_hiddenKinds"
-                                   OnVisibilityChange="OnLayerVisibilityChange"
-                                   OnOverlayVisibilityChange="OnOverlayVisibilityChange"
-                                   OnOrganizerOverlayVisibilityChange="OnOrganizerOverlayVisibilityChange"
-                                   OnKindToggle="OnKindToggle" />
-
+                <div class="oh-map-shell">
                     <div class="oh-map-canvas">
+                        <MapLayerRail LocationsVisible="@_locationsVisible"
+                                       StashesVisible="@_stashesVisible"
+                                       OverlaysVisible="@_overlaysVisible"
+                                       OrganizerOverlayEnabled="@_isOrganizer"
+                                       OrganizerOverlayVisible="@_organizerOverlayVisible"
+                                       ShowRegionsOnMap="@_showRegionsOnMap"
+                                       ShowDoneLocations="@_showDoneLocations"
+                                       LocationsCount="@(_data?.Locations.Count ?? 0)"
+                                       StashesCount="@(_data?.Stashes.Count ?? 0)"
+                                       LocationsByKind="@_locationsByKind"
+                                       HiddenKinds="@_hiddenKinds"
+                                       OnVisibilityChange="OnLayerVisibilityChange"
+                                       OnOverlayVisibilityChange="OnOverlayVisibilityChange"
+                                       OnOrganizerOverlayVisibilityChange="OnOrganizerOverlayVisibilityChange"
+                                       OnRegionLabelsChange="SetRegionLabelsAsync"
+                                       OnDoneLocationsChange="SetDoneLocationsAsync"
+                                       OnKindToggle="OnKindToggle" />
+
                         <div class="oh-map-treasure-filter" role="group" aria-label="Filtr pokladů podle fáze">
                             <span class="oh-map-treasure-filter-lbl">Poklady</span>
                             @foreach (var phase in TreasureMapPhaseOptions)
@@ -66,18 +58,6 @@
                                     @phase.Label
                                 </button>
                             }
-                            <label class="oh-map-region-toggle @(_showRegionsOnMap ? "is-active" : "")">
-                                <input type="checkbox"
-                                       checked="@_showRegionsOnMap"
-                                       @onchange="SetRegionLabelsAsync" />
-                                <span>Zobrazit oblasti</span>
-                            </label>
-                            <label class="oh-map-region-toggle oh-map-done-toggle @(_showDoneLocations ? "is-active" : "")">
-                                <input type="checkbox"
-                                       checked="@_showDoneLocations"
-                                       @onchange="SetDoneLocationsAsync" />
-                                <span>Hotové lokace</span>
-                            </label>
                         </div>
                         <div class="oh-map-style-toolbar">
                             <button class="oh-map-style-btn @(_activeStyle == "tourist" ? "is-active" : "")"
@@ -296,9 +276,6 @@
     private string _placeSearch = "";
     private bool _placeSaving;
     private string? _placeError;
-    // Issue #216 — phone-only layer rail toggle. CSS gates the visible
-    // surface so on tablet/desktop this flag has no effect.
-    private bool _railOpen;
     private bool _firstStyleLoadDone;
     // Monotonically increasing token so a slow peek fetch doesn't overwrite
     // a newer one if the user clicks pins faster than the network responds.
@@ -552,9 +529,8 @@
         await PaintPinsAsync();
     }
 
-    private async Task SetRegionLabelsAsync(ChangeEventArgs e)
+    private async Task SetRegionLabelsAsync(bool enabled)
     {
-        var enabled = e.Value is bool value && value;
         if (_showRegionsOnMap == enabled) return;
 
         _showRegionsOnMap = enabled;
@@ -563,9 +539,8 @@
         await PaintPinsAsync();
     }
 
-    private async Task SetDoneLocationsAsync(ChangeEventArgs e)
+    private async Task SetDoneLocationsAsync(bool enabled)
     {
-        var enabled = e.Value is bool value && value;
         if (_showDoneLocations == enabled) return;
 
         _showDoneLocations = enabled;

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3784,14 +3784,24 @@
     color:var(--oh-text,#2a2a2a);font:600 .8rem var(--oh-font-body);cursor:pointer}
 .oh-map-tb-mode.is-active{background:#2D5016;border-color:#2D5016;color:#fff}
 .oh-map-tb-counts{margin-left:auto;font-variant-numeric:tabular-nums}
-.oh-map-shell{display:grid;grid-template-columns:220px 1fr;gap:10px;flex:1;min-height:0;position:relative}
-.oh-map-layer-rail{padding:10px 12px;background:var(--oh-surface,#FAF6EC);
-    border:1px solid var(--oh-border,#d8d2be);border-radius:8px;align-self:start}
+.oh-map-shell{display:grid;grid-template-columns:1fr;gap:10px;flex:1;min-height:0;position:relative}
+.oh-map-layers-control{position:absolute;top:8px;left:8px;z-index:12}
+.oh-map-layers-button{display:inline-flex;align-items:center;gap:6px;height:32px;padding:0 11px;
+    border-radius:99px;border:1px solid var(--oh-border,#d8d2be);background:rgba(250,246,236,.94);
+    color:var(--oh-text,#2a2a2a);font:700 .75rem var(--oh-font-body);cursor:pointer;
+    box-shadow:0 1px 4px rgba(0,0,0,.12)}
+.oh-map-layers-button:hover,.oh-map-layers-button.is-active{background:#2D5016;border-color:#2D5016;color:#fff}
+.oh-map-layers-button i{font-size:.95rem}
+.oh-map-layers-panel{position:absolute;top:38px;left:0;width:250px;max-height:min(72vh,540px);overflow:auto;
+    padding:10px 12px;background:var(--oh-surface,#FAF6EC);border:1px solid var(--oh-border,#d8d2be);
+    border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.18)}
 .oh-map-layer-title{margin:0 0 8px;font:700 .95rem var(--oh-font-heading)}
 .oh-map-layer-row{display:flex;align-items:center;gap:8px;padding:6px 4px;cursor:pointer;border-radius:5px}
 .oh-map-layer-row:hover{background:var(--oh-surface-alt,#F2EBD8)}
 .oh-map-layer-dot{width:10px;height:10px;border-radius:50%;flex-shrink:0;background:#2D5016}
 .oh-map-layer-stash{background:#C19A3A}
+.oh-map-layer-region{background:#2D5016}
+.oh-map-layer-done{background:#1F8F3A}
 .oh-map-layer-overlay{background:#7048a8}
 .oh-map-layer-organizer-overlay{background:#b26223}
 .oh-map-layer-lbl{flex:1}
@@ -3828,8 +3838,8 @@
 .oh-map-style-btn{padding:3px 9px;border-radius:99px;border:none;background:transparent;
     color:var(--oh-text,#2a2a2a);font:600 .72rem var(--oh-font-body);cursor:pointer}
 .oh-map-style-btn.is-active{background:#2D5016;color:#fff}
-.oh-map-treasure-filter{position:absolute;top:8px;left:8px;z-index:10;display:flex;align-items:center;
-    gap:4px;flex-wrap:wrap;max-width:calc(100% - 360px);background:rgba(250,246,236,.94);
+.oh-map-treasure-filter{position:absolute;top:8px;left:102px;z-index:10;display:flex;align-items:center;
+    gap:4px;flex-wrap:wrap;max-width:calc(100% - 454px);background:rgba(250,246,236,.94);
     padding:3px;border-radius:99px;box-shadow:0 1px 4px rgba(0,0,0,.12)}
 .oh-map-treasure-filter-lbl{padding:0 5px;color:var(--oh-text-secondary,#6b6257);
     font:700 .68rem var(--oh-font-body);letter-spacing:0;text-transform:uppercase}
@@ -3842,17 +3852,9 @@
 .oh-map-treasure-chip[data-stage="early"]{--c:var(--oh-stage-early);color:#3a2612}
 .oh-map-treasure-chip[data-stage="midgame"]{--c:var(--oh-stage-midgame)}
 .oh-map-treasure-chip[data-stage="lategame"]{--c:var(--oh-stage-lategame)}
-.oh-map-region-toggle{display:flex;align-items:center;gap:5px;margin-left:4px;padding:3px 9px;
-    border-radius:99px;color:var(--oh-text,#2a2a2a);font:600 .72rem var(--oh-font-body);
-    cursor:pointer;user-select:none}
-.oh-map-region-toggle input{width:13px;height:13px;margin:0;accent-color:#2D5016}
-.oh-map-region-toggle:hover{background:rgba(45,80,22,.08);color:#2D5016}
-.oh-map-region-toggle.is-active{background:#2D5016;color:#fff}
-.oh-map-done-toggle input{accent-color:#1F8F3A}
-.oh-map-done-toggle:hover{background:rgba(31,143,58,.08);color:#1F8F3A}
-.oh-map-done-toggle.is-active{background:#1F8F3A;color:#fff}
 @media (max-width: 900px){
-    .oh-map-treasure-filter{top:48px;right:8px;max-width:calc(100% - 16px)}
+    .oh-map-treasure-filter{top:48px;left:8px;right:8px;max-width:calc(100% - 16px)}
+    .oh-map-layers-panel{width:min(250px,calc(100vw - 24px))}
 }
 /* Issue #257 — tear-drop pins. Outer .oh-map-pin is a transparent
    anchor box; the round bubble + downward tail are painted by
@@ -4030,13 +4032,6 @@ body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label.oh-map-pin-label-with-re
     gap:10px;padding:60px 20px;text-align:center}
 .oh-map-empty-art i{font-size:4rem;color:rgba(45,80,22,.35)}
 .oh-map-empty h2{font:700 1.4rem var(--oh-font-heading);margin:0}
-@media (max-width:900px){
-    .oh-map-shell{grid-template-columns:1fr}
-    .oh-map-layer-rail{position:absolute;left:8px;top:8px;z-index:5;width:200px;
-        box-shadow:0 1px 4px rgba(0,0,0,.18)}
-}
-}
-
 /* ===========================================================================
  * Shared coin/groše pill — extracted from buildings port (#208). Reuse on
  * Items + Recipes catalogs in follow-ups.
@@ -4205,27 +4200,7 @@ body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label.oh-map-pin-label-with-re
    - Desktop (>900px): unchanged.
    ====================================================================== */
 
-/* Hamburger toggle — only visible on phone, sits over the canvas. */
-.oh-map-rail-toggle{display:none;position:absolute;top:8px;left:8px;z-index:11;
-    width:36px;height:36px;border-radius:99px;border:1px solid var(--oh-border,#d8d2be);
-    background:rgba(250,246,236,.94);color:var(--oh-text,#2a2a2a);cursor:pointer;
-    align-items:center;justify-content:center;box-shadow:0 1px 4px rgba(0,0,0,.18)}
-.oh-map-rail-toggle i{font-size:1.05rem}
-.oh-map-rail-backdrop{display:none;position:fixed;inset:0;background:rgba(20,16,8,.32);z-index:9}
-
 @media (max-width:600px){
-    /* Hamburger replaces the always-visible rail. */
-    .oh-map-rail-toggle{display:flex}
-    /* Layer rail hidden by default; slides in via .is-rail-open. */
-    .oh-map-shell .oh-map-layer-rail{
-        position:fixed;top:64px;left:0;bottom:0;width:min(260px,80vw);z-index:10;
-        background:var(--oh-surface,#FAF6EC);border-right:1px solid var(--oh-border,#d8d2be);
-        box-shadow:6px 0 24px rgba(0,0,0,.18);overflow-y:auto;
-        transform:translateX(-100%);transition:transform .25s cubic-bezier(.2,.7,.2,1)}
-    .oh-map-shell.is-rail-open .oh-map-layer-rail{transform:translateX(0)}
-    .oh-map-shell.is-rail-open .oh-map-rail-backdrop{display:block}
-
-    /* Canvas takes full width (rail no longer in flow). */
     .oh-map-shell{grid-template-columns:1fr}
 
     /* Peek becomes a bottom sheet — slides up from below covering ~70vh. */

--- a/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
+++ b/src/OvcinaHra.Client/wwwroot/js/overlay-interop.js
@@ -32,6 +32,10 @@
     // SVGs use fill="currentColor"; we rasterize them with a black silhouette
     // and add to MapLibre as SDF icons so `icon-color` tints them per shape.
     const ICON_ASSETS = ['flag', 'tent', 'chest', 'skull', 'door', 'fire'];
+    const FREEHAND_SIMPLIFY_EPSILON_PX = 2.5;
+    const FREEHAND_EDGE_JOIN_THRESHOLD_PX = 10;
+    const FREEHAND_SPLINE_SAMPLE_PX = 8;
+    const FREEHAND_SPLINE_MAX_STEPS = 8;
 
     // Singleton state, keyed by mapId so future multi-map callers don't collide.
     const instances = {};
@@ -39,6 +43,15 @@
     function mapDiag(event, data) {
         try {
             console.log('[map-diag] overlay.' + event + ' ' + JSON.stringify(data || {}));
+        } catch (e) { }
+    }
+
+    function handdrawDiag(event, data) {
+        try {
+            const values = Object.entries(data || {})
+                .map(function (entry) { return entry[0] + '=' + entry[1]; })
+                .join(' ');
+            console.log('[map-handdraw] ' + event + (values ? ' ' + values : ''));
         } catch (e) { }
     }
 
@@ -115,6 +128,179 @@
         return (points || [])
             .map(normalizeCoord)
             .filter(p => p !== null);
+    }
+
+    function projectedDistance(a, b) {
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    function projectOverlayPoint(map, point) {
+        const projected = map.project([point.lng, point.lat]);
+        return { x: projected.x, y: projected.y };
+    }
+
+    function unprojectOverlayPoint(map, point) {
+        const lngLat = map.unproject([point.x, point.y]);
+        return { lat: lngLat.lat, lng: lngLat.lng };
+    }
+
+    function perpendicularDistance(point, start, end) {
+        const dx = end.x - start.x;
+        const dy = end.y - start.y;
+        if (dx === 0 && dy === 0) return projectedDistance(point, start);
+        const t = Math.max(0, Math.min(1, ((point.x - start.x) * dx + (point.y - start.y) * dy) / (dx * dx + dy * dy)));
+        return projectedDistance(point, { x: start.x + t * dx, y: start.y + t * dy });
+    }
+
+    function simplifyProjectedPoints(points, epsilon) {
+        if (!points || points.length <= 2) return (points || []).slice();
+
+        let index = 0;
+        let maxDistance = 0;
+        const lastIndex = points.length - 1;
+        for (let i = 1; i < lastIndex; i++) {
+            const distance = perpendicularDistance(points[i], points[0], points[lastIndex]);
+            if (distance > maxDistance) {
+                index = i;
+                maxDistance = distance;
+            }
+        }
+
+        if (maxDistance <= epsilon) {
+            return [points[0], points[lastIndex]];
+        }
+
+        const left = simplifyProjectedPoints(points.slice(0, index + 1), epsilon);
+        const right = simplifyProjectedPoints(points.slice(index), epsilon);
+        return left.slice(0, -1).concat(right);
+    }
+
+    function catmullRomPoint(p0, p1, p2, p3, t) {
+        const t2 = t * t;
+        const t3 = t2 * t;
+        return {
+            x: 0.5 * ((2 * p1.x) + (-p0.x + p2.x) * t
+                + (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t2
+                + (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t3),
+            y: 0.5 * ((2 * p1.y) + (-p0.y + p2.y) * t
+                + (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t2
+                + (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t3)
+        };
+    }
+
+    function catmullRomSpline(points) {
+        if (!points || points.length <= 2) return (points || []).slice();
+
+        const output = [];
+        for (let i = 0; i < points.length - 1; i++) {
+            const p0 = points[Math.max(0, i - 1)];
+            const p1 = points[i];
+            const p2 = points[i + 1];
+            const p3 = points[Math.min(points.length - 1, i + 2)];
+            const segmentLength = projectedDistance(p1, p2);
+            const steps = Math.max(2, Math.min(FREEHAND_SPLINE_MAX_STEPS, Math.ceil(segmentLength / FREEHAND_SPLINE_SAMPLE_PX)));
+            for (let step = 0; step < steps; step++) {
+                if (i > 0 && step === 0) continue;
+                output.push(catmullRomPoint(p0, p1, p2, p3, step / steps));
+            }
+        }
+        output.push(points[points.length - 1]);
+        return output;
+    }
+
+    function smoothFreehandPoints(map, points, logDiagnostics) {
+        const normalized = normalizePoints(points);
+        if (logDiagnostics) handdrawDiag('smoothing.input', { pointCount: normalized.length });
+        if (normalized.length <= 2) {
+            if (logDiagnostics) {
+                handdrawDiag('smoothing.simplified', { pointCount: normalized.length });
+                handdrawDiag('smoothing.splined', { controlPoints: normalized.length, pointCount: normalized.length });
+            }
+            return normalized;
+        }
+
+        const projected = normalized.map(function (p) { return projectOverlayPoint(map, p); });
+        const simplified = simplifyProjectedPoints(projected, FREEHAND_SIMPLIFY_EPSILON_PX);
+        const splined = catmullRomSpline(simplified);
+        if (logDiagnostics) {
+            handdrawDiag('smoothing.simplified', { pointCount: simplified.length });
+            handdrawDiag('smoothing.splined', { controlPoints: simplified.length, pointCount: splined.length });
+        }
+        return splined.map(function (p) { return unprojectOverlayPoint(map, p); });
+    }
+
+    function sameFreehandStyle(a, b) {
+        if (!a || !b || a.type !== 'freehand' || b.type !== 'freehand') return false;
+        const colorA = (a.color || '').toLowerCase();
+        const colorB = (b.color || '').toLowerCase();
+        return colorA === colorB && Math.abs(numberOr(a.strokeWidth, 2) - numberOr(b.strokeWidth, 2)) < 0.01;
+    }
+
+    function endpointDistancePx(map, a, b) {
+        return projectedDistance(projectOverlayPoint(map, a), projectOverlayPoint(map, b));
+    }
+
+    function closestFreehandJoin(map, existingShape, newShape) {
+        const existing = normalizePoints(existingShape.points || []);
+        const incoming = normalizePoints(newShape.points || []);
+        if (existing.length < 2 || incoming.length < 2) return null;
+
+        const candidates = [
+            { mode: 'existing-end:new-start', distance: endpointDistancePx(map, existing[existing.length - 1], incoming[0]) },
+            { mode: 'existing-start:new-end', distance: endpointDistancePx(map, existing[0], incoming[incoming.length - 1]) },
+            { mode: 'existing-start:new-start', distance: endpointDistancePx(map, existing[0], incoming[0]) },
+            { mode: 'existing-end:new-end', distance: endpointDistancePx(map, existing[existing.length - 1], incoming[incoming.length - 1]) }
+        ].sort(function (a, b) { return a.distance - b.distance; });
+
+        return candidates[0].distance <= FREEHAND_EDGE_JOIN_THRESHOLD_PX ? candidates[0] : null;
+    }
+
+    function joinFreehandPoints(existing, incoming, mode) {
+        switch (mode) {
+            case 'existing-end:new-start':
+                return existing.concat(incoming);
+            case 'existing-start:new-end':
+                return incoming.concat(existing);
+            case 'existing-start:new-start':
+                return incoming.slice().reverse().concat(existing);
+            case 'existing-end:new-end':
+                return existing.concat(incoming.slice().reverse());
+            default:
+                return incoming;
+        }
+    }
+
+    function maybeJoinFreehandShape(map, inst, newShape) {
+        const freehands = (inst.shapes || []).filter(function (shape) {
+            return sameFreehandStyle(shape, newShape);
+        });
+        const strokesBefore = freehands.length + 1;
+        let best = null;
+        for (const shape of freehands) {
+            const join = closestFreehandJoin(map, shape, newShape);
+            if (join && (!best || join.distance < best.join.distance)) {
+                best = { shape: shape, join: join };
+            }
+        }
+
+        if (!best) {
+            handdrawDiag('edge-join.merged', { strokesBefore: strokesBefore, strokesAfter: strokesBefore });
+            return newShape;
+        }
+
+        const combinedPoints = joinFreehandPoints(
+            normalizePoints(best.shape.points || []),
+            normalizePoints(newShape.points || []),
+            best.join.mode);
+        const joined = {
+            ...best.shape,
+            type: 'freehand',
+            points: smoothFreehandPoints(map, combinedPoints, false)
+        };
+        handdrawDiag('edge-join.merged', { strokesBefore: strokesBefore, strokesAfter: strokesBefore - 1 });
+        return joined;
     }
 
     function normalizeShape(shape) {
@@ -745,13 +931,15 @@
             if (map.dragPan && map.dragPan.enable) map.dragPan.enable();
             mapDiag('freehand.up', { mapId: inst.mapId, pointCount: inst.tempPoints.length });
             if (inst.tempPoints.length >= 2) {
-                emitShape(inst, {
+                const points = smoothFreehandPoints(map, inst.tempPoints.slice(), true);
+                const shape = maybeJoinFreehandShape(map, inst, {
                     id: uuid(),
                     type: 'freehand',
                     color: currentStyle().color,
                     strokeWidth: currentStyle().strokeWidth,
-                    points: inst.tempPoints.slice()
+                    points: points
                 });
+                emitShape(inst, shape);
             }
             inst.tempPoints = [];
             teardownPreview(map);
@@ -1215,6 +1403,8 @@
         focusTextPopup: focusTextPopup,
         // Exposed for unit-testability / future tools; not called by Blazor.
         _circleToPolygonRing: circleToPolygonRing,
-        _normalizeShape: normalizeShape
+        _normalizeShape: normalizeShape,
+        _simplifyProjectedPoints: simplifyProjectedPoints,
+        _catmullRomSpline: catmullRomSpline
     };
 })();

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/MapDoneOverlaySmokeTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/MapDoneOverlaySmokeTests.cs
@@ -20,6 +20,12 @@ public class MapDoneOverlaySmokeTests
             "wwwroot",
             "js",
             "map-interop.js"));
+        var mapLayerRail = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Components",
+            "MapLayerRail.razor"));
         var theme = File.ReadAllText(Path.Combine(
             root,
             "src",
@@ -28,7 +34,9 @@ public class MapDoneOverlaySmokeTests
             "css",
             "ovcinahra-theme.css"));
 
-        Assert.Contains("Hotové lokace", mapPage);
+        Assert.Contains("Hotové lokace", mapLayerRail);
+        Assert.Contains("ShowDoneLocations", mapLayerRail);
+        Assert.Contains("OnDoneLocationsChange", mapLayerRail);
         Assert.Contains("DoneLocationStateKey", mapPage);
         Assert.Contains("[map-done] toggle changed", mapPage);
         Assert.Contains("l.IsPlacementDone", mapPage);
@@ -36,7 +44,7 @@ public class MapDoneOverlaySmokeTests
         Assert.Contains("bi-check-circle-fill", mapInterop);
         Assert.Contains("oh-map-pin-done", mapInterop);
         Assert.Contains("oh-map-pin-has-count", mapInterop);
-        Assert.Contains(".oh-map-done-toggle", theme);
+        Assert.Contains(".oh-map-layer-done", theme);
         Assert.Contains(".oh-map-pin-done", theme);
         Assert.Contains(".oh-map-pin.oh-map-pin-has-count .oh-map-pin-done", theme);
     }

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/MapHanddrawAndLayersSmokeTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/MapHanddrawAndLayersSmokeTests.cs
@@ -1,0 +1,82 @@
+namespace OvcinaHra.Api.Tests.ClientSmoke;
+
+public class MapHanddrawAndLayersSmokeTests
+{
+    [Fact]
+    public void OverlayInterop_SmoothsAndJoinsFreehandStrokes()
+    {
+        var root = FindRepoRoot();
+        var overlayInterop = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "wwwroot",
+            "js",
+            "overlay-interop.js"));
+        var mapView = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Components",
+            "MapView.razor"));
+
+        Assert.Contains("FREEHAND_SIMPLIFY_EPSILON_PX", overlayInterop);
+        Assert.Contains("simplifyProjectedPoints", overlayInterop);
+        Assert.Contains("catmullRomSpline", overlayInterop);
+        Assert.Contains("maybeJoinFreehandShape", overlayInterop);
+        Assert.Contains("[map-handdraw]", overlayInterop);
+        Assert.Contains("smoothing.input", overlayInterop);
+        Assert.Contains("smoothing.simplified", overlayInterop);
+        Assert.Contains("smoothing.splined", overlayInterop);
+        Assert.Contains("edge-join.merged", overlayInterop);
+        Assert.Contains("[map-handdraw] shape-replaced", mapView);
+    }
+
+    [Fact]
+    public void MapPage_UsesCompactLayersControlForOverlayToggles()
+    {
+        var root = FindRepoRoot();
+        var mapPage = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Pages",
+            "Map",
+            "MapPage.razor"));
+        var mapLayerRail = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Components",
+            "MapLayerRail.razor"));
+        var theme = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "wwwroot",
+            "css",
+            "ovcinahra-theme.css"));
+
+        Assert.Contains("oh-map-layers-button", mapLayerRail);
+        Assert.Contains("DxFlyout", mapLayerRail);
+        Assert.Contains("[map-layers] layers-control", mapLayerRail);
+        Assert.Contains("[map-layers] layer-toggle changed", mapLayerRail);
+        Assert.Contains("Skrýše", mapLayerRail);
+        Assert.Contains("Zobrazit oblasti", mapLayerRail);
+        Assert.Contains("Hotové lokace", mapLayerRail);
+        Assert.DoesNotContain("oh-map-rail-toggle", mapPage);
+        Assert.DoesNotContain("oh-map-region-toggle", mapPage);
+        Assert.Contains(".oh-map-layers-control", theme);
+        Assert.Contains(".oh-map-layers-panel", theme);
+        Assert.Contains("left:102px", theme);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "OvcinaHra.slnx")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not find repository root.");
+    }
+}


### PR DESCRIPTION
## Summary
- smooth freehand overlay strokes with Douglas-Peucker simplification and Catmull-Rom splines
- join close same-color freehand stroke endpoints into a single persisted shape
- replace the always-visible layer rail with a compact `Vrstvy` dropdown and move display overlays into it
- add smoke coverage for handdraw processing and the compact layers control

## Verification
- `dotnet build OvcinaHra.slnx --nologo`
- `dotnet test OvcinaHra.slnx --nologo --no-build`
- `node --check src/OvcinaHra.Client/wwwroot/js/overlay-interop.js`

## Visual smoke
- #464: open `/map` for game 30, edit overlay, draw a jagged freehand line; on mouseup it should smooth. Draw a second same-color stroke close to the first endpoint; it should join.
- #465: open `/map`, click `Vrstvy`, verify `Skrýše & Poklady`, `Zobrazit oblasti`, and `Hotové lokace` live in the dropdown and toggle as before. Phase chips stay top-level.

Closes #464
Closes #465