### PR TITLE
Add organizer roles CSV export

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/OrganizerRoleEndpoints.cs
@@ -1,11 +1,15 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using System.Diagnostics;
+using System.Globalization;
 using System.Security.Claims;
+using System.Text;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
+using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Api.Endpoints;
 
@@ -15,6 +19,8 @@ public static class OrganizerRoleEndpoints
     private const int PersonNameMaxLength = 200;
     private const int PersonEmailMaxLength = 200;
     private const int NotesMaxLength = 1000;
+    private static readonly CultureInfo CzechCulture = CultureInfo.GetCultureInfo("cs-CZ");
+    private static readonly TimeZoneInfo PragueTimeZone = ResolvePragueTimeZone();
 
     public static RouteGroupBuilder MapOrganizerRoleEndpoints(this IEndpointRouteBuilder routes)
     {
@@ -30,6 +36,9 @@ public static class OrganizerRoleEndpoints
             .WithTags("OrganizerRoles")
             .RequireAuthorization();
         routes.MapPost("/api/organizer-roles/bulk-fill-remaining", BulkFillRemaining)
+            .WithTags("OrganizerRoles")
+            .RequireAuthorization();
+        routes.MapGet("/api/organizer-roles/export", ExportCsv)
             .WithTags("OrganizerRoles")
             .RequireAuthorization();
 
@@ -99,6 +108,82 @@ public static class OrganizerRoleEndpoints
             assignments.Count);
 
         return TypedResults.Ok(new OrganizerRoleMatrixDto(gameId, slots, npcs, assignments));
+    }
+
+    private static async Task<IResult> ExportCsv(
+        int gameId,
+        string? format,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger(LoggerCategory);
+        var timer = Stopwatch.StartNew();
+        var requestedFormat = string.IsNullOrWhiteSpace(format) ? "csv" : format.Trim();
+        if (!string.Equals(requestedFormat, "csv", StringComparison.OrdinalIgnoreCase))
+        {
+            return Problem(
+                "Podporovaný formát exportu je csv.",
+                "Nepodporovaný formát exportu",
+                StatusCodes.Status400BadRequest);
+        }
+
+        var game = await db.Games
+            .AsNoTracking()
+            .Where(g => g.Id == gameId)
+            .Select(g => new { g.Id, g.Name })
+            .SingleOrDefaultAsync(ct);
+        if (game is null)
+        {
+            logger.LogInformation("[organizer-roles-export] game_not_found gameId={GameId} format={Format}", gameId, requestedFormat);
+            return TypedResults.NotFound();
+        }
+
+        var slots = await db.GameTimeSlots
+            .AsNoTracking()
+            .Where(s => s.GameId == gameId)
+            .OrderBy(s => s.StartTime)
+            .Select(s => new OrganizerRoleExportSlot(
+                s.Id,
+                s.StartTime,
+                s.Duration,
+                s.InGameYear,
+                s.Stage))
+            .ToListAsync(ct);
+
+        var assignments = await db.OrganizerRoleAssignments
+            .AsNoTracking()
+            .Where(a => a.GameId == gameId)
+            .OrderBy(a => a.PersonName)
+            .ThenBy(a => a.PersonEmail)
+            .ThenBy(a => a.TimeSlot.StartTime)
+            .ThenBy(a => a.Npc.Name)
+            .Select(a => new OrganizerRoleExportAssignment(
+                a.GameTimeSlotId,
+                a.NpcId,
+                a.Npc.Name,
+                a.Npc.Role,
+                a.PersonId,
+                a.PersonName,
+                a.PersonEmail))
+            .ToListAsync(ct);
+
+        var csvBytes = BuildOrganizerRoleCsv(slots, assignments, out var rowCount);
+        var fileName = ExportFilenameBuilder.BuildExportFilename(
+            "OrganizerRoles",
+            game.Name,
+            includeDate: true,
+            extension: "csv");
+
+        timer.Stop();
+        logger.LogInformation(
+            "[organizer-roles-export] requested gameId={GameId} format={Format} rowCount={RowCount} elapsedMs={ElapsedMs}",
+            gameId,
+            requestedFormat,
+            rowCount,
+            timer.ElapsedMilliseconds);
+
+        return TypedResults.File(csvBytes, "text/csv; charset=utf-8", fileName);
     }
 
     private static async Task<Results<Ok<OrganizerRoleMeDto>, NotFound, UnauthorizedHttpResult>> GetMine(
@@ -868,6 +953,135 @@ public static class OrganizerRoleEndpoints
             .SingleOrDefaultAsync(ct);
     }
 
+    private static byte[] BuildOrganizerRoleCsv(
+        IReadOnlyList<OrganizerRoleExportSlot> slots,
+        IReadOnlyList<OrganizerRoleExportAssignment> assignments,
+        out int rowCount)
+    {
+        var builder = new StringBuilder();
+        AppendCsvRow(
+            builder,
+            [
+                "Dospělý",
+                "E-mail",
+                "Slot",
+                "Začátek",
+                "Konec",
+                "Fáze",
+                "NPC role",
+                "Role tag"
+            ]);
+
+        rowCount = 0;
+        var assignmentsByAdultSlot = assignments
+            .GroupBy(a => (a.PersonId, a.GameTimeSlotId))
+            .ToDictionary(g => g.Key, g => g
+                .OrderBy(a => a.NpcName, StringComparer.CurrentCultureIgnoreCase)
+                .ThenBy(a => a.NpcId)
+                .ToList());
+
+        var adults = assignments
+            .GroupBy(a => a.PersonId)
+            .Select(g => new OrganizerRoleExportAdult(
+                g.Key,
+                g.Select(a => a.PersonName).FirstOrDefault(name => !string.IsNullOrWhiteSpace(name)) ?? "",
+                g.Select(a => a.PersonEmail).FirstOrDefault(email => !string.IsNullOrWhiteSpace(email))))
+            .OrderBy(a => a.PersonName, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(a => a.PersonEmail, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+
+        foreach (var adult in adults)
+        {
+            foreach (var slot in slots)
+            {
+                assignmentsByAdultSlot.TryGetValue((adult.PersonId, slot.Id), out var slotAssignments);
+                AppendCsvRow(
+                    builder,
+                    [
+                        adult.PersonName,
+                        adult.PersonEmail ?? "",
+                        FormatSlotLabel(slot),
+                        FormatPragueDateTime(slot.StartTime),
+                        FormatPragueDateTime(slot.StartTime + slot.Duration),
+                        slot.Stage.GetDisplayName(),
+                        FormatNpcRoles(slotAssignments),
+                        FormatRoleTags(slotAssignments)
+                    ]);
+                rowCount++;
+            }
+        }
+
+        var preamble = Encoding.UTF8.GetPreamble();
+        var body = Encoding.UTF8.GetBytes(builder.ToString());
+        var bytes = new byte[preamble.Length + body.Length];
+        Buffer.BlockCopy(preamble, 0, bytes, 0, preamble.Length);
+        Buffer.BlockCopy(body, 0, bytes, preamble.Length, body.Length);
+        return bytes;
+    }
+
+    private static void AppendCsvRow(StringBuilder builder, IEnumerable<string?> values)
+    {
+        var isFirst = true;
+        foreach (var value in values)
+        {
+            if (!isFirst)
+                builder.Append(';');
+
+            builder.Append('"');
+            builder.Append((value ?? "").Replace("\"", "\"\"", StringComparison.Ordinal));
+            builder.Append('"');
+            isFirst = false;
+        }
+
+        builder.AppendLine();
+    }
+
+    private static string FormatSlotLabel(OrganizerRoleExportSlot slot)
+    {
+        var year = slot.InGameYear is int inGameYear ? $"Rok {inGameYear}, " : "";
+        return $"{slot.Stage.GetDisplayName()}: {year}{FormatPragueDateTime(slot.StartTime)}";
+    }
+
+    private static string FormatPragueDateTime(DateTime value) =>
+        ToPragueTime(value).ToString("d.M.yyyy H:mm", CzechCulture);
+
+    private static DateTime ToPragueTime(DateTime value)
+    {
+        var utc = value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+        return TimeZoneInfo.ConvertTimeFromUtc(utc, PragueTimeZone);
+    }
+
+    private static string FormatNpcRoles(IReadOnlyList<OrganizerRoleExportAssignment>? assignments) =>
+        assignments is null || assignments.Count == 0
+            ? ""
+            : string.Join(", ", assignments.Select(a => a.NpcName).Distinct(StringComparer.CurrentCultureIgnoreCase));
+
+    private static string FormatRoleTags(IReadOnlyList<OrganizerRoleExportAssignment>? assignments) =>
+        assignments is null || assignments.Count == 0
+            ? ""
+            : string.Join(
+                ", ",
+                assignments
+                    .Select(a => a.Role.GetDisplayName())
+                    .Distinct(StringComparer.CurrentCultureIgnoreCase));
+
+    private static TimeZoneInfo ResolvePragueTimeZone()
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById("Europe/Prague");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById("Central Europe Standard Time");
+        }
+    }
+
     private sealed record OrganizerRoleMineAssignmentRow(
         int GameTimeSlotId,
         int NpcId,
@@ -875,6 +1089,27 @@ public static class OrganizerRoleEndpoints
         NpcRole Role,
         string? Description,
         string? Notes,
+        int PersonId,
+        string PersonName,
+        string? PersonEmail);
+
+    private sealed record OrganizerRoleExportSlot(
+        int Id,
+        DateTime StartTime,
+        TimeSpan Duration,
+        int? InGameYear,
+        GameTimePhase Stage);
+
+    private sealed record OrganizerRoleExportAssignment(
+        int GameTimeSlotId,
+        int NpcId,
+        string NpcName,
+        NpcRole Role,
+        int PersonId,
+        string PersonName,
+        string? PersonEmail);
+
+    private sealed record OrganizerRoleExportAdult(
         int PersonId,
         string PersonName,
         string? PersonEmail);

--- a/src/OvcinaHra.Api/Services/ExportFilenameBuilder.cs
+++ b/src/OvcinaHra.Api/Services/ExportFilenameBuilder.cs
@@ -5,10 +5,14 @@ namespace OvcinaHra.Api.Services;
 
 public static class ExportFilenameBuilder
 {
-    public static string BuildExportFilename(string exportType, string gameName, bool includeDate = false)
+    public static string BuildExportFilename(
+        string exportType,
+        string gameName,
+        bool includeDate = false,
+        string extension = "pdf")
     {
         var date = includeDate ? $"_{DateTime.Today:yyyy-MM-dd}" : string.Empty;
-        return $"{SanitizePart(exportType, "Export")}_{SanitizePart(gameName, "Hra")}{date}.pdf";
+        return $"{SanitizePart(exportType, "Export")}_{SanitizePart(gameName, "Hra")}{date}.{SanitizeExtension(extension)}";
     }
 
     private static string SanitizePart(string value, string fallback)
@@ -49,5 +53,14 @@ public static class ExportFilenameBuilder
 
         var result = builder.ToString().Trim('-');
         return string.IsNullOrWhiteSpace(result) ? fallback : result;
+    }
+
+    private static string SanitizeExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+            return "pdf";
+
+        var sanitized = string.Concat(extension.Trim().TrimStart('.').Where(char.IsLetterOrDigit));
+        return string.IsNullOrWhiteSpace(sanitized) ? "pdf" : sanitized.ToLowerInvariant();
     }
 }

--- a/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor
+++ b/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor
@@ -1,8 +1,10 @@
 @page "/organizer-roles"
 @attribute [Authorize]
 @using System.Globalization
+@using Microsoft.JSInterop
 @inject ApiClient Api
 @inject GameContextService GameContext
+@inject IJSRuntime JS
 @implements IDisposable
 
 <PageTitle>Rozpis rolí</PageTitle>
@@ -13,6 +15,20 @@
         <div class="oh-orgrole-sub">@(GameContext.GameName ?? "Žádná hra")</div>
     </div>
     <div class="oh-orgrole-actions">
+        <button type="button"
+                class="btn btn-outline-secondary"
+                @onclick="DownloadCsvAsync"
+                disabled="@(GameContext.SelectedGameId is null || isCsvDownloading)">
+            @if (isCsvDownloading)
+            {
+                <span class="spinner-border spinner-border-sm"></span>
+            }
+            else
+            {
+                <i class="bi bi-download"></i>
+            }
+            Stáhnout CSV
+        </button>
         <button type="button"
                 class="btn btn-primary"
                 @onclick="OpenBulkAssign"
@@ -83,6 +99,10 @@
 @if (!string.IsNullOrWhiteSpace(bulkFillError))
 {
     <div class="alert alert-warning">@bulkFillError</div>
+}
+@if (!string.IsNullOrWhiteSpace(csvDownloadError))
+{
+    <div class="alert alert-warning">@csvDownloadError</div>
 }
 @if (!string.IsNullOrWhiteSpace(bulkFillToastMessage))
 {
@@ -425,8 +445,10 @@ else
 
     private bool loading = true;
     private bool isSaving;
+    private bool isCsvDownloading;
     private string? error;
     private string? adultsLoadError;
+    private string? csvDownloadError;
 
     private NpcRole? selectedRole;
     private int? selectedAdultPersonId;
@@ -577,6 +599,43 @@ else
         {
             adultsLoadError = $"Dospělé z registrace se nepodařilo načíst: {ex.Message}";
             Console.WriteLine($"[organizer-roles] adults load.failed gameId={gameId} message={ex.Message}");
+        }
+    }
+
+    private async Task DownloadCsvAsync()
+    {
+        if (GameContext.SelectedGameId is not int gameId)
+        {
+            csvDownloadError = "Nejdřív vyberte hru.";
+            return;
+        }
+
+        isCsvDownloading = true;
+        csvDownloadError = null;
+        try
+        {
+            Console.WriteLine($"[organizer-roles-export] download.start gameId={gameId}");
+            var (ok, file, problem) = await Api.DownloadWithProblemAsync($"/api/organizer-roles/export?gameId={gameId}&format=csv");
+            if (!ok || file is null)
+            {
+                csvDownloadError = problem ?? "CSV se nepodařilo připravit.";
+                Console.WriteLine($"[organizer-roles-export] download.failed gameId={gameId} message={csvDownloadError}");
+                return;
+            }
+
+            await using var stream = new MemoryStream(file.Bytes);
+            using var streamReference = new DotNetStreamReference(stream);
+            await JS.InvokeVoidAsync("ovcinaDownloadFile", file.FileName, file.ContentType, streamReference);
+            Console.WriteLine($"[organizer-roles-export] download.ok gameId={gameId} fileName={file.FileName} bytes={file.Bytes.Length}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex);
+            csvDownloadError = "CSV se nepodařilo stáhnout.";
+        }
+        finally
+        {
+            isCsvDownloading = false;
         }
     }
 

--- a/tests/OvcinaHra.Api.Tests/Endpoints/OrganizerRoleEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/OrganizerRoleEndpointTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Enums;
@@ -302,6 +303,50 @@ public class OrganizerRoleEndpointTests(PostgresFixture postgres) : IntegrationT
         Assert.Contains("výchozí role", problem.Detail ?? "");
     }
 
+    [Fact]
+    public async Task ExportCsv_ReturnsUtf8BomSemicolonCsvForAdultSlots()
+    {
+        var game = await CreateGameAsync("Balinova pozvánka");
+        var firstSlot = await CreateSlotAsync(game.Id, hour: 10, GameTimePhase.Early);
+        var secondSlot = await CreateSlotAsync(game.Id, hour: 11, GameTimePhase.Midgame);
+        var merchant = await CreateNpcAsync("Kupec Čenda", NpcRole.Merchant);
+        var monster = await CreateNpcAsync("Vlkodlak", NpcRole.Monster);
+        await AssignNpcAsync(game.Id, merchant.Id);
+        await AssignNpcAsync(game.Id, monster.Id);
+        await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{firstSlot.Id}/npcs/{merchant.Id}",
+            new UpsertOrganizerRoleAssignmentDto(501, "Pavel Dospělý", "pavel@example.com"));
+        await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{firstSlot.Id}/npcs/{monster.Id}",
+            new UpsertOrganizerRoleAssignmentDto(501, "Pavel Dospělý", "pavel@example.com"));
+        await Client.PutAsJsonAsync(
+            $"/api/games/{game.Id}/organizer-role-assignments/slots/{secondSlot.Id}/npcs/{merchant.Id}",
+            new UpsertOrganizerRoleAssignmentDto(777, "Jana Žlutá", "jana@example.com"));
+
+        var response = await Client.GetAsync($"/api/organizer-roles/export?gameId={game.Id}&format=csv");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/csv", response.Content.Headers.ContentType?.MediaType);
+        Assert.Contains("utf-8", (response.Content.Headers.ContentType?.CharSet ?? "").ToLowerInvariant());
+        Assert.Equal(
+            $"OrganizerRoles_Balinova-pozvanka_{DateTime.Today:yyyy-MM-dd}.csv",
+            response.Content.Headers.ContentDisposition?.FileNameStar
+                ?? response.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        Assert.True(bytes.AsSpan().StartsWith(Encoding.UTF8.GetPreamble()));
+        var csv = Encoding.UTF8.GetString(bytes[Encoding.UTF8.GetPreamble().Length..]);
+        var lines = csv.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(5, lines.Length);
+        Assert.Equal("\"Dospělý\";\"E-mail\";\"Slot\";\"Začátek\";\"Konec\";\"Fáze\";\"NPC role\";\"Role tag\"", lines[0]);
+        Assert.Contains(
+            "\"Pavel Dospělý\";\"pavel@example.com\";\"Rozvoj hry: Rok 1247, 1.5.2026 12:00\";\"1.5.2026 12:00\";\"1.5.2026 13:00\";\"Rozvoj hry\";\"Kupec Čenda, Vlkodlak\";\"Obchodník, Nestvůra\"",
+            lines);
+        Assert.Contains(
+            "\"Jana Žlutá\";\"jana@example.com\";\"Rozvoj hry: Rok 1247, 1.5.2026 12:00\";\"1.5.2026 12:00\";\"1.5.2026 13:00\";\"Rozvoj hry\";\"\";\"\"",
+            lines);
+    }
+
     private async Task<(GameDetailDto Game, NpcDetailDto Npc, List<GameTimeSlotDto> Slots)> CreateGameWithNpcAndSlotsAsync(int slotCount)
     {
         var game = await CreateGameAsync();
@@ -317,11 +362,11 @@ public class OrganizerRoleEndpointTests(PostgresFixture postgres) : IntegrationT
         return (game, npc, slots);
     }
 
-    private async Task<GameDetailDto> CreateGameAsync()
+    private async Task<GameDetailDto> CreateGameAsync(string name = "Rozpis rolí")
     {
         var response = await Client.PostAsJsonAsync(
             "/api/games",
-            new CreateGameDto("Rozpis rolí", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+            new CreateGameDto(name, 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
     }
@@ -341,7 +386,10 @@ public class OrganizerRoleEndpointTests(PostgresFixture postgres) : IntegrationT
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
-    private async Task<GameTimeSlotDto> CreateSlotAsync(int gameId, int hour)
+    private async Task<GameTimeSlotDto> CreateSlotAsync(
+        int gameId,
+        int hour,
+        GameTimePhase stage = GameTimePhase.Start)
     {
         var response = await Client.PostAsJsonAsync(
             "/api/timeline/slots",
@@ -349,7 +397,8 @@ public class OrganizerRoleEndpointTests(PostgresFixture postgres) : IntegrationT
                 GameId: gameId,
                 StartTime: new DateTime(2026, 5, 1, hour, 0, 0, DateTimeKind.Utc),
                 DurationHours: 1,
-                InGameYear: 1247));
+                InGameYear: 1247,
+                Stage: stage));
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         return (await response.Content.ReadFromJsonAsync<GameTimeSlotDto>())!;
     }

--- a/tests/OvcinaHra.Api.Tests/Services/ExportFilenameBuilderTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Services/ExportFilenameBuilderTests.cs
@@ -24,4 +24,16 @@ public class ExportFilenameBuilderTests
 
         Assert.Equal("SeznamKouzel_Zlutoucky-kun-Cerny-les.pdf", fileName);
     }
+
+    [Fact]
+    public void BuildExportFilename_AllowsCsvExtension()
+    {
+        var fileName = ExportFilenameBuilder.BuildExportFilename(
+            "OrganizerRoles",
+            "Balinova pozvánka",
+            includeDate: true,
+            extension: "csv");
+
+        Assert.Equal($"OrganizerRoles_Balinova-pozvanka_{DateTime.Today:yyyy-MM-dd}.csv", fileName);
+    }
 }


### PR DESCRIPTION
## Summary
- adds `GET /api/organizer-roles/export?gameId={id}&format=csv` with UTF-8 BOM, semicolon delimiter, Prague-time slot columns, and `OrganizerRoles_<GameName>_<Date>.csv` filenames
- adds `Stáhnout CSV` to `/organizer-roles` using the existing `Api.DownloadWithProblemAsync` + `ovcinaDownloadFile` path
- extends `ExportFilenameBuilder` to support non-PDF extensions while preserving existing PDF callers

## Notes
- Export rows are one row per adult + time slot. If an adult has multiple NPC roles in the same slot, the role names/tags are joined in that single row so the export keeps the requested grain without dropping data.
- Server logs `[organizer-roles-export] requested gameId=... format=csv rowCount=... elapsedMs=...`.

## Verification
- `dotnet build OvcinaHra.slnx`
- `dotnet test OvcinaHra.slnx`
- Focused: `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter "FullyQualifiedName~OrganizerRoleEndpointTests|FullyQualifiedName~ExportFilenameBuilderTests"`
- Manual browser smoke: local API + client, Playwright clicked `/organizer-roles` → `Stáhnout CSV`; verified downloaded filename, UTF-8 BOM, semicolon delimiter, and Czech strings.

Closes #485