### PR TITLE
Treasures missing-location dashboard

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -31,6 +31,7 @@ public static class TreasurePlanningEndpoints
 
         // Location cards with treasure counts
         group.MapGet("/locations/{gameId:int}", GetLocationCards);
+        group.MapGet("/missing", GetMissingLocations);
 
         // Summary
         group.MapGet("/summary/{gameId:int}", GetSummary);
@@ -119,7 +120,10 @@ public static class TreasurePlanningEndpoints
 
         var ti = new TreasureItem
         {
-            ItemId = dto.ItemId, GameId = dto.GameId, Count = dto.Count, TreasureQuestId = null
+            ItemId = dto.ItemId,
+            GameId = dto.GameId,
+            Count = dto.Count,
+            TreasureQuestId = null
         };
         db.TreasureItems.Add(ti);
         await db.SaveChangesAsync();
@@ -207,6 +211,57 @@ public static class TreasurePlanningEndpoints
         HttpContext http)
     {
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
+        var result = await BuildLocationCardsAsync(gameId, db, logger, http);
+        return TypedResults.Ok(result);
+    }
+
+    private static async Task<Results<Ok<List<MissingTreasureLocationDto>>, ValidationProblem>> GetMissingLocations(
+        int gameId,
+        int? threshold,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory,
+        HttpContext http)
+    {
+        var effectiveThreshold = threshold ?? 1;
+        if (effectiveThreshold < 0)
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["threshold"] = ["Prahová hodnota nesmí být záporná."]
+            });
+        }
+
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
+        var locationCards = await BuildLocationCardsAsync(gameId, db, logger, http);
+        var missing = locationCards
+            .Where(l => l.TotalItems < effectiveThreshold)
+            .OrderBy(l => l.TotalItems)
+            .ThenBy(l => string.IsNullOrWhiteSpace(l.Region))
+            .ThenBy(l => l.Region)
+            .ThenBy(l => l.LocationName)
+            .Select(l => new MissingTreasureLocationDto(
+                l.LocationId,
+                l.LocationName,
+                l.Region,
+                l.TotalItems,
+                effectiveThreshold,
+                effectiveThreshold - l.TotalItems))
+            .ToList();
+
+        logger.LogInformation(
+            "[treasure-alloc] missing-view loaded gameId={GameId} threshold={Threshold} matched={Matched}",
+            gameId,
+            effectiveThreshold,
+            missing.Count);
+        return TypedResults.Ok(missing);
+    }
+
+    private static async Task<List<TreasurePlanningLocationDto>> BuildLocationCardsAsync(
+        int gameId,
+        WorldDbContext db,
+        ILogger logger,
+        HttpContext http)
+    {
         var assignedLocationIds = await db.GameLocations
             .Where(gl => gl.GameId == gameId)
             .Select(gl => gl.LocationId)
@@ -318,7 +373,7 @@ public static class TreasurePlanningEndpoints
                 AssignedTreasureCount: allAssignedTreasures.Count);
         }).ToList();
 
-        return TypedResults.Ok(result);
+        return result;
     }
 
     private static async Task<Ok<TreasureSummaryDto>> GetSummary(int gameId, WorldDbContext db)
@@ -528,8 +583,12 @@ public static class TreasurePlanningEndpoints
             // Create the quest
             var quest = new TreasureQuest
             {
-                Title = dto.Title, Clue = dto.Clue, Difficulty = dto.Difficulty,
-                LocationId = targetLocationId, SecretStashId = targetSecretStashId, GameId = dto.GameId
+                Title = dto.Title,
+                Clue = dto.Clue,
+                Difficulty = dto.Difficulty,
+                LocationId = targetLocationId,
+                SecretStashId = targetSecretStashId,
+                GameId = dto.GameId
             };
             db.TreasureQuests.Add(quest);
             LogTreasureAlloc(logger, LogLevel.Information, "assign-before-save", new
@@ -597,7 +656,10 @@ public static class TreasurePlanningEndpoints
                 {
                     db.TreasureItems.Add(new TreasureItem
                     {
-                        ItemId = ui.ItemId, GameId = dto.GameId, Count = ui.Count, TreasureQuestId = quest.Id
+                        ItemId = ui.ItemId,
+                        GameId = dto.GameId,
+                        Count = ui.Count,
+                        TreasureQuestId = quest.Id
                     });
                 }
             }

--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -227,12 +227,12 @@ public static class TreasurePlanningEndpoints
         {
             return TypedResults.ValidationProblem(new Dictionary<string, string[]>
             {
-                ["threshold"] = ["Prahová hodnota nesmí být záporná."]
+                ["Threshold"] = ["Prahová hodnota nesmí být záporná."]
             });
         }
 
         var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.TreasurePlanningEndpoints");
-        var locationCards = await BuildLocationCardsAsync(gameId, db, logger, http);
+        var locationCards = await BuildLocationCardsAsync(gameId, db, logger, http, includeAssignedTreasures: false);
         var missing = locationCards
             .Where(l => l.TotalItems < effectiveThreshold)
             .OrderBy(l => l.TotalItems)
@@ -260,7 +260,8 @@ public static class TreasurePlanningEndpoints
         int gameId,
         WorldDbContext db,
         ILogger logger,
-        HttpContext http)
+        HttpContext http,
+        bool includeAssignedTreasures = true)
     {
         var assignedLocationIds = await db.GameLocations
             .Where(gl => gl.GameId == gameId)
@@ -300,12 +301,16 @@ public static class TreasurePlanningEndpoints
             .Where(l => !l.ParentLocationId.HasValue)
             .ToList();
 
-        // Get all treasure quests for this game with their items
-        var quests = await db.TreasureQuests
-            .Where(tq => tq.GameId == gameId)
-            .Include(tq => tq.TreasureItems)
-            .ThenInclude(ti => ti.Item)
-            .ToListAsync();
+        var quests = includeAssignedTreasures
+            ? await db.TreasureQuests
+                .Where(tq => tq.GameId == gameId)
+                .Include(tq => tq.TreasureItems)
+                .ThenInclude(ti => ti.Item)
+                .ToListAsync()
+            : await db.TreasureQuests
+                .Where(tq => tq.GameId == gameId)
+                .Include(tq => tq.TreasureItems)
+                .ToListAsync();
 
         var result = parentLocations.Select(loc =>
         {
@@ -328,31 +333,35 @@ public static class TreasurePlanningEndpoints
                 var sQuests = quests.Where(q => q.SecretStashId == gs.SecretStashId).ToList();
                 return new StashSummaryDto(gs.SecretStashId, gs.SecretStash.Name, sQuests.SelectMany(q => q.TreasureItems).Sum(ti => ti.Count));
             }).ToList();
-            var allAssignedTreasures = allQuests
-                .OrderBy(q => q.Difficulty)
-                .ThenBy(q => q.Title)
-                .SelectMany(q => q.TreasureItems
-                    .OrderBy(ti => ti.Item.Name)
-                    .Select(ti => new TreasurePlanningAssignedTreasureDto(
-                        ti.Id,
-                        q.Id,
-                        q.Title,
-                        q.Difficulty,
-                        ti.ItemId,
-                        ti.Item.Name,
-                        ti.Count,
-                        ItemThumbnailUrl(http, ti.ItemId, ti.Item.ImagePath))))
-                .GroupBy(ti => new { ti.QuestId, ti.Difficulty, ti.ItemId, ti.ItemName, ti.ItemThumbnailUrl })
-                .Select(g => new TreasurePlanningAssignedTreasureDto(
-                    g.Min(ti => ti.TreasureItemId),
-                    g.Key.QuestId,
-                    g.First().QuestTitle,
-                    g.Key.Difficulty,
-                    g.Key.ItemId,
-                    g.Key.ItemName,
-                    g.Sum(ti => ti.Count),
-                    g.Key.ItemThumbnailUrl))
-                .ToList();
+            List<TreasurePlanningAssignedTreasureDto> allAssignedTreasures = [];
+            if (includeAssignedTreasures)
+            {
+                allAssignedTreasures = allQuests
+                    .OrderBy(q => q.Difficulty)
+                    .ThenBy(q => q.Title)
+                    .SelectMany(q => q.TreasureItems
+                        .OrderBy(ti => ti.Item.Name)
+                        .Select(ti => new TreasurePlanningAssignedTreasureDto(
+                            ti.Id,
+                            q.Id,
+                            q.Title,
+                            q.Difficulty,
+                            ti.ItemId,
+                            ti.Item.Name,
+                            ti.Count,
+                            ItemThumbnailUrl(http, ti.ItemId, ti.Item.ImagePath))))
+                    .GroupBy(ti => new { ti.QuestId, ti.Difficulty, ti.ItemId, ti.ItemName, ti.ItemThumbnailUrl })
+                    .Select(g => new TreasurePlanningAssignedTreasureDto(
+                        g.Min(ti => ti.TreasureItemId),
+                        g.Key.QuestId,
+                        g.First().QuestTitle,
+                        g.Key.Difficulty,
+                        g.Key.ItemId,
+                        g.Key.ItemName,
+                        g.Sum(ti => ti.Count),
+                        g.Key.ItemThumbnailUrl))
+                    .ToList();
+            }
             var assignedTreasures = allAssignedTreasures.Take(4).ToList();
 
             return new TreasurePlanningLocationDto(

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -1649,28 +1649,21 @@ else
         poolRemoveError = null;
         var poolTask       = Api.GetListAsync<TreasurePoolItemDto>($"/api/treasure-planning/pool/{gameId}");
         var cardsTask      = Api.GetListAsync<TreasurePlanningLocationDto>($"/api/treasure-planning/locations/{gameId}");
-        var missingTask    = Api.GetListAsync<MissingTreasureLocationDto>($"/api/treasure-planning/missing?gameId={gameId}&threshold={MissingTreasureThreshold}");
         var locationsTask  = Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gameId}");
         var questTask      = Api.GetListAsync<TreasureQuestListDto>($"/api/treasure-quests/by-game/{gameId}");
         var summaryTask    = Api.GetAsync<TreasureSummaryDto>($"/api/treasure-planning/summary/{gameId}");
         var unlimitedTask  = Api.GetListAsync<UnlimitedItemDto>($"/api/treasure-planning/unlimited/{gameId}");
 
-        await Task.WhenAll(poolTask, cardsTask, missingTask, locationsTask, questTask, summaryTask, unlimitedTask);
+        await Task.WhenAll(poolTask, cardsTask, locationsTask, questTask, summaryTask, unlimitedTask);
 
         poolItems      = poolTask.Result;
         locationCards  = cardsTask.Result;
-        missingTreasureLocations = missingTask.Result;
+        missingTreasureLocations = BuildMissingTreasureLocations();
         locations      = locationsTask.Result;
         allQuests      = questTask.Result;
         summary        = summaryTask.Result;
         unlimitedItems = unlimitedTask.Result;
         Console.WriteLine($"[treasure-alloc] missing-view loaded gameId={gameId} threshold={MissingTreasureThreshold} matched={missingTreasureLocations.Count}");
-        LogTreasureAlloc("missing-view loaded", new
-        {
-            gameId,
-            threshold = MissingTreasureThreshold,
-            matched = missingTreasureLocations.Count
-        });
 
         // Prune selection of items that left the pool.
         var poolIds = poolItems.Select(p => p.Id).ToHashSet();
@@ -1770,6 +1763,22 @@ else
 
     private static string MissingRegionLabel(MissingTreasureLocationDto location) =>
         string.IsNullOrWhiteSpace(location.Region) ? NoRegionLabel : location.Region.Trim();
+
+    private List<MissingTreasureLocationDto> BuildMissingTreasureLocations() =>
+        locationCards
+            .Where(l => l.TotalItems < MissingTreasureThreshold)
+            .OrderBy(l => l.TotalItems)
+            .ThenBy(l => string.IsNullOrWhiteSpace(l.Region))
+            .ThenBy(GetRegionLabel)
+            .ThenBy(l => l.LocationName)
+            .Select(l => new MissingTreasureLocationDto(
+                l.LocationId,
+                l.LocationName,
+                string.IsNullOrWhiteSpace(l.Region) ? null : l.Region.Trim(),
+                l.TotalItems,
+                MissingTreasureThreshold,
+                MissingTreasureThreshold - l.TotalItems))
+            .ToList();
 
     private static string GetRegionSortKey(string region) =>
         region == NoRegionLabel ? "\uFFFF" : region;
@@ -1934,13 +1943,6 @@ else
         allocationError = null;
         quickAllocation = null;
         Console.WriteLine($"[treasure-alloc] missing-view jump locationId={location.LocationId}");
-        LogTreasureAlloc("missing-view jump", new
-        {
-            gameId,
-            locationId = location.LocationId,
-            location.LocationName,
-            threshold = MissingTreasureThreshold
-        });
 
         if (treasuresView != "cards")
         {

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -73,6 +73,40 @@ else
             </div>
         </div>
 
+        <div class="oh-tp-missing-card @(missingTreasureLocations.Count == 0 ? "complete" : "")">
+            <div class="oh-tp-missing-head">
+                <div>
+                    <h5><i class="bi bi-exclamation-diamond"></i> Lokace bez pokladů</h5>
+                    <span>Prahová hodnota: @MissingTreasureThreshold poklad</span>
+                </div>
+                <span class="oh-tp-missing-count">@missingTreasureLocations.Count</span>
+            </div>
+            @if (missingTreasureLocations.Count == 0)
+            {
+                <div class="oh-tp-missing-empty">Všechny lokace mají poklady ✓</div>
+            }
+            else
+            {
+                <div class="oh-tp-missing-list">
+                    @foreach (var loc in missingTreasureLocations)
+                    {
+                        <div class="oh-tp-missing-row" @key="loc.LocationId">
+                            <div class="oh-tp-missing-main">
+                                <strong>@loc.LocationName</strong>
+                                <span>@MissingRegionLabel(loc)</span>
+                            </div>
+                            <span class="oh-tp-missing-total">@loc.TotalItems / @loc.Threshold</span>
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-primary"
+                                    @onclick="() => JumpToMissingLocationAsync(loc)">
+                                <i class="bi bi-crosshair me-1"></i>Přiřadit poklad
+                            </button>
+                        </div>
+                    }
+                </div>
+            }
+        </div>
+
         @* ================== ZONE 2 — Workspace ================== *@
         <div class="oh-tp-workspace" @onclick="CollapseQuickAllocationStepper">
 
@@ -242,7 +276,7 @@ else
             </div>
 
             @* RIGHT: assignment panel *@
-            <div class="oh-tp-assign-panel">
+            <div class="oh-tp-assign-panel" id="oh-tp-assign-panel">
                 <div class="oh-tp-placement-phase">
                     <span class="oh-tp-placement-phase-lbl">Fáze umístění</span>
                     <div class="oh-tl-seg" role="group" aria-label="Fáze, do které se ukládají nové poklady">
@@ -928,11 +962,13 @@ else
 
 @code {
     private static readonly JsonSerializerOptions TreasureAllocLogJsonOptions = new(JsonSerializerDefaults.Web);
+    private const int MissingTreasureThreshold = 1;
     private const string NoRegionLabel = "Bez regionu";
 
     // ===== Data =====
     private List<TreasurePoolItemDto> poolItems = [];
     private List<TreasurePlanningLocationDto> locationCards = [];
+    private List<MissingTreasureLocationDto> missingTreasureLocations = [];
     private List<LocationListDto> locations = [];
     private List<TreasureQuestListDto> allQuests = [];
     private List<UnlimitedItemDto> unlimitedItems = [];
@@ -1613,19 +1649,28 @@ else
         poolRemoveError = null;
         var poolTask       = Api.GetListAsync<TreasurePoolItemDto>($"/api/treasure-planning/pool/{gameId}");
         var cardsTask      = Api.GetListAsync<TreasurePlanningLocationDto>($"/api/treasure-planning/locations/{gameId}");
+        var missingTask    = Api.GetListAsync<MissingTreasureLocationDto>($"/api/treasure-planning/missing?gameId={gameId}&threshold={MissingTreasureThreshold}");
         var locationsTask  = Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gameId}");
         var questTask      = Api.GetListAsync<TreasureQuestListDto>($"/api/treasure-quests/by-game/{gameId}");
         var summaryTask    = Api.GetAsync<TreasureSummaryDto>($"/api/treasure-planning/summary/{gameId}");
         var unlimitedTask  = Api.GetListAsync<UnlimitedItemDto>($"/api/treasure-planning/unlimited/{gameId}");
 
-        await Task.WhenAll(poolTask, cardsTask, locationsTask, questTask, summaryTask, unlimitedTask);
+        await Task.WhenAll(poolTask, cardsTask, missingTask, locationsTask, questTask, summaryTask, unlimitedTask);
 
         poolItems      = poolTask.Result;
         locationCards  = cardsTask.Result;
+        missingTreasureLocations = missingTask.Result;
         locations      = locationsTask.Result;
         allQuests      = questTask.Result;
         summary        = summaryTask.Result;
         unlimitedItems = unlimitedTask.Result;
+        Console.WriteLine($"[treasure-alloc] missing-view loaded gameId={gameId} threshold={MissingTreasureThreshold} matched={missingTreasureLocations.Count}");
+        LogTreasureAlloc("missing-view loaded", new
+        {
+            gameId,
+            threshold = MissingTreasureThreshold,
+            matched = missingTreasureLocations.Count
+        });
 
         // Prune selection of items that left the pool.
         var poolIds = poolItems.Select(p => p.Id).ToHashSet();
@@ -1721,6 +1766,9 @@ else
     }
 
     private static string GetRegionLabel(TreasurePlanningLocationDto location) =>
+        string.IsNullOrWhiteSpace(location.Region) ? NoRegionLabel : location.Region.Trim();
+
+    private static string MissingRegionLabel(MissingTreasureLocationDto location) =>
         string.IsNullOrWhiteSpace(location.Region) ? NoRegionLabel : location.Region.Trim();
 
     private static string GetRegionSortKey(string region) =>
@@ -1878,6 +1926,34 @@ else
 
     // ===== Handlers from MapView =====
     private Task HandlePieClick(int locationId) => HandleLocationTargetClick(locationId);
+
+    private async Task JumpToMissingLocationAsync(MissingTreasureLocationDto location)
+    {
+        focusedLocationId = location.LocationId;
+        focusTab = "pridat";
+        allocationError = null;
+        quickAllocation = null;
+        Console.WriteLine($"[treasure-alloc] missing-view jump locationId={location.LocationId}");
+        LogTreasureAlloc("missing-view jump", new
+        {
+            gameId,
+            locationId = location.LocationId,
+            location.LocationName,
+            threshold = MissingTreasureThreshold
+        });
+
+        if (treasuresView != "cards")
+        {
+            await SetTreasuresViewAsync("cards");
+        }
+
+        StateHasChanged();
+        try
+        {
+            await JS.InvokeVoidAsync("ovcinaDnd.scrollIntoViewById", "oh-tp-assign-panel");
+        }
+        catch { /* best-effort scroll — ignore if JS host missing */ }
+    }
 
     private async Task HandleLocationTargetClick(int locationId)
     {

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -2464,6 +2464,22 @@
 .oh-tp-pool-mini-sub{font:400 .8125rem var(--oh-font-body);color:var(--oh-text-secondary);margin-top:2px}
 .oh-tp-pool-mini-jump{margin-top:auto;font:600 .75rem var(--oh-font-body);color:var(--oh-primary-light);display:inline-flex;align-items:center;gap:4px}
 
+/* Missing treasures dashboard -------------------------------- */
+.oh-tp-missing-card{background:var(--oh-surface);border:1px solid var(--oh-card-border,var(--oh-border));border-radius:var(--oh-radius);box-shadow:var(--oh-shadow);padding:12px 14px;display:flex;flex-direction:column;gap:10px}
+.oh-tp-missing-card.complete{border-color:rgba(45,80,22,.35);background:rgba(45,80,22,.06)}
+.oh-tp-missing-head{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.oh-tp-missing-head h5{margin:0;font:700 1rem/1.2 var(--oh-font-heading);display:flex;align-items:center;gap:8px;color:var(--oh-text);letter-spacing:0}
+.oh-tp-missing-head span{font-size:.82rem;color:var(--oh-text-secondary)}
+.oh-tp-missing-count{min-width:36px;height:32px;border-radius:999px;background:#B26223;color:#fff;display:inline-flex;align-items:center;justify-content:center;font-weight:700}
+.oh-tp-missing-card.complete .oh-tp-missing-count{background:#2D5016}
+.oh-tp-missing-empty{color:#2D5016;font-weight:600}
+.oh-tp-missing-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:8px}
+.oh-tp-missing-row{display:grid;grid-template-columns:minmax(0,1fr) auto auto;gap:10px;align-items:center;padding:8px 10px;background:var(--oh-surface-alt,#F2EBD8);border:1px solid var(--oh-border);border-radius:6px}
+.oh-tp-missing-main{min-width:0;display:flex;flex-direction:column}
+.oh-tp-missing-main strong{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--oh-text)}
+.oh-tp-missing-main span{font-size:.78rem;color:var(--oh-text-secondary)}
+.oh-tp-missing-total{font:700 .82rem/1 var(--oh-font-mono);color:#7a5520;white-space:nowrap}
+
 /* Zone 2 — workspace --------------------------------------- */
 /* Zone 2 — portrait map left, assignment panel right (issue #103). */
 .oh-tp-workspace{display:grid;grid-template-columns:40fr 60fr;gap:16px;min-height:720px}
@@ -2636,6 +2652,11 @@
 @media (max-width:1100px){
     .oh-tp-pipeline{grid-template-columns:repeat(2,1fr);grid-auto-rows:auto}
     .oh-tp-workspace{grid-template-columns:1fr;min-height:auto}
+}
+
+@media (max-width:640px){
+    .oh-tp-missing-row{grid-template-columns:1fr}
+    .oh-tp-missing-row .btn{justify-self:start}
 }
 
 /* ------------------------------------------------------------

--- a/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
@@ -68,6 +68,14 @@ public record TreasurePlanningLocationDto(
     List<TreasurePlanningAssignedTreasureDto>? AssignedTreasures = null,
     int AssignedTreasureCount = 0);
 
+public record MissingTreasureLocationDto(
+    int LocationId,
+    string LocationName,
+    string? Region,
+    int TotalItems,
+    int Threshold,
+    int MissingCount);
+
 public record TreasurePlanningAssignedTreasureDto(
     int TreasureItemId,
     int QuestId,

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningMissingEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningMissingEndpointTests.cs
@@ -1,0 +1,177 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Domain.ValueObjects;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+public class TreasurePlanningMissingEndpointTests(PostgresFixture postgres)
+    : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    [Fact]
+    public async Task Missing_UsesThresholdAndExistingLocationCardRollups()
+    {
+        int gameId;
+        int fullLocationId;
+        int emptyLocationId;
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var game = CreateGame("Chybějící poklady");
+            var fullLocation = new Location
+            {
+                Name = "Starý brod",
+                LocationKind = LocationKind.Wilderness,
+                Region = "Sever"
+            };
+            var emptyLocation = new Location
+            {
+                Name = "Prázdná louka",
+                LocationKind = LocationKind.Wilderness,
+                Region = "Jih"
+            };
+            var item = CreateItem("Rubín");
+            var stash = new SecretStash { Name = "Skrýš u brodu" };
+
+            db.AddRange(game, fullLocation, emptyLocation, item, stash);
+            await db.SaveChangesAsync();
+
+            var childLocation = new Location
+            {
+                Name = "Dcera řeky",
+                LocationKind = LocationKind.Hobbit,
+                Region = "Sever",
+                ParentLocationId = fullLocation.Id
+            };
+            db.Locations.Add(childLocation);
+            await db.SaveChangesAsync();
+
+            db.GameLocations.AddRange(
+                new GameLocation { GameId = game.Id, LocationId = fullLocation.Id },
+                new GameLocation { GameId = game.Id, LocationId = childLocation.Id },
+                new GameLocation { GameId = game.Id, LocationId = emptyLocation.Id });
+            db.GameSecretStashes.Add(new GameSecretStash
+            {
+                GameId = game.Id,
+                LocationId = fullLocation.Id,
+                SecretStashId = stash.Id
+            });
+            db.TreasureQuests.AddRange(
+                CreateQuest(game.Id, "Brod", GameTimePhase.Start, item.Id, 1, locationId: fullLocation.Id),
+                CreateQuest(game.Id, "Dcera", GameTimePhase.Early, item.Id, 1, locationId: childLocation.Id),
+                CreateQuest(game.Id, "Skrýš", GameTimePhase.Midgame, item.Id, 1, secretStashId: stash.Id));
+            await db.SaveChangesAsync();
+
+            gameId = game.Id;
+            fullLocationId = fullLocation.Id;
+            emptyLocationId = emptyLocation.Id;
+        }
+
+        var missingAtTwo = await Client.GetFromJsonAsync<List<MissingTreasureLocationDto>>(
+            $"/api/treasure-planning/missing?gameId={gameId}&threshold=2");
+
+        Assert.NotNull(missingAtTwo);
+        var empty = Assert.Single(missingAtTwo!);
+        Assert.Equal(emptyLocationId, empty.LocationId);
+        Assert.Equal("Prázdná louka", empty.LocationName);
+        Assert.Equal(0, empty.TotalItems);
+        Assert.Equal(2, empty.MissingCount);
+
+        var missingAtFour = await Client.GetFromJsonAsync<List<MissingTreasureLocationDto>>(
+            $"/api/treasure-planning/missing?gameId={gameId}&threshold=4");
+
+        Assert.NotNull(missingAtFour);
+        var rolledUp = Assert.Single(missingAtFour!, l => l.LocationId == fullLocationId);
+        Assert.Equal(3, rolledUp.TotalItems);
+        Assert.Equal(1, rolledUp.MissingCount);
+    }
+
+    [Fact]
+    public async Task Missing_DefaultThresholdIsOneAndScopedToGame()
+    {
+        int gameId;
+        int otherGameLocationId;
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var game = CreateGame("První hra");
+            var otherGame = CreateGame("Druhá hra");
+            var location = new Location { Name = "Bez pokladu", LocationKind = LocationKind.Wilderness };
+            var otherLocation = new Location { Name = "Cizí lokace", LocationKind = LocationKind.Wilderness };
+
+            db.AddRange(game, otherGame, location, otherLocation);
+            await db.SaveChangesAsync();
+
+            db.GameLocations.AddRange(
+                new GameLocation { GameId = game.Id, LocationId = location.Id },
+                new GameLocation { GameId = otherGame.Id, LocationId = otherLocation.Id });
+            await db.SaveChangesAsync();
+
+            gameId = game.Id;
+            otherGameLocationId = otherLocation.Id;
+        }
+
+        var missing = await Client.GetFromJsonAsync<List<MissingTreasureLocationDto>>(
+            $"/api/treasure-planning/missing?gameId={gameId}");
+
+        Assert.NotNull(missing);
+        var row = Assert.Single(missing!);
+        Assert.Equal(1, row.Threshold);
+        Assert.DoesNotContain(missing!, l => l.LocationId == otherGameLocationId);
+    }
+
+    [Fact]
+    public async Task Missing_RejectsNegativeThreshold()
+    {
+        var response = await Client.GetAsync("/api/treasure-planning/missing?gameId=1&threshold=-1");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private static Game CreateGame(string name) => new()
+    {
+        Name = name,
+        Edition = 1,
+        StartDate = new DateOnly(2026, 5, 1),
+        EndDate = new DateOnly(2026, 5, 3)
+    };
+
+    private static Item CreateItem(string name) => new()
+    {
+        Name = name,
+        ItemType = ItemType.Potion,
+        ClassRequirements = new ClassRequirements(0, 0, 0, 0)
+    };
+
+    private static TreasureQuest CreateQuest(
+        int gameId,
+        string title,
+        GameTimePhase difficulty,
+        int itemId,
+        int count,
+        int? locationId = null,
+        int? secretStashId = null) => new()
+        {
+            Title = title,
+            Difficulty = difficulty,
+            GameId = gameId,
+            LocationId = locationId,
+            SecretStashId = secretStashId,
+            TreasureItems =
+            [
+                new TreasureItem
+                {
+                    ItemId = itemId,
+                    GameId = gameId,
+                    Count = count
+                }
+            ]
+        };
+}


### PR DESCRIPTION
## Summary
- add `GET /api/treasure-planning/missing?gameId=&threshold=` using existing treasure location rollups
- add `/treasures` card `Lokace bez pokladů` with count, empty state, and jump-to-allocation action
- cover default threshold, game scoping, threshold filtering, child/stash rollup, and negative threshold validation

## Verification
- `dotnet restore OvcinaHra.slnx`
- `dotnet build OvcinaHra.slnx --no-restore --verbosity minimal`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter TreasurePlanningMissingEndpointTests --no-build --verbosity minimal`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --verbosity minimal`
- scoped `dotnet format --verify-no-changes` on touched C# files

closes #484