### PR TITLE
feat(stamps): Rozpoznat skrýš — multi-image stamp recognition with top-3 candidates [v0.17.29]

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/StampLlmVerificationConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/StampLlmVerificationConfiguration.cs
@@ -12,8 +12,12 @@ public class StampLlmVerificationConfiguration : IEntityTypeConfiguration<StampL
         builder.Property(e => e.OrganizerUserId).IsRequired().HasMaxLength(200);
         builder.Property(e => e.OrganizerName).IsRequired().HasMaxLength(200);
         builder.Property(e => e.RawResponse).IsRequired().HasMaxLength(1000);
+        // Mode discriminator. Default "verify" so existing rows backfill cleanly when the
+        // column is added; new rows from /recognize set "recognize".
+        builder.Property(e => e.Mode).IsRequired().HasMaxLength(20).HasDefaultValue(StampLlmVerification.ModeVerify);
         builder.HasOne(e => e.Location).WithMany().HasForeignKey(e => e.LocationId);
         builder.HasIndex(e => e.TimestampUtc);
         builder.HasIndex(e => e.LocationId);
+        builder.HasIndex(e => e.Mode);
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/StampLlmEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/StampLlmEndpoints.cs
@@ -28,7 +28,7 @@ public static class StampLlmEndpoints
         ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
-        var logger = loggerFactory.CreateLogger("StampLlmEndpoints");
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.StampLlmEndpoints");
         logger.LogInformation(
             "[stamp-llm-server] recognize endpoint enter gameId={GameId}",
             request.GameId);
@@ -108,7 +108,7 @@ public static class StampLlmEndpoints
         }
         catch (StampLlmRateLimitedException ex)
         {
-            await AuditRecognizeFailureAsync(db, request, organizer, ex, ct);
+            await AuditRecognizeFailureAsync(db, request, organizer, ex, references.Count, ct);
             logger.LogWarning(
                 ex,
                 "[stamp-llm-server] recognize endpoint rate-limited gameId={GameId} rawResponse={RawResponse}",
@@ -125,7 +125,7 @@ public static class StampLlmEndpoints
         }
         catch (StampLlmProviderException ex)
         {
-            await AuditRecognizeFailureAsync(db, request, organizer, ex, ct);
+            await AuditRecognizeFailureAsync(db, request, organizer, ex, references.Count, ct);
             logger.LogError(
                 ex,
                 "[stamp-llm-server] recognize endpoint provider-error gameId={GameId} rawResponse={RawResponse}",
@@ -221,6 +221,7 @@ public static class StampLlmEndpoints
         RecognizeStashRequest request,
         OrganizerIdentity organizer,
         StampLlmProviderException ex,
+        int referencesScanned,
         CancellationToken ct)
     {
         // For failure audit we don't have a top-1 location to attach to, but the LocationId
@@ -250,7 +251,9 @@ public static class StampLlmEndpoints
             RawResponse = Truncate(ex.RawResponse),
             Mode = StampLlmVerification.ModeRecognize,
             GameId = request.GameId,
-            ReferencesScanned = 0
+            // Persist the intended reference count even on failure: failing calls also cost
+            // (the request was sent), so cost analysis needs the count regardless of outcome.
+            ReferencesScanned = referencesScanned
         });
         await db.SaveChangesAsync(ct);
     }

--- a/src/OvcinaHra.Api/Endpoints/StampLlmEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/StampLlmEndpoints.cs
@@ -15,8 +15,244 @@ public static class StampLlmEndpoints
         var group = routes.MapGroup("/api/stamps").WithTags("Stamps").RequireAuthorization();
 
         group.MapPost("/verify-llm", VerifyStampAsync);
+        group.MapPost("/recognize", RecognizeStashAsync);
 
         return group;
+    }
+
+    private static async Task<Results<Ok<RecognizeStashResponse>, ProblemHttpResult>> RecognizeStashAsync(
+        RecognizeStashRequest request,
+        WorldDbContext db,
+        IStampLlmVerifyService verifier,
+        HttpContext http,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("StampLlmEndpoints");
+        logger.LogInformation(
+            "[stamp-llm-server] recognize endpoint enter gameId={GameId}",
+            request.GameId);
+
+        if (!IsOrganizer(http.User))
+        {
+            return TypedResults.Problem(
+                title: "Přístup odepřen",
+                detail: "Pouze organizátoři mohou rozpoznávat razítka pomocí LLM.",
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        if (!verifier.IsConfigured)
+            return AnthropicConfigurationMissing(logger);
+
+        var gameExists = await db.Games.AnyAsync(g => g.Id == request.GameId, ct);
+        if (!gameExists)
+        {
+            return TypedResults.Problem(
+                title: "Hra neexistuje",
+                detail: $"Hra s ID {request.GameId} neexistuje.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        StampImagePayload capturedImage;
+        try
+        {
+            capturedImage = StampImagePayload.ParseCaptured(request.CapturedImageBase64);
+        }
+        catch (StampLlmValidationException ex)
+        {
+            return BadRequest(ex.Title, ex.Detail);
+        }
+
+        // Reference set: every Location in this game that has a stamp image set.
+        // GameLocations is the authoritative game-membership join (mirrors GetGameStamps);
+        // we don't filter by GameSecretStashes here because organizers may want to recognize
+        // a glejt stamp even from a location that has no stash yet.
+        var references = await db.GameLocations
+            .AsNoTracking()
+            .Where(gl => gl.GameId == request.GameId
+                && gl.Location.StampImagePath != null
+                && gl.Location.StampImagePath != "")
+            .OrderBy(gl => gl.Location.Name)
+            .Select(gl => new
+            {
+                gl.LocationId,
+                LocationName = gl.Location.Name,
+                StampImagePath = gl.Location.StampImagePath!
+            })
+            .ToListAsync(ct);
+
+        if (references.Count == 0)
+        {
+            // Distinct shape with NoReferences=true so the client renders a calm
+            // "Tato hra nemá žádné lokace s razítkem" hint instead of an error toast.
+            return TypedResults.Ok(new RecognizeStashResponse(
+                Array.Empty<StampMatchCandidate>(),
+                TotalReferencesScanned: 0,
+                LatencyMs: 0,
+                NoReferences: true));
+        }
+
+        var organizer = GetOrganizer(http.User);
+        var job = new StampLlmRecognizeJob(
+            capturedImage,
+            references.Select(r => new StampReference(r.LocationId, r.LocationName, r.StampImagePath)).ToList());
+
+        StampLlmRecognizeResult result;
+        try
+        {
+            result = await verifier.RecognizeAsync(job, ct);
+        }
+        catch (StampLlmValidationException ex)
+        {
+            return BadRequest(ex.Title, ex.Detail);
+        }
+        catch (StampLlmRateLimitedException ex)
+        {
+            await AuditRecognizeFailureAsync(db, request, organizer, ex, ct);
+            logger.LogWarning(
+                ex,
+                "[stamp-llm-server] recognize endpoint rate-limited gameId={GameId} rawResponse={RawResponse}",
+                request.GameId,
+                ex.RawResponse);
+            return TypedResults.Problem(
+                title: "LLM rozpoznání je dočasně omezené",
+                detail: "LLM rozpoznání je dočasně omezené, zkus to za chvíli znovu.",
+                statusCode: StatusCodes.Status429TooManyRequests);
+        }
+        catch (StampLlmConfigurationException)
+        {
+            return AnthropicConfigurationMissing(logger);
+        }
+        catch (StampLlmProviderException ex)
+        {
+            await AuditRecognizeFailureAsync(db, request, organizer, ex, ct);
+            logger.LogError(
+                ex,
+                "[stamp-llm-server] recognize endpoint provider-error gameId={GameId} rawResponse={RawResponse}",
+                request.GameId,
+                ex.RawResponse);
+            return TypedResults.Problem(
+                title: "LLM rozpoznání selhalo",
+                detail: "LLM rozpoznání selhalo, zkus snímek znovu nebo použij ruční výběr.",
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        // Top-3 by confidence, with stash projection joined per location. Empty
+        // candidates (e.g. all references missing blobs at runtime) collapses to
+        // NoReferences=false but Candidates=[] — UI renders "Žádná shoda" hint.
+        var topCandidateIds = result.Candidates.Take(3).Select(c => c.LocationId).ToList();
+
+        var stashesByLocation = await db.GameSecretStashes
+            .AsNoTracking()
+            .Where(gs => gs.GameId == request.GameId && topCandidateIds.Contains(gs.LocationId))
+            .OrderBy(gs => gs.SecretStash.Name)
+            .Select(gs => new
+            {
+                gs.LocationId,
+                Stash = new StashSummary(
+                    gs.SecretStashId,
+                    gs.SecretStash.Name,
+                    gs.SecretStash.Description)
+            })
+            .ToListAsync(ct);
+
+        var stashLookup = stashesByLocation
+            .GroupBy(x => x.LocationId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<StashSummary>)g.Select(x => x.Stash).ToList());
+
+        var responseCandidates = result.Candidates
+            .Take(3)
+            .Select(c => new StampMatchCandidate(
+                c.LocationId,
+                c.LocationName,
+                c.Confidence,
+                stashLookup.TryGetValue(c.LocationId, out var stashes) ? stashes : Array.Empty<StashSummary>()))
+            .ToList();
+
+        // Audit row: top-1 candidate location + match=true if confident, plus aggregated
+        // metadata (game id, references scanned). Endpoint cannot be reached without ≥1
+        // resolved reference (the NoReferences shortcut returns earlier), so result.Candidates
+        // has at least one entry whenever the LLM call succeeds.
+        if (result.Candidates.Count > 0)
+        {
+            db.StampLlmVerifications.Add(ToRecognizeAuditRow(request, organizer, result));
+            await db.SaveChangesAsync(ct);
+        }
+
+        logger.LogInformation(
+            "[stamp-llm-server] recognize endpoint exit gameId={GameId} candidates={CandidateCount} top1Confidence={Top1Confidence} latencyMs={LatencyMs}",
+            request.GameId,
+            responseCandidates.Count,
+            responseCandidates.Count > 0 ? responseCandidates[0].Confidence : 0,
+            result.LatencyMs);
+
+        return TypedResults.Ok(new RecognizeStashResponse(
+            responseCandidates,
+            result.TotalReferencesScanned,
+            result.LatencyMs));
+    }
+
+    private static StampLlmVerification ToRecognizeAuditRow(
+        RecognizeStashRequest request,
+        OrganizerIdentity organizer,
+        StampLlmRecognizeResult result)
+    {
+        var top = result.Candidates[0];
+        return new StampLlmVerification
+        {
+            TimestampUtc = DateTime.UtcNow,
+            OrganizerUserId = organizer.UserId,
+            OrganizerName = organizer.Name,
+            LocationId = top.LocationId,
+            ContextStashId = null,
+            ContextQuestId = null,
+            Match = top.Confidence >= 0.7,
+            Confidence = top.Confidence,
+            LatencyMs = result.LatencyMs,
+            RawResponse = Truncate(result.RawResponse),
+            Mode = StampLlmVerification.ModeRecognize,
+            GameId = request.GameId,
+            ReferencesScanned = result.TotalReferencesScanned
+        };
+    }
+
+    private static async Task AuditRecognizeFailureAsync(
+        WorldDbContext db,
+        RecognizeStashRequest request,
+        OrganizerIdentity organizer,
+        StampLlmProviderException ex,
+        CancellationToken ct)
+    {
+        // For failure audit we don't have a top-1 location to attach to, but the LocationId
+        // FK is required. Sentinel of 0 won't satisfy the FK; instead we look up any location
+        // in the game to satisfy the constraint, falling back to skipping the audit if the
+        // game is empty. Matches the philosophy: audit cost-bearing calls without crashing
+        // the response path on a missing FK target.
+        var fallbackLocationId = await db.GameLocations
+            .Where(gl => gl.GameId == request.GameId)
+            .Select(gl => (int?)gl.LocationId)
+            .FirstOrDefaultAsync(ct);
+
+        if (fallbackLocationId is null)
+            return;
+
+        db.StampLlmVerifications.Add(new StampLlmVerification
+        {
+            TimestampUtc = DateTime.UtcNow,
+            OrganizerUserId = organizer.UserId,
+            OrganizerName = organizer.Name,
+            LocationId = fallbackLocationId.Value,
+            ContextStashId = null,
+            ContextQuestId = null,
+            Match = false,
+            Confidence = 0,
+            LatencyMs = ex.LatencyMs,
+            RawResponse = Truncate(ex.RawResponse),
+            Mode = StampLlmVerification.ModeRecognize,
+            GameId = request.GameId,
+            ReferencesScanned = 0
+        });
+        await db.SaveChangesAsync(ct);
     }
 
     private static async Task<Results<Ok<VerifyStampLlmResponse>, ProblemHttpResult>> VerifyStampAsync(

--- a/src/OvcinaHra.Api/Migrations/20260501061440_AddStampLlmVerificationMode.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260501061440_AddStampLlmVerificationMode.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260501061440_AddStampLlmVerificationMode")]
+    partial class AddStampLlmVerificationMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260501061440_AddStampLlmVerificationMode.cs
+++ b/src/OvcinaHra.Api/Migrations/20260501061440_AddStampLlmVerificationMode.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStampLlmVerificationMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "GameId",
+                table: "StampLlmVerifications",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Mode",
+                table: "StampLlmVerifications",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "verify");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReferencesScanned",
+                table: "StampLlmVerifications",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StampLlmVerifications_Mode",
+                table: "StampLlmVerifications",
+                column: "Mode");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_StampLlmVerifications_Mode",
+                table: "StampLlmVerifications");
+
+            migrationBuilder.DropColumn(
+                name: "GameId",
+                table: "StampLlmVerifications");
+
+            migrationBuilder.DropColumn(
+                name: "Mode",
+                table: "StampLlmVerifications");
+
+            migrationBuilder.DropColumn(
+                name: "ReferencesScanned",
+                table: "StampLlmVerifications");
+        }
+    }
+}

--- a/src/OvcinaHra.Api/Services/StampLlmVerifyService.cs
+++ b/src/OvcinaHra.Api/Services/StampLlmVerifyService.cs
@@ -582,6 +582,13 @@ public sealed class StampLlmVerifyService : IStampLlmVerifyService, IDisposable
                 ex.Message,
                 ex);
         }
+        catch (StampLlmProviderException)
+        {
+            // Already-typed provider exceptions (e.g. malformed JSON from ParseRecognizeResponse)
+            // bubble up unchanged. Wrapping here would discard the original Title/RawResponse
+            // and replace ex.RawResponse with ex.Message — debugging info lost.
+            throw;
+        }
         catch (Exception ex) when (ex is not StampLlmValidationException and not OperationCanceledException)
         {
             stopwatch.Stop();

--- a/src/OvcinaHra.Api/Services/StampLlmVerifyService.cs
+++ b/src/OvcinaHra.Api/Services/StampLlmVerifyService.cs
@@ -10,6 +10,7 @@ public interface IStampLlmVerifyService
 {
     bool IsConfigured { get; }
     Task<StampLlmVerifyResult> VerifyAsync(StampLlmVerifyJob job, CancellationToken ct = default);
+    Task<StampLlmRecognizeResult> RecognizeAsync(StampLlmRecognizeJob job, CancellationToken ct = default);
 }
 
 public sealed record StampLlmVerifyJob(
@@ -17,6 +18,30 @@ public sealed record StampLlmVerifyJob(
     string ReferenceLocationName,
     string ReferenceBlobKey,
     StampImagePayload CapturedImage);
+
+/// <summary>
+/// Multi-image recognition job: rank captured photo against N reference stamps in a single
+/// Anthropic Vision call (or batched 2–3 calls when N &gt; 20).
+/// </summary>
+public sealed record StampLlmRecognizeJob(
+    StampImagePayload CapturedImage,
+    IReadOnlyList<StampReference> References);
+
+public sealed record StampReference(
+    int LocationId,
+    string LocationName,
+    string ReferenceBlobKey);
+
+public sealed record StampLlmRecognizeResult(
+    IReadOnlyList<StampLlmRankedCandidate> Candidates,
+    int TotalReferencesScanned,
+    int LatencyMs,
+    string RawResponse);
+
+public sealed record StampLlmRankedCandidate(
+    int LocationId,
+    string LocationName,
+    double Confidence);
 
 public sealed record StampImagePayload(byte[] Bytes, string MediaType)
 {
@@ -345,6 +370,296 @@ public sealed class StampLlmVerifyService : IStampLlmVerifyService, IDisposable
                 "Anthropic API call failed",
                 (int)stopwatch.ElapsedMilliseconds,
                 ex.Message,
+                ex);
+        }
+    }
+
+    /// <summary>
+    /// Anthropic Vision allows up to 20 images per request. With 1 captured image we can fit 19
+    /// references per call; if there are more we batch into 2–3 sequential calls and aggregate by
+    /// max confidence per location. The vast majority of games stay under one batch.
+    /// </summary>
+    private const int MaxReferencesPerBatch = 19;
+
+    private const string RecognizeSystemPrompt = """
+        You are a stamp recognition assistant for Ovčina, a Czech children's LARP game.
+
+        You will receive:
+        1. CAPTURED — a photograph of an ink impression of a rubber stamp on paper, taken with a phone.
+        2. A numbered set of REFERENCE — clean digital designs of rubber stamps belonging to specific locations in the game world.
+
+        Your job is to RANK the references by visual similarity to the captured impression. Account for:
+        - Ink density and coverage variations (children press unevenly).
+        - Paper texture and lighting differences.
+        - Slight rotation (up to ~30°) and translation.
+        - Partial smudges, missing edges, or doubled impressions.
+        - The difference between a vector/digital design and a physical ink impression of it.
+
+        Focus on the SILHOUETTE and DISTINCTIVE FEATURES — the overall shape, recognizable elements
+        (e.g. an owl, an anchor, a tree, a runic mark). Ignore color (impressions are usually
+        black-on-white regardless of reference color).
+
+        Respond ONLY with a single JSON object, no prose, no markdown fence:
+
+        {"candidates": [{"index": <reference number>, "confidence": <0.0-1.0>}, ...]}
+
+        Rules:
+        - Include EVERY reference number exactly once.
+        - "index" matches the 1-based number printed before each reference image.
+        - "confidence" interpretation:
+          - 0.90+ : silhouette and key features clearly match
+          - 0.70-0.89 : likely match, minor doubts
+          - 0.50-0.69 : ambiguous
+          - below 0.50 : unlikely / different stamp
+        - Sort by confidence descending.
+        - No prose, no comments, JSON only.
+        """;
+
+    public async Task<StampLlmRecognizeResult> RecognizeAsync(StampLlmRecognizeJob job, CancellationToken ct = default)
+    {
+        if (!IsConfigured || _client is null)
+            throw new StampLlmConfigurationException();
+
+        if (job.References.Count == 0)
+        {
+            // Defensive — endpoint should already 400 before we get here. Kept so that
+            // future callers don't accidentally pay the round-trip for an empty batch.
+            return new StampLlmRecognizeResult(
+                Array.Empty<StampLlmRankedCandidate>(),
+                0,
+                0,
+                "{\"candidates\":[]}");
+        }
+
+        var batches = await ResolveBatchesAsync(job.References, MaxReferencesPerBatch, ct);
+        var resolvedCount = batches.Sum(b => b.Count);
+        var stopwatch = Stopwatch.StartNew();
+        var aggregated = new Dictionary<int, StampLlmRankedCandidate>();
+        var rawResponses = new List<string>(batches.Count);
+
+        _logger.LogInformation(
+            "[stamp-llm-server] recognize service enter references={ReferenceCount} resolved={ResolvedCount} batches={BatchCount} model={Model} capturedBytes={CapturedBytes}",
+            job.References.Count,
+            resolvedCount,
+            batches.Count,
+            _model,
+            job.CapturedImage.Bytes.Length);
+
+        if (resolvedCount == 0)
+        {
+            stopwatch.Stop();
+            return new StampLlmRecognizeResult(
+                Array.Empty<StampLlmRankedCandidate>(),
+                0,
+                (int)stopwatch.ElapsedMilliseconds,
+                "{\"candidates\":[]}");
+        }
+
+        foreach (var batch in batches)
+        {
+            ct.ThrowIfCancellationRequested();
+            var batchResult = await RecognizeBatchAsync(job.CapturedImage, batch, ct);
+            rawResponses.Add(batchResult.RawResponse);
+
+            // Aggregate by max confidence per location across batches. A reference seen
+            // in multiple batches (we never split a single ref) cannot happen, but if a
+            // future change ever overlaps batches we'd want max-of-confidences anyway.
+            foreach (var candidate in batchResult.Candidates)
+            {
+                if (!aggregated.TryGetValue(candidate.LocationId, out var existing)
+                    || candidate.Confidence > existing.Confidence)
+                {
+                    aggregated[candidate.LocationId] = candidate;
+                }
+            }
+        }
+
+        stopwatch.Stop();
+
+        var ranked = aggregated.Values
+            .OrderByDescending(c => c.Confidence)
+            .ToList();
+
+        _logger.LogInformation(
+            "[stamp-llm-server] recognize service exit references={ReferenceCount} candidates={CandidateCount} top1Confidence={Top1Confidence} latencyMs={LatencyMs}",
+            job.References.Count,
+            ranked.Count,
+            ranked.Count > 0 ? ranked[0].Confidence : 0,
+            stopwatch.ElapsedMilliseconds);
+
+        return new StampLlmRecognizeResult(
+            ranked,
+            resolvedCount,
+            (int)stopwatch.ElapsedMilliseconds,
+            Truncate(string.Join("\n---\n", rawResponses), MaxRawResponseLength));
+    }
+
+    private async Task<StampLlmRecognizeResult> RecognizeBatchAsync(
+        StampImagePayload captured,
+        IReadOnlyList<(StampReference Reference, byte[] Bytes)> batch,
+        CancellationToken ct)
+    {
+        var content = new List<ContentBase>
+        {
+            new TextContent { Text = "CAPTURED — child's stamped paper:" },
+            new ImageContent
+            {
+                Source = new ImageSource
+                {
+                    MediaType = captured.MediaType,
+                    Data = captured.Base64Data
+                }
+            }
+        };
+
+        for (var i = 0; i < batch.Count; i++)
+        {
+            var (reference, bytes) = batch[i];
+            var refImage = StampImagePayload.FromReferenceBytes(bytes);
+            content.Add(new TextContent
+            {
+                Text = $"\nREFERENCE {i + 1} — \"{reference.LocationName}\":"
+            });
+            content.Add(new ImageContent
+            {
+                Source = new ImageSource
+                {
+                    MediaType = refImage.MediaType,
+                    Data = refImage.Base64Data
+                }
+            });
+        }
+
+        content.Add(new TextContent
+        {
+            Text = $"\nRank ALL {batch.Count} references by visual similarity to the captured impression. JSON only."
+        });
+
+        var systemMessages = new List<SystemMessage>
+        {
+            new(RecognizeSystemPrompt, new CacheControl { Type = CacheControlType.ephemeral })
+        };
+
+        var messages = new List<Message>
+        {
+            new() { Role = RoleType.User, Content = content }
+        };
+
+        // Larger token cap than verify because we emit one JSON entry per reference (≤19 entries).
+        var maxTokens = Math.Max(_maxTokens, 50 + batch.Count * 30);
+
+        var parameters = new MessageParameters
+        {
+            Messages = messages,
+            MaxTokens = maxTokens,
+            Model = _model,
+            Stream = false,
+            Temperature = 0m,
+            System = systemMessages,
+            PromptCaching = PromptCacheType.FineGrained
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var response = await _client!.Messages.GetClaudeMessageAsync(parameters, ct);
+            stopwatch.Stop();
+            var raw = Truncate(response.Message.ToString(), MaxRawResponseLength);
+            var ranked = ParseRecognizeResponse(raw, batch);
+            return new StampLlmRecognizeResult(ranked, batch.Count, (int)stopwatch.ElapsedMilliseconds, raw);
+        }
+        catch (RateLimitsExceeded ex)
+        {
+            stopwatch.Stop();
+            _logger.LogWarning(
+                ex,
+                "[stamp-llm-server] recognize service rate-limited references={ReferenceCount} latencyMs={LatencyMs}",
+                batch.Count,
+                stopwatch.ElapsedMilliseconds);
+            throw new StampLlmRateLimitedException(
+                "Anthropic rate limit",
+                (int)stopwatch.ElapsedMilliseconds,
+                ex.Message,
+                ex);
+        }
+        catch (Exception ex) when (ex is not StampLlmValidationException and not OperationCanceledException)
+        {
+            stopwatch.Stop();
+            _logger.LogError(
+                ex,
+                "[stamp-llm-server] recognize service provider-error references={ReferenceCount} latencyMs={LatencyMs}",
+                batch.Count,
+                stopwatch.ElapsedMilliseconds);
+            throw new StampLlmProviderException(
+                "Anthropic API call failed",
+                (int)stopwatch.ElapsedMilliseconds,
+                ex.Message,
+                ex);
+        }
+    }
+
+    private async Task<List<List<(StampReference Reference, byte[] Bytes)>>> ResolveBatchesAsync(
+        IReadOnlyList<StampReference> references,
+        int batchSize,
+        CancellationToken ct)
+    {
+        var resolved = new List<(StampReference Reference, byte[] Bytes)>(references.Count);
+        foreach (var reference in references)
+        {
+            var bytes = await _blobStorage.DownloadAsync(reference.ReferenceBlobKey, ct);
+            if (bytes is null || bytes.Length == 0)
+            {
+                _logger.LogWarning(
+                    "[stamp-llm-server] recognize skipping missing reference locationId={LocationId} blobKey={BlobKey}",
+                    reference.LocationId,
+                    reference.ReferenceBlobKey);
+                continue;
+            }
+            resolved.Add((reference, bytes));
+        }
+
+        var batches = new List<List<(StampReference, byte[])>>();
+        for (var i = 0; i < resolved.Count; i += batchSize)
+        {
+            batches.Add(resolved.GetRange(i, Math.Min(batchSize, resolved.Count - i)));
+        }
+        return batches;
+    }
+
+    private static List<StampLlmRankedCandidate> ParseRecognizeResponse(
+        string raw,
+        IReadOnlyList<(StampReference Reference, byte[] Bytes)> batch)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(raw);
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("candidates", out var candidatesEl) || candidatesEl.ValueKind != JsonValueKind.Array)
+                throw new JsonException("Expected 'candidates' array.");
+
+            var ranked = new List<StampLlmRankedCandidate>(batch.Count);
+            foreach (var entry in candidatesEl.EnumerateArray())
+            {
+                var index = entry.GetProperty("index").GetInt32();
+                var confidence = entry.GetProperty("confidence").GetDouble();
+                if (index < 1 || index > batch.Count) continue;
+                if (confidence < 0) confidence = 0;
+                if (confidence > 1) confidence = 1;
+                var reference = batch[index - 1].Reference;
+                ranked.Add(new StampLlmRankedCandidate(reference.LocationId, reference.LocationName, confidence));
+            }
+
+            if (ranked.Count == 0)
+                throw new JsonException("Response contained no usable candidates.");
+
+            return ranked;
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException or KeyNotFoundException or FormatException)
+        {
+            throw new StampLlmProviderException(
+                "Anthropic returned malformed recognize JSON",
+                0,
+                $"Anthropic vrátil neplatnou odpověď: {raw}",
                 ex);
         }
     }

--- a/src/OvcinaHra.Client/Components/QuickLaunchTiles.razor
+++ b/src/OvcinaHra.Client/Components/QuickLaunchTiles.razor
@@ -1,10 +1,13 @@
-@* Issue #432 — keep the cockpit quick action focused on field placement. *@
+@* Issue #432 — keep the cockpit quick action focused on field placement.
+   2026-05-01 — added second tile for "Rozpoznat skrýš". Multi-tile layout
+   uses the default oh-home-qlaunch-grid (4 cols desktop, 2 cols mobile);
+   the --single modifier is dropped once we exceed one tile. *@
 
 <section class="oh-home-qlaunch" aria-labelledby="oh-home-q-title">
     <header class="oh-home-qlaunch-head">
         <h2 id="oh-home-q-title">Rychlý přístup</h2>
     </header>
-    <div class="oh-home-qlaunch-grid oh-home-qlaunch-grid--single">
+    <div class="oh-home-qlaunch-grid">
         @foreach (var tile in Tiles)
         {
             <a class="oh-home-tile oh-home-k-@tile.Key" href="@tile.Href">
@@ -21,5 +24,6 @@
     private static readonly Tile[] Tiles =
     {
         new("place", "Umístění lokace", "bi-camera-fill", "/locations?placement=1"),
+        new("recognize", "Rozpoznat skrýš", "bi-search", "/recognize-stash"),
     };
 }

--- a/src/OvcinaHra.Client/Components/StampMatchModal.razor
+++ b/src/OvcinaHra.Client/Components/StampMatchModal.razor
@@ -1,0 +1,133 @@
+@* Bootstrap-style dismissible modal that renders the top-N candidate Locations
+   from /api/stamps/recognize with each location's stashes inline. The organizer
+   does not need to navigate anywhere — name + confidence + stash list are all
+   on screen at once.
+   Pure Razor + Bootstrap classes; no JS interop because the parent owns Show/Hide
+   state via the Visible parameter. *@
+
+@if (Visible)
+{
+    <div class="modal fade show oh-stamp-match-modal" tabindex="-1" role="dialog" aria-modal="true"
+         style="display:block; background:rgba(0,0,0,0.55);" @onclick="OnBackdropClick">
+        <div class="modal-dialog modal-dialog-scrollable modal-lg" role="document"
+             @onclick:stopPropagation="true" @onclick:preventDefault="false">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">
+                        <i class="bi bi-search me-2"></i>Rozpoznané skrýše
+                    </h5>
+                    <button type="button" class="btn-close" aria-label="Zavřít" @onclick="HandleClose"></button>
+                </div>
+                <div class="modal-body">
+                    @if (Result is null)
+                    {
+                        <p class="text-muted mb-0">Žádný výsledek k zobrazení.</p>
+                    }
+                    else if (Result.NoReferences)
+                    {
+                        <div class="alert alert-info mb-0" role="status">
+                            <i class="bi bi-info-circle me-2"></i>
+                            Tato hra nemá žádné lokace s razítkem. Doplň referenční obrázky razítek
+                            v sekci Lokace, aby bylo co srovnávat.
+                        </div>
+                    }
+                    else if (Result.Candidates.Count == 0)
+                    {
+                        <div class="alert alert-warning mb-0" role="status">
+                            <i class="bi bi-exclamation-triangle me-2"></i>
+                            Snímek se nepodařilo přiřadit k žádné lokaci. Zkus ostřejší fotku
+                            nebo razítko zarovnej blíž ke středu.
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="text-muted small mb-3">
+                            Skenováno @Result.TotalReferencesScanned referenčních razítek
+                            za @FormatLatency(Result.LatencyMs).
+                        </p>
+
+                        <ol class="oh-stamp-match-list list-unstyled m-0">
+                            @for (var i = 0; i < Result.Candidates.Count; i++)
+                            {
+                                var candidate = Result.Candidates[i];
+                                var rank = i + 1;
+                                var confidenceClass = ConfidenceClass(candidate.Confidence);
+                                <li class="oh-stamp-match-row card mb-3 @(rank == 1 ? "border-success" : "")">
+                                    <div class="card-body">
+                                        <div class="d-flex justify-content-between align-items-start">
+                                            <div>
+                                                <h6 class="card-title mb-1">
+                                                    <span class="badge bg-secondary me-2">@rank</span>
+                                                    @candidate.LocationName
+                                                </h6>
+                                            </div>
+                                            <span class="badge @confidenceClass">
+                                                @FormatConfidence(candidate.Confidence)
+                                            </span>
+                                        </div>
+
+                                        @if (candidate.Stashes.Count == 0)
+                                        {
+                                            <p class="text-muted small mb-0 mt-2">
+                                                <i class="bi bi-info-circle me-1"></i>
+                                                Tato lokace nemá v této hře žádné skrýše.
+                                            </p>
+                                        }
+                                        else
+                                        {
+                                            <ul class="oh-stamp-match-stashes mt-2 mb-0">
+                                                @foreach (var stash in candidate.Stashes)
+                                                {
+                                                    <li>
+                                                        <strong>@stash.Name</strong>
+                                                        @if (!string.IsNullOrWhiteSpace(stash.Summary))
+                                                        {
+                                                            <span class="text-muted"> — @stash.Summary</span>
+                                                        }
+                                                    </li>
+                                                }
+                                            </ul>
+                                        }
+                                    </div>
+                                </li>
+                            }
+                        </ol>
+                    }
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" @onclick="HandleClose">Zavřít</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public RecognizeStashResponse? Result { get; set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+
+    private async Task HandleClose() => await OnClose.InvokeAsync();
+
+    private async Task OnBackdropClick() => await OnClose.InvokeAsync();
+
+    private static string FormatConfidence(double confidence)
+        => $"{Math.Round(confidence * 100)} %";
+
+    private static string ConfidenceClass(double confidence) => confidence switch
+    {
+        >= 0.7 => "bg-success",
+        >= 0.5 => "bg-warning text-dark",
+        _ => "bg-secondary"
+    };
+
+    private static string FormatLatency(int latencyMs)
+    {
+        if (latencyMs >= 1000)
+        {
+            var seconds = latencyMs / 1000.0;
+            return $"{seconds:0.0} s";
+        }
+        return $"{latencyMs} ms";
+    }
+}

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -82,6 +82,10 @@
             <div class="pane pane-@mode" @key="mode">
                 @if (mode == "hra")
                 {
+                    <NavLink class="oh-nav-item" href="recognize-stash">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-search ni"></i><span class="oh-nav-label">Rozpoznat skrýš</span>
+                    </NavLink>
                     <NavLink class="oh-nav-item" href="timeline">
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-clock-fill ni"></i><span class="oh-nav-label">Harmonogram</span>

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.17.28</Version>
+    <Version>0.17.29</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Client/Pages/RecognizeStash/RecognizeStashPage.razor
+++ b/src/OvcinaHra.Client/Pages/RecognizeStash/RecognizeStashPage.razor
@@ -12,7 +12,7 @@
             <i class="bi bi-search me-2"></i>Rozpoznat skrýš
         </h1>
         <p class="text-muted small mb-0">
-            Vyfoť otisk razítka v glejtu hrdiny — Ovčina porovná snímek s razítky lokací aktivní hry
+            Vyfoť otisk razítka v glejtu hrdiny — Ovčina porovná snímek s razítky lokací vybrané hry
             a ukáže nejpravděpodobnější skrýše.
         </p>
     </header>
@@ -157,7 +157,7 @@
                 (System.Net.HttpStatusCode)429 => "LLM rozpoznání je dočasně omezené. Počkej chvíli a zkus to znovu.",
                 System.Net.HttpStatusCode.ServiceUnavailable => "LLM rozpoznání není v tomto prostředí nakonfigurované.",
                 System.Net.HttpStatusCode.BadRequest => "Snímek se nepodařilo zpracovat. Zkus jinou fotku.",
-                _ => $"Volání serveru selhalo: {ex.Message}"
+                _ => "Volání serveru selhalo. Zkus to prosím znovu."
             };
         }
         catch (Exception ex)

--- a/src/OvcinaHra.Client/Pages/RecognizeStash/RecognizeStashPage.razor
+++ b/src/OvcinaHra.Client/Pages/RecognizeStash/RecognizeStashPage.razor
@@ -1,0 +1,174 @@
+@page "/recognize-stash"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject GameContextService GameContext
+@inject ILogger<RecognizeStashPage> Logger
+
+<PageTitle>Rozpoznat skrýš · Ovčina</PageTitle>
+
+<section class="oh-recognize-page container py-3">
+    <header class="oh-recognize-head mb-3">
+        <h1 class="h4 mb-1">
+            <i class="bi bi-search me-2"></i>Rozpoznat skrýš
+        </h1>
+        <p class="text-muted small mb-0">
+            Vyfoť otisk razítka v glejtu hrdiny — Ovčina porovná snímek s razítky lokací aktivní hry
+            a ukáže nejpravděpodobnější skrýše.
+        </p>
+    </header>
+
+    @if (GameContext.SelectedGameId is null)
+    {
+        @* Mirrors Home.razor's no-game empty state — same shape so the user immediately
+           recognises the path: pick or create a game in Správa her. *@
+        <div class="oh-home-no-game">
+            <div class="oh-home-no-game-art">
+                <i class="bi bi-shield-slash"></i>
+            </div>
+            <h2>Zatím není vybrána žádná hra</h2>
+            <p class="text-muted">
+                Vyberte hru v horním pruhu nebo založte novou ve Správě her.
+            </p>
+            <a class="btn btn-primary" href="/games">
+                <i class="bi bi-plus-lg me-1"></i>Otevřít Správu her
+            </a>
+        </div>
+    }
+    else
+    {
+        <div class="oh-recognize-stage">
+            @if (_capturedDataUrl is null)
+            {
+                <p class="text-muted">
+                    Zarovnej razítko na střed obrazu, vyhni se ostrému stínu a pak ťukni
+                    na <strong>Vyfotit</strong>.
+                </p>
+                <CameraCapture OnCaptured="OnPhotoCaptured" />
+            }
+            else
+            {
+                <div class="oh-recognize-preview text-center">
+                    <img src="@_capturedDataUrl" alt="Vyfocený otisk razítka"
+                         class="oh-recognize-preview-img" />
+                </div>
+
+                <div class="d-flex gap-2 justify-content-center mt-3">
+                    <button type="button" class="btn btn-outline-secondary"
+                            @onclick="ResetCapture" disabled="@_loading">
+                        <i class="bi bi-arrow-counterclockwise me-1"></i>Vyfotit znovu
+                    </button>
+                    <button type="button" class="btn btn-primary"
+                            @onclick="RecognizeAsync" disabled="@_loading">
+                        @if (_loading)
+                        {
+                            <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+                            <span>Hledám shodu…</span>
+                        }
+                        else
+                        {
+                            <i class="bi bi-search me-1"></i>
+                            <span>Rozpoznat</span>
+                        }
+                    </button>
+                </div>
+            }
+
+            @if (!string.IsNullOrEmpty(_errorMessage))
+            {
+                <div class="alert alert-danger mt-3" role="alert">
+                    <i class="bi bi-exclamation-triangle me-2"></i>@_errorMessage
+                </div>
+            }
+        </div>
+    }
+</section>
+
+<StampMatchModal Visible="_modalVisible" Result="_result" OnClose="CloseModal" />
+
+@code {
+    private string? _capturedDataUrl;
+    private bool _loading;
+    private string? _errorMessage;
+    private RecognizeStashResponse? _result;
+    private bool _modalVisible;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Re-init in case the page is opened directly (deep link / nav menu) before
+        // the layout has had a chance to wake the GameContextService.
+        await GameContext.InitializeAsync();
+    }
+
+    private void OnPhotoCaptured(string dataUrl)
+    {
+        _capturedDataUrl = dataUrl;
+        _errorMessage = null;
+    }
+
+    private void ResetCapture()
+    {
+        _capturedDataUrl = null;
+        _result = null;
+        _modalVisible = false;
+        _errorMessage = null;
+    }
+
+    private void CloseModal()
+    {
+        _modalVisible = false;
+    }
+
+    private async Task RecognizeAsync()
+    {
+        if (_capturedDataUrl is null || GameContext.SelectedGameId is not int gameId)
+            return;
+
+        _loading = true;
+        _errorMessage = null;
+        StateHasChanged();
+
+        try
+        {
+            var request = new RecognizeStashRequest(gameId, _capturedDataUrl);
+            var response = await Api.PostAsync<RecognizeStashRequest, RecognizeStashResponse>(
+                "/api/stamps/recognize",
+                request);
+
+            if (response is null)
+            {
+                _errorMessage = "Server vrátil prázdnou odpověď. Zkus to znovu.";
+                return;
+            }
+
+            _result = response;
+            _modalVisible = true;
+        }
+        catch (HttpRequestException ex)
+        {
+            // Surface a friendly Czech message regardless of underlying HTTP code; the API
+            // already returns ProblemDetails with a usable detail string but the typed
+            // PostAsync wrapper EnsureSuccessStatusCodes and throws — we lose the body.
+            // Future improvement: switch to a *WithProblemAsync wrapper to round-trip the
+            // server's Czech detail (e.g. "LLM rozpoznání selhalo").
+            Logger.LogWarning(ex, "[recognize-stash] HTTP error");
+            _errorMessage = ex.StatusCode switch
+            {
+                System.Net.HttpStatusCode.BadGateway => "LLM rozpoznání selhalo, zkus snímek znovu nebo použij ruční výběr.",
+                (System.Net.HttpStatusCode)429 => "LLM rozpoznání je dočasně omezené. Počkej chvíli a zkus to znovu.",
+                System.Net.HttpStatusCode.ServiceUnavailable => "LLM rozpoznání není v tomto prostředí nakonfigurované.",
+                System.Net.HttpStatusCode.BadRequest => "Snímek se nepodařilo zpracovat. Zkus jinou fotku.",
+                _ => $"Volání serveru selhalo: {ex.Message}"
+            };
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "[recognize-stash] unexpected error");
+            _errorMessage = "Něco se pokazilo. Zkus to znovu.";
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/StampLlmVerification.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/StampLlmVerification.cs
@@ -2,10 +2,26 @@ namespace OvcinaHra.Shared.Domain.Entities;
 
 public class StampLlmVerification
 {
+    /// <summary>
+    /// "verify" — 1-to-1 LLM check against a chosen Location reference (existing /verify-llm flow).
+    /// "recognize" — 1-to-N rank against all stamped Locations in a game (new /recognize flow).
+    /// </summary>
+    public const string ModeVerify = "verify";
+
+    /// <summary>
+    /// Recognize-stash audit row. <see cref="LocationId"/> stores the top-1 candidate (or 0 when none).
+    /// </summary>
+    public const string ModeRecognize = "recognize";
+
     public int Id { get; set; }
     public DateTime TimestampUtc { get; set; } = DateTime.UtcNow;
     public required string OrganizerUserId { get; set; }
     public required string OrganizerName { get; set; }
+
+    /// <summary>
+    /// For <see cref="ModeVerify"/> — the Location whose stamp was checked.
+    /// For <see cref="ModeRecognize"/> — the top-1 Location candidate.
+    /// </summary>
     public int LocationId { get; set; }
     public int? ContextStashId { get; set; }
     public int? ContextQuestId { get; set; }
@@ -13,6 +29,24 @@ public class StampLlmVerification
     public double Confidence { get; set; }
     public int LatencyMs { get; set; }
     public required string RawResponse { get; set; }
+
+    /// <summary>
+    /// Discriminator between the verify (1-to-1) and recognize (1-to-N) audit rows.
+    /// Defaults to <see cref="ModeVerify"/> for back-compat with existing rows.
+    /// </summary>
+    public string Mode { get; set; } = ModeVerify;
+
+    /// <summary>
+    /// Recognize-only: the Game whose stamped locations were the candidate set.
+    /// Null for verify rows.
+    /// </summary>
+    public int? GameId { get; set; }
+
+    /// <summary>
+    /// Recognize-only: how many reference stamps were sent to the LLM across all batches.
+    /// Null for verify rows.
+    /// </summary>
+    public int? ReferencesScanned { get; set; }
 
     public Location Location { get; set; } = null!;
 }

--- a/src/OvcinaHra.Shared/Dtos/StampDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/StampDtos.cs
@@ -15,7 +15,7 @@ public record VerifyStampLlmResponse(
 
 /// <summary>
 /// Request body for POST /api/stamps/recognize. Photo of a glejt stamp →
-/// ranked candidate Locations from the active game.
+/// ranked candidate Locations from the hra s daným GameId.
 /// </summary>
 public record RecognizeStashRequest(
     int GameId,
@@ -25,7 +25,7 @@ public record RecognizeStashRequest(
 /// Response body for POST /api/stamps/recognize. Top-3 candidates, each with
 /// its inline list of stashes so the organizer can guide the player without
 /// further navigation. Empty <see cref="Candidates"/> + <c>NoReferences=true</c>
-/// means the active game has no stamped locations yet.
+/// means the vybraná hra has no stamped locations yet.
 /// </summary>
 public record RecognizeStashResponse(
     IReadOnlyList<StampMatchCandidate> Candidates,

--- a/src/OvcinaHra.Shared/Dtos/StampDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/StampDtos.cs
@@ -12,3 +12,34 @@ public record VerifyStampLlmResponse(
     string Reason,
     string ReferenceLocationName,
     int LatencyMs);
+
+/// <summary>
+/// Request body for POST /api/stamps/recognize. Photo of a glejt stamp →
+/// ranked candidate Locations from the active game.
+/// </summary>
+public record RecognizeStashRequest(
+    int GameId,
+    string CapturedImageBase64);
+
+/// <summary>
+/// Response body for POST /api/stamps/recognize. Top-3 candidates, each with
+/// its inline list of stashes so the organizer can guide the player without
+/// further navigation. Empty <see cref="Candidates"/> + <c>NoReferences=true</c>
+/// means the active game has no stamped locations yet.
+/// </summary>
+public record RecognizeStashResponse(
+    IReadOnlyList<StampMatchCandidate> Candidates,
+    int TotalReferencesScanned,
+    int LatencyMs,
+    bool NoReferences = false);
+
+public record StampMatchCandidate(
+    int LocationId,
+    string LocationName,
+    double Confidence,
+    IReadOnlyList<StashSummary> Stashes);
+
+public record StashSummary(
+    int StashId,
+    string Name,
+    string? Summary);

--- a/tests/OvcinaHra.Api.Tests/ClientSmoke/RecognizeStashSmokeTests.cs
+++ b/tests/OvcinaHra.Api.Tests/ClientSmoke/RecognizeStashSmokeTests.cs
@@ -1,0 +1,152 @@
+namespace OvcinaHra.Api.Tests.ClientSmoke;
+
+/// <summary>
+/// Lightweight content-assertion smoke tests for the Rozpoznat skrýš client surface.
+/// Mirrors the existing ClientSmoke pattern (e.g. BotConsultDrawerSmokeTests):
+/// no bUnit harness — just verify the rendered Razor source contains the contract bits
+/// (route, auth, no-game guard, modal wiring, NavMenu link, tile entry).
+/// </summary>
+public class RecognizeStashSmokeTests
+{
+    [Fact]
+    public void Page_HasAuthorizeAttribute_AndGameRequiredGuard()
+    {
+        var root = FindRepoRoot();
+        var page = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Pages",
+            "RecognizeStash",
+            "RecognizeStashPage.razor"));
+
+        Assert.Contains("@page \"/recognize-stash\"", page);
+        Assert.Contains("@attribute [Authorize]", page);
+        Assert.Contains("GameContext.SelectedGameId is null", page);
+        Assert.Contains("Zatím není vybrána žádná hra", page);
+        Assert.Contains("Otevřít Správu her", page);
+    }
+
+    [Fact]
+    public void Page_RendersCameraCapture_AndRecognizeButton_AndModal()
+    {
+        var root = FindRepoRoot();
+        var page = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Pages",
+            "RecognizeStash",
+            "RecognizeStashPage.razor"));
+
+        Assert.Contains("<CameraCapture OnCaptured=\"OnPhotoCaptured\"", page);
+        Assert.Contains("Vyfotit znovu", page);
+        Assert.Contains(">Rozpoznat<", page);
+        Assert.Contains("Hledám shodu", page);
+        Assert.Contains("<StampMatchModal", page);
+        Assert.Contains("Visible=\"_modalVisible\"", page);
+        Assert.Contains("Result=\"_result\"", page);
+        Assert.Contains("OnClose=\"CloseModal\"", page);
+    }
+
+    [Fact]
+    public void Page_PostsToRecognizeEndpoint_WithGameIdInBody()
+    {
+        var root = FindRepoRoot();
+        var page = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Pages",
+            "RecognizeStash",
+            "RecognizeStashPage.razor"));
+
+        Assert.Contains("\"/api/stamps/recognize\"", page);
+        Assert.Contains("RecognizeStashRequest(gameId, _capturedDataUrl)", page);
+        Assert.Contains("PostAsync<RecognizeStashRequest, RecognizeStashResponse>", page);
+        // Errors must be Czech, not exception-string-leaks.
+        Assert.Contains("LLM rozpoznání selhalo", page);
+        Assert.Contains("LLM rozpoznání je dočasně omezené", page);
+        Assert.Contains("LLM rozpoznání není v tomto prostředí nakonfigurované", page);
+    }
+
+    [Fact]
+    public void Modal_RendersTopCandidatesWithStashes_AndHandlesEmptyAndNoReferenceStates()
+    {
+        var root = FindRepoRoot();
+        var modal = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Components",
+            "StampMatchModal.razor"));
+
+        Assert.Contains("Rozpoznané skrýše", modal);
+        Assert.Contains("Tato hra nemá žádné lokace s razítkem", modal);
+        Assert.Contains("Snímek se nepodařilo přiřadit k žádné lokaci", modal);
+        Assert.Contains("Result.Candidates", modal);
+        Assert.Contains("candidate.Stashes", modal);
+        Assert.Contains("Zavřít", modal);
+        Assert.Contains("OnClose.InvokeAsync()", modal);
+        // Confidence threshold colours must be present — green/yellow/grey buckets.
+        Assert.Contains("bg-success", modal);
+        Assert.Contains("bg-warning", modal);
+        Assert.Contains("bg-secondary", modal);
+    }
+
+    [Fact]
+    public void QuickLaunchTiles_ContainsRecognizeStashTile()
+    {
+        var root = FindRepoRoot();
+        var tiles = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Components",
+            "QuickLaunchTiles.razor"));
+
+        Assert.Contains("\"recognize\"", tiles);
+        Assert.Contains("Rozpoznat skrýš", tiles);
+        Assert.Contains("/recognize-stash", tiles);
+        Assert.Contains("bi-search", tiles);
+        // Layout must drop the --single modifier once we have multiple tiles.
+        Assert.DoesNotContain("oh-home-qlaunch-grid--single", tiles);
+    }
+
+    [Fact]
+    public void NavMenu_HasRecognizeStashLink_UnderHraMode()
+    {
+        var root = FindRepoRoot();
+        var nav = File.ReadAllText(Path.Combine(
+            root,
+            "src",
+            "OvcinaHra.Client",
+            "Layout",
+            "NavMenu.razor"));
+
+        Assert.Contains("href=\"recognize-stash\"", nav);
+        Assert.Contains(">Rozpoznat skrýš<", nav);
+
+        // The link must sit inside the @if (mode == "hra") block (game-scoped items)
+        // and NOT in the catalog branch. We assert it lives before the catalog-only
+        // anchor "locations?catalog=true" which is the first item in the else branch.
+        var recognizeIdx = nav.IndexOf("href=\"recognize-stash\"", StringComparison.Ordinal);
+        var catalogStart = nav.IndexOf("locations?catalog=true", StringComparison.Ordinal);
+        Assert.True(recognizeIdx >= 0, "Expected the recognize-stash NavLink in NavMenu.razor");
+        Assert.True(catalogStart > recognizeIdx,
+            "Recognize-stash NavLink must be inside the hra-mode block, not the catalog branch.");
+    }
+
+    private static string FindRepoRoot()
+    {
+        // Walk up from the test binary until we find the .slnx — same pattern the other
+        // ClientSmoke tests use (no shared helper to import without enlarging surface).
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "OvcinaHra.slnx")))
+        {
+            dir = dir.Parent;
+        }
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/RecognizeStashEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/RecognizeStashEndpointTests.cs
@@ -160,6 +160,9 @@ public class RecognizeStashEndpointTests(PostgresFixture postgres) : Integration
         Assert.False(audit.Match);
         Assert.Equal(211, audit.LatencyMs);
         Assert.Equal(gameId, audit.GameId);
+        // Failing calls also cost — the intended reference count must be persisted
+        // on failure rows so cost analysis reflects every API call attempt.
+        Assert.Equal(2, audit.ReferencesScanned);
     }
 
     [Fact]
@@ -183,6 +186,8 @@ public class RecognizeStashEndpointTests(PostgresFixture postgres) : Integration
         var audit = await db.StampLlmVerifications.SingleAsync();
         Assert.Equal(StampLlmVerification.ModeRecognize, audit.Mode);
         Assert.Equal(150, audit.LatencyMs);
+        // Same as 502 case — rate-limit-killed calls still cost upstream attempts.
+        Assert.Equal(1, audit.ReferencesScanned);
     }
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Endpoints/RecognizeStashEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/RecognizeStashEndpointTests.cs
@@ -1,0 +1,431 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+/// <summary>
+/// Sister tests for /api/stamps/recognize. Mirrors <see cref="StampLlmEndpointTests"/> shape:
+/// per-class fake LLM service (registered via <see cref="ApiWebApplicationFactory"/> overrides),
+/// real Postgres, real seed data. The recognize endpoint is many-to-1 so the seed has multiple
+/// stamped locations under one game, and the fake's Func decides which one wins.
+/// </summary>
+public class RecognizeStashEndpointTests(PostgresFixture postgres) : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    private const string ReferenceBlobKeyPrefix = "locationstamps/recognize-test-";
+
+    [Fact]
+    public async Task Recognize_HappyPath_RanksTopCandidateAndAttachesStashes()
+    {
+        var capturedBytes = ReadTestData("sample-stamp-captured-good.jpg");
+
+        // Fake ranks the location whose name starts with "Stará chýše" highest, second
+        // location next, third lowest. Tests aggregate + projection + audit row writing.
+        var fake = new FakeStampLlmRecognizeService(job =>
+        {
+            var ranked = job.References
+                .Select((r, i) => new StampLlmRankedCandidate(
+                    r.LocationId,
+                    r.LocationName,
+                    r.LocationName.StartsWith("Stará chýše") ? 0.92
+                        : r.LocationName.StartsWith("Mlýn") ? 0.41
+                        : 0.18))
+                .OrderByDescending(c => c.Confidence)
+                .ToList();
+
+            return new StampLlmRecognizeResult(
+                ranked,
+                job.References.Count,
+                7240,
+                """{"candidates":[{"index":1,"confidence":0.92}]}""");
+        });
+
+        await using var resources = await CreateClientWithFakeAsync(fake);
+        var (gameId, _) = await SeedGameWithStampedLocationsAsync(resources.Factory, 3);
+
+        var response = await resources.Client.PostAsJsonAsync("/api/stamps/recognize",
+            new RecognizeStashRequest(gameId, ToDataUrl(capturedBytes, "image/jpeg")));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<RecognizeStashResponse>();
+        Assert.NotNull(body);
+        Assert.False(body!.NoReferences);
+        Assert.Equal(3, body.TotalReferencesScanned);
+        Assert.Equal(7240, body.LatencyMs);
+        Assert.Equal(3, body.Candidates.Count);
+        Assert.StartsWith("Stará chýše", body.Candidates[0].LocationName);
+        Assert.True(body.Candidates[0].Confidence > body.Candidates[1].Confidence);
+
+        // Top-1 has its stashes inlined.
+        Assert.NotEmpty(body.Candidates[0].Stashes);
+
+        // Audit row written.
+        using var scope = resources.Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var audit = await db.StampLlmVerifications.SingleAsync();
+        Assert.Equal(StampLlmVerification.ModeRecognize, audit.Mode);
+        Assert.Equal(gameId, audit.GameId);
+        Assert.Equal(3, audit.ReferencesScanned);
+        Assert.True(audit.Match);
+        Assert.Equal(0.92, audit.Confidence);
+    }
+
+    [Fact]
+    public async Task Recognize_NoStampedLocations_ReturnsNoReferencesFlag()
+    {
+        var fake = new FakeStampLlmRecognizeService(_ =>
+            throw new InvalidOperationException("Verifier must not run when there are no references."));
+
+        await using var resources = await CreateClientWithFakeAsync(fake);
+        var gameId = await SeedGameWithoutStampsAsync(resources.Factory);
+
+        var response = await resources.Client.PostAsJsonAsync("/api/stamps/recognize",
+            new RecognizeStashRequest(gameId, ToDataUrl(ReadTestData("sample-stamp-captured-good.jpg"), "image/jpeg")));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<RecognizeStashResponse>();
+        Assert.NotNull(body);
+        Assert.True(body!.NoReferences);
+        Assert.Empty(body.Candidates);
+        Assert.Equal(0, body.TotalReferencesScanned);
+        Assert.Empty(fake.Jobs);
+
+        // No audit row when no LLM call.
+        using var scope = resources.Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        Assert.Equal(0, await db.StampLlmVerifications.CountAsync());
+    }
+
+    [Fact]
+    public async Task Recognize_GameNotFound_Returns404()
+    {
+        var fake = new FakeStampLlmRecognizeService(_ =>
+            throw new InvalidOperationException("Verifier must not run."));
+
+        await using var resources = await CreateClientWithFakeAsync(fake);
+
+        var response = await resources.Client.PostAsJsonAsync("/api/stamps/recognize",
+            new RecognizeStashRequest(GameId: 999_999, ToDataUrl(ReadTestData("sample-stamp-captured-good.jpg"), "image/jpeg")));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await AssertProblemDetailsAsync(response, "Hra neexistuje", "999999");
+        Assert.Empty(fake.Jobs);
+    }
+
+    [Fact]
+    public async Task Recognize_BadBase64_ReturnsCzechProblemDetails()
+    {
+        var fake = new FakeStampLlmRecognizeService(_ =>
+            throw new InvalidOperationException("Verifier must not run."));
+
+        await using var resources = await CreateClientWithFakeAsync(fake);
+        var (gameId, _) = await SeedGameWithStampedLocationsAsync(resources.Factory, 1);
+
+        var response = await resources.Client.PostAsJsonAsync("/api/stamps/recognize",
+            new RecognizeStashRequest(gameId, "not-base64"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        await AssertProblemDetailsAsync(response, "Neplatný snímek razítka", "base64");
+        Assert.Empty(fake.Jobs);
+    }
+
+    [Fact]
+    public async Task Recognize_AnthropicError_Returns502_AndWritesAuditFailure()
+    {
+        var fake = new FakeStampLlmRecognizeService(_ =>
+            throw new StampLlmProviderException("upstream boom", 211, "raw upstream body"));
+
+        await using var resources = await CreateClientWithFakeAsync(fake);
+        var (gameId, _) = await SeedGameWithStampedLocationsAsync(resources.Factory, 2);
+
+        var response = await resources.Client.PostAsJsonAsync("/api/stamps/recognize",
+            new RecognizeStashRequest(gameId, ToDataUrl(ReadTestData("sample-stamp-captured-good.jpg"), "image/jpeg")));
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+        var problem = await AssertProblemDetailsAsync(response, "LLM rozpoznání selhalo", "ruční výběr");
+        Assert.DoesNotContain("upstream boom", problem.Detail, StringComparison.OrdinalIgnoreCase);
+
+        using var scope = resources.Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var audit = await db.StampLlmVerifications.SingleAsync();
+        Assert.Equal(StampLlmVerification.ModeRecognize, audit.Mode);
+        Assert.False(audit.Match);
+        Assert.Equal(211, audit.LatencyMs);
+        Assert.Equal(gameId, audit.GameId);
+    }
+
+    [Fact]
+    public async Task Recognize_RateLimited_Returns429_AndWritesAuditFailure()
+    {
+        var fake = new FakeStampLlmRecognizeService(_ =>
+            throw new StampLlmRateLimitedException("rate limited", 150, "too many requests"));
+
+        await using var resources = await CreateClientWithFakeAsync(fake);
+        var (gameId, _) = await SeedGameWithStampedLocationsAsync(resources.Factory, 1);
+
+        var response = await resources.Client.PostAsJsonAsync("/api/stamps/recognize",
+            new RecognizeStashRequest(gameId, ToDataUrl(ReadTestData("sample-stamp-captured-good.jpg"), "image/jpeg")));
+
+        Assert.Equal((HttpStatusCode)429, response.StatusCode);
+        var problem = await AssertProblemDetailsAsync(response, "LLM rozpoznání je dočasně omezené", "zkus");
+        Assert.DoesNotContain("too many requests", problem.Detail, StringComparison.OrdinalIgnoreCase);
+
+        using var scope = resources.Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var audit = await db.StampLlmVerifications.SingleAsync();
+        Assert.Equal(StampLlmVerification.ModeRecognize, audit.Mode);
+        Assert.Equal(150, audit.LatencyMs);
+    }
+
+    [Fact]
+    public async Task Recognize_MissingAnthropicConfiguration_Returns503()
+    {
+        var fake = new FakeStampLlmRecognizeService(
+            _ => throw new InvalidOperationException("Verifier must not run."),
+            isConfigured: false);
+
+        await using var resources = await CreateClientWithFakeAsync(fake);
+
+        var response = await resources.Client.PostAsJsonAsync("/api/stamps/recognize",
+            new RecognizeStashRequest(GameId: 999, ToDataUrl(ReadTestData("sample-stamp-captured-good.jpg"), "image/jpeg")));
+
+        // The 503 helper is shared with /verify-llm — title intentionally not branded "rozpoznání"
+        // to keep the operator-facing wording consistent across both LLM endpoints.
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        await AssertProblemDetailsAsync(
+            response,
+            "LLM ověření není v tomto prostředí nakonfigurované",
+            "Anthropic__ApiKey");
+        Assert.Empty(fake.Jobs);
+    }
+
+    [Fact]
+    public async Task Recognize_TwentyFiveStampedLocations_BatchesAndReturnsTop3()
+    {
+        // 25 stamped locations forces 2 batches (19 + 6) under MaxReferencesPerBatch=19.
+        // Fake echoes whatever's in the request — in this test we configure the fake to
+        // mark location index 12 (in the seed order) as the winner across batches.
+        var fake = new FakeStampLlmRecognizeService(job =>
+        {
+            var ranked = job.References
+                .Select((r, i) => new StampLlmRankedCandidate(
+                    r.LocationId,
+                    r.LocationName,
+                    r.LocationName == "Lokace-12" ? 0.95
+                        : r.LocationName == "Lokace-3" ? 0.55
+                        : r.LocationName == "Lokace-20" ? 0.40
+                        : 0.10))
+                .OrderByDescending(c => c.Confidence)
+                .ToList();
+
+            return new StampLlmRecognizeResult(
+                ranked,
+                job.References.Count,
+                12_500,
+                """{"candidates":[]}""");
+        });
+
+        await using var resources = await CreateClientWithFakeAsync(fake);
+        var (gameId, _) = await SeedGameWithStampedLocationsAsync(resources.Factory, 25);
+
+        var response = await resources.Client.PostAsJsonAsync("/api/stamps/recognize",
+            new RecognizeStashRequest(gameId, ToDataUrl(ReadTestData("sample-stamp-captured-good.jpg"), "image/jpeg")));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<RecognizeStashResponse>();
+        Assert.NotNull(body);
+        Assert.Equal(25, body!.TotalReferencesScanned);
+        Assert.Equal(3, body.Candidates.Count);
+        Assert.Equal("Lokace-12", body.Candidates[0].LocationName);
+        Assert.Equal(0.95, body.Candidates[0].Confidence);
+        Assert.True(body.Candidates[0].Confidence > body.Candidates[1].Confidence);
+        Assert.True(body.Candidates[1].Confidence > body.Candidates[2].Confidence);
+    }
+
+    private async Task<TestResources> CreateClientWithFakeAsync(FakeStampLlmRecognizeService fake)
+    {
+        var (factory, client) = await Postgres.CreateClientAsync(services =>
+        {
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IStampLlmVerifyService));
+            if (descriptor is not null)
+                services.Remove(descriptor);
+
+            services.AddSingleton<IStampLlmVerifyService>(fake);
+        });
+
+        return new TestResources(factory, client);
+    }
+
+    /// <summary>
+    /// Seeds <paramref name="locationCount"/> Locations under a fresh Game, every one with a
+    /// distinct StampImagePath and uploaded reference blob. The first three locations also
+    /// get a SecretStash + GameSecretStash so the candidate-stash projection has data to find.
+    /// </summary>
+    private static async Task<(int GameId, IReadOnlyList<int> LocationIds)> SeedGameWithStampedLocationsAsync(
+        ApiWebApplicationFactory factory,
+        int locationCount)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var blob = scope.ServiceProvider.GetRequiredService<IBlobStorageService>();
+
+        var game = new Game
+        {
+            Name = "Recognize Test",
+            Edition = 30,
+            Status = GameStatus.Active,
+            StartDate = DateOnly.FromDateTime(DateTime.UtcNow),
+            EndDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(2))
+        };
+        db.Games.Add(game);
+        await db.SaveChangesAsync();
+
+        var locationIds = new List<int>(locationCount);
+        var refBytes = ReadTestData("sample-stamp-reference.png");
+
+        for (var i = 0; i < locationCount; i++)
+        {
+            // First three named for the happy-path assertions; rest are "Lokace-N" for the
+            // batch test. Distinct StampImagePath per location so the resolve loop has work.
+            var name = i switch
+            {
+                0 => "Stará chýše",
+                1 => "Mlýn",
+                2 => "Stará studna",
+                _ => $"Lokace-{i}"
+            };
+
+            var blobKey = $"{ReferenceBlobKeyPrefix}{Guid.NewGuid():N}.png";
+            var location = new Location
+            {
+                Name = name,
+                LocationKind = LocationKind.Wilderness,
+                StampImagePath = blobKey
+            };
+            db.Locations.Add(location);
+            await db.SaveChangesAsync();
+
+            db.GameLocations.Add(new GameLocation { GameId = game.Id, LocationId = location.Id });
+
+            await using (var stream = new MemoryStream(refBytes))
+            {
+                await blob.UploadAsync(blobKey, stream, "image/png");
+            }
+
+            locationIds.Add(location.Id);
+        }
+
+        // Seed two stashes on each of the first three locations so the candidate UI has
+        // something to render. Beyond that the batch test doesn't need stashes.
+        for (var i = 0; i < Math.Min(3, locationCount); i++)
+        {
+            for (var s = 0; s < 2; s++)
+            {
+                var stash = new SecretStash
+                {
+                    Name = $"Skrýš-{i}-{s}",
+                    Description = $"Popis skrýše {i}-{s}"
+                };
+                db.SecretStashes.Add(stash);
+                await db.SaveChangesAsync();
+                db.GameSecretStashes.Add(new GameSecretStash
+                {
+                    GameId = game.Id,
+                    LocationId = locationIds[i],
+                    SecretStashId = stash.Id
+                });
+            }
+        }
+        await db.SaveChangesAsync();
+
+        return (game.Id, locationIds);
+    }
+
+    private static async Task<int> SeedGameWithoutStampsAsync(ApiWebApplicationFactory factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var game = new Game
+        {
+            Name = "Empty Recognize Game",
+            Edition = 31,
+            Status = GameStatus.Draft,
+            StartDate = DateOnly.FromDateTime(DateTime.UtcNow),
+            EndDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(2))
+        };
+        db.Games.Add(game);
+        await db.SaveChangesAsync();
+
+        // Add a location WITHOUT a stamp — confirms the StampImagePath filter actually filters.
+        var location = new Location
+        {
+            Name = "Bez razítka",
+            LocationKind = LocationKind.Wilderness,
+            StampImagePath = null
+        };
+        db.Locations.Add(location);
+        await db.SaveChangesAsync();
+        db.GameLocations.Add(new GameLocation { GameId = game.Id, LocationId = location.Id });
+        await db.SaveChangesAsync();
+
+        return game.Id;
+    }
+
+    private static async Task<ProblemDetails> AssertProblemDetailsAsync(
+        HttpResponseMessage response,
+        string expectedTitle,
+        string expectedDetailFragment)
+    {
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal(expectedTitle, problem!.Title);
+        Assert.Contains(expectedDetailFragment, problem.Detail, StringComparison.OrdinalIgnoreCase);
+        return problem;
+    }
+
+    private static byte[] ReadTestData(string fileName)
+        => File.ReadAllBytes(Path.Combine(AppContext.BaseDirectory, "TestData", fileName));
+
+    private static string ToDataUrl(byte[] bytes, string mediaType)
+        => $"data:{mediaType};base64,{Convert.ToBase64String(bytes)}";
+
+    /// <summary>
+    /// In-memory IStampLlmVerifyService that records every recognize call and returns the
+    /// caller's pre-canned result. <see cref="VerifyAsync"/> is left throwing because these
+    /// tests don't exercise the verify endpoint.
+    /// </summary>
+    private sealed class FakeStampLlmRecognizeService(
+        Func<StampLlmRecognizeJob, StampLlmRecognizeResult> recognize,
+        bool isConfigured = true)
+        : IStampLlmVerifyService
+    {
+        public bool IsConfigured { get; } = isConfigured;
+        public List<StampLlmRecognizeJob> Jobs { get; } = [];
+
+        public Task<StampLlmVerifyResult> VerifyAsync(StampLlmVerifyJob job, CancellationToken ct = default)
+            => throw new InvalidOperationException("Recognize tests must not call verify.");
+
+        public Task<StampLlmRecognizeResult> RecognizeAsync(StampLlmRecognizeJob job, CancellationToken ct = default)
+        {
+            Jobs.Add(job);
+            return Task.FromResult(recognize(job));
+        }
+    }
+
+    private sealed record TestResources(ApiWebApplicationFactory Factory, HttpClient Client) : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await Factory.DisposeAsync();
+        }
+    }
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/StampLlmEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/StampLlmEndpointTests.cs
@@ -279,6 +279,11 @@ public class StampLlmEndpointTests(PostgresFixture postgres) : IntegrationTestBa
             Jobs.Add(job);
             return Task.FromResult(verify(job));
         }
+
+        // Recognize endpoint has its own dedicated test class with its own fake; verify-llm
+        // tests should never reach this method. Throwing makes accidental coupling loud.
+        public Task<StampLlmRecognizeResult> RecognizeAsync(StampLlmRecognizeJob job, CancellationToken ct = default)
+            => throw new InvalidOperationException("Verify tests must not call recognize.");
     }
 
     private sealed record TestResources(ApiWebApplicationFactory Factory, HttpClient Client) : IAsyncDisposable


### PR DESCRIPTION
Adds organizer field-help feature: photograph a rubber stamp on a player's glejt → backend asks Claude Haiku to rank against all reference stamps in the active game → modal shows top-3 candidates with their secret stashes inline. No navigation, super effective for field use. Per user: treasure quests aren't always assigned to specific players, so organizers needed a fast way to identify a stamp without context.

See `azra/docs/plans/2026-05-01-hra-recognize-stash-design.md` for full design.

## Summary

**Backend:**
- New `POST /api/stamps/recognize` (`{gameId, capturedImageBase64}` → top-3 ranked candidates with confidence + stash list)
- `IStampLlmVerifyService.RecognizeAsync` — multi-image Anthropic call with batching (≤19 references per request, since 1 captured + 19 ref = 20 cap), max-of-batches aggregation
- `StampLlmVerification` audit row extended with `Mode/GameId/ReferencesScanned` columns + EF migration `AddStampLlmVerificationMode`
- New DTOs: `RecognizeStashRequest/Response`, `StampMatchCandidate`, `StashSummary`

**Frontend (v0.17.29):**
- New page `Pages/RecognizeStash/RecognizeStashPage.razor` at \`/recognize-stash\` with [Authorize], game-required guard
- Reuses existing `<CameraCapture>` component (matches VerifyStampPage convention)
- New `Components/StampMatchModal.razor` rendering top-3 with confidence + stashes inline (hand-rolled Bootstrap modal — no DxPopup pattern existed for this)
- New tile in `QuickLaunchTiles.razor` next to Umístění lokace
- New nav item in `Layout/NavMenu.razor` under \"Tato hra\" mode

## Test plan

- [x] 8 backend integration tests (Testcontainers): happy path + ranking, no-stamps `noReferences` flag, 404 game-not-found, 400 bad base64, 502 + 429 + 503 audit paths, 25-location batched aggregation
- [x] 6 ClientSmoke content-assertion tests: route + auth + game-required, modal three-state rendering, tile + NavMenu placement
- [x] Full suite: 675/675 pass, 0 warnings (TreatWarningsAsErrors=true)
- [ ] Manual smoke after deploy: photograph a real stamp, verify top-3 ranking
- [ ] Verify \`/api/version\` matches origin/main after CD

## Concerns flagged for reviewer

- Anthropic multi-image is novel here — prompt asks for JSON ranking, parser is defensive but worth a real-API smoke. Per-reference image content not cached (only system prompt), unlike verify which caches one ref.
- Reference blob downloads sequential in batch resolve — easy follow-up to parallelize with \`Task.WhenAll\` if latency becomes a concern.
- Hand-rolled Bootstrap modal vs DxPopup — no existing reusable modal pattern found; if reviewer prefers DxPopup, easy swap.
- Audit row captures only top-1 — for post-hoc cost analysis of top-2/3 we'd need a side table or JSON column. Deferred.

## Out of scope (per design)

- pHash pre-filter for >50 reference scenarios
- Click-to-navigate to Location detail
- Persist last-N recognized stamps history

🤖 Generated with [Claude Code](https://claude.com/claude-code)