### PR TITLE
Contain mobile grid overflow

### DIFF
--- a/src/OvcinaHra.Client/Components/OvcinaGrid.razor
+++ b/src/OvcinaHra.Client/Components/OvcinaGrid.razor
@@ -26,37 +26,39 @@
    anything, the property stays null and DevExpress falls back to its stock
    "No data" text — no behavior change for the read-only grids that
    haven't opted in yet. *@
-<DxGrid @ref="Grid"
-        Data="@Data"
-        KeyFieldName="@KeyFieldName"
-        SelectionMode="@SelectionMode"
-        AllowSelectRowByClick="@(EditMode != GridEditMode.EditCell)"
-        SelectedDataItems="@SelectedDataItems"
-        SelectedDataItemsChanged="@SelectedDataItemsChanged"
-        RowClick="@RowClick"
-        RowDoubleClick="@RowDoubleClick"
-        ShowGroupPanel="@ShowGroupPanel"
-        VirtualScrollingEnabled="true"
-        ColumnResizeMode="GridColumnResizeMode.NextColumn"
-        TextWrapEnabled="@TextWrapEnabled"
-        AutoExpandAllGroupRows="@AutoExpandAllGroupRows"
-        CustomizeElement="@OnCustomizeElement"
-        CssClass="@($"ovcina-grid {CssClass}")"
-        ContextMenus="GridContextMenus.Header"
-        ShowSearchBox="@ShowSearchBox"
-        SearchText="@SearchText"
-        SearchTextChanged="@SearchTextChanged"
-        FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
-        EditMode="@(EditMode ?? GridEditMode.PopupEditForm)"
-        EditModelSaving="@EditModelSaving"
-        CustomizeEditModel="@CustomizeEditModel"
-        EmptyDataAreaTemplate="@EmptyDataAreaTemplate"
-        LayoutAutoLoading="OnLayoutLoading"
-        LayoutAutoSaving="OnLayoutSaving">
-    <Columns>
-        @Columns
-    </Columns>
-</DxGrid>
+<div class="ovcina-grid-scroll">
+    <DxGrid @ref="Grid"
+            Data="@Data"
+            KeyFieldName="@KeyFieldName"
+            SelectionMode="@SelectionMode"
+            AllowSelectRowByClick="@(EditMode != GridEditMode.EditCell)"
+            SelectedDataItems="@SelectedDataItems"
+            SelectedDataItemsChanged="@SelectedDataItemsChanged"
+            RowClick="@RowClick"
+            RowDoubleClick="@RowDoubleClick"
+            ShowGroupPanel="@ShowGroupPanel"
+            VirtualScrollingEnabled="true"
+            ColumnResizeMode="GridColumnResizeMode.NextColumn"
+            TextWrapEnabled="@TextWrapEnabled"
+            AutoExpandAllGroupRows="@AutoExpandAllGroupRows"
+            CustomizeElement="@OnCustomizeElement"
+            CssClass="@($"ovcina-grid {CssClass}")"
+            ContextMenus="GridContextMenus.Header"
+            ShowSearchBox="@ShowSearchBox"
+            SearchText="@SearchText"
+            SearchTextChanged="@SearchTextChanged"
+            FilterMenuButtonDisplayMode="GridFilterMenuButtonDisplayMode.Always"
+            EditMode="@(EditMode ?? GridEditMode.PopupEditForm)"
+            EditModelSaving="@EditModelSaving"
+            CustomizeEditModel="@CustomizeEditModel"
+            EmptyDataAreaTemplate="@EmptyDataAreaTemplate"
+            LayoutAutoLoading="OnLayoutLoading"
+            LayoutAutoSaving="OnLayoutSaving">
+        <Columns>
+            @Columns
+        </Columns>
+    </DxGrid>
+</div>
 
 @if (!string.IsNullOrEmpty(LayoutKey))
 {

--- a/src/OvcinaHra.Client/Components/OvcinaGrid.razor.css
+++ b/src/OvcinaHra.Client/Components/OvcinaGrid.razor.css
@@ -6,6 +6,18 @@
     height: 100%;
 }
 
+.ovcina-grid-scroll {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.ovcina-grid-scroll ::deep .ovcina-grid {
+    min-width: 100%;
+}
+
 .ovcina-grid-tools {
     display: flex;
     justify-content: flex-end;

--- a/src/OvcinaHra.Client/Layout/MainLayout.razor.css
+++ b/src/OvcinaHra.Client/Layout/MainLayout.razor.css
@@ -7,6 +7,7 @@
 
 main {
     flex: 1;
+    min-width: 0;
     background-color: var(--oh-surface-alt);
 }
 
@@ -24,6 +25,11 @@ main {
     height: 3.5rem;
     display: flex;
     align-items: center;
+    min-width: 0;
+}
+
+article {
+    min-width: 0;
 }
 
     .top-row ::deep a, .top-row ::deep .btn-link {

--- a/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor.css
+++ b/src/OvcinaHra.Client/Pages/OrganizerRoles/OrganizerRoleMatrix.razor.css
@@ -28,6 +28,7 @@
     gap: 12px;
     align-items: end;
     margin-bottom: 16px;
+    min-width: 0;
 }
 
 .oh-orgrole-filters label,
@@ -35,6 +36,7 @@
     display: grid;
     gap: 4px;
     font-weight: 600;
+    min-width: 0;
 }
 
 .oh-orgrole-view-buttons {
@@ -94,7 +96,11 @@
 }
 
 .oh-orgrole-matrix-wrap {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
     overflow: auto;
+    -webkit-overflow-scrolling: touch;
     border: 1px solid var(--bs-border-color);
     max-height: calc(100vh - 260px);
     background: var(--bs-body-bg);
@@ -286,6 +292,12 @@
     color: #6f4e00;
     font-size: 0.72rem;
     font-weight: 700;
+}
+
+@media (max-width: 1100px) {
+    .oh-orgrole-filters {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    }
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- contain shared `OvcinaGrid` instances in a horizontal scroll wrapper so wide DevExpress grids stop widening the page
- add `min-width: 0` to the main layout flex/content containers so page-level layout can shrink before grid wrappers scroll
- harden organizer-role matrix/filter layout with the same containment pattern

## LayoutKey
No LayoutKey bumps: this PR does not add, remove, rename, or reorder grid columns.

## Verification
- `git diff --check`
- `dotnet build OvcinaHra.slnx --no-restore --verbosity minimal`
- focused Playwright smoke: `/dovednosti/sifry`, `/games`, `/organizer-roles`, `/skills`, `/spells` at 768 portrait, 1024 landscape, and 375 mobile; no page-level horizontal scrollbar; grid filter control click verified

Closes #491
Closes #492
Closes #495
Closes #497
Closes #498