### PR TITLE
fix(librarian-export): vertical-centre all cell text, not just phase

### DIFF
--- a/src/OvcinaHra.Api/Services/LibrarianTreasureExportService.cs
+++ b/src/OvcinaHra.Api/Services/LibrarianTreasureExportService.cs
@@ -417,7 +417,11 @@ public sealed class LibrarianTreasureExportService(
         var lines = WrapText(text, font, width, maxLines);
         var lineHeight = font.Size * 1.2f;
         var totalHeight = lines.Count * lineHeight;
-        var startY = center ? y + Math.Max(0, (height - totalHeight) / 2) : y;
+        // Issue #507 follow-up — always vertical-centre within the cell,
+        // regardless of the horizontal `center` flag. With the strip grown
+        // to 295 px, top-aligned text left a lot of empty space at the
+        // bottom of every Obsah / Skrýše / Razítko cell.
+        var startY = y + Math.Max(0, (height - totalHeight) / 2);
 
         for (var i = 0; i < lines.Count; i++)
         {


### PR DESCRIPTION
## Summary

One-line fixup on PR #514. Previous follow-up only centred the phase cell (special-cased via `DrawCentered`); the other cells (Obsah pokladu, Skrýše/Lokace, Razítko) still routed through `DrawWrappedText` which top-aligned the text and left a visible gap at the bottom of every cell on the now-295 px tall strip.

`DrawWrappedText` now always vertical-centres within the cell; horizontal centring stays gated on the existing `center` flag (still only the phase cell uses it).

Single line behaviour change, no API.

## Test plan

- [x] `dotnet build` clean
- [ ] After deploy re-export Knihovník PDF for game 30 → text in every cell sits in the vertical centre, not glued to the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)