### PR TITLE
hotfix(map): center Upravit překryv under chip toolbar + hide text on mobile

### DIFF
--- a/src/OvcinaHra.Client/Components/MapView.razor
+++ b/src/OvcinaHra.Client/Components/MapView.razor
@@ -15,8 +15,9 @@
             <Authorized>
                 <button type="button" class="btn btn-sm btn-outline-primary oh-map-overlay-edit-btn"
                         title="Upravit vektorový překryv mapy"
+                        aria-label="Upravit překryv"
                         @onclick="EnterEditModeAsync">
-                    <i class="bi bi-vector-pen"></i> Upravit překryv
+                    <i class="bi bi-vector-pen"></i><span class="d-none d-md-inline ms-1">Upravit překryv</span>
                 </button>
             </Authorized>
         </AuthorizeView>

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2686,7 +2686,7 @@
 .oh-mo-label input[type="range"]{width:80px;margin:0}
 .oh-mo-stroke-val{font-family:var(--oh-font-mono,Menlo,monospace);color:var(--oh-text,#2a2a2a);
     font-size:.75rem;min-width:30px;text-align:right}
-.oh-map-overlay-edit-btn{position:absolute;top:12px;left:12px;right:auto;z-index:19}
+.oh-map-overlay-edit-btn{position:absolute;top:56px;left:50%;transform:translateX(-50%);right:auto;z-index:19}
 .oh-map-overlay-audience{position:absolute;top:12px;left:12px;right:auto;z-index:21;
     display:flex;gap:6px;padding:6px;background:rgba(250,246,236,.94);
     border:1px solid var(--oh-border,#d8d2be);border-radius:6px;


### PR DESCRIPTION
## Summary

ASAP map UX fix — the "Upravit překryv" button was overlapping the chip toolbar (POKLADY phase chips + region/done toggles).

* **Position**: now `top:56px; left:50%; translateX(-50%)` — centered just below the toolbar
* **Mobile (<md)**: hide the "Upravit překryv" label via Bootstrap `d-none d-md-inline`, show only the `bi-vector-pen` icon. `aria-label="Upravit překryv"` preserved for screen readers.

## Test plan

- [ ] CI passes (build + test + GitGuardian)
- [ ] Open `/map` → button visible, centered below the chip row, not overlapping
- [ ] Mobile viewport (DevTools ≤768px) → button shows ONLY the pen icon
- [ ] Click button → still enters edit mode (`EnterEditModeAsync` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)