### PR TITLE
fix(npcs): hide linked organizers in assign popup with toggle + ✓ marker

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/NpcEndpoints.cs
@@ -31,13 +31,36 @@ public static class NpcEndpoints
         return group;
     }
 
-    private static async Task<Results<Ok<List<RegistraceAdultDto>>, ProblemHttpResult>> GetAvailablePlayers(
-        int gameId, RegistraceImportService registrace, CancellationToken ct)
+    private static async Task<Results<Ok<List<NpcAdultPickerItemDto>>, ProblemHttpResult>> GetAvailablePlayers(
+        int gameId, RegistraceImportService registrace, WorldDbContext db, CancellationToken ct)
     {
         try
         {
             var adults = await registrace.FetchAdultsAsync(gameId, ct);
-            return TypedResults.Ok(adults);
+
+            // Set of registrace PersonIds that already play an NPC in this
+            // game — drives the picker's ✓ marker + "Skrýt obsazené" toggle.
+            // Distinct because the same adult could in theory hold multiple
+            // NPC roles, but for the picker view one match is enough.
+            var assigned = await db.GameNpcs
+                .Where(gn => gn.GameId == gameId && gn.PlayedByPersonId != null)
+                .Select(gn => gn.PlayedByPersonId!.Value)
+                .Distinct()
+                .ToListAsync(ct);
+            var assignedSet = assigned.ToHashSet();
+
+            var items = adults
+                .Select(a => new NpcAdultPickerItemDto(
+                    a.PersonId,
+                    a.FirstName,
+                    a.LastName,
+                    a.BirthYear,
+                    a.Email,
+                    a.Roles,
+                    assignedSet.Contains(a.PersonId)))
+                .ToList();
+
+            return TypedResults.Ok(items);
         }
         catch (GameNotFoundException)
         {

--- a/src/OvcinaHra.Client/Pages/Npcs/NpcList.razor
+++ b/src/OvcinaHra.Client/Pages/Npcs/NpcList.razor
@@ -194,11 +194,28 @@ else
         else
         {
             <DxFormLayout>
+                <DxFormLayoutItem Caption="" ColSpanMd="12">
+                    <label class="oh-npc-assign-toggle">
+                        <input type="checkbox" @bind="hideOccupiedAdults" />
+                        <span>Skrýt obsazené organizátory</span>
+                    </label>
+                </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Hráč" ColSpanMd="12">
-                    <DxComboBox Data="@availableAdults" @bind-Value="@selectedAdultPersonId"
+                    <DxComboBox Data="@displayedAdults" @bind-Value="@selectedAdultPersonId"
                                 TextFieldName="Display" ValueFieldName="PersonId"
                                 NullText="(vyberte dospělého hráče)"
-                                SearchMode="ListSearchMode.AutoSearch" />
+                                SearchMode="ListSearchMode.AutoSearch">
+                        <ItemTemplate Context="adult">
+                            <span class="oh-npc-adult-row">
+                                @if (adult.HasNpcLinked)
+                                {
+                                    <i class="bi bi-check-circle-fill oh-npc-adult-row__check"
+                                       title="Tento organizátor už má přiřazené NPC"></i>
+                                }
+                                <span>@adult.Display</span>
+                            </span>
+                        </ItemTemplate>
+                    </DxComboBox>
                 </DxFormLayoutItem>
                 <DxFormLayoutItem Caption="Poznámky" ColSpanMd="12">
                     <DxMemo @bind-Text="@assignNotes" Rows="2" />
@@ -258,7 +275,16 @@ else
     private List<AdultPickerItem> availableAdults = [];
     private int? selectedAdultPersonId;
 
-    private record AdultPickerItem(int PersonId, string FirstName, string LastName, string? Email, string Display);
+    private record AdultPickerItem(int PersonId, string FirstName, string LastName, string? Email, string Display, bool HasNpcLinked);
+
+    // "Skrýt obsazené organizátory" — defaults true so the picker only shows
+    // adults free to take a new NPC role; flipping it off shows everyone with
+    // a ✓ on the rows that already have an NPC linked in this game.
+    private bool hideOccupiedAdults = true;
+
+    private List<AdultPickerItem> displayedAdults => hideOccupiedAdults
+        ? availableAdults.Where(a => !a.HasNpcLinked).ToList()
+        : availableAdults;
 
     private bool _previousCatalog;
 
@@ -366,6 +392,9 @@ else
         selectedAdultPersonId = null;
         assignError = null;
         adultsLoadError = null;
+        // Reset the "Skrýt obsazené" toggle to its default each time so a
+        // previous picker session's state doesn't bleed into a fresh assign.
+        hideOccupiedAdults = true;
         isAssignVisible = true;
         _ = LoadAvailableAdultsAsync();
     }
@@ -386,12 +415,13 @@ else
 
         try
         {
-            var adults = await Api.GetListAsync<RegistraceAdultDto>($"/api/npcs/available-players/{gid}");
+            var adults = await Api.GetListAsync<NpcAdultPickerItemDto>($"/api/npcs/available-players/{gid}");
             availableAdults = adults
                 .OrderBy(a => a.LastName).ThenBy(a => a.FirstName)
                 .Select(a => new AdultPickerItem(
                     a.PersonId, a.FirstName, a.LastName, a.Email,
-                    BuildAdultDisplay(a)))
+                    BuildAdultDisplay(a),
+                    a.HasNpcLinked))
                 .ToList();
         }
         catch (Exception ex)
@@ -406,7 +436,7 @@ else
         }
     }
 
-    private static string BuildAdultDisplay(RegistraceAdultDto a)
+    private static string BuildAdultDisplay(NpcAdultPickerItemDto a)
     {
         var name = $"{a.FirstName} {a.LastName}".Trim();
         return a.Roles is { Count: > 0 } ? $"{name} — {string.Join(", ", a.Roles)}" : name;

--- a/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
+++ b/src/OvcinaHra.Client/wwwroot/css/ovcinahra-theme.css
@@ -4504,3 +4504,10 @@ body.oh-map-print-labeled .oh-map-pin .oh-map-pin-label.oh-map-pin-label-with-re
 .oh-cipher-error{border-left:3px solid #842029;background:#f8d7da;color:#842029;border-radius:3px;padding:8px 10px;font-size:.88rem}
 .oh-cipher-actions{display:flex;justify-content:flex-end;gap:8px;flex-wrap:wrap}
 @media (max-width:720px){.oh-cipher-panel-head{align-items:flex-start;flex-direction:column}.oh-cipher-actions{justify-content:flex-start}}
+
+/* Assign-NPC popup — "Skrýt obsazené" toggle + ✓ marker on already-linked adults */
+.oh-npc-assign-toggle{display:inline-flex;align-items:center;gap:6px;cursor:pointer;
+    font:500 .88rem var(--oh-font-body)}
+.oh-npc-assign-toggle input[type=checkbox]{margin:0}
+.oh-npc-adult-row{display:inline-flex;align-items:center;gap:6px}
+.oh-npc-adult-row__check{color:#2D5016;font-size:1rem}

--- a/src/OvcinaHra.Shared/Dtos/NpcDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/NpcDtos.cs
@@ -55,3 +55,16 @@ public record RegistraceAdultDto(
     int? BirthYear,
     string? Email,
     List<string>? Roles);
+
+// NPC-picker view of a registrace adult — same fields as
+// <see cref="RegistraceAdultDto"/> plus <c>HasNpcLinked</c>, true when the
+// adult is already assigned to at least one GameNpc in this game. Drives the
+// "Skrýt obsazené" toggle + ✓ marker in the assign-NPC popup.
+public record NpcAdultPickerItemDto(
+    int PersonId,
+    string FirstName,
+    string LastName,
+    int? BirthYear,
+    string? Email,
+    List<string>? Roles,
+    bool HasNpcLinked);


### PR DESCRIPTION
## Summary

Quick hotfix for the catalog→game NPC assign popup: easy to double-assign an organizer because the picker showed everyone, including adults already playing another NPC.

- **Server**: `GET /api/npcs/available-players/{gameId}` now returns `NpcAdultPickerItemDto` with a new `HasNpcLinked` boolean — true when the adult is already `PlayedByPersonId` of any `GameNpc` in this game. One distinct join query, no N+1.
- **Client**: new "Skrýt obsazené organizátory" toggle in the assign popup, **default ON** — picker shows only free organizers. Off → everyone with a green ✓ on rows already linked. Resets to ON each time the popup reopens.

## Test plan

- [x] `dotnet build OvcinaHra.slnx` clean (0 warnings)
- [ ] Manual: NPC catalog → "Přidat" on an unassigned NPC → popup opens with toggle ON
- [ ] Verify dropdown contains only free organizers
- [ ] Toggle OFF → already-linked organizers reappear with green ✓ next to their name
- [ ] Pick a free organizer + Přiřadit → assignment persists
- [ ] Reopen popup on a different NPC → toggle is back ON

🤖 Generated with [Claude Code](https://claude.com/claude-code)