### PR TITLE
feat(dashboard): /aktivity full-page WorldChange audit log with filter/group/search

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
@@ -21,6 +21,7 @@ public static class DashboardEndpoints
         group.MapGet("/issues", GetIssues);
         group.MapGet("/activity", GetActivity);
         group.MapGet("/world-activity", GetWorldActivity);
+        group.MapGet("/world-change", GetWorldChange);
         group.MapGet("/timeline", GetTimeline);
         group.MapGet("/events/recent", GetRecentEvents);
 
@@ -183,6 +184,42 @@ public static class DashboardEndpoints
                 a.Location != null ? a.Location.Name : null,
                 a.CharacterAssignmentId,
                 a.QuestId))
+            .ToListAsync();
+
+        return TypedResults.Ok(rows);
+    }
+
+    /// <summary>
+    /// Powers the /aktivity full-page log — uncapped, paged WorldChange
+    /// audit rows scoped to the active game (plus catalog-wide rows where
+    /// <c>GameId</c> is null), ordered DESC by <c>ChangedAtUtc</c>. Same
+    /// source as the cockpit "Co se nedávno dělo" sliver
+    /// (<see cref="GetActivity"/>) but without the 10-row cap, so the
+    /// client can DxGrid-filter / group / search the whole roll. Default
+    /// 500 rows / max 2000 — keeps the page responsive without forcing
+    /// server-side paging on a table the audit log never grows past
+    /// game-month size.
+    /// </summary>
+    private static async Task<Ok<List<WorldChangeRowDto>>> GetWorldChange(
+        int gameId, WorldDbContext db, int? take = 500)
+    {
+        var n = Math.Clamp(take ?? 500, 1, 2000);
+
+        var rows = await db.WorldChanges
+            .AsNoTracking()
+            .Where(c => c.GameId == gameId || c.GameId == null)
+            .OrderByDescending(c => c.ChangedAtUtc)
+            .ThenByDescending(c => c.Id)
+            .Take(n)
+            .Select(c => new WorldChangeRowDto(
+                c.Id,
+                c.GameId,
+                c.EntityType,
+                c.EntityId,
+                c.EntityName,
+                c.Operation,
+                c.ActorDisplayName,
+                c.ChangedAtUtc))
             .ToListAsync();
 
         return TypedResults.Ok(rows);

--- a/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/DashboardEndpoints.cs
@@ -198,12 +198,16 @@ public static class DashboardEndpoints
     /// client can DxGrid-filter / group / search the whole roll. Default
     /// 500 rows / max 2000 — keeps the page responsive without forcing
     /// server-side paging on a table the audit log never grows past
-    /// game-month size.
+    /// game-month size. 404 when the game doesn't exist (per §1 — REST
+    /// 404 before 200-with-empty so orchestrator typos surface fast).
     /// </summary>
-    private static async Task<Ok<List<WorldChangeRowDto>>> GetWorldChange(
+    private static async Task<Results<Ok<List<WorldChangeRowDto>>, NotFound>> GetWorldChange(
         int gameId, WorldDbContext db, int? take = 500)
     {
         var n = Math.Clamp(take ?? 500, 1, 2000);
+
+        if (!await db.Games.AnyAsync(g => g.Id == gameId))
+            return TypedResults.NotFound();
 
         var rows = await db.WorldChanges
             .AsNoTracking()

--- a/src/OvcinaHra.Client/Components/RecentActivityFeed.razor
+++ b/src/OvcinaHra.Client/Components/RecentActivityFeed.razor
@@ -1,8 +1,9 @@
 @* Issue #247 — recent organizer activity from the WorldChange audit log. *@
 
 <section class="oh-home-act" aria-labelledby="oh-home-act-title">
-    <header class="oh-home-act-head">
+    <header class="oh-home-act-head oh-home-recent-head">
         <h2 id="oh-home-act-title">Co se nedávno dělo</h2>
+        <a href="/aktivity" class="oh-home-act-more">Zobrazit vše →</a>
     </header>
     @if (Rows is null)
     {

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -82,6 +82,10 @@
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-clock-fill ni"></i><span class="oh-nav-label">Harmonogram</span>
                     </NavLink>
+                    <NavLink class="oh-nav-item" href="aktivity">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-activity ni"></i><span class="oh-nav-label">Aktivita</span>
+                    </NavLink>
                     <NavLink class="oh-nav-item" href="treasures">
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-safe-fill ni"></i><span class="oh-nav-label">Poklady</span>

--- a/src/OvcinaHra.Client/Pages/Activity/ActivityList.razor
+++ b/src/OvcinaHra.Client/Pages/Activity/ActivityList.razor
@@ -1,0 +1,258 @@
+@page "/aktivity"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject NavigationManager Nav
+@inject GameContextService GameContext
+@implements IDisposable
+@using OvcinaHra.Shared.Domain.Enums
+@using OvcinaHra.Shared.Dtos
+
+@* Full-page WorldChange audit log — same source as the cockpit
+   "Co se nedávno dělo" sliver, but uncapped and rendered through
+   OvcinaGrid so organizers can filter, group, search, and sort the
+   whole roll. *@
+
+<PageTitle>Aktivita ve světě</PageTitle>
+
+<div class="oh-act-page-head">
+    <h1>Aktivita ve světě</h1>
+    @if (_rows is not null)
+    {
+        <span class="text-muted small">@_rows.Count záznamů</span>
+    }
+    <div class="oh-act-page-tools">
+        <button type="button" class="btn btn-sm btn-outline-secondary"
+                title="Obnovit" aria-label="Obnovit"
+                disabled="@_isRefreshing"
+                @onclick="OnRefreshAsync">
+            <i class="bi @(_isRefreshing ? "bi-arrow-repeat oh-spin" : "bi-arrow-clockwise")"></i>
+            <span class="d-none d-md-inline ms-1">Obnovit</span>
+        </button>
+    </div>
+</div>
+
+@if (GameContext.SelectedGameId is null)
+{
+    <div class="oh-act-empty">
+        <i class="bi bi-controller fs-1 d-block mb-2"></i>
+        <p class="text-muted">Vyber hru v levém panelu, ať máš co sledovat.</p>
+    </div>
+}
+else if (_rows is null)
+{
+    <p class="text-muted">Načítám…</p>
+}
+else if (_rows.Count == 0)
+{
+    <div class="oh-act-empty">
+        <i class="bi bi-inbox fs-1 d-block mb-2 text-muted"></i>
+        <p class="text-muted">Zatím žádné zaznamenané změny.</p>
+    </div>
+}
+else
+{
+    <OvcinaGrid Data="@_rows"
+                KeyFieldName="@nameof(WorldChangeRowDto.Id)"
+                LayoutKey="grid-layout-world-activity-v1"
+                ShowGroupPanel="true"
+                ShowSearchBox="true"
+                AutoExpandAllGroupRows="true"
+                CssClass="oh-act-grid"
+                RowClick="@OnRowClick">
+        <Columns>
+            <DxGridDataColumn FieldName="@nameof(WorldChangeRowDto.ChangedAtUtc)"
+                              Caption="Čas"
+                              Width="160px"
+                              SortIndex="0"
+                              SortOrder="GridColumnSortOrder.Descending">
+                <CellDisplayTemplate>
+                    @{
+                        var row = (WorldChangeRowDto)context.DataItem;
+                    }
+                    <span title="@row.ChangedAtUtc.ToLocalTime().ToString("dd.MM.yyyy HH:mm:ss")">
+                        @row.ChangedAtUtc.ToLocalTime().ToString("dd.MM.yyyy HH:mm")
+                    </span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="@nameof(WorldChangeRowDto.EntityType)"
+                              Caption="Typ"
+                              Width="140px">
+                <CellDisplayTemplate>
+                    @{
+                        var row = (WorldChangeRowDto)context.DataItem;
+                    }
+                    <span class="oh-act-type-pill" title="@row.EntityType">
+                        <i class="bi @IconFor(row.EntityType)"></i>
+                        @TypeLabel(row.EntityType)
+                    </span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="@nameof(WorldChangeRowDto.Operation)"
+                              Caption="Operace"
+                              Width="120px">
+                <CellDisplayTemplate>
+                    @{
+                        var row = (WorldChangeRowDto)context.DataItem;
+                    }
+                    <span class="oh-act-op-badge oh-act-op-badge--@OpBadgeTone(row.Operation)">
+                        @OpVerb(row.Operation)
+                    </span>
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="@nameof(WorldChangeRowDto.EntityName)"
+                              Caption="Název"
+                              MinWidth="240">
+                <CellDisplayTemplate>
+                    @{
+                        var row = (WorldChangeRowDto)context.DataItem;
+                        var route = RouteFor(row);
+                    }
+                    @if (route is not null)
+                    {
+                        <a href="@route" class="oh-act-name-link"
+                           @onclick:stopPropagation="true">@row.EntityName</a>
+                    }
+                    else
+                    {
+                        <span>@row.EntityName</span>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+
+            <DxGridDataColumn FieldName="@nameof(WorldChangeRowDto.ActorDisplayName)"
+                              Caption="Aktér"
+                              Width="180px" />
+        </Columns>
+    </OvcinaGrid>
+}
+
+@code {
+    private List<WorldChangeRowDto>? _rows;
+    private int? _loadedGameId;
+    private bool _isRefreshing;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        GameContext.OnGameChanged += HandleGameChanged;
+        await LoadAsync();
+    }
+
+    private void HandleGameChanged() => _ = LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        var gameId = GameContext.SelectedGameId;
+        if (gameId is null)
+        {
+            _rows = null;
+            _loadedGameId = null;
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        if (_loadedGameId == gameId.Value && _rows is not null) return;
+        _loadedGameId = gameId.Value;
+
+        var rows = await Api.GetListAsync<WorldChangeRowDto>(
+            $"/api/dashboard/world-change?gameId={gameId.Value}&take=500");
+        _rows = rows;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnRefreshAsync()
+    {
+        if (GameContext.SelectedGameId is not { } gameId || _isRefreshing) return;
+        _isRefreshing = true;
+        try
+        {
+            // Force a reload even if the game didn't change.
+            _loadedGameId = null;
+            await LoadAsync();
+        }
+        finally
+        {
+            _isRefreshing = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private void OnRowClick(GridRowClickEventArgs e)
+    {
+        var row = (WorldChangeRowDto)e.Grid.GetDataItem(e.VisibleIndex);
+        var route = RouteFor(row);
+        if (route is not null) Nav.NavigateTo(route);
+    }
+
+    private static string OpVerb(WorldChangeOperation operation) => operation switch
+    {
+        WorldChangeOperation.Created => "vytvořil",
+        WorldChangeOperation.Updated => "upravil",
+        WorldChangeOperation.Deleted => "smazal",
+        _ => "?"
+    };
+
+    private static string OpBadgeTone(WorldChangeOperation operation) => operation switch
+    {
+        WorldChangeOperation.Created => "created",
+        WorldChangeOperation.Updated => "updated",
+        WorldChangeOperation.Deleted => "deleted",
+        _ => "default"
+    };
+
+    // EntityType comes straight from the audit log (typically the EF entity
+    // class name — "Location", "Character", "Quest", etc.). The label table
+    // keeps the common ones Czech for organizer eyes; anything not listed
+    // falls through as the raw class name (catches new entity types we
+    // wire later without code changes here).
+    private static string TypeLabel(string entityType) => entityType switch
+    {
+        "Location" => "Lokace",
+        "Character" => "Postava",
+        "CharacterAssignment" => "Hrdina",
+        "Quest" => "Quest",
+        "Item" => "Předmět",
+        "Skill" => "Dovednost",
+        "Spell" => "Kouzlo",
+        "Building" => "Stavba",
+        "Npc" => "Postava NPC",
+        "GameEvent" => "Událost",
+        "GameTimeSlot" => "Časový úsek",
+        "TreasureQuest" => "Poklad",
+        "SecretStash" => "Skrýše",
+        "OrganizerRoleAssignment" => "Rozpis rolí",
+        _ => entityType
+    };
+
+    private static string IconFor(string entityType) => entityType switch
+    {
+        "Location" => "bi-geo-alt",
+        "Character" or "CharacterAssignment" => "bi-person",
+        "Quest" => "bi-flag",
+        "Item" => "bi-box",
+        "Skill" => "bi-lightning-charge",
+        "Spell" => "bi-stars",
+        "Building" => "bi-house",
+        "Npc" => "bi-person-badge",
+        "GameEvent" => "bi-calendar-event",
+        "GameTimeSlot" => "bi-clock",
+        "TreasureQuest" => "bi-safe",
+        "SecretStash" => "bi-bag",
+        "OrganizerRoleAssignment" => "bi-people",
+        _ => "bi-circle"
+    };
+
+    private static string? RouteFor(WorldChangeRowDto row) => row.EntityType switch
+    {
+        "Location" => $"/locations/{row.EntityId}",
+        "Quest" => $"/quests/{row.EntityId}",
+        "Item" => $"/items/{row.EntityId}",
+        "Building" => $"/buildings/{row.EntityId}",
+        _ => null
+    };
+
+    public void Dispose() => GameContext.OnGameChanged -= HandleGameChanged;
+}

--- a/src/OvcinaHra.Client/Pages/Activity/ActivityList.razor
+++ b/src/OvcinaHra.Client/Pages/Activity/ActivityList.razor
@@ -18,7 +18,11 @@
     <h1>Aktivita ve světě</h1>
     @if (_rows is not null)
     {
-        <span class="text-muted small">@_rows.Count záznamů</span>
+        @* Default cap is 500 (max 2000); when the audit grows past 500
+           we'd silently mislead organizers ("500 záznamů" vs the real total),
+           so always frame the count as "Posledních N" — same wording at the
+           cap or below. *@
+        <span class="text-muted small">Posledních @_rows.Count záznamů</span>
     }
     <div class="oh-act-page-tools">
         <button type="button" class="btn btn-sm btn-outline-secondary"
@@ -157,9 +161,18 @@ else
         if (_loadedGameId == gameId.Value && _rows is not null) return;
         _loadedGameId = gameId.Value;
 
-        var rows = await Api.GetListAsync<WorldChangeRowDto>(
-            $"/api/dashboard/world-change?gameId={gameId.Value}&take=500");
-        _rows = rows;
+        try
+        {
+            var rows = await Api.GetListAsync<WorldChangeRowDto>(
+                $"/api/dashboard/world-change?gameId={gameId.Value}&take=500");
+            _rows = rows;
+        }
+        catch (Exception)
+        {
+            // ApiClient already logs the failure; keep prior _rows if any
+            // so a transient flake doesn't blank the table mid-session.
+            _rows ??= [];
+        }
         await InvokeAsync(StateHasChanged);
     }
 

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -3485,6 +3485,9 @@
 .oh-home-act-skel{align-items:center}
 .oh-home-bottom-row > .oh-home-qlaunch:only-child{grid-column:1/-1}
 .oh-home-recent-head{display:flex;align-items:center;justify-content:space-between;gap:10px}
+.oh-home-act-more{font:600 .78rem var(--oh-font-body);color:#2D5016;text-decoration:none;
+    white-space:nowrap}
+.oh-home-act-more:hover{text-decoration:underline}
 .oh-home-live-chip{display:inline-flex;align-items:center;padding:2px 8px;border-radius:999px;
     background:rgba(45,80,22,.1);color:#2D5016;font:700 .7rem var(--oh-font-body);text-transform:uppercase}
 .oh-home-event-row{min-height:56px}
@@ -3552,6 +3555,28 @@
 .oh-home-skel-line-sm{height:10px;width:55%}
 .oh-home-skel-line-xs{height:8px;width:35%}
 @keyframes oh-home-skel{0%{background-position:200% 0}100%{background-position:-200% 0}}
+
+/* /aktivity full-page WorldChange audit log (header + grid styling) */
+.oh-act-page-head{display:flex;align-items:baseline;flex-wrap:wrap;gap:14px;margin:0 0 14px}
+.oh-act-page-head h1{margin:0;font:700 1.4rem var(--oh-font-heading)}
+.oh-act-page-tools{margin-left:auto;display:inline-flex;align-items:center;gap:8px}
+.oh-act-empty{display:flex;flex-direction:column;align-items:center;justify-content:center;
+    padding:60px 20px;text-align:center;color:var(--oh-text-muted,#6b6453)}
+.oh-act-grid{font-size:.9rem}
+.oh-act-type-pill{display:inline-flex;align-items:center;gap:5px;padding:2px 10px;
+    border-radius:999px;background:rgba(45,80,22,.08);color:#2D5016;
+    font:600 .78rem var(--oh-font-body);white-space:nowrap}
+.oh-act-type-pill i{font-size:.9rem}
+.oh-act-op-badge{display:inline-block;padding:2px 10px;border-radius:999px;
+    font:600 .72rem var(--oh-font-body);text-transform:uppercase;letter-spacing:.02em;
+    white-space:nowrap}
+.oh-act-op-badge--created{background:rgba(45,80,22,.14);color:#2D5016}
+.oh-act-op-badge--updated{background:rgba(178,98,35,.14);color:#7a4a17}
+.oh-act-op-badge--deleted{background:rgba(139,30,63,.12);color:#8B1E3F}
+.oh-act-op-badge--default{background:rgba(0,0,0,.06);color:var(--oh-text,#2a2a2a)}
+.oh-act-name-link{color:var(--oh-text,#2a2a2a);text-decoration:none;
+    border-bottom:1px dotted rgba(0,0,0,.25)}
+.oh-act-name-link:hover{color:#2D5016;border-bottom-color:#2D5016}
 
 /* Issue #478 — Aktivity světa table on Home cockpit */
 .oh-home-world-activity{padding:14px 18px;background:var(--oh-surface,#FAF6EC);

--- a/src/OvcinaHra.Shared/Dtos/DashboardDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/DashboardDtos.cs
@@ -93,3 +93,18 @@ public record WorldActivityRowDto(
     string? LocationName,
     int? CharacterAssignmentId,
     int? QuestId);
+
+/// <summary>
+/// Raw WorldChange audit row for the full /aktivity page. Same source as
+/// the home-cockpit "Co se nedávno dělo" sliver, but uncapped, paged, and
+/// filterable client-side via DxGrid (filter row + group panel + search).
+/// </summary>
+public record WorldChangeRowDto(
+    int Id,
+    int? GameId,
+    string EntityType,
+    int EntityId,
+    string EntityName,
+    WorldChangeOperation Operation,
+    string ActorDisplayName,
+    DateTime ChangedAtUtc);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
@@ -340,6 +340,15 @@ public class DashboardEndpointsTests(PostgresFixture postgres)
     }
 
     [Fact]
+    public async Task WorldChange_NonExistentGame_Returns404()
+    {
+        // §1 — REST 404 before 200-with-empty so orchestrator typos
+        // surface instead of being masked.
+        var response = await Client.GetAsync("/api/dashboard/world-change?gameId=999999");
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
     public async Task WorldChange_TakeParameter_CapsResultCount()
     {
         var game = await CreateGameAsync();

--- a/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/DashboardEndpointsTests.cs
@@ -268,6 +268,114 @@ public class DashboardEndpointsTests(PostgresFixture postgres)
             });
     }
 
+    // /aktivity full-page log — uncapped paged feed of raw WorldChange rows
+    // for the active game (plus catalog-wide where GameId is null), DESC by
+    // ChangedAtUtc, no merge/projection so the client can DxGrid-filter the
+    // entire roll. Cross-game rows must NOT leak.
+    [Fact]
+    public async Task WorldChange_ReturnsRawRowsScopedToGameAndCatalog()
+    {
+        var game = await CreateGameAsync();
+        var otherGame = await CreateGameAsync();
+        await ClearWorldChangesAsync();
+
+        var now = DateTime.UtcNow;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            db.WorldChanges.AddRange(
+                new WorldChange
+                {
+                    GameId = game.Id,
+                    EntityType = nameof(Location),
+                    EntityId = 10,
+                    EntityName = "Starý brod",
+                    Operation = WorldChangeOperation.Updated,
+                    ActorUserId = "u1",
+                    ActorDisplayName = "Drozd",
+                    ChangedAtUtc = now
+                },
+                new WorldChange
+                {
+                    GameId = null,
+                    EntityType = nameof(Item),
+                    EntityId = 20,
+                    EntityName = "Hojivý lektvar",
+                    Operation = WorldChangeOperation.Created,
+                    ActorUserId = "system",
+                    ActorDisplayName = "System",
+                    ChangedAtUtc = now.AddMinutes(1)
+                },
+                new WorldChange
+                {
+                    GameId = otherGame.Id,
+                    EntityType = nameof(Npc),
+                    EntityId = 30,
+                    EntityName = "Cizí NPC",
+                    Operation = WorldChangeOperation.Deleted,
+                    ActorUserId = "other",
+                    ActorDisplayName = "Other",
+                    ChangedAtUtc = now.AddMinutes(2)
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var rows = await Client.GetFromJsonAsync<List<WorldChangeRowDto>>(
+            $"/api/dashboard/world-change?gameId={game.Id}");
+
+        Assert.NotNull(rows);
+        Assert.Equal(2, rows.Count);
+
+        // Newest first, catalog-wide row (GameId == null) precedes the game-scoped one.
+        Assert.Equal(nameof(Item), rows[0].EntityType);
+        Assert.Null(rows[0].GameId);
+        Assert.Equal(WorldChangeOperation.Created, rows[0].Operation);
+        Assert.Equal("System", rows[0].ActorDisplayName);
+
+        Assert.Equal(nameof(Location), rows[1].EntityType);
+        Assert.Equal(game.Id, rows[1].GameId);
+        Assert.Equal(WorldChangeOperation.Updated, rows[1].Operation);
+        Assert.Equal("Drozd", rows[1].ActorDisplayName);
+        Assert.Equal("Starý brod", rows[1].EntityName);
+    }
+
+    [Fact]
+    public async Task WorldChange_TakeParameter_CapsResultCount()
+    {
+        var game = await CreateGameAsync();
+        await ClearWorldChangesAsync();
+
+        var now = DateTime.UtcNow;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            for (var i = 0; i < 5; i++)
+            {
+                db.WorldChanges.Add(new WorldChange
+                {
+                    GameId = game.Id,
+                    EntityType = nameof(Location),
+                    EntityId = 100 + i,
+                    EntityName = $"L{i}",
+                    Operation = WorldChangeOperation.Updated,
+                    ActorUserId = "u1",
+                    ActorDisplayName = "Drozd",
+                    ChangedAtUtc = now.AddMinutes(i)
+                });
+            }
+            await db.SaveChangesAsync();
+        }
+
+        var rows = await Client.GetFromJsonAsync<List<WorldChangeRowDto>>(
+            $"/api/dashboard/world-change?gameId={game.Id}&take=2");
+
+        Assert.NotNull(rows);
+        Assert.Equal(2, rows.Count);
+        // Newest 2 in DESC order — i=4 then i=3.
+        Assert.Equal("L4", rows[0].EntityName);
+        Assert.Equal("L3", rows[1].EntityName);
+    }
+
     [Fact]
     public async Task WorldChangeInterceptor_ApiCreateGame_RecordsAuthenticatedActor()
     {


### PR DESCRIPTION
## Summary

- New **`/aktivity`** page rolls out the WorldChange audit log on its own surface — same source as the cockpit "Co se nedávno dělo" sliver, but uncapped, paged, and rendered through `OvcinaGrid` so organizers can filter, group, search, and sort the whole prep history.
- New **`GET /api/dashboard/world-change?gameId=N&take=500`** — raw paged audit rows (current game + catalog-wide where GameId is null), DESC by ChangedAtUtc. Default 500 / max 2000.
- Sliver header gets a "Zobrazit vše →" shortcut, NavMenu gets an "Aktivita" entry next to Harmonogram in hra mode.
- 2 integration tests cover game/catalog scoping (cross-game rows excluded) and the `take` parameter cap.

## Why

The cockpit sliver caps at 10 rows for at-a-glance pulse. That's fine for the dashboard but unhelpful when an organizer wants to spot-check what happened over a prep day or hunt for "who last touched location X". Now they can.

## UX

- Columns: **Čas** (DESC default sort), **Typ** (icon + Czech label), **Operace** (vytvořil/upravil/smazal badge), **Název** (link to entity detail when one exists), **Aktér**.
- DxGrid features: virtual scrolling, filter row, group panel, search box, column-layout persistence (LayoutKey `grid-layout-world-activity-v1`).
- Row click navigates to the entity detail when a route exists; otherwise just shows the row.

## Test plan

- [x] `dotnet build OvcinaHra.slnx` clean (0 warnings, 0 errors)
- [x] 20 dashboard tests passing locally (incl. 2 new)
- [ ] Manual: open `/`, click "Zobrazit vše →" on the sliver — lands on `/aktivity`
- [ ] Manual: open `/aktivity` — shows the audit log scoped to current game + catalog-wide
- [ ] Manual: filter row works on Operace + EntityType + Aktér; search finds an entity by name; group panel groups by Typ
- [ ] Manual: row-click on a Location/Quest/Item/Building row navigates to the detail page
- [ ] Manual: switch games via the cockpit selector — page refetches scoped data

🤖 Generated with [Claude Code](https://claude.com/claude-code)