### PR TITLE
feat(scan): mirror MonsterVictory/MonsterDefeat into WorldActivity feed [v0.17.34]

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -206,6 +206,58 @@ public static class ScanEndpoints
             }
         }
 
+        // Monster combat audit overlay — mirror MonsterVictory/MonsterDefeat
+        // into Aktivity světa so organizers see fights in the cockpit feed
+        // alongside placements + level-ups. Same best-effort pattern as
+        // CharacterLevelUp above; failures must not roll back the primary
+        // CharacterEvent.
+        if ((dto.EventType == CharacterEventType.MonsterVictory
+             || dto.EventType == CharacterEventType.MonsterDefeat)
+            && await db.Games.AnyAsync(g => g.Id == assignment.GameId))
+        {
+            try
+            {
+                string monsterName = "nestvůrou";
+                try
+                {
+                    using var doc = JsonDocument.Parse(eventData);
+                    if (doc.RootElement.TryGetProperty("monsterName", out var mn)
+                        && mn.GetString() is { Length: > 0 } parsed)
+                    {
+                        monsterName = parsed;
+                    }
+                }
+                catch (JsonException) { }
+
+                var (activityType, description) = dto.EventType switch
+                {
+                    CharacterEventType.MonsterVictory =>
+                        (WorldActivityType.HeroFell,
+                         $"{assignment.Character.Name} padl pod nestvůrou: {monsterName}"),
+                    _ =>
+                        (WorldActivityType.MonsterDefeated,
+                         $"{assignment.Character.Name} přemohl nestvůru: {monsterName}"),
+                };
+
+                db.WorldActivities.Add(new WorldActivity
+                {
+                    GameId = assignment.GameId,
+                    TimestampUtc = ev.Timestamp,
+                    OrganizerUserId = organizer.UserId,
+                    OrganizerName = organizer.Name,
+                    ActivityType = activityType,
+                    Description = description,
+                    CharacterAssignmentId = assignment.Id,
+                    DataJson = eventData
+                });
+                await db.SaveChangesAsync();
+            }
+            catch (Exception)
+            {
+                // Audit overlay only — primary combat event is persisted.
+            }
+        }
+
         return TypedResults.Created($"/api/scan/{personId}/events/{ev.Id}", ToDto(ev));
     }
 

--- a/src/OvcinaHra.Client/Components/WorldActivityTable.razor
+++ b/src/OvcinaHra.Client/Components/WorldActivityTable.razor
@@ -164,6 +164,8 @@
         WorldActivityType.CharacterLevelUp => "Postup postavy",
         WorldActivityType.QuestCompleted => "Dokončený quest",
         WorldActivityType.CharacterLevelReverted => "Vrácená úroveň",
+        WorldActivityType.MonsterDefeated => "Přemožená nestvůra",
+        WorldActivityType.HeroFell => "Padlý hrdina",
         _ => "Aktivita"
     };
 
@@ -173,6 +175,8 @@
         WorldActivityType.CharacterLevelUp => "bi-stars",
         WorldActivityType.QuestCompleted => "bi-patch-check-fill",
         WorldActivityType.CharacterLevelReverted => "bi-arrow-counterclockwise",
+        WorldActivityType.MonsterDefeated => "bi-shield-fill-check",
+        WorldActivityType.HeroFell => "bi-heartbreak-fill",
         _ => "bi-circle"
     };
 
@@ -182,6 +186,8 @@
         WorldActivityType.CharacterLevelUp => "levelup",
         WorldActivityType.QuestCompleted => "quest",
         WorldActivityType.CharacterLevelReverted => "reverted",
+        WorldActivityType.MonsterDefeated => "monster-defeated",
+        WorldActivityType.HeroFell => "hero-fell",
         _ => "default"
     };
 

--- a/src/OvcinaHra.Client/OvcinaHra.Client.csproj
+++ b/src/OvcinaHra.Client/OvcinaHra.Client.csproj
@@ -7,7 +7,7 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>0.17.33</Version>
+    <Version>0.17.34</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OvcinaHra.Shared/Domain/Enums/WorldActivityType.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/WorldActivityType.cs
@@ -8,5 +8,7 @@ public enum WorldActivityType
     LocationPlaced = 0,
     CharacterLevelUp = 1,
     QuestCompleted = 2,
-    CharacterLevelReverted = 3
+    CharacterLevelReverted = 3,
+    MonsterDefeated = 4,
+    HeroFell = 5,
 }


### PR DESCRIPTION
Same pattern as CharacterLevelUp from #478 — best-effort audit overlay so monster combat shows up in the cockpit **Aktivity světa** feed alongside level-ups and placements.

## Changes

- `WorldActivityType`: `+MonsterDefeated (4)`, `+HeroFell (5)`. Stored as string via `HasConversion<string>`, no migration needed.
- `ScanEndpoints.PostEvent`: write `WorldActivity` row right after CharacterEvent persists, with monster name pulled from event payload, Czech description ("Hrdina X přemohl nestvůru: Skret" / "Hrdina X padl pod nestvůrou: Skret"). Same try/catch shield as the LevelUp audit so failures don't roll back the primary event.
- `Components/WorldActivityTable.razor`: label/icon/badge for the new types
  - `MonsterDefeated` → "Přemožená nestvůra" `bi-shield-fill-check`
  - `HeroFell` → "Padlý hrdina" `bi-heartbreak-fill`

## Test plan

- [x] dotnet build clean (Api + Client), 0 warnings
- [x] 10/10 ScanMonsterCombat tests pass
- [ ] After deploy: record a monster Win/Loss in Glejt → row shows in /aktivity feed within seconds (RecentActivityPanel polls 5s)

🤖 Generated with Claude Code