### PR TITLE
feat(items): add catalog inventory tracking

### DIFF
--- a/src/OvcinaHra.Api/Data/Configurations/ItemConfiguration.cs
+++ b/src/OvcinaHra.Api/Data/Configurations/ItemConfiguration.cs
@@ -14,6 +14,11 @@ public class ItemConfiguration : IEntityTypeConfiguration<Item>
         builder.Property(e => e.ItemType).HasConversion<string>().HasMaxLength(30);
         builder.Property(e => e.PhysicalForm).HasConversion<string>().HasMaxLength(30);
         builder.Property(e => e.Note).HasMaxLength(2000);
+        builder.Property(e => e.StockNote).HasMaxLength(500);
+        builder.Property(e => e.StockUpdatedBy).HasMaxLength(200);
+        builder.ToTable(t => t.HasCheckConstraint(
+            "CK_Item_StockCount_NonNegative",
+            "\"StockCount\" >= 0"));
 
         builder.OwnsOne(e => e.ClassRequirements, cr =>
         {

--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
@@ -21,6 +22,7 @@ public static class ItemEndpoints
         group.MapGet("/{id:int}", GetById);
         group.MapPost("/", Create);
         group.MapPut("/{id:int}", Update);
+        group.MapPut("/{id:int}/stock", UpdateStock);
         group.MapDelete("/{id:int}", Delete);
 
         // Class/level query — "can this class at this level use this item?"
@@ -58,7 +60,11 @@ public static class ItemEndpoints
                 i.IsUnique,
                 i.IsLimited,
                 i.ImagePath,
-                i.Note
+                i.Note,
+                i.StockCount,
+                i.StockNote,
+                i.StockUpdatedUtc,
+                i.StockUpdatedBy
             })
             .ToListAsync();
 
@@ -81,7 +87,11 @@ public static class ItemEndpoints
             // (5:7) so the bytes match the .oh-it-tile container ratio and
             // ImageSharp's Crop mode no longer eats the card art.
             ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "items", r.Id, "medium"),
-            HasRecipe: craftedSet.Contains(r.Id))).ToList();
+            HasRecipe: craftedSet.Contains(r.Id),
+            StockCount: r.StockCount,
+            StockNote: r.StockNote,
+            StockUpdatedUtc: r.StockUpdatedUtc,
+            StockUpdatedBy: r.StockUpdatedBy)).ToList();
         return TypedResults.Ok(items);
     }
 
@@ -109,6 +119,8 @@ public static class ItemEndpoints
     // belongs in the wiki. DevExpress DxMemo MaxLength isn't reliable in
     // 25.2.5 so the cap is enforced server-side.
     private const int NoteMaxLength = 2000;
+    private const int StockNoteMaxLength = 500;
+    private const int StockUpdatedByMaxLength = 200;
 
     private static async Task<Results<Created<ItemDetailDto>, ProblemHttpResult>> Create(CreateItemDto dto, WorldDbContext db)
     {
@@ -171,6 +183,37 @@ public static class ItemEndpoints
         item.IsUnique = dto.IsUnique;
         item.IsLimited = dto.IsLimited;
         item.Note = string.IsNullOrWhiteSpace(note) ? null : note;
+
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> UpdateStock(
+        int id,
+        UpdateItemStockDto dto,
+        WorldDbContext db,
+        HttpContext http)
+    {
+        var item = await db.Items.FindAsync(id);
+        if (item is null) return TypedResults.NotFound();
+
+        if (dto.StockCount < 0)
+            return TypedResults.Problem(
+                title: "Neplatný počet kusů",
+                detail: "Počet kusů na skladě nesmí být záporný.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        var stockNote = dto.StockNote?.Trim();
+        if (!string.IsNullOrEmpty(stockNote) && stockNote.Length > StockNoteMaxLength)
+            return TypedResults.Problem(
+                title: "Poznámka inventury je příliš dlouhá",
+                detail: $"Poznámka inventury nesmí být delší než {StockNoteMaxLength} znaků.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        item.StockCount = dto.StockCount;
+        item.StockNote = string.IsNullOrWhiteSpace(stockNote) ? null : stockNote;
+        item.StockUpdatedUtc = DateTime.UtcNow;
+        item.StockUpdatedBy = GetOrganizerDisplayName(http.User);
 
         await db.SaveChangesAsync();
         return TypedResults.NoContent();
@@ -454,7 +497,25 @@ public static class ItemEndpoints
         item.ClassRequirements.Warrior, item.ClassRequirements.Archer,
         item.ClassRequirements.Mage, item.ClassRequirements.Thief,
         item.IsUnique, item.IsLimited, item.ImagePath,
-        Note: item.Note);
+        Note: item.Note,
+        StockCount: item.StockCount,
+        StockNote: item.StockNote,
+        StockUpdatedUtc: item.StockUpdatedUtc,
+        StockUpdatedBy: item.StockUpdatedBy);
+
+    private static string? GetOrganizerDisplayName(ClaimsPrincipal user)
+    {
+        var value = user.FindFirstValue("name")
+            ?? user.FindFirstValue(ClaimTypes.Name)
+            ?? user.FindFirstValue("sub")
+            ?? user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(value)) return null;
+
+        var trimmed = value.Trim();
+        return trimmed.Length <= StockUpdatedByMaxLength
+            ? trimmed
+            : trimmed[..StockUpdatedByMaxLength];
+    }
 
     // Detail-page aggregate. One round-trip returns:
     //  - CraftedBy:    recipes whose OutputItemId == this item

--- a/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ItemEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
@@ -41,8 +42,12 @@ public static class ItemEndpoints
         return group;
     }
 
-    private static async Task<Ok<List<ItemListDto>>> GetAll(WorldDbContext db, HttpContext http)
+    private static async Task<Ok<List<ItemListDto>>> GetAll(
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory)
     {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.ItemInventory");
         var rows = await db.Items
             .OrderBy(i => i.Name)
             .Select(i => new
@@ -86,7 +91,7 @@ public static class ItemEndpoints
             // top + bottom of 5:7 portrait card photos. "medium" is 240×336
             // (5:7) so the bytes match the .oh-it-tile container ratio and
             // ImageSharp's Crop mode no longer eats the card art.
-            ImageUrl: string.IsNullOrWhiteSpace(r.ImagePath) ? null : ImageEndpoints.ThumbUrl(http, "items", r.Id, "medium"),
+            ImageUrl: GetInventoryThumbUrl(http, logger, "items-list", r.Id, r.ImagePath),
             HasRecipe: craftedSet.Contains(r.Id),
             StockCount: r.StockCount,
             StockNote: r.StockNote,
@@ -95,17 +100,20 @@ public static class ItemEndpoints
         return TypedResults.Ok(items);
     }
 
-    private static async Task<Results<Ok<ItemDetailDto>, NotFound>> GetById(int id, WorldDbContext db, HttpContext http)
+    private static async Task<Results<Ok<ItemDetailDto>, NotFound>> GetById(
+        int id,
+        WorldDbContext db,
+        HttpContext http,
+        ILoggerFactory loggerFactory)
     {
         var item = await db.Items.FindAsync(id);
         if (item is null) return TypedResults.NotFound();
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.ItemInventory");
 
         // Populate ImageUrl on the detail DTO so the new ItemDetail page (and any
         // future caller) doesn't have to make a second /api/images/items/{id}
         // round-trip just to render the hero (per Copilot review on PR #90).
-        var imageUrl = string.IsNullOrWhiteSpace(item.ImagePath)
-            ? null
-            : ImageEndpoints.ThumbUrl(http, "items", item.Id, "medium");
+        var imageUrl = GetInventoryThumbUrl(http, logger, "item-detail", item.Id, item.ImagePath);
 
         // Issue #154 — same flag as the catalog list, populated here so the
         // quick-peek popup can gate the IsCraftable badge consistently.
@@ -192,31 +200,87 @@ public static class ItemEndpoints
         int id,
         UpdateItemStockDto dto,
         WorldDbContext db,
-        HttpContext http)
+        HttpContext http,
+        ILoggerFactory loggerFactory)
     {
-        var item = await db.Items.FindAsync(id);
-        if (item is null) return TypedResults.NotFound();
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.ItemInventory");
+        var endpointTimer = Stopwatch.StartNew();
+        logger.LogInformation(
+            "[inventory] description=stock-update.entry itemId={ItemId} stockCount={StockCount} hasNote={HasNote}",
+            id,
+            dto.StockCount,
+            !string.IsNullOrWhiteSpace(dto.StockNote));
 
-        if (dto.StockCount < 0)
-            return TypedResults.Problem(
-                title: "Neplatný počet kusů",
-                detail: "Počet kusů na skladě nesmí být záporný.",
-                statusCode: StatusCodes.Status400BadRequest);
+        try
+        {
+            var item = await db.Items.FindAsync(id);
+            if (item is null)
+            {
+                logger.LogInformation(
+                    "[inventory] description=stock-update.not-found itemId={ItemId} elapsedMs={ElapsedMs}",
+                    id,
+                    endpointTimer.ElapsedMilliseconds);
+                return TypedResults.NotFound();
+            }
 
-        var stockNote = dto.StockNote?.Trim();
-        if (!string.IsNullOrEmpty(stockNote) && stockNote.Length > StockNoteMaxLength)
-            return TypedResults.Problem(
-                title: "Poznámka inventury je příliš dlouhá",
-                detail: $"Poznámka inventury nesmí být delší než {StockNoteMaxLength} znaků.",
-                statusCode: StatusCodes.Status400BadRequest);
+            if (dto.StockCount < 0)
+            {
+                logger.LogInformation(
+                    "[inventory] description=stock-update.validation-failed itemId={ItemId} reason=negative-count elapsedMs={ElapsedMs}",
+                    id,
+                    endpointTimer.ElapsedMilliseconds);
+                return TypedResults.Problem(
+                    title: "Neplatný počet kusů",
+                    detail: "Počet kusů na skladě nesmí být záporný.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
 
-        item.StockCount = dto.StockCount;
-        item.StockNote = string.IsNullOrWhiteSpace(stockNote) ? null : stockNote;
-        item.StockUpdatedUtc = DateTime.UtcNow;
-        item.StockUpdatedBy = GetOrganizerDisplayName(http.User);
+            var stockNote = dto.StockNote?.Trim();
+            if (!string.IsNullOrEmpty(stockNote) && stockNote.Length > StockNoteMaxLength)
+            {
+                logger.LogInformation(
+                    "[inventory] description=stock-update.validation-failed itemId={ItemId} reason=note-too-long noteLength={NoteLength} elapsedMs={ElapsedMs}",
+                    id,
+                    stockNote.Length,
+                    endpointTimer.ElapsedMilliseconds);
+                return TypedResults.Problem(
+                    title: "Poznámka inventury je příliš dlouhá",
+                    detail: $"Poznámka inventury nesmí být delší než {StockNoteMaxLength} znaků.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
 
-        await db.SaveChangesAsync();
-        return TypedResults.NoContent();
+            item.StockCount = dto.StockCount;
+            item.StockNote = string.IsNullOrWhiteSpace(stockNote) ? null : stockNote;
+            item.StockUpdatedUtc = DateTime.UtcNow;
+            item.StockUpdatedBy = GetOrganizerDisplayName(http.User);
+
+            logger.LogInformation(
+                "[inventory] description=stock-update.db-write.before itemId={ItemId}",
+                id);
+            var dbTimer = Stopwatch.StartNew();
+            var rowsAffected = await db.SaveChangesAsync();
+            dbTimer.Stop();
+            logger.LogInformation(
+                "[inventory] description=stock-update.db-write.after itemId={ItemId} rowsAffected={RowsAffected} elapsedMs={ElapsedMs}",
+                id,
+                rowsAffected,
+                dbTimer.ElapsedMilliseconds);
+            logger.LogInformation(
+                "[inventory] description=stock-update.exit itemId={ItemId} status=204 elapsedMs={ElapsedMs}",
+                id,
+                endpointTimer.ElapsedMilliseconds);
+            return TypedResults.NoContent();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "[inventory] description=stock-update.catch itemId={ItemId} elapsedMs={ElapsedMs} detail={Detail}",
+                id,
+                endpointTimer.ElapsedMilliseconds,
+                ex.Message);
+            throw;
+        }
     }
 
     private static async Task<Results<NoContent, NotFound>> Delete(int id, WorldDbContext db)
@@ -502,6 +566,46 @@ public static class ItemEndpoints
         StockNote: item.StockNote,
         StockUpdatedUtc: item.StockUpdatedUtc,
         StockUpdatedBy: item.StockUpdatedBy);
+
+    private static string? GetInventoryThumbUrl(
+        HttpContext http,
+        ILogger logger,
+        string source,
+        int itemId,
+        string? imagePath)
+    {
+        if (string.IsNullOrWhiteSpace(imagePath)) return null;
+
+        logger.LogInformation(
+            "[inventory] description=image-sas.before source={Source} itemId={ItemId}",
+            source,
+            itemId);
+        var timer = Stopwatch.StartNew();
+        try
+        {
+            var url = ImageEndpoints.ThumbUrl(http, "items", itemId, "medium");
+            timer.Stop();
+            logger.LogInformation(
+                "[inventory] description=image-sas.after source={Source} itemId={ItemId} hasUrl={HasUrl} elapsedMs={ElapsedMs}",
+                source,
+                itemId,
+                !string.IsNullOrWhiteSpace(url),
+                timer.ElapsedMilliseconds);
+            return url;
+        }
+        catch (Exception ex)
+        {
+            timer.Stop();
+            logger.LogWarning(
+                ex,
+                "[inventory] description=image-sas.catch source={Source} itemId={ItemId} elapsedMs={ElapsedMs} detail={Detail}",
+                source,
+                itemId,
+                timer.ElapsedMilliseconds,
+                ex.Message);
+            return null;
+        }
+    }
 
     private static string? GetOrganizerDisplayName(ClaimsPrincipal user)
     {

--- a/src/OvcinaHra.Api/Migrations/20260503092851_AddItemStockInventory.Designer.cs
+++ b/src/OvcinaHra.Api/Migrations/20260503092851_AddItemStockInventory.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using OvcinaHra.Api.Data;
 namespace OvcinaHra.Api.Migrations
 {
     [DbContext(typeof(WorldDbContext))]
-    partial class WorldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260503092851_AddItemStockInventory")]
+    partial class AddItemStockInventory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OvcinaHra.Api/Migrations/20260503092851_AddItemStockInventory.cs
+++ b/src/OvcinaHra.Api/Migrations/20260503092851_AddItemStockInventory.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OvcinaHra.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddItemStockInventory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "StockCount",
+                table: "Items",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "StockNote",
+                table: "Items",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "StockUpdatedBy",
+                table: "Items",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "StockUpdatedUtc",
+                table: "Items",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_Item_StockCount_NonNegative",
+                table: "Items",
+                sql: "\"StockCount\" >= 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_Item_StockCount_NonNegative",
+                table: "Items");
+
+            migrationBuilder.DropColumn(
+                name: "StockCount",
+                table: "Items");
+
+            migrationBuilder.DropColumn(
+                name: "StockNote",
+                table: "Items");
+
+            migrationBuilder.DropColumn(
+                name: "StockUpdatedBy",
+                table: "Items");
+
+            migrationBuilder.DropColumn(
+                name: "StockUpdatedUtc",
+                table: "Items");
+        }
+    }
+}

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -183,6 +183,10 @@
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-gem ni"></i><span class="oh-nav-label">Předměty</span>
                     </NavLink>
+                    <NavLink class="oh-nav-item" href="items/inventory">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-clipboard-check ni"></i><span class="oh-nav-label">Inventura</span>
+                    </NavLink>
                     <NavLink class="oh-nav-item" href="monsters?catalog=true">
                         <span class="oh-nav-rail"></span>
                         <img src="img/troll.svg" class="ni oh-nav-icon-svg" alt="" /><span class="oh-nav-label">Příšery</span>

--- a/src/OvcinaHra.Client/Pages/Items/ItemInventory.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemInventory.razor
@@ -96,13 +96,19 @@ else
 
         <div class="d-flex flex-column gap-3">
             <div style="width: 180px; aspect-ratio: 2 / 3; border: 1px solid var(--bs-border-color); border-radius: 6px; overflow: hidden; background: var(--oh-surface-muted, #f6f2e8);">
-                @if (!string.IsNullOrWhiteSpace(uploadPreviewUrl))
+                @if (!string.IsNullOrWhiteSpace(uploadPreviewUrl) && !uploadPreviewImageFailed)
                 {
-                    <img src="@uploadPreviewUrl" alt="Náhled obrázku" style="width: 100%; height: 100%; object-fit: cover;" />
+                    <img src="@uploadPreviewUrl"
+                         alt="Náhled obrázku"
+                         style="width: 100%; height: 100%; object-fit: cover;"
+                         @onerror="() => uploadPreviewImageFailed = true" />
                 }
-                else if (!string.IsNullOrWhiteSpace(uploadItem?.ImageUrl))
+                else if (!string.IsNullOrWhiteSpace(uploadItem?.ImageUrl) && !uploadExistingImageFailed)
                 {
-                    <img src="@uploadItem.ImageUrl" alt="Obrázek předmětu" style="width: 100%; height: 100%; object-fit: cover;" />
+                    <img src="@uploadItem.ImageUrl"
+                         alt="Obrázek předmětu"
+                         style="width: 100%; height: 100%; object-fit: cover;"
+                         @onerror="() => uploadExistingImageFailed = true" />
                 }
                 else
                 {
@@ -144,6 +150,8 @@ else
     private string? uploadError;
     private string uploadFileName = "item-image";
     private string uploadContentType = "image/jpeg";
+    private bool uploadPreviewImageFailed;
+    private bool uploadExistingImageFailed;
 
     private string UploadHeader => uploadItem is null ? "Nahrát obrázek" : $"Nahrát obrázek: {uploadItem.Name}";
 
@@ -200,22 +208,50 @@ else
             return;
         }
 
-        var (ok, problem) = await Api.PutWithProblemAsync(
-            $"/api/items/{src.Id}/stock",
-            new UpdateItemStockDto(buf.StockCount, normalizedNote));
-        if (!ok)
+        try
         {
-            error = problem ?? "Uložení inventury se nezdařilo.";
-            e.Cancel = true;
-            return;
-        }
+            Console.WriteLine($"[inventory] description=stock-save.api.before itemId={src.Id} stockCount={buf.StockCount}");
+            var timer = System.Diagnostics.Stopwatch.StartNew();
+            var (ok, problem) = await Api.PutWithProblemAsync(
+                $"/api/items/{src.Id}/stock",
+                new UpdateItemStockDto(buf.StockCount, normalizedNote));
+            timer.Stop();
+            Console.WriteLine($"[inventory] description=stock-save.api.after itemId={src.Id} ok={ok} elapsedMs={timer.ElapsedMilliseconds}");
+            if (!ok)
+            {
+                error = problem ?? "Uložení inventury se nezdařilo.";
+                e.Cancel = true;
+                return;
+            }
 
-        await RefreshItemRowAsync(src.Id);
+            await RefreshItemRowAsync(src.Id);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[inventory] description=stock-save.catch itemId={src.Id} detail={ex.Message}");
+            error = ex.Message;
+            e.Cancel = true;
+        }
     }
 
     private async Task RefreshItemRowAsync(int itemId)
     {
-        var detail = await Api.GetAsync<ItemDetailDto>($"/api/items/{itemId}");
+        Console.WriteLine($"[inventory] description=row-refresh.api.before itemId={itemId}");
+        var timer = System.Diagnostics.Stopwatch.StartNew();
+        ItemDetailDto? detail;
+        try
+        {
+            detail = await Api.GetAsync<ItemDetailDto>($"/api/items/{itemId}");
+        }
+        catch (Exception ex)
+        {
+            timer.Stop();
+            Console.WriteLine($"[inventory] description=row-refresh.catch itemId={itemId} elapsedMs={timer.ElapsedMilliseconds} detail={ex.Message}");
+            throw;
+        }
+
+        timer.Stop();
+        Console.WriteLine($"[inventory] description=row-refresh.api.after itemId={itemId} found={detail is not null} elapsedMs={timer.ElapsedMilliseconds}");
         if (detail is null) return;
 
         var idx = items.FindIndex(i => i.Id == itemId);
@@ -235,12 +271,15 @@ else
 
     private void OpenUploadPopup(ItemListDto item)
     {
+        Console.WriteLine($"[inventory] description=upload-popup.open itemId={item.Id} hasImage={item.HasImage}");
         uploadItem = item;
         uploadBytes = null;
         uploadPreviewUrl = null;
         uploadError = null;
         uploadFileName = "item-image";
         uploadContentType = "image/jpeg";
+        uploadPreviewImageFailed = false;
+        uploadExistingImageFailed = false;
         isUploadPopupVisible = true;
     }
 
@@ -251,6 +290,8 @@ else
         uploadBytes = null;
         uploadPreviewUrl = null;
         uploadError = null;
+        uploadPreviewImageFailed = false;
+        uploadExistingImageFailed = false;
     }
 
     private async Task OnUploadFileSelected(InputFileChangeEventArgs e)
@@ -262,17 +303,33 @@ else
             uploadError = $"Soubor je příliš velký (max {MaxUploadFileSize / 1024 / 1024} MB).";
             uploadBytes = null;
             uploadPreviewUrl = null;
+            uploadPreviewImageFailed = false;
+            Console.WriteLine($"[inventory] description=file-select.rejected reason=too-large size={file.Size}");
             return;
         }
 
-        uploadFileName = string.IsNullOrWhiteSpace(file.Name) ? "item-image" : file.Name;
-        uploadContentType = string.IsNullOrWhiteSpace(file.ContentType) ? "image/jpeg" : file.ContentType;
+        try
+        {
+            Console.WriteLine($"[inventory] description=file-select.read.before fileName={file.Name} size={file.Size}");
+            uploadFileName = string.IsNullOrWhiteSpace(file.Name) ? "item-image" : file.Name;
+            uploadContentType = string.IsNullOrWhiteSpace(file.ContentType) ? "image/jpeg" : file.ContentType;
 
-        await using var stream = file.OpenReadStream(MaxUploadFileSize);
-        using var buffer = new MemoryStream();
-        await stream.CopyToAsync(buffer);
-        uploadBytes = buffer.ToArray();
-        uploadPreviewUrl = $"data:{uploadContentType};base64,{Convert.ToBase64String(uploadBytes)}";
+            await using var stream = file.OpenReadStream(MaxUploadFileSize);
+            using var buffer = new MemoryStream();
+            await stream.CopyToAsync(buffer);
+            uploadBytes = buffer.ToArray();
+            uploadPreviewUrl = $"data:{uploadContentType};base64,{Convert.ToBase64String(uploadBytes)}";
+            uploadPreviewImageFailed = false;
+            Console.WriteLine($"[inventory] description=file-select.read.after fileName={uploadFileName} bytes={uploadBytes.Length}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[inventory] description=file-select.catch detail={ex.Message}");
+            uploadError = "Obrázek se nepodařilo načíst.";
+            uploadBytes = null;
+            uploadPreviewUrl = null;
+            uploadPreviewImageFailed = false;
+        }
     }
 
     private async Task UploadImageAsync()
@@ -288,9 +345,13 @@ else
             fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(uploadContentType);
             content.Add(fileContent, "file", uploadFileName);
 
+            Console.WriteLine($"[inventory] description=image-upload.api.before itemId={uploadItem.Id} fileName={uploadFileName} bytes={uploadBytes.Length}");
+            var uploadTimer = System.Diagnostics.Stopwatch.StartNew();
             var (ok, _, problemDetail, _) = await Api.PostMultipartWithProblemAsync<ImageUploadResult>(
                 $"/api/images/items/{uploadItem.Id}",
                 content);
+            uploadTimer.Stop();
+            Console.WriteLine($"[inventory] description=image-upload.api.after itemId={uploadItem.Id} ok={ok} elapsedMs={uploadTimer.ElapsedMilliseconds}");
             if (!ok)
             {
                 uploadError = problemDetail ?? "Nahrání obrázku selhalo.";
@@ -302,6 +363,7 @@ else
         }
         catch (Exception ex)
         {
+            Console.WriteLine($"[inventory] description=image-upload.catch itemId={uploadItem?.Id} detail={ex.Message}");
             uploadError = ex.Message;
         }
         finally

--- a/src/OvcinaHra.Client/Pages/Items/ItemInventory.razor
+++ b/src/OvcinaHra.Client/Pages/Items/ItemInventory.razor
@@ -1,0 +1,322 @@
+@page "/items/inventory"
+@attribute [Authorize]
+@inject ApiClient Api
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Inventura katalogu</h1>
+    <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="LoadAsync" disabled="@loading">
+        <i class="bi bi-arrow-clockwise"></i>
+        Obnovit
+    </button>
+</div>
+
+@if (!string.IsNullOrWhiteSpace(error))
+{
+    <div class="alert alert-danger">@error</div>
+}
+
+@if (loading)
+{
+    <p>Načítám inventuru...</p>
+}
+else
+{
+    <OvcinaGrid Data="@items" KeyFieldName="Id" LayoutKey="grid-inventory-v1"
+                EditMode="GridEditMode.EditCell"
+                CustomizeEditModel="OnCustomizeEdit"
+                EditModelSaving="OnStockSaving"
+                ShowColumnChooserButton="true">
+        <Columns>
+            <DxGridDataColumn Caption="Foto" Width="92px" AllowSort="false" AllowGroup="false">
+                <CellDisplayTemplate>
+                    @{
+                        var item = (ItemListDto)context.DataItem;
+                    }
+                    @if (!string.IsNullOrWhiteSpace(item.ImageUrl))
+                    {
+                        <button type="button"
+                                class="btn btn-link p-0"
+                                title="Změnit obrázek"
+                                @onclick="() => OpenUploadPopup(item)"
+                                @onclick:stopPropagation="true">
+                            <ItemGridImageTile @key="item.Id" Name="@item.Name" ImageUrl="@item.ImageUrl" />
+                        </button>
+                    }
+                    else
+                    {
+                        <button type="button"
+                                class="btn btn-sm btn-outline-primary"
+                                @onclick="() => OpenUploadPopup(item)"
+                                @onclick:stopPropagation="true">
+                            <i class="bi bi-upload"></i>
+                            Nahrát
+                        </button>
+                    }
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="Name" Caption="Název" Width="240px" ReadOnly="true" />
+            <DxGridDataColumn FieldName="ItemTypeDisplay" Caption="Typ" Width="140px" ReadOnly="true" />
+            <DxGridDataColumn FieldName="StockCount" Caption="Kusů" Width="110px">
+                <CellEditTemplate>
+                    <DxSpinEdit TValue="int"
+                                Value="@(((StockEditBuffer)context.EditModel).StockCount)"
+                                ValueExpression="@(() => ((StockEditBuffer)context.EditModel).StockCount)"
+                                ValueChanged="@((int v) => ((StockEditBuffer)context.EditModel).StockCount = v)"
+                                MinValue="0" />
+                </CellEditTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="StockNote" Caption="Poznámka inventury" Width="320px">
+                <CellEditTemplate>
+                    <DxTextBox Text="@(((StockEditBuffer)context.EditModel).StockNote)"
+                               TextExpression="@(() => ((StockEditBuffer)context.EditModel).StockNote)"
+                               TextChanged="@(v => ((StockEditBuffer)context.EditModel).StockNote = v)"
+                               NullText="(bez poznámky)" />
+                </CellEditTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="StockUpdatedUtc" Caption="Aktualizováno" Width="210px" ReadOnly="true">
+                <CellDisplayTemplate>
+                    @{
+                        var item = (ItemListDto)context.DataItem;
+                    }
+                    @FormatUpdated(item)
+                </CellDisplayTemplate>
+            </DxGridDataColumn>
+            <DxGridDataColumn FieldName="ImagePath" Caption="Cesta obrázku" Width="220px" Visible="false" ReadOnly="true" />
+            <DxGridDataColumn FieldName="Note" Caption="Katalogová poznámka" Width="260px" Visible="false" ReadOnly="true" />
+        </Columns>
+    </OvcinaGrid>
+}
+
+<DxPopup @bind-Visible="@isUploadPopupVisible" HeaderText="@UploadHeader" Width="460px">
+    <BodyContentTemplate Context="popupContext">
+        @if (!string.IsNullOrWhiteSpace(uploadError))
+        {
+            <div class="alert alert-danger">@uploadError</div>
+        }
+
+        <div class="d-flex flex-column gap-3">
+            <div style="width: 180px; aspect-ratio: 2 / 3; border: 1px solid var(--bs-border-color); border-radius: 6px; overflow: hidden; background: var(--oh-surface-muted, #f6f2e8);">
+                @if (!string.IsNullOrWhiteSpace(uploadPreviewUrl))
+                {
+                    <img src="@uploadPreviewUrl" alt="Náhled obrázku" style="width: 100%; height: 100%; object-fit: cover;" />
+                }
+                else if (!string.IsNullOrWhiteSpace(uploadItem?.ImageUrl))
+                {
+                    <img src="@uploadItem.ImageUrl" alt="Obrázek předmětu" style="width: 100%; height: 100%; object-fit: cover;" />
+                }
+                else
+                {
+                    <div class="d-flex align-items-center justify-content-center h-100 text-muted">
+                        <i class="bi bi-image" style="font-size: 2rem;"></i>
+                    </div>
+                }
+            </div>
+
+            <InputFile OnChange="OnUploadFileSelected" accept=".jpg,.jpeg,.png,.webp" disabled="@isUploading" />
+
+            <div class="d-flex gap-2 justify-content-end">
+                <button type="button" class="btn btn-secondary" @onclick="CloseUploadPopup" disabled="@isUploading">Zrušit</button>
+                <button type="button" class="btn btn-primary" @onclick="UploadImageAsync" disabled="@(isUploading || uploadBytes is null)">
+                    @if (isUploading)
+                    {
+                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                    }
+                    <i class="bi bi-upload"></i>
+                    Nahrát
+                </button>
+            </div>
+        </div>
+    </BodyContentTemplate>
+</DxPopup>
+
+@code {
+    private const long MaxUploadFileSize = 5 * 1024 * 1024;
+
+    private List<ItemListDto> items = [];
+    private bool loading = true;
+    private string? error;
+
+    private bool isUploadPopupVisible;
+    private bool isUploading;
+    private ItemListDto? uploadItem;
+    private byte[]? uploadBytes;
+    private string? uploadPreviewUrl;
+    private string? uploadError;
+    private string uploadFileName = "item-image";
+    private string uploadContentType = "image/jpeg";
+
+    private string UploadHeader => uploadItem is null ? "Nahrát obrázek" : $"Nahrát obrázek: {uploadItem.Name}";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        loading = true;
+        error = null;
+        try
+        {
+            items = await Api.GetListAsync<ItemListDto>("/api/items");
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            loading = false;
+        }
+    }
+
+    private sealed class StockEditBuffer
+    {
+        public int StockCount { get; set; }
+        public string? StockNote { get; set; }
+    }
+
+    private void OnCustomizeEdit(GridCustomizeEditModelEventArgs e)
+    {
+        if (e.IsNew) return;
+        var src = (ItemListDto)e.DataItem;
+        e.EditModel = new StockEditBuffer
+        {
+            StockCount = src.StockCount ?? 0,
+            StockNote = src.StockNote,
+        };
+    }
+
+    private async Task OnStockSaving(GridEditModelSavingEventArgs e)
+    {
+        if (e.IsNew) return;
+        var src = (ItemListDto)e.DataItem;
+        var buf = (StockEditBuffer)e.EditModel;
+        var normalizedNote = string.IsNullOrWhiteSpace(buf.StockNote) ? null : buf.StockNote.Trim();
+
+        if (buf.StockCount == src.StockCount.GetValueOrDefault()
+            && string.Equals(normalizedNote, src.StockNote, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var (ok, problem) = await Api.PutWithProblemAsync(
+            $"/api/items/{src.Id}/stock",
+            new UpdateItemStockDto(buf.StockCount, normalizedNote));
+        if (!ok)
+        {
+            error = problem ?? "Uložení inventury se nezdařilo.";
+            e.Cancel = true;
+            return;
+        }
+
+        await RefreshItemRowAsync(src.Id);
+    }
+
+    private async Task RefreshItemRowAsync(int itemId)
+    {
+        var detail = await Api.GetAsync<ItemDetailDto>($"/api/items/{itemId}");
+        if (detail is null) return;
+
+        var idx = items.FindIndex(i => i.Id == itemId);
+        if (idx < 0) return;
+
+        var current = items[idx];
+        items[idx] = current with
+        {
+            ImagePath = detail.ImagePath,
+            ImageUrl = detail.ImageUrl,
+            StockCount = detail.StockCount,
+            StockNote = detail.StockNote,
+            StockUpdatedUtc = detail.StockUpdatedUtc,
+            StockUpdatedBy = detail.StockUpdatedBy,
+        };
+    }
+
+    private void OpenUploadPopup(ItemListDto item)
+    {
+        uploadItem = item;
+        uploadBytes = null;
+        uploadPreviewUrl = null;
+        uploadError = null;
+        uploadFileName = "item-image";
+        uploadContentType = "image/jpeg";
+        isUploadPopupVisible = true;
+    }
+
+    private void CloseUploadPopup()
+    {
+        isUploadPopupVisible = false;
+        uploadItem = null;
+        uploadBytes = null;
+        uploadPreviewUrl = null;
+        uploadError = null;
+    }
+
+    private async Task OnUploadFileSelected(InputFileChangeEventArgs e)
+    {
+        uploadError = null;
+        var file = e.File;
+        if (file.Size > MaxUploadFileSize)
+        {
+            uploadError = $"Soubor je příliš velký (max {MaxUploadFileSize / 1024 / 1024} MB).";
+            uploadBytes = null;
+            uploadPreviewUrl = null;
+            return;
+        }
+
+        uploadFileName = string.IsNullOrWhiteSpace(file.Name) ? "item-image" : file.Name;
+        uploadContentType = string.IsNullOrWhiteSpace(file.ContentType) ? "image/jpeg" : file.ContentType;
+
+        await using var stream = file.OpenReadStream(MaxUploadFileSize);
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer);
+        uploadBytes = buffer.ToArray();
+        uploadPreviewUrl = $"data:{uploadContentType};base64,{Convert.ToBase64String(uploadBytes)}";
+    }
+
+    private async Task UploadImageAsync()
+    {
+        if (uploadItem is null || uploadBytes is null) return;
+
+        uploadError = null;
+        isUploading = true;
+        try
+        {
+            using var content = new MultipartFormDataContent();
+            using var fileContent = new ByteArrayContent(uploadBytes);
+            fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(uploadContentType);
+            content.Add(fileContent, "file", uploadFileName);
+
+            var (ok, _, problemDetail, _) = await Api.PostMultipartWithProblemAsync<ImageUploadResult>(
+                $"/api/images/items/{uploadItem.Id}",
+                content);
+            if (!ok)
+            {
+                uploadError = problemDetail ?? "Nahrání obrázku selhalo.";
+                return;
+            }
+
+            await RefreshItemRowAsync(uploadItem.Id);
+            CloseUploadPopup();
+        }
+        catch (Exception ex)
+        {
+            uploadError = ex.Message;
+        }
+        finally
+        {
+            isUploading = false;
+        }
+    }
+
+    private static string FormatUpdated(ItemListDto item)
+    {
+        if (item.StockUpdatedUtc is null) return "";
+
+        var value = item.StockUpdatedUtc.Value.ToLocalTime().ToString("dd.MM. HH:mm");
+        return string.IsNullOrWhiteSpace(item.StockUpdatedBy)
+            ? value
+            : $"{value} - {item.StockUpdatedBy}";
+    }
+}

--- a/src/OvcinaHra.Shared/Domain/Entities/Item.cs
+++ b/src/OvcinaHra.Shared/Domain/Entities/Item.cs
@@ -15,6 +15,10 @@ public class Item
     public bool IsUnique { get; set; }
     public bool IsLimited { get; set; }
     public string? ImagePath { get; set; }
+    public int StockCount { get; set; }
+    public string? StockNote { get; set; }
+    public DateTime? StockUpdatedUtc { get; set; }
+    public string? StockUpdatedBy { get; set; }
 
     // Free-text organizer note — issue #120. Visible in catalog + game grid
     // columns and on the detail page. Catalog-scoped (no per-game override).

--- a/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/ItemDtos.cs
@@ -20,7 +20,11 @@ public record ItemListDto(
     string? ImagePath,
     string? Note = null,
     string? ImageUrl = null,
-    bool HasRecipe = false)
+    bool HasRecipe = false,
+    int? StockCount = null,
+    string? StockNote = null,
+    DateTime? StockUpdatedUtc = null,
+    string? StockUpdatedBy = null)
 {
     [JsonIgnore]
     public string ItemTypeDisplay => ItemType.GetDisplayName();
@@ -87,7 +91,11 @@ public record ItemDetailDto(
     string? ImagePath,
     string? Note = null,
     string? ImageUrl = null,
-    bool HasRecipe = false);
+    bool HasRecipe = false,
+    int StockCount = 0,
+    string? StockNote = null,
+    DateTime? StockUpdatedUtc = null,
+    string? StockUpdatedBy = null);
 
 public record CreateItemDto(
     string Name,
@@ -116,6 +124,10 @@ public record UpdateItemDto(
     bool IsUnique,
     bool IsLimited,
     string? Note = null);
+
+public record UpdateItemStockDto(
+    int StockCount,
+    string? StockNote = null);
 
 // Per-game item configuration
 public record GameItemDto(

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ItemStockEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ItemStockEndpointTests.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Endpoints;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+public class ItemStockEndpointTests(PostgresFixture postgres)
+    : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    private async Task<ItemDetailDto> CreateItemAsync(string name)
+    {
+        var response = await Client.PostAsJsonAsync("/api/items", new CreateItemDto(name, ItemType.Potion));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<ItemDetailDto>())!;
+    }
+
+    [Fact]
+    public async Task UpdateStock_ValidPayload_PersistsCatalogStockAndAudit()
+    {
+        var item = await CreateItemAsync("Inventurní lektvar");
+        var beforeUpdate = DateTime.UtcNow.AddSeconds(-5);
+
+        var response = await Client.PutAsJsonAsync(
+            $"/api/items/{item.Id}/stock",
+            new UpdateItemStockDto(StockCount: 7, StockNote: "  Po finále zůstalo v krabici.  "));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var detail = await Client.GetFromJsonAsync<ItemDetailDto>($"/api/items/{item.Id}");
+        Assert.NotNull(detail);
+        Assert.Equal(7, detail!.StockCount);
+        Assert.Equal("Po finále zůstalo v krabici.", detail.StockNote);
+        Assert.NotNull(detail.StockUpdatedUtc);
+        Assert.True(detail.StockUpdatedUtc >= beforeUpdate);
+        Assert.Equal("Test Organizátor", detail.StockUpdatedBy);
+
+        var list = await Client.GetFromJsonAsync<List<ItemListDto>>("/api/items");
+        var row = list!.Single(i => i.Id == item.Id);
+        Assert.Equal(7, row.StockCount.GetValueOrDefault());
+        Assert.Equal("Po finále zůstalo v krabici.", row.StockNote);
+        Assert.Equal(detail.StockUpdatedUtc, row.StockUpdatedUtc);
+        Assert.Equal("Test Organizátor", row.StockUpdatedBy);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        var audit = await db.WorldChanges.SingleOrDefaultAsync(c =>
+            c.EntityType == nameof(Item)
+            && c.EntityId == item.Id
+            && c.Operation == WorldChangeOperation.Updated);
+        Assert.NotNull(audit);
+        Assert.Equal("Test Organizátor", audit!.ActorDisplayName);
+        Assert.Equal("test-user", audit.ActorUserId);
+    }
+
+    [Fact]
+    public async Task UpdateStock_LongOrganizerName_TruncatesAuditName()
+    {
+        var item = await CreateItemAsync("Dlouhé jméno organizátora");
+        var longName = new string('A', 250);
+
+        using var client = Factory.CreateClient();
+        var tokenResponse = await client.PostAsJsonAsync(
+            "/api/auth/dev-token",
+            new DevTokenRequest("long-user", "long@ovcina.cz", longName));
+        tokenResponse.EnsureSuccessStatusCode();
+        var token = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token!.Token);
+
+        var response = await client.PutAsJsonAsync(
+            $"/api/items/{item.Id}/stock",
+            new UpdateItemStockDto(StockCount: 4));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var detail = await Client.GetFromJsonAsync<ItemDetailDto>($"/api/items/{item.Id}");
+        Assert.Equal(longName[..200], detail!.StockUpdatedBy);
+    }
+
+    [Fact]
+    public async Task UpdateStock_MissingItem_ReturnsNotFoundBeforeValidation()
+    {
+        var response = await Client.PutAsJsonAsync(
+            "/api/items/999999/stock",
+            new UpdateItemStockDto(StockCount: -1, StockNote: new string('x', 501)));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateStock_NegativeCount_ReturnsProblemDetails()
+    {
+        var item = await CreateItemAsync("Záporná inventura");
+
+        var response = await Client.PutAsJsonAsync(
+            $"/api/items/{item.Id}/stock",
+            new UpdateItemStockDto(StockCount: -1));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        await AssertProblemDetailsAsync(response, "Neplatný počet kusů", "záporný");
+    }
+
+    [Fact]
+    public async Task UpdateStock_TooLongNote_ReturnsProblemDetails()
+    {
+        var item = await CreateItemAsync("Dlouhá inventura");
+
+        var response = await Client.PutAsJsonAsync(
+            $"/api/items/{item.Id}/stock",
+            new UpdateItemStockDto(StockCount: 1, StockNote: new string('x', 501)));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        await AssertProblemDetailsAsync(response, "Poznámka inventury je příliš dlouhá", "500");
+    }
+
+    [Fact]
+    public async Task UpdateStock_WhitespaceNote_PersistsAsNull()
+    {
+        var item = await CreateItemAsync("Prázdná poznámka");
+
+        var response = await Client.PutAsJsonAsync(
+            $"/api/items/{item.Id}/stock",
+            new UpdateItemStockDto(StockCount: 2, StockNote: "   "));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var detail = await Client.GetFromJsonAsync<ItemDetailDto>($"/api/items/{item.Id}");
+        Assert.Equal(2, detail!.StockCount);
+        Assert.Null(detail.StockNote);
+    }
+
+    private static async Task AssertProblemDetailsAsync(
+        HttpResponseMessage response,
+        string expectedTitle,
+        string expectedDetailFragment)
+    {
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal(expectedTitle, problem!.Title);
+        Assert.False(string.IsNullOrWhiteSpace(problem.Detail));
+        Assert.Contains(expectedDetailFragment, problem.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- add catalog item stock fields, EF migration, and PUT /api/items/{id}/stock
- add organizer catalog inventory page with inline stock editing and image upload via existing /api/images/items/{id}
- add inventory nav entry and API coverage for validation/audit behavior

Refs #527

## Verification
- dotnet build OvcinaHra.slnx --no-restore
- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter ItemStockEndpointTests --no-build
- dotnet test OvcinaHra.slnx --no-build
- dotnet format OvcinaHra.slnx --verify-no-changes --no-restore --include changed files