### PR TITLE
fix(images): validate capturedAt and clean placement EXIF logs

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ImageEndpoints.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using System.Diagnostics;
 using System.Globalization;
 using System.Security.Claims;
+using System.Text.RegularExpressions;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Dtos;
@@ -11,7 +12,7 @@ using SixLabors.ImageSharp;
 
 namespace OvcinaHra.Api.Endpoints;
 
-public static class ImageEndpoints
+public static partial class ImageEndpoints
 {
     // "locationstamps" and "locationplacements" are logical aliases keyed by
     // Location.Id. They write Location.StampImagePath / PlacementPhotoPath but
@@ -23,6 +24,9 @@ public static class ImageEndpoints
     private const long MaxFileSize = 5 * 1024 * 1024; // 5 MB
     private const int LocationStampMinimumPixels = 200;
     private const double LocationStampAspectTolerance = 0.10;
+    private const int CapturedAtMaxLength = 64;
+    [GeneratedRegex(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$", RegexOptions.CultureInvariant)]
+    private static partial Regex CapturedAtIsoRegex();
 
     public static RouteGroupBuilder MapImageEndpoints(this IEndpointRouteBuilder routes)
     {
@@ -192,7 +196,19 @@ public static class ImageEndpoints
                 return TypedResults.NotFound();
             }
 
-            var metadata = await ReadUploadMetadataAsync(http, ct);
+            var metadataResult = await ReadUploadMetadataAsync(http, ct);
+            if (metadataResult.Problem is not null)
+            {
+                logger.LogInformation(
+                    "[image-upload-server] metadata.validation-failed capturedAt={CapturedAt} reason={Reason}",
+                    metadataResult.CapturedAtForLog,
+                    metadataResult.FailureReason);
+                LogPlacementImageExit(logger, isPlacementUpload, entityId, gameId, userId, 400, detail: $"capturedAt:{metadataResult.FailureReason}");
+                LogImageUploadServerExit(logger, isServerTimedImageUpload, http, entityType, entityId, userId, serverTimer, 400, detail: $"capturedAt:{metadataResult.FailureReason}");
+                return TypedResults.BadRequest(metadataResult.Problem);
+            }
+
+            var metadata = metadataResult.Metadata;
             var isPlacement = string.Equals(field, "placement", StringComparison.OrdinalIgnoreCase);
             var suffix = isPlacement ? "placement" : "image";
             var ext = file.ContentType switch
@@ -413,17 +429,48 @@ public static class ImageEndpoints
         }
     }
 
-    private static async Task<ImageUploadMetadataDto?> ReadUploadMetadataAsync(HttpContext http, CancellationToken ct)
+    private static async Task<UploadMetadataReadResult> ReadUploadMetadataAsync(HttpContext http, CancellationToken ct)
     {
         var form = await http.Request.ReadFormAsync(ct);
         var gpsLatitude = ReadNullableDouble(form, "gpsLatitude");
         var gpsLongitude = ReadNullableDouble(form, "gpsLongitude");
         var capturedAt = ReadNullableString(form, "capturedAt");
 
+        var capturedAtValidationFailure = ValidateCapturedAt(capturedAt);
+        if (capturedAtValidationFailure is not null)
+        {
+            return new UploadMetadataReadResult(
+                null,
+                ImageFieldValidationProblem("capturedAt", "Neplatný formát data v poli capturedAt."),
+                capturedAtValidationFailure,
+                TruncateForLog(capturedAt));
+        }
+
         if (gpsLatitude is null && gpsLongitude is null && capturedAt is null)
+            return new UploadMetadataReadResult(null, null, null, null);
+
+        return new UploadMetadataReadResult(new ImageUploadMetadataDto(gpsLatitude, gpsLongitude, capturedAt), null, null, null);
+    }
+
+    private static string? ValidateCapturedAt(string? capturedAt)
+    {
+        if (capturedAt is null)
             return null;
 
-        return new ImageUploadMetadataDto(gpsLatitude, gpsLongitude, capturedAt);
+        if (capturedAt.Length > CapturedAtMaxLength)
+            return "too-long";
+
+        if (!CapturedAtIsoRegex().IsMatch(capturedAt))
+            return "invalid-format";
+
+        return DateTime.TryParseExact(
+            capturedAt,
+            "yyyy-MM-dd'T'HH:mm:ss",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out _)
+            ? null
+            : "invalid-format";
     }
 
     private static double? ReadNullableDouble(IFormCollection form, string key)
@@ -444,6 +491,14 @@ public static class ImageEndpoints
 
         var value = values.ToString();
         return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private static string? TruncateForLog(string? value)
+    {
+        if (value is null || value.Length <= 96)
+            return value;
+
+        return value[..96] + "...";
     }
 
     /// <summary>
@@ -922,6 +977,22 @@ public static class ImageEndpoints
         Detail = detail,
         Status = StatusCodes.Status400BadRequest
     };
+
+    private static ProblemDetails ImageFieldValidationProblem(string field, string detail)
+    {
+        var problem = ImageValidationProblem(detail);
+        problem.Extensions["errors"] = new Dictionary<string, string[]>
+        {
+            [field] = [detail]
+        };
+        return problem;
+    }
+
+    private sealed record UploadMetadataReadResult(
+        ImageUploadMetadataDto? Metadata,
+        ProblemDetails? Problem,
+        string? FailureReason,
+        string? CapturedAtForLog);
 
     private static async Task<bool> EntityExists(WorldDbContext db, string entityType, int entityId)
     {

--- a/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
+++ b/src/OvcinaHra.Client/Pages/Locations/LocationList.razor
@@ -1196,7 +1196,6 @@ else
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[loc-placement] exif read result=parse-failed gameId={gameId} detail={ex.Message}");
             Console.WriteLine($"[image-upload] exif.read result=parse-failed surface=placement gameId={gameId} detail={ex.Message}");
             return;
         }
@@ -1209,13 +1208,10 @@ else
 
         if (gps is null)
         {
-            Console.WriteLine($"[loc-placement] exif read result=no-gps gameId={gameId}");
             return;
         }
 
         placementPhotoGps = gps;
-        Console.WriteLine($"[loc-placement] exif read result=found-gps gameId={gameId}");
-        Console.WriteLine($"[loc-placement] exif gps-coords lat={FormatPlacementGpsCoord(gps.Lat)} lng={FormatPlacementGpsCoord(gps.Lng)}");
 
         var selected = SelectedPlacementLocation;
         if (selected is null)

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ImageEndpointTests.cs
@@ -78,6 +78,52 @@ public class ImageEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
     }
 
     [Fact]
+    public async Task Upload_WithInvalidCapturedAt_ReturnsCzechProblemDetails()
+    {
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Foto se špatným datem", LocationKind.Village, 49.5m, 17.1m));
+        var loc = await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        using var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(ValidPng);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        content.Add(fileContent, "file", "photo.png");
+        content.Add(new StringContent("NotADate"), "capturedAt");
+
+        var response = await Client.PostAsync($"/api/images/locations/{loc!.Id}", content);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal((int)HttpStatusCode.BadRequest, problem.Status);
+        Assert.Contains("Neplatný formát data", problem.Detail);
+        Assert.Contains("capturedAt", problem.Detail);
+    }
+
+    [Fact]
+    public async Task Upload_WithTooLongCapturedAt_ReturnsCzechProblemDetails()
+    {
+        var locResponse = await Client.PostAsJsonAsync("/api/locations",
+            new CreateLocationDto("Foto s dlouhým datem", LocationKind.Village, 49.5m, 17.1m));
+        var loc = await locResponse.Content.ReadFromJsonAsync<LocationDetailDto>();
+
+        using var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(ValidPng);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        content.Add(fileContent, "file", "photo.png");
+        content.Add(new StringContent(new string('1', 65)), "capturedAt");
+
+        var response = await Client.PostAsync($"/api/images/locations/{loc!.Id}", content);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal((int)HttpStatusCode.BadRequest, problem.Status);
+        Assert.Contains("Neplatný formát data", problem.Detail);
+        Assert.Contains("capturedAt", problem.Detail);
+    }
+
+    [Fact]
     public async Task Upload_LocationStamp_PersistsStampPathAndFullSasUrl()
     {
         var locResponse = await Client.PostAsJsonAsync("/api/locations",


### PR DESCRIPTION
## Summary
- Validate `capturedAt` server-side with a 64-character cap and strict `YYYY-MM-DDTHH:MM:SS` parsing.
- Return Czech ProblemDetails for invalid `capturedAt` and log `[image-upload-server] metadata.validation-failed ...`.
- Remove legacy `[loc-placement] exif...` placement wizard logs so EXIF reads use only the `[image-upload]` family.

## Verification
- `dotnet build OvcinaHra.slnx`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --filter FullyQualifiedName~ImageEndpointTests`
- `dotnet test OvcinaHra.slnx --no-build`

Closes #483