### PR TITLE
feat(scan): MonsterVictory/MonsterDefeat + last-note/last-combat undo (#518)

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -21,6 +21,7 @@ public static class ScanEndpoints
         group.MapGet("/{personId:int}", GetCharacterProfile);
         group.MapPost("/{personId:int}/events", PostEvent);
         group.MapDelete("/{personId:int}/events/last-levelup", DeleteLastLevelUp);
+        group.MapDelete("/{personId:int}/events/last-note", DeleteLastNote);
         group.MapGet("/{personId:int}/events", GetRecentEvents);
         group.MapGet("/{personId:int}/treasure-quests/pending", GetPendingTreasureQuests);
         group.MapPost("/{personId:int}/treasure-quests/{questId:int}/verify", VerifyTreasureQuest);
@@ -288,6 +289,33 @@ public static class ScanEndpoints
         }
 
         return TypedResults.Ok(ToDto(audit));
+    }
+
+    /// <summary>
+    /// Glejt monster-combat (#518) — undo the most recent Note event on a
+    /// hero. Mirrors the regular-mode "Vrátit poznámku" affordance. No
+    /// monster-role gating: any signed-in organizer who can hit
+    /// <c>/api/scan/*</c> may undo, matching the existing
+    /// <see cref="DeleteLastLevelUp"/> permission model.
+    /// </summary>
+    private static async Task<Results<NoContent, NotFound>> DeleteLastNote(
+        int personId, WorldDbContext db)
+    {
+        var assignment = await db.CharacterAssignments
+            .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
+        if (assignment is null) return TypedResults.NotFound();
+
+        var lastNote = await db.CharacterEvents
+            .Where(e => e.CharacterAssignmentId == assignment.Id
+                && e.EventType == CharacterEventType.Note)
+            .OrderByDescending(e => e.Timestamp)
+            .ThenByDescending(e => e.Id)
+            .FirstOrDefaultAsync();
+        if (lastNote is null) return TypedResults.NotFound();
+
+        db.CharacterEvents.Remove(lastNote);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
     }
 
     private static async Task<Results<Ok<List<CharacterEventDto>>, NotFound>> GetRecentEvents(

--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -99,6 +99,19 @@ public static class ScanEndpoints
         if (!IsValidIdempotencyKey(idempotencyKey))
             return SaveFailed("Hlavička X-Idempotency-Key je příliš dlouhá.");
 
+        // Glejt monster-combat (#518) — MonsterVictory/MonsterDefeat are gated
+        // by an active OrganizerRoleAssignment for the caller's email on an
+        // NPC with Role == Monster, where the slot covers now ± 15 min. The
+        // payload's monsterNpcId is the load-bearing identifier; monsterName
+        // is trusted from the client (see design doc §"Identity of the
+        // monster"). Any other event type falls through to the existing
+        // any-organizer flow.
+        if (dto.EventType is CharacterEventType.MonsterVictory or CharacterEventType.MonsterDefeat)
+        {
+            var monsterAuth = await AuthorizeMonsterEventAsync(dto, assignment.GameId, httpContext, db);
+            if (monsterAuth is { } denied) return denied;
+        }
+
         var organizer = GetOrganizer(httpContext);
 
         string eventData = dto.Data;
@@ -495,5 +508,82 @@ public static class ScanEndpoints
         return (
             user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier) ?? "unknown",
             user.FindFirstValue("name") ?? user.FindFirstValue(ClaimTypes.Name) ?? "Unknown");
+    }
+
+    /// <summary>
+    /// Verifies the caller is currently playing the monster NPC referenced in
+    /// the payload. Returns a 403 result on any failure, or <c>null</c> when
+    /// authorization passes. Buffer is ±15 min around the slot's window per
+    /// the Glejt monster-combat design.
+    /// </summary>
+    private static async Task<IResult?> AuthorizeMonsterEventAsync(
+        CreateCharacterEventDto dto,
+        int gameId,
+        HttpContext httpContext,
+        WorldDbContext db)
+    {
+        const int bufferMinutes = 15;
+
+        var callerEmail = httpContext.User.FindFirstValue(ClaimTypes.Email)
+            ?? httpContext.User.FindFirstValue("email");
+        if (string.IsNullOrWhiteSpace(callerEmail))
+        {
+            return TypedResults.Problem(
+                title: "Souboj s nestvůrou nelze zapsat",
+                detail: "Token bez emailu — nelze ověřit monster roli.",
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        int? monsterNpcId = TryReadMonsterNpcId(dto.Data);
+        if (monsterNpcId is null)
+        {
+            return TypedResults.Problem(
+                title: "Souboj s nestvůrou nelze zapsat",
+                detail: "Payload musí obsahovat číselné monsterNpcId.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var nowUtc = DateTime.UtcNow;
+        var leadingEdge = nowUtc.AddMinutes(bufferMinutes);  // slot must start ≤ this
+        var trailingEdge = nowUtc.AddMinutes(-bufferMinutes); // slot must end ≥ this
+        var callerEmailUpper = callerEmail.ToUpperInvariant();
+
+        var hasActiveRole = await db.OrganizerRoleAssignments
+            .AsNoTracking()
+            .Where(a => a.GameId == gameId
+                && a.NpcId == monsterNpcId.Value
+                && a.PersonEmail != null
+                && a.PersonEmail.ToUpper() == callerEmailUpper
+                && a.Npc.Role == NpcRole.Monster
+                && a.TimeSlot.StartTime <= leadingEdge
+                && a.TimeSlot.StartTime + a.TimeSlot.Duration >= trailingEdge)
+            .AnyAsync();
+
+        if (!hasActiveRole)
+        {
+            return TypedResults.Problem(
+                title: "Souboj s nestvůrou nelze zapsat",
+                detail: "Nemáš v tuto chvíli aktivní monster roli pro tuto nestvůru.",
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        return null;
+    }
+
+    private static int? TryReadMonsterNpcId(string data)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(data);
+            return doc.RootElement.TryGetProperty("monsterNpcId", out var v)
+                && v.ValueKind == JsonValueKind.Number
+                && v.TryGetInt32(out var id)
+                    ? id
+                    : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -95,31 +95,26 @@ public static class ScanEndpoints
 
         if (assignment is null) return TypedResults.NotFound();
 
-        var idempotencyKey = GetIdempotencyKey(httpContext);
-        // Idempotency keys are scoped to (assignmentId, key) and are trusted to
-        // be unique per caller — Glejt always generates Guid.NewGuid() per tap,
-        // so collision across organizers is essentially impossible. NOTE: this
-        // replay check runs BEFORE the monster-auth gate below, so a key
-        // collision across two callers WOULD replay the original caller's
-        // monster-combat response without re-running auth. Keep keys per-caller
-        // unique (Guids) to preserve that invariant.
-        if (await TryGetIdempotentEventAsync(db, assignment.Id, idempotencyKey) is { } replay)
-            return TypedResults.Ok(replay);
-        if (!IsValidIdempotencyKey(idempotencyKey))
-            return SaveFailed("Hlavička X-Idempotency-Key je příliš dlouhá.");
-
         // Glejt monster-combat (#518) — MonsterVictory/MonsterDefeat are gated
         // by an active OrganizerRoleAssignment for the caller's email on an
         // NPC with Role == Monster, where the slot covers now ± 15 min. The
         // payload's monsterNpcId is the load-bearing identifier; monsterName
         // is trusted from the client (see design doc §"Identity of the
-        // monster"). Any other event type falls through to the existing
-        // any-organizer flow.
+        // monster"). Runs BEFORE idempotency replay so an unauthorized caller
+        // who supplies a previously-seen X-Idempotency-Key can't bypass auth
+        // and receive the original event as a 200 replay. Any other event
+        // type falls through to the existing any-organizer flow.
         if (dto.EventType is CharacterEventType.MonsterVictory or CharacterEventType.MonsterDefeat)
         {
             var monsterAuth = await AuthorizeMonsterEventAsync(dto, assignment.GameId, httpContext, db);
             if (monsterAuth is { } denied) return denied;
         }
+
+        var idempotencyKey = GetIdempotencyKey(httpContext);
+        if (await TryGetIdempotentEventAsync(db, assignment.Id, idempotencyKey) is { } replay)
+            return TypedResults.Ok(replay);
+        if (!IsValidIdempotencyKey(idempotencyKey))
+            return SaveFailed("Hlavička X-Idempotency-Key je příliš dlouhá.");
 
         var organizer = GetOrganizer(httpContext);
 

--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -22,6 +22,7 @@ public static class ScanEndpoints
         group.MapPost("/{personId:int}/events", PostEvent);
         group.MapDelete("/{personId:int}/events/last-levelup", DeleteLastLevelUp);
         group.MapDelete("/{personId:int}/events/last-note", DeleteLastNote);
+        group.MapDelete("/{personId:int}/events/last-combat", DeleteLastCombat);
         group.MapGet("/{personId:int}/events", GetRecentEvents);
         group.MapGet("/{personId:int}/treasure-quests/pending", GetPendingTreasureQuests);
         group.MapPost("/{personId:int}/treasure-quests/{questId:int}/verify", VerifyTreasureQuest);
@@ -314,6 +315,33 @@ public static class ScanEndpoints
         if (lastNote is null) return TypedResults.NotFound();
 
         db.CharacterEvents.Remove(lastNote);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    /// <summary>
+    /// Glejt monster-combat (#518) — undo the most recent monster-combat
+    /// event (MonsterVictory or MonsterDefeat) on a hero. An intervening
+    /// LevelUp recorded after the combat is intentionally ignored — the
+    /// scope is "newest combat row, even if other event types are newer".
+    /// </summary>
+    private static async Task<Results<NoContent, NotFound>> DeleteLastCombat(
+        int personId, WorldDbContext db)
+    {
+        var assignment = await db.CharacterAssignments
+            .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
+        if (assignment is null) return TypedResults.NotFound();
+
+        var lastCombat = await db.CharacterEvents
+            .Where(e => e.CharacterAssignmentId == assignment.Id
+                && (e.EventType == CharacterEventType.MonsterVictory
+                    || e.EventType == CharacterEventType.MonsterDefeat))
+            .OrderByDescending(e => e.Timestamp)
+            .ThenByDescending(e => e.Id)
+            .FirstOrDefaultAsync();
+        if (lastCombat is null) return TypedResults.NotFound();
+
+        db.CharacterEvents.Remove(lastCombat);
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
     }

--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -96,6 +96,13 @@ public static class ScanEndpoints
         if (assignment is null) return TypedResults.NotFound();
 
         var idempotencyKey = GetIdempotencyKey(httpContext);
+        // Idempotency keys are scoped to (assignmentId, key) and are trusted to
+        // be unique per caller — Glejt always generates Guid.NewGuid() per tap,
+        // so collision across organizers is essentially impossible. NOTE: this
+        // replay check runs BEFORE the monster-auth gate below, so a key
+        // collision across two callers WOULD replay the original caller's
+        // monster-combat response without re-running auth. Keep keys per-caller
+        // unique (Guids) to preserve that invariant.
         if (await TryGetIdempotentEventAsync(db, assignment.Id, idempotencyKey) is { } replay)
             return TypedResults.Ok(replay);
         if (!IsValidIdempotencyKey(idempotencyKey))
@@ -580,8 +587,8 @@ public static class ScanEndpoints
     {
         const int bufferMinutes = 15;
 
-        var callerEmail = httpContext.User.FindFirstValue(ClaimTypes.Email)
-            ?? httpContext.User.FindFirstValue("email");
+        var callerEmail = (httpContext.User.FindFirstValue(ClaimTypes.Email)
+            ?? httpContext.User.FindFirstValue("email"))?.Trim();
         if (string.IsNullOrWhiteSpace(callerEmail))
         {
             return TypedResults.Problem(
@@ -609,6 +616,7 @@ public static class ScanEndpoints
             .Where(a => a.GameId == gameId
                 && a.NpcId == monsterNpcId.Value
                 && a.PersonEmail != null
+                // Npgsql can't translate ToUpperInvariant — ToUpper maps to Postgres UPPER(), equivalent for ASCII emails.
                 && a.PersonEmail.ToUpper() == callerEmailUpper
                 && a.Npc.Role == NpcRole.Monster
                 && a.TimeSlot.StartTime <= leadingEdge

--- a/src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs
@@ -25,5 +25,11 @@ public enum CharacterEventType
     ClassChosen,
 
     [Display(Name = "Ověření pokladového razítka")]
-    TreasureQuestStampVerified
+    TreasureQuestStampVerified,
+
+    [Display(Name = "vítězství nad nestvůrou")]
+    MonsterVictory,
+
+    [Display(Name = "porážka nestvůrou")]
+    MonsterDefeat
 }

--- a/src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs
@@ -27,9 +27,9 @@ public enum CharacterEventType
     [Display(Name = "Ověření pokladového razítka")]
     TreasureQuestStampVerified,
 
-    [Display(Name = "vítězství nad nestvůrou")]
+    [Display(Name = "Vítězství nad nestvůrou")]
     MonsterVictory,
 
-    [Display(Name = "porážka nestvůrou")]
+    [Display(Name = "Porážka nestvůrou")]
     MonsterDefeat
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
@@ -427,6 +427,30 @@ public class ScanMonsterCombatEndpointTests(PostgresFixture postgres)
     }
 
     [Fact]
+    public async Task PostMonsterVictory_PayloadMissingMonsterNpcId_Returns400()
+    {
+        // Caller has an active monster role, but the payload omits the
+        // load-bearing monsterNpcId field. AuthorizeMonsterEventAsync must
+        // refuse to assume an NPC id and return 400 with a Czech problem
+        // detail naming the missing field. This same branch also fires when
+        // dto.Data is malformed JSON (TryReadMonsterNpcId returns null in
+        // both cases).
+        var (_, personId, _) = await SeedActiveMonsterRoleAsync(externalPersonId: 206);
+
+        var dto = new CreateCharacterEventDto(
+            CharacterEventType.MonsterVictory,
+            JsonSerializer.Serialize(new { monsterName = "Skret" }),
+            Location: "Glejt");
+
+        var response = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/{personId}/events", dto, $"victory-no-npcid-{personId}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("monsterNpcId", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task PostMonsterVictory_NoOrganizerRoleAssignmentAtAll_Returns403()
     {
         // Game + hero exist, but no monster NPC seeded and no role assignment

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
@@ -1,0 +1,178 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+/// <summary>
+/// Integration tests for the Glejt monster-combat surface on /api/scan:
+/// MonsterVictory/MonsterDefeat event posting (with server-side
+/// OrganizerRoleAssignment authorization) plus the two undo endpoints
+/// (last-note, last-combat).
+///
+/// The shared <see cref="PostgresFixture"/> client authenticates as
+/// <c>test@ovcina.cz</c> / "Test Organizátor" — that email is what
+/// <see cref="OrganizerRoleAssignment.PersonEmail"/> rows must match for
+/// the monster-role lookup to succeed.
+/// </summary>
+public class ScanMonsterCombatEndpointTests(PostgresFixture postgres)
+    : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    private const string CallerEmail = "test@ovcina.cz";
+
+    private async Task<HttpResponseMessage> PostJsonWithIdempotencyAsync<T>(
+        string url, T payload, string key)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = JsonContent.Create(payload)
+        };
+        request.Headers.Add("X-Idempotency-Key", key);
+        return await Client.SendAsync(request);
+    }
+
+    private async Task<int> CreateGameAsync(string name = "Souboj s nestvůrou")
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto(name, 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        response.EnsureSuccessStatusCode();
+        var game = await response.Content.ReadFromJsonAsync<GameDetailDto>();
+        return game!.Id;
+    }
+
+    private async Task<int> CreateNpcAsync(string name, NpcRole role)
+    {
+        var response = await Client.PostAsJsonAsync("/api/npcs",
+            new CreateNpcDto(name, role, "Testovací nestvůra"));
+        response.EnsureSuccessStatusCode();
+        var npc = await response.Content.ReadFromJsonAsync<NpcDetailDto>();
+        return npc!.Id;
+    }
+
+    private async Task AssignNpcToGameAsync(int gameId, int npcId)
+    {
+        var response = await Client.PostAsJsonAsync("/api/npcs/game-npc",
+            new CreateGameNpcDto(gameId, npcId));
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<int> CreateSlotAsync(int gameId)
+    {
+        // The exact StartTime / Duration we need is set directly via DbContext
+        // afterwards (see SetSlotWindowAsync), because the API's
+        // CreateGameTimeSlotDto pegs StartTime to a fixed game date that we
+        // can't easily move relative to DateTime.UtcNow.
+        var response = await Client.PostAsJsonAsync("/api/timeline/slots",
+            new CreateGameTimeSlotDto(
+                GameId: gameId,
+                StartTime: new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc),
+                DurationHours: 1m,
+                InGameYear: 1247,
+                Stage: GameTimePhase.Start));
+        response.EnsureSuccessStatusCode();
+        var slot = await response.Content.ReadFromJsonAsync<GameTimeSlotDto>();
+        return slot!.Id;
+    }
+
+    /// <summary>
+    /// Mutates the slot's window directly in the database. Used so each
+    /// authorization test can control whether "now" falls inside the
+    /// slot's ±15 min window.
+    /// </summary>
+    private async Task SetSlotWindowAsync(int slotId, DateTime startUtc, TimeSpan duration)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var slot = await db.GameTimeSlots.FirstAsync(s => s.Id == slotId);
+        slot.StartTime = startUtc;
+        slot.Duration = duration;
+        await db.SaveChangesAsync();
+    }
+
+    private async Task UpsertOrganizerRoleAsync(
+        int gameId, int slotId, int npcId, string email)
+    {
+        var response = await Client.PutAsJsonAsync(
+            $"/api/games/{gameId}/organizer-role-assignments/slots/{slotId}/npcs/{npcId}",
+            new UpsertOrganizerRoleAssignmentDto(501, "Test Organizátor", email));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private async Task<int> SeedHeroAsync(int gameId, int externalPersonId)
+    {
+        var createResponse = await Client.PostAsJsonAsync("/api/characters",
+            new CreateCharacterDto(
+                "Frodo",
+                Race: Race.Hobbit,
+                IsPlayedCharacter: true,
+                ExternalPersonId: externalPersonId));
+        createResponse.EnsureSuccessStatusCode();
+        var character = await createResponse.Content.ReadFromJsonAsync<CharacterDetailDto>();
+
+        var assignResponse = await Client.PostAsJsonAsync(
+            $"/api/characters/{character!.Id}/assignments",
+            new CreateCharacterAssignmentDto(gameId, externalPersonId, null, null));
+        assignResponse.EnsureSuccessStatusCode();
+        return character.Id;
+    }
+
+    /// <summary>
+    /// One-call seed: game + slot in active window + monster NPC + role
+    /// assignment for the test caller + scanned hero. Returns the personId,
+    /// the npcId of the monster, and the gameId.
+    /// </summary>
+    private async Task<(int gameId, int personId, int monsterNpcId)> SeedActiveMonsterRoleAsync(
+        int externalPersonId,
+        DateTime? slotStartUtc = null,
+        TimeSpan? slotDuration = null,
+        NpcRole npcRole = NpcRole.Monster,
+        string? assignedEmail = null)
+    {
+        var gameId = await CreateGameAsync();
+        var npcId = await CreateNpcAsync("Skret hlídač u brány", npcRole);
+        await AssignNpcToGameAsync(gameId, npcId);
+        var slotId = await CreateSlotAsync(gameId);
+
+        // Default: slot started 30 min ago, runs 2h — caller is mid-window.
+        await SetSlotWindowAsync(
+            slotId,
+            slotStartUtc ?? DateTime.UtcNow.AddMinutes(-30),
+            slotDuration ?? TimeSpan.FromHours(2));
+
+        await UpsertOrganizerRoleAsync(gameId, slotId, npcId, assignedEmail ?? CallerEmail);
+        await SeedHeroAsync(gameId, externalPersonId);
+
+        return (gameId, externalPersonId, npcId);
+    }
+
+    [Fact]
+    public async Task PostMonsterVictory_WithActiveMonsterRole_ReturnsCreatedAndPersistsEvent()
+    {
+        var (_, personId, npcId) = await SeedActiveMonsterRoleAsync(externalPersonId: 200);
+
+        var dto = new CreateCharacterEventDto(
+            CharacterEventType.MonsterVictory,
+            JsonSerializer.Serialize(new { monsterNpcId = npcId, monsterName = "Skret hlídač u brány" }),
+            Location: "Glejt");
+
+        var response = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/{personId}/events", dto, $"victory-{personId}");
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var saved = await db.CharacterEvents
+            .Where(e => e.Assignment.ExternalPersonId == personId
+                && e.EventType == CharacterEventType.MonsterVictory)
+            .ToListAsync();
+        Assert.Single(saved);
+        Assert.Contains("\"monsterNpcId\":" + npcId, saved[0].Data);
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
@@ -379,6 +379,38 @@ public class ScanMonsterCombatEndpointTests(PostgresFixture postgres)
     }
 
     [Fact]
+    public async Task PostMonsterVictory_SameIdempotencyKey_Twice_PersistsOnceAndReplaysResponse()
+    {
+        var (_, personId, npcId) = await SeedActiveMonsterRoleAsync(externalPersonId: 320);
+
+        var dto = new CreateCharacterEventDto(
+            CharacterEventType.MonsterVictory,
+            JsonSerializer.Serialize(new { monsterNpcId = npcId, monsterName = "Skret" }),
+            Location: "Glejt");
+        const string key = "monster-victory-replay";
+
+        var first = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/{personId}/events", dto, key);
+        var second = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/{personId}/events", dto, key);
+
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+
+        var firstDto = await first.Content.ReadFromJsonAsync<CharacterEventDto>();
+        var secondDto = await second.Content.ReadFromJsonAsync<CharacterEventDto>();
+        Assert.Equal(firstDto!.Id, secondDto!.Id);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var combatRows = await db.CharacterEvents
+            .Where(e => e.Assignment.ExternalPersonId == personId
+                && e.EventType == CharacterEventType.MonsterVictory)
+            .CountAsync();
+        Assert.Equal(1, combatRows);
+    }
+
+    [Fact]
     public async Task DeleteLastCombat_NoCombatHistory_Returns404()
     {
         var gameId = await CreateGameAsync("Combat 404");

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
@@ -282,7 +282,10 @@ public class ScanMonsterCombatEndpointTests(PostgresFixture postgres)
             .OrderBy(e => e.Timestamp)
             .ToListAsync();
         Assert.Single(notes);
-        Assert.Contains("\"první\"", notes[0].Data);
+        // Note payload is forwarded verbatim by the API; assert against the
+        // JSON-encoded form actually stored.
+        Assert.Contains("prvn", notes[0].Data, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("druh", notes[0].Data, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -292,6 +295,101 @@ public class ScanMonsterCombatEndpointTests(PostgresFixture postgres)
         await SeedHeroAsync(gameId, externalPersonId: 301);
 
         var response = await Client.DeleteAsync("/api/scan/301/events/last-note");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteLastCombat_RemovesNewestMonsterEvent()
+    {
+        var (_, personId, npcId) = await SeedActiveMonsterRoleAsync(externalPersonId: 310);
+
+        // Two combat events, second one is the newest.
+        var first = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/{personId}/events",
+            new CreateCharacterEventDto(
+                CharacterEventType.MonsterVictory,
+                JsonSerializer.Serialize(new { monsterNpcId = npcId, monsterName = "První" }),
+                Location: "Glejt"),
+            $"combat-1-{personId}");
+        first.EnsureSuccessStatusCode();
+
+        var second = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/{personId}/events",
+            new CreateCharacterEventDto(
+                CharacterEventType.MonsterDefeat,
+                JsonSerializer.Serialize(new { monsterNpcId = npcId, monsterName = "Druhý" }),
+                Location: "Glejt"),
+            $"combat-2-{personId}");
+        second.EnsureSuccessStatusCode();
+
+        var response = await Client.DeleteAsync($"/api/scan/{personId}/events/last-combat");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var combat = await db.CharacterEvents
+            .Where(e => e.Assignment.ExternalPersonId == personId
+                && (e.EventType == CharacterEventType.MonsterVictory
+                    || e.EventType == CharacterEventType.MonsterDefeat))
+            .ToListAsync();
+        Assert.Single(combat);
+        Assert.Equal(CharacterEventType.MonsterVictory, combat[0].EventType);
+        // JsonSerializer escapes non-ASCII by default; match the escaped form
+        // so the assertion isn't sensitive to encoder settings.
+        Assert.Contains("Prvn\\u00ED", combat[0].Data, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DeleteLastCombat_IgnoresLevelUpAfterCombat()
+    {
+        // The undo scope is "newest combat row", NOT "newest event of any
+        // type". A LevelUp recorded AFTER a MonsterVictory must not be
+        // touched by last-combat — that's last-levelup's job.
+        var (_, personId, npcId) = await SeedActiveMonsterRoleAsync(externalPersonId: 311);
+
+        var combat = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/{personId}/events",
+            new CreateCharacterEventDto(
+                CharacterEventType.MonsterVictory,
+                JsonSerializer.Serialize(new { monsterNpcId = npcId, monsterName = "Skret" }),
+                Location: "Glejt"),
+            $"combat-{personId}");
+        combat.EnsureSuccessStatusCode();
+
+        var levelUp = await Client.PostAsJsonAsync($"/api/scan/{personId}/events",
+            new CreateCharacterEventDto(CharacterEventType.LevelUp, "{}"));
+        levelUp.EnsureSuccessStatusCode();
+
+        var response = await Client.DeleteAsync($"/api/scan/{personId}/events/last-combat");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var events = await db.CharacterEvents
+            .Where(e => e.Assignment.ExternalPersonId == personId)
+            .OrderBy(e => e.Timestamp)
+            .ToListAsync();
+
+        // LevelUp is preserved; MonsterVictory is gone.
+        Assert.Single(events);
+        Assert.Equal(CharacterEventType.LevelUp, events[0].EventType);
+    }
+
+    [Fact]
+    public async Task DeleteLastCombat_NoCombatHistory_Returns404()
+    {
+        var gameId = await CreateGameAsync("Combat 404");
+        await SeedHeroAsync(gameId, externalPersonId: 312);
+
+        // Hero has a Note but no combat — must return 404.
+        var note = await Client.PostAsJsonAsync("/api/scan/312/events",
+            new CreateCharacterEventDto(CharacterEventType.Note, """{"note":"jen poznámka"}"""));
+        note.EnsureSuccessStatusCode();
+
+        var response = await Client.DeleteAsync("/api/scan/312/events/last-combat");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
@@ -257,6 +257,46 @@ public class ScanMonsterCombatEndpointTests(PostgresFixture postgres)
     }
 
     [Fact]
+    public async Task DeleteLastNote_WithExistingNote_Returns204AndRemovesEvent()
+    {
+        var gameId = await CreateGameAsync("Note undo");
+        await SeedHeroAsync(gameId, externalPersonId: 300);
+
+        // Two notes; the newest one should be removed.
+        var firstNote = await Client.PostAsJsonAsync("/api/scan/300/events",
+            new CreateCharacterEventDto(CharacterEventType.Note, """{"note":"první"}""", "Bran"));
+        firstNote.EnsureSuccessStatusCode();
+        var secondNote = await Client.PostAsJsonAsync("/api/scan/300/events",
+            new CreateCharacterEventDto(CharacterEventType.Note, """{"note":"druhá"}""", "Bran"));
+        secondNote.EnsureSuccessStatusCode();
+
+        var response = await Client.DeleteAsync("/api/scan/300/events/last-note");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var notes = await db.CharacterEvents
+            .Where(e => e.Assignment.ExternalPersonId == 300
+                && e.EventType == CharacterEventType.Note)
+            .OrderBy(e => e.Timestamp)
+            .ToListAsync();
+        Assert.Single(notes);
+        Assert.Contains("\"první\"", notes[0].Data);
+    }
+
+    [Fact]
+    public async Task DeleteLastNote_NoNoteHistory_Returns404()
+    {
+        var gameId = await CreateGameAsync("Note 404");
+        await SeedHeroAsync(gameId, externalPersonId: 301);
+
+        var response = await Client.DeleteAsync("/api/scan/301/events/last-note");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
     public async Task PostMonsterVictory_NoOrganizerRoleAssignmentAtAll_Returns403()
     {
         // Game + hero exist, but no monster NPC seeded and no role assignment

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
@@ -175,4 +175,103 @@ public class ScanMonsterCombatEndpointTests(PostgresFixture postgres)
         Assert.Single(saved);
         Assert.Contains("\"monsterNpcId\":" + npcId, saved[0].Data);
     }
+
+    [Fact]
+    public async Task PostMonsterVictory_SlotAlreadyEnded_BeyondBuffer_Returns403()
+    {
+        // Slot ended 30 min ago — outside the +15 min trailing buffer.
+        var (_, personId, npcId) = await SeedActiveMonsterRoleAsync(
+            externalPersonId: 201,
+            slotStartUtc: DateTime.UtcNow.AddHours(-2).AddMinutes(-30),
+            slotDuration: TimeSpan.FromHours(2));
+
+        var dto = new CreateCharacterEventDto(
+            CharacterEventType.MonsterVictory,
+            JsonSerializer.Serialize(new { monsterNpcId = npcId, monsterName = "Skret" }),
+            Location: "Glejt");
+
+        var response = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/{personId}/events", dto, $"victory-late-{personId}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostMonsterVictory_SlotStartsInFuture_BeyondBuffer_Returns403()
+    {
+        // Slot starts in 30 min — outside the -15 min leading buffer.
+        var (_, personId, npcId) = await SeedActiveMonsterRoleAsync(
+            externalPersonId: 202,
+            slotStartUtc: DateTime.UtcNow.AddMinutes(30),
+            slotDuration: TimeSpan.FromHours(2));
+
+        var dto = new CreateCharacterEventDto(
+            CharacterEventType.MonsterVictory,
+            JsonSerializer.Serialize(new { monsterNpcId = npcId, monsterName = "Skret" }),
+            Location: "Glejt");
+
+        var response = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/{personId}/events", dto, $"victory-early-{personId}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostMonsterVictory_NpcRoleIsNotMonster_Returns403()
+    {
+        // Caller is assigned to this NPC in an active slot, but the NPC has
+        // role Merchant — only Monster roles may record monster combat.
+        var (_, personId, npcId) = await SeedActiveMonsterRoleAsync(
+            externalPersonId: 203,
+            npcRole: NpcRole.Merchant);
+
+        var dto = new CreateCharacterEventDto(
+            CharacterEventType.MonsterVictory,
+            JsonSerializer.Serialize(new { monsterNpcId = npcId, monsterName = "Kupec" }),
+            Location: "Glejt");
+
+        var response = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/{personId}/events", dto, $"victory-merchant-{personId}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostMonsterVictory_CallerNotAssignedToNpc_Returns403()
+    {
+        // Active monster role exists, but for a DIFFERENT email — the test
+        // caller (test@ovcina.cz) does not own this monster.
+        var (_, personId, npcId) = await SeedActiveMonsterRoleAsync(
+            externalPersonId: 204,
+            assignedEmail: "kdosi-jiny@ovcina.cz");
+
+        var dto = new CreateCharacterEventDto(
+            CharacterEventType.MonsterVictory,
+            JsonSerializer.Serialize(new { monsterNpcId = npcId, monsterName = "Skret" }),
+            Location: "Glejt");
+
+        var response = await PostJsonWithIdempotencyAsync(
+            $"/api/scan/{personId}/events", dto, $"victory-other-{personId}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostMonsterVictory_NoOrganizerRoleAssignmentAtAll_Returns403()
+    {
+        // Game + hero exist, but no monster NPC seeded and no role assignment
+        // for the caller — payload references an NPC id that nobody owns.
+        var gameId = await CreateGameAsync();
+        await SeedHeroAsync(gameId, externalPersonId: 205);
+
+        var dto = new CreateCharacterEventDto(
+            CharacterEventType.MonsterVictory,
+            JsonSerializer.Serialize(new { monsterNpcId = 99999, monsterName = "Fiktivní" }),
+            Location: "Glejt");
+
+        var response = await PostJsonWithIdempotencyAsync(
+            "/api/scan/205/events", dto, "victory-no-role");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
 }


### PR DESCRIPTION
Closes #518.

Backend support for Glejt monster-combat recording. See `azra/docs/plans/2026-05-01-glejt-monster-combat-design.md` for full design.

## Summary

- Two new `CharacterEventType` values: `MonsterVictory` ("vítězství nad nestvůrou") and `MonsterDefeat` ("porážka nestvůrou"). No EF migration — enum is `.HasConversion<string>()`.
- `POST /api/scan/{personId}/events` for monster types is gated server-side: caller (by JWT email) must have an active `OrganizerRoleAssignment` with `Npc.Role == NpcRole.Monster` and slot covering `now ± 15 min`. Reject with 403 problem+json otherwise. 400 if payload is missing `monsterNpcId`.
- `DELETE /api/scan/{personId}/events/last-note` — mirror of existing `last-levelup`.
- `DELETE /api/scan/{personId}/events/last-combat` — removes latest `MonsterVictory|MonsterDefeat`, ignores intervening `LevelUp`.
- 13 new integration tests in `ScanMonsterCombatEndpointTests` (Testcontainers PostgreSQL): happy path, 5 deny cases (slot expired, slot future, NPC role wrong, caller email mismatch, no assignment at all), DELETE last-note success+404, DELETE last-combat success+ignores-LevelUp+404, idempotency replay, payload-missing-monsterNpcId 400.
- Auth-gate query email comparison: caller side `ToUpperInvariant().Trim()`, SQL side `ToUpper()` → Postgres `UPPER()`. Equivalent for ASCII emails (commented inline).

## Test plan

- [x] dotnet build clean, no warnings
- [x] dotnet test \`tests/OvcinaHra.Api.Tests\` — **661 pass / 0 fail**
- [ ] CI green
- [ ] After merge: \`curl -s https://api.hra.ovcina.cz/api/version\` matches \`origin/main\`

## Out of scope (deferred)

- Frontend (glejt-ovcina-cz) — Phase B, separate PR after this deploys
- Server-side overwrite of `monsterName` from `Npc.Name` — current impl trusts client
- Refresh token / 401 retry — separate pre-existing TODO

🤖 Generated with [Claude Code](https://claude.com/claude-code)