### PR TITLE
fix(stamps): strip Markdown fence around Anthropic recognize JSON [hotfix]

### DIFF
--- a/src/OvcinaHra.Api/Services/StampLlmVerifyService.cs
+++ b/src/OvcinaHra.Api/Services/StampLlmVerifyService.cs
@@ -639,7 +639,10 @@ public sealed class StampLlmVerifyService : IStampLlmVerifyService, IDisposable
     {
         try
         {
-            using var doc = JsonDocument.Parse(raw);
+            // Haiku-4.5 sometimes wraps JSON in ```json ... ``` markdown fences
+            // or emits a short prose preamble. Extract the outermost {…} block.
+            var json = ExtractJsonObject(raw);
+            using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
             if (!root.TryGetProperty("candidates", out var candidatesEl) || candidatesEl.ValueKind != JsonValueKind.Array)
                 throw new JsonException("Expected 'candidates' array.");
@@ -669,6 +672,16 @@ public sealed class StampLlmVerifyService : IStampLlmVerifyService, IDisposable
                 $"Anthropic vrátil neplatnou odpověď: {raw}",
                 ex);
         }
+    }
+
+    private static string ExtractJsonObject(string raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return raw;
+        var first = raw.IndexOf('{');
+        var last = raw.LastIndexOf('}');
+        if (first >= 0 && last > first)
+            return raw.Substring(first, last - first + 1);
+        return raw;
     }
 
     public void Dispose()


### PR DESCRIPTION
HOTFIX for production /api/stamps/recognize 502s.

Real-API smoke against game 30 (81 stamped locations, 5 batches) showed Haiku-4.5 wraps recognize response in `````json … ````` markdown fences. JsonDocument.Parse rejects with `"'`'` is an invalid start of a value` → 502 instead of ranking.

Implementer + code reviewer flagged this exact risk during PR #521 review; production smoke confirmed.

## Fix

Extract outermost {…} block before parsing. Robust to fenced output, prose preamble, fence-free path.

## Test plan

- [x] 14/14 RecognizeStash tests pass
- [x] Build clean, 0 warnings
- [ ] Live smoke after merge: re-POST the same image that produced the 502

🤖 Generated with Claude Code