### PR TITLE
feat(treasures): unload placed treasures back to pool [v0.17.2]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/TreasurePlanningEndpoints.cs
@@ -34,6 +34,7 @@ public static class TreasurePlanningEndpoints
 
         // Summary
         group.MapGet("/summary/{gameId:int}", GetSummary);
+        group.MapPost("/unload/{gameId:int}", UnloadTreasures);
 
         // Available items for pool (with remaining stock)
         group.MapGet("/available-items/{gameId:int}", GetAvailableItems);
@@ -346,6 +347,27 @@ public static class TreasurePlanningEndpoints
             CountByDifficulty(GameTimePhase.Early),
             CountByDifficulty(GameTimePhase.Midgame),
             CountByDifficulty(GameTimePhase.Lategame)));
+    }
+
+    private static async Task<Ok<UnloadTreasuresResponse>> UnloadTreasures(int gameId, WorldDbContext db)
+    {
+        var quests = await db.TreasureQuests
+            .Where(tq => tq.GameId == gameId)
+            .Include(tq => tq.TreasureItems)
+            .ToListAsync();
+
+        var treasureItems = quests.SelectMany(tq => tq.TreasureItems).ToList();
+        var itemsReturned = treasureItems.Sum(ti => ti.Count);
+
+        foreach (var item in treasureItems)
+        {
+            item.TreasureQuestId = null;
+        }
+
+        db.TreasureQuests.RemoveRange(quests);
+        await db.SaveChangesAsync();
+
+        return TypedResults.Ok(new UnloadTreasuresResponse(quests.Count, itemsReturned));
     }
 
     private static async Task<Results<Created<TreasureQuestDetailDto>, ValidationProblem>> AssignTreasure(

--- a/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
+++ b/src/OvcinaHra.Client/Pages/Treasures/TreasurePlanning.razor
@@ -23,6 +23,13 @@
             @if (_isLoadingPreview) { <span class="spinner-border spinner-border-sm me-1"></span> }
             <i class="bi bi-arrow-down-circle me-1"></i> Doplnit vše zbývající k schování do zásobníku
         </button>
+        <button class="btn btn-outline-danger btn-sm" type="button"
+                @onclick="() => isUnloadConfirmVisible = true"
+                disabled="@(isUnloading || (summary?.Placed ?? 0) == 0)"
+                title="Vrátí všechny umístěné poklady zpět do zásobníku.">
+            @if (isUnloading) { <span class="spinner-border spinner-border-sm me-1"></span> }
+            <i class="bi bi-box-arrow-in-down me-1"></i> Vrátit umístěné poklady
+        </button>
         <button class="btn btn-primary btn-sm" type="button" @onclick="OpenAddToPoolModal">
             <i class="bi bi-plus-circle me-1"></i> Přidat do zásobníku
         </button>
@@ -881,6 +888,24 @@ else
     </BodyContentTemplate>
 </DxPopup>
 
+<DxPopup @bind-Visible="@isUnloadConfirmVisible" HeaderText="Vrátit poklady do zásobníku?" Width="460px">
+    <BodyContentTemplate Context="popupContext">
+        <p>
+            Opravdu vrátit všech <strong>@(summary?.Placed ?? 0)</strong> umístěných předmětů zpět do zásobníku?
+            Umístěné poklady se smažou.
+        </p>
+        <div class="d-flex gap-2 justify-content-end">
+            <button class="btn btn-secondary" type="button"
+                    @onclick="() => isUnloadConfirmVisible = false" disabled="@isUnloading">Zrušit</button>
+            <button class="btn btn-danger" type="button"
+                    @onclick="UnloadTreasuresAsync" disabled="@isUnloading">
+                @if (isUnloading) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                Vrátit
+            </button>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
 @* Result banner — rendered after the API call returns. Dismissible via the
    button. Shows over-allocated items as a follow-up note. *@
 @if (_refillResult is not null)
@@ -923,6 +948,25 @@ else
         <i class="bi bi-wifi-off"></i>
         <span>Doplnění se nepodařilo: @_refillError</span>
         <button type="button" class="btn-close ms-auto" aria-label="Zavřít" @onclick="() => _refillError = null"></button>
+    </div>
+}
+@if (_unloadResult is not null)
+{
+    <div class="alert alert-success d-flex align-items-start gap-2 mt-2">
+        <i class="bi bi-check2-circle fs-5"></i>
+        <div class="flex-fill">
+            <strong>Vráceno @_unloadResult.ItemsReturned předmětů do zásobníku.</strong>
+            <div class="small text-muted">Smazáno @_unloadResult.QuestsRemoved umístěných pokladů.</div>
+        </div>
+        <button type="button" class="btn-close" aria-label="Zavřít" @onclick="() => _unloadResult = null"></button>
+    </div>
+}
+@if (_unloadError is not null)
+{
+    <div class="alert alert-danger d-flex align-items-center gap-2 mt-2">
+        <i class="bi bi-wifi-off"></i>
+        <span>Vrácení pokladů se nepodařilo: @_unloadError</span>
+        <button type="button" class="btn-close ms-auto" aria-label="Zavřít" @onclick="() => _unloadError = null"></button>
     </div>
 }
 
@@ -1499,6 +1543,10 @@ else
     private RefillPoolResponse? _refillPreview;
     private RefillPoolResponse? _refillResult;
     private string? _refillError;
+    private bool isUnloadConfirmVisible;
+    private bool isUnloading;
+    private UnloadTreasuresResponse? _unloadResult;
+    private string? _unloadError;
     private int? poolItemId;
     private int poolItemCount = 1;
     private string? poolError;
@@ -1595,6 +1643,8 @@ else
         treasuresRegionFilter = null;
         quickAllocation = null;
         allocationError = null;
+        _unloadResult = null;
+        _unloadError = null;
         await LoadAllAsync();
         await PlaceMarkersIfReadyAsync();
         StateHasChanged();
@@ -2509,6 +2559,37 @@ else
             isRefillConfirmVisible = false;
             isRefilling = false;
             _refillPreview = null;
+            StateHasChanged();
+        }
+    }
+
+    private async Task UnloadTreasuresAsync()
+    {
+        _unloadError = null;
+        _unloadResult = null;
+        isUnloading = true;
+        try
+        {
+            var (ok, value, problem) = await Api.PostWithProblemAsync<object, UnloadTreasuresResponse>(
+                $"/api/treasure-planning/unload/{gameId}",
+                new { });
+            if (!ok)
+            {
+                _unloadError = problem ?? "Server odmítl požadavek bez podrobností.";
+            }
+            else
+            {
+                _unloadResult = value;
+                selectedPool.Clear();
+                CancelCompositeBundle();
+                await LoadAllAsync();
+            }
+        }
+        catch (Exception ex) { _unloadError = ex.Message; }
+        finally
+        {
+            isUnloadConfirmVisible = false;
+            isUnloading = false;
             StateHasChanged();
         }
     }

--- a/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/TreasureQuestDtos.cs
@@ -95,6 +95,8 @@ public record TreasureSummaryDto(
     int PoolRemaining, int Placed,
     int StartCount, int EarlyCount, int MidgameCount, int LategameCount);
 
+public record UnloadTreasuresResponse(int QuestsRemoved, int ItemsReturned);
+
 public record UnlimitedItemDto(int ItemId, string ItemName, ItemType ItemType);
 
 public record AvailablePoolItemDto(int ItemId, string DisplayName, int Remaining, int StockCount);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/TreasurePlanningPoolEndpointTests.cs
@@ -439,6 +439,50 @@ public class TreasurePlanningPoolEndpointTests(PostgresFixture postgres) : Integ
     }
 
     [Fact]
+    public async Task UnloadTreasures_ReturnsPlacedTreasureToPoolAndDeletesQuests()
+    {
+        var game = await CreateGameAsync();
+        var location = await CreateLocationAsync();
+        var stash = await CreateSecretStashAsync("Truhla u pařezu");
+        await AssignStashToGameAsync(game.Id, stash.Id, location.Id);
+        var item = await CreateItemAsync("Bronz");
+        await AssignItemToGameAsync(game.Id, item.Id);
+        var pool = await AddPoolItemAsync(game.Id, item.Id, count: 5);
+
+        var locationAssign = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto("Poklad venku", GameTimePhase.Early, game.Id,
+                LocationId: location.Id,
+                PoolItems: [new PoolItemAssignDto(pool.Id, 2)]));
+        locationAssign.EnsureSuccessStatusCode();
+
+        var stashAssign = await Client.PostAsJsonAsync("/api/treasure-planning/assign",
+            new AssignTreasureDto("Poklad ve skrýši", GameTimePhase.Midgame, game.Id,
+                SecretStashId: stash.Id,
+                PoolItems: [new PoolItemAssignDto(pool.Id, 1)]));
+        stashAssign.EnsureSuccessStatusCode();
+
+        var response = await Client.PostAsync($"/api/treasure-planning/unload/{game.Id}", null);
+        response.EnsureSuccessStatusCode();
+
+        var result = (await response.Content.ReadFromJsonAsync<UnloadTreasuresResponse>())!;
+        Assert.Equal(2, result.QuestsRemoved);
+        Assert.Equal(3, result.ItemsReturned);
+
+        var quests = await Client.GetFromJsonAsync<List<TreasureQuestListDto>>(
+            $"/api/treasure-quests/by-game/{game.Id}");
+        Assert.Empty(quests!);
+
+        var poolAfter = await Client.GetFromJsonAsync<List<TreasurePoolItemDto>>(
+            $"/api/treasure-planning/pool/{game.Id}");
+        Assert.Equal(5, poolAfter!.Where(p => p.ItemId == item.Id).Sum(p => p.Count));
+
+        var summaryAfter = await Client.GetFromJsonAsync<TreasureSummaryDto>(
+            $"/api/treasure-planning/summary/{game.Id}");
+        Assert.Equal(0, summaryAfter!.Placed);
+        Assert.Equal(5, summaryAfter.PoolRemaining);
+    }
+
+    [Fact]
     public async Task RemoveFromPool_NonExistentRow_ReturnsNotFound()
     {
         var response = await Client.DeleteAsync("/api/treasure-planning/pool/999999");


### PR DESCRIPTION
## Summary
- Add `POST /api/treasure-planning/unload/{gameId}` to remove placed treasure quests and return their items to the pool.
- Add a `/treasures` confirmation action and result/error banners.
- Cover location + secret-stash unload behavior with integration tests.

## Verification
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter TreasurePlanningPoolEndpointTests --logger "console;verbosity=minimal"`
- `dotnet build OvcinaHra.slnx --no-restore`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --no-build --logger "console;verbosity=minimal"`