### PR TITLE
fix(ui): wrap quests toolbar at tablet portrait

### DIFF
--- a/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
+++ b/src/OvcinaHra.Client/Pages/Quests/QuestList.razor
@@ -8,9 +8,9 @@
 @using OvcinaHra.Shared.Domain.Enums
 @using OvcinaHra.Shared.Extensions
 
-<div class="d-flex justify-content-between align-items-center mb-3">
+<div class="oh-qst-page-head mb-3">
     <h1 class="mb-0">Katalog questů</h1>
-    <div class="d-flex gap-2 align-items-center">
+    <div class="oh-qst-page-actions">
         @* Mode toggle: Catalog (templates) ↔ Per-game grid. Per-game lives at
            /games/{gid}/quests so this is just a navigation jump, not a query
            flag. *@

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3611,6 +3611,21 @@ a.oh-world-activity-desc:hover{color:#2D5016;border-bottom-color:#2D5016}
  * parchment (Inactive) / forest (Active) / dim-gold (Completed).
  * =========================================================================== */
 
+/* — Catalog header toolbar — */
+.oh-qst-page-head{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+.oh-qst-page-actions{display:flex;align-items:center;justify-content:flex-end;gap:8px;flex-wrap:wrap;min-width:0}
+
+@media (max-width:768px){
+    .oh-qst-page-head{align-items:flex-start}
+    .oh-qst-page-actions{width:100%;justify-content:flex-start}
+}
+
+@media (max-width:420px){
+    .oh-qst-page-actions .oh-segmented{display:flex;width:100%}
+    .oh-qst-page-actions .oh-segmented-btn{flex:1 1 0;justify-content:center;padding-inline:8px}
+    .oh-qst-page-actions .btn{width:100%;justify-content:center}
+}
+
 /* — Filters above the gallery — */
 .oh-qst-filters{display:flex;gap:12px;align-items:center;flex-wrap:wrap;
     padding:10px 12px;background:#FFF8F0;border:1px solid #ead9b8;border-radius:8px}


### PR DESCRIPTION
## Summary
- Scope the `/quests` catalog header to quest-specific classes.
- Allow the title/action toolbar to wrap at tablet portrait and stack cleanly on narrow phones.
- Keep the fix out of shared toolbar/grid components; no shared toolbar component was touched.

## Verification
- Static layout smoke: quest header/action classes and responsive wrap CSS present for 375/390/768/1024/1280 coverage intent.
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test OvcinaHra.slnx --no-build`

Closes #496