### PR TITLE
feat(world-activity): wire QuestCompleted + LevelUpReverted into audit log (closes #502) [v0.17.12]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
@@ -341,7 +342,12 @@ public static class QuestEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Results<NoContent, NotFound, BadRequest<string>>> UpdateState(int id, UpdateQuestStateDto dto, WorldDbContext db)
+    private static async Task<Results<NoContent, NotFound, BadRequest<string>>> UpdateState(
+        int id,
+        UpdateQuestStateDto dto,
+        WorldDbContext db,
+        HttpContext httpContext,
+        ILoggerFactory loggerFactory)
     {
         var q = await db.Quests.FindAsync(id);
         if (q is null) return TypedResults.NotFound();
@@ -349,9 +355,60 @@ public static class QuestEndpoints
         if (!Enum.IsDefined(dto.State))
             return TypedResults.BadRequest($"Unknown state '{dto.State}'.");
 
+        var previousState = q.State;
         q.State = dto.State;
         await db.SaveChangesAsync();
+
+        if (dto.State == QuestState.Completed && previousState != QuestState.Completed)
+            await MirrorQuestCompletedAsync(db, q, httpContext, loggerFactory);
+
         return TypedResults.NoContent();
+    }
+
+    private static async Task MirrorQuestCompletedAsync(
+        WorldDbContext db,
+        Quest quest,
+        HttpContext httpContext,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.WorldActivityMirror");
+        if (quest.GameId is not { } gameId || !await db.Games.AnyAsync(g => g.Id == gameId))
+        {
+            logger.LogInformation(
+                "[world-activity-mirror] quest-completed questId={QuestId} gameId={GameId} skipped-no-game=true",
+                quest.Id,
+                quest.GameId);
+            return;
+        }
+
+        logger.LogInformation(
+            "[world-activity-mirror] quest-completed questId={QuestId} gameId={GameId} skipped-no-game=false",
+            quest.Id,
+            gameId);
+
+        try
+        {
+            var organizer = GetOrganizer(httpContext.User);
+            db.WorldActivities.Add(new WorldActivity
+            {
+                GameId = gameId,
+                TimestampUtc = DateTime.UtcNow,
+                OrganizerUserId = organizer.UserId,
+                OrganizerName = organizer.Name,
+                ActivityType = WorldActivityType.QuestCompleted,
+                Description = $"Splněn úkol: {quest.Name}",
+                QuestId = quest.Id,
+                DataJson = "{}"
+            });
+            await db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "[world-activity-mirror] quest-completed audit-failed questId={QuestId} gameId={GameId}",
+                quest.Id,
+                gameId);
+        }
     }
 
     private static async Task<Results<NoContent, NotFound>> Delete(int id, WorldDbContext db)
@@ -615,5 +672,16 @@ public static class QuestEndpoints
 
         await tx.CommitAsync();
         return TypedResults.NoContent();
+    }
+
+    private static (string UserId, string Name) GetOrganizer(ClaimsPrincipal user)
+    {
+        var userId = user.FindFirstValue("sub")
+            ?? user.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? "unknown";
+        var name = user.FindFirstValue("name")
+            ?? user.FindFirstValue(ClaimTypes.Name)
+            ?? "Unknown";
+        return (userId, name);
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -192,9 +192,10 @@ public static class ScanEndpoints
     }
 
     private static async Task<IResult> DeleteLastLevelUp(
-        int personId, WorldDbContext db, HttpContext httpContext)
+        int personId, WorldDbContext db, HttpContext httpContext, ILoggerFactory loggerFactory)
     {
         var assignment = await db.CharacterAssignments
+            .Include(a => a.Character)
             .Include(a => a.Events)
             .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
 
@@ -234,6 +235,44 @@ public static class ScanEndpoints
         db.CharacterEvents.Add(audit);
         TrackIdempotency(db, assignment.Id, idempotencyKey, audit);
         await db.SaveChangesAsync();
+
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.WorldActivityMirror");
+        if (!await db.Games.AnyAsync(g => g.Id == assignment.GameId))
+        {
+            logger.LogInformation(
+                "[world-activity-mirror] level-reverted assignmentId={AssignmentId} gameId={GameId} skipped-no-game=true",
+                assignment.Id,
+                assignment.GameId);
+        }
+        else
+        {
+            logger.LogInformation(
+                "[world-activity-mirror] level-reverted assignmentId={AssignmentId} gameId={GameId} skipped-no-game=false",
+                assignment.Id,
+                assignment.GameId);
+            try
+            {
+                db.WorldActivities.Add(new WorldActivity
+                {
+                    GameId = assignment.GameId,
+                    TimestampUtc = audit.Timestamp,
+                    OrganizerUserId = organizer.UserId,
+                    OrganizerName = organizer.Name,
+                    ActivityType = WorldActivityType.CharacterLevelReverted,
+                    Description = $"{assignment.Character.Name} – vrácena úroveň",
+                    CharacterAssignmentId = assignment.Id,
+                    DataJson = audit.Data
+                });
+                await db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "[world-activity-mirror] level-reverted audit-failed assignmentId={AssignmentId} gameId={GameId}",
+                    assignment.Id,
+                    assignment.GameId);
+            }
+        }
 
         return TypedResults.Ok(ToDto(audit));
     }

--- a/src/OvcinaHra.Client/Components/WorldActivityTable.razor
+++ b/src/OvcinaHra.Client/Components/WorldActivityTable.razor
@@ -163,6 +163,7 @@
         WorldActivityType.LocationPlaced => "Umístění lokace",
         WorldActivityType.CharacterLevelUp => "Postup postavy",
         WorldActivityType.QuestCompleted => "Dokončený quest",
+        WorldActivityType.CharacterLevelReverted => "Vrácená úroveň",
         _ => "Aktivita"
     };
 
@@ -171,6 +172,7 @@
         WorldActivityType.LocationPlaced => "bi-geo-alt-fill",
         WorldActivityType.CharacterLevelUp => "bi-stars",
         WorldActivityType.QuestCompleted => "bi-patch-check-fill",
+        WorldActivityType.CharacterLevelReverted => "bi-arrow-counterclockwise",
         _ => "bi-circle"
     };
 
@@ -179,6 +181,7 @@
         WorldActivityType.LocationPlaced => "location",
         WorldActivityType.CharacterLevelUp => "levelup",
         WorldActivityType.QuestCompleted => "quest",
+        WorldActivityType.CharacterLevelReverted => "reverted",
         _ => "default"
     };
 

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3557,6 +3557,7 @@
 .oh-world-activity-badge--location{background:rgba(45,80,22,.1);color:#2D5016}
 .oh-world-activity-badge--levelup{background:rgba(193,154,58,.18);color:#7a5520}
 .oh-world-activity-badge--quest{background:rgba(139,30,63,.1);color:#8B1E3F}
+.oh-world-activity-badge--reverted{background:rgba(107,100,83,.18);color:#5a5642}
 .oh-world-activity-badge--default{background:rgba(0,0,0,.06);color:var(--oh-text,#2a2a2a)}
 .oh-world-activity-desc{color:var(--oh-text,#2a2a2a)}
 a.oh-world-activity-desc{text-decoration:none;border-bottom:1px dotted rgba(0,0,0,.25)}

--- a/src/OvcinaHra.Shared/Domain/Enums/WorldActivityType.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/WorldActivityType.cs
@@ -7,5 +7,6 @@ public enum WorldActivityType
 {
     LocationPlaced = 0,
     CharacterLevelUp = 1,
-    QuestCompleted = 2
+    QuestCompleted = 2,
+    CharacterLevelReverted = 3
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/QuestPhase1Tests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/QuestPhase1Tests.cs
@@ -1,5 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
@@ -85,6 +88,35 @@ public class QuestPhase1Tests(PostgresFixture postgres) : IntegrationTestBase(po
         Assert.Equal(HttpStatusCode.NoContent, r3.StatusCode);
         var afterRevert = await Client.GetFromJsonAsync<QuestDetailDto>($"/api/quests/{created.Id}");
         Assert.Equal(QuestState.Inactive, afterRevert!.State);
+    }
+
+    [Fact]
+    public async Task PatchState_TransitionToCompleted_WritesWorldActivityMirrorOnce()
+    {
+        var gameResponse = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Quest audit", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        var game = await gameResponse.Content.ReadFromJsonAsync<GameDetailDto>();
+
+        var createResponse = await Client.PostAsJsonAsync("/api/quests",
+            new CreateQuestDto("Najít prsten", QuestType.General, game!.Id));
+        var created = await createResponse.Content.ReadFromJsonAsync<QuestListDto>();
+
+        var first = await Client.PatchAsJsonAsync($"/api/quests/{created!.Id}/state",
+            new UpdateQuestStateDto(QuestState.Completed));
+        var second = await Client.PatchAsJsonAsync($"/api/quests/{created.Id}/state",
+            new UpdateQuestStateDto(QuestState.Completed));
+
+        Assert.Equal(HttpStatusCode.NoContent, first.StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, second.StatusCode);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var row = await db.WorldActivities.SingleAsync(a =>
+            a.GameId == game.Id && a.ActivityType == WorldActivityType.QuestCompleted);
+
+        Assert.Equal(created.Id, row.QuestId);
+        Assert.Equal("Splněn úkol: Najít prsten", row.Description);
+        Assert.Equal("Test Organizátor", row.OrganizerName);
     }
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
@@ -234,6 +234,28 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
     }
 
     [Fact]
+    public async Task DeleteLastLevelUp_WithRealGame_WritesWorldActivityMirror()
+    {
+        var game = await CreateGameAsync("Scan revert mirror");
+        await SeedCharacterWithAssignment(externalPersonId: 115, gameId: game.Id);
+        await Client.PostAsJsonAsync("/api/scan/115/events",
+            new CreateCharacterEventDto(CharacterEventType.LevelUp, "{}"));
+
+        var response = await Client.DeleteAsync("/api/scan/115/events/last-levelup");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var row = await db.WorldActivities.SingleAsync(a =>
+            a.GameId == game.Id && a.ActivityType == WorldActivityType.CharacterLevelReverted);
+
+        Assert.Equal("Thorin – vrácena úroveň", row.Description);
+        Assert.Equal("Test Organizátor", row.OrganizerName);
+        Assert.NotNull(row.CharacterAssignmentId);
+    }
+
+    [Fact]
     public async Task DeleteLastLevelUp_WhenNoLevelUp_ReturnsNotFound()
     {
         await SeedCharacterWithAssignment(externalPersonId: 106);


### PR DESCRIPTION
Closes #502

## Summary
- Add `WorldActivityType.CharacterLevelReverted` and cockpit table label/icon/badge tone.
- Mirror `DeleteLastLevelUp` into `WorldActivity` as `CharacterLevelReverted` with best-effort pre-check + try/catch + separate save.
- Mirror quest transitions into `QuestState.Completed` as `QuestCompleted`, only on transition and not on no-op writes.
- Add `[world-activity-mirror]` markers for written/skipped/failed mirror paths.

## Verification
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --logger "console;verbosity=minimal"`
- `dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include <changed C# files>`

## Notes
- Main uses `QuestState.Completed` rather than `QuestState.Done`; the mirror triggers on transition into `Completed`.
- No EF migration: `WorldActivity.ActivityType` is string-converted and has no enum check constraint.
