### PR TITLE
feat(stats): end-game overview dashboard

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/EndGameStatsEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/EndGameStatsEndpoints.cs
@@ -47,8 +47,12 @@ public static partial class GameEndpoints
                 a.DataJson))
             .ToListAsync();
 
-        var monsterIds = activities
-            .Select(a => TryReadInt(a.DataJson, "monsterId"))
+        var parsedActivities = activities
+            .Select(ParseActivity)
+            .ToList();
+
+        var monsterIds = parsedActivities
+            .Select(a => a.MonsterId)
             .OfType<int>()
             .Distinct()
             .ToArray();
@@ -60,14 +64,14 @@ public static partial class GameEndpoints
                 .ToDictionaryAsync(m => m.Id, m => m.Name);
 
         var assignmentById = assignments.ToDictionary(a => a.AssignmentId);
-        var levelEvents = ExtractLevelEvents(activities);
+        var levelEvents = ExtractLevelEvents(parsedActivities);
         var currentLevelByAssignment = levelEvents
             .GroupBy(e => e.AssignmentId)
             .ToDictionary(g => g.Key, g => Math.Max(1, g.Max(e => e.Level)));
 
         var kingdomBreakdowns = BuildKingdomBreakdowns(assignments, currentLevelByAssignment);
         var firstToLevel5 = BuildFirstToLevel5(levelEvents, assignmentById);
-        var monsterStats = BuildMonsterStats(activities, assignmentById, monsterNamesById);
+        var monsterStats = BuildMonsterStats(parsedActivities, assignmentById, monsterNamesById);
 
         var leaderboard = kingdomBreakdowns
             .Select(k => new KingdomLeaderboardEntryDto(
@@ -151,7 +155,7 @@ public static partial class GameEndpoints
     }
 
     private static MonsterStatsDto BuildMonsterStats(
-        List<EndGameActivityRow> activities,
+        List<EndGameParsedActivityRow> activities,
         Dictionary<int, EndGameAssignmentRow> assignmentById,
         Dictionary<int, string> monsterNamesById)
     {
@@ -183,7 +187,7 @@ public static partial class GameEndpoints
             fallen.Sum(e => e.Count));
     }
 
-    private static List<EndGameLevelEvent> ExtractLevelEvents(List<EndGameActivityRow> activities)
+    private static List<EndGameLevelEvent> ExtractLevelEvents(List<EndGameParsedActivityRow> activities)
     {
         var events = new List<EndGameLevelEvent>();
         foreach (var activity in activities)
@@ -192,7 +196,7 @@ public static partial class GameEndpoints
                 || activity.CharacterAssignmentId is not { } assignmentId)
                 continue;
 
-            if (TryReadInt(activity.DataJson, "level") is { } level)
+            if (activity.Level is { } level)
             {
                 events.Add(new EndGameLevelEvent(
                     activity.ActivityId,
@@ -202,6 +206,40 @@ public static partial class GameEndpoints
             }
         }
         return events;
+    }
+
+    private static EndGameParsedActivityRow ParseActivity(EndGameActivityRow activity)
+    {
+        int? level = null;
+        int? monsterId = null;
+        string? monsterName = null;
+
+        if (!string.IsNullOrWhiteSpace(activity.DataJson))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(activity.DataJson);
+                level = TryReadInt(doc.RootElement, "level");
+                monsterName = TryReadString(doc.RootElement, "monsterName")
+                    ?? TryReadString(doc.RootElement, "monster");
+                monsterId = TryReadInt(doc.RootElement, "monsterId")
+                    ?? TryReadInt(doc.RootElement, "monsterNpcId");
+            }
+            catch (JsonException)
+            {
+                // Treat malformed audit JSON as missing optional stats fields.
+            }
+        }
+
+        return new EndGameParsedActivityRow(
+            activity.ActivityId,
+            activity.TimestampUtc,
+            activity.ActivityType,
+            activity.CharacterAssignmentId,
+            activity.Description,
+            level,
+            monsterName,
+            monsterId);
     }
 
     private static int CurrentLevel(int assignmentId, Dictionary<int, int> currentLevelByAssignment) =>
@@ -224,20 +262,31 @@ public static partial class GameEndpoints
     }
 
     private static string MonsterName(
-        EndGameActivityRow activity,
+        EndGameParsedActivityRow activity,
         Dictionary<int, string> monsterNamesById)
     {
-        if (TryReadString(activity.DataJson, "monsterName") is { } jsonName)
-            return jsonName;
-        if (TryReadString(activity.DataJson, "monster") is { } monster)
-            return monster;
+        if (!string.IsNullOrWhiteSpace(activity.MonsterName))
+            return activity.MonsterName;
 
-        var monsterId = TryReadInt(activity.DataJson, "monsterId")
-            ?? TryReadInt(activity.DataJson, "monsterNpcId");
-        if (monsterId is { } id)
-            return monsterNamesById.TryGetValue(id, out var name) ? name : $"Nestvůra #{id}";
+        if (activity.MonsterId is { } id && monsterNamesById.TryGetValue(id, out var name))
+            return name;
+
+        if (MonsterNameFromDescription(activity.Description) is { } descriptionName)
+            return descriptionName;
+
+        if (activity.MonsterId is { } unknownId)
+            return $"Nestvůra #{unknownId}";
 
         return "Neznámá nestvůra";
+    }
+
+    private static string? MonsterNameFromDescription(string description)
+    {
+        var colonIndex = description.LastIndexOf(':');
+        if (colonIndex < 0 || colonIndex == description.Length - 1) return null;
+
+        var name = description[(colonIndex + 1)..].Trim();
+        return string.IsNullOrWhiteSpace(name) ? null : name;
     }
 
     private static string CanonKingdomColor(string kingdomName, string? storedHex) =>
@@ -255,48 +304,30 @@ public static partial class GameEndpoints
     private static string LevelLabel(int level) =>
         level >= 5 ? "5+" : level.ToString(CultureInfo.InvariantCulture);
 
-    private static int? TryReadInt(string? dataJson, string propertyName)
+    private static int? TryReadInt(JsonElement root, string propertyName)
     {
-        if (string.IsNullOrWhiteSpace(dataJson)) return null;
-        try
-        {
-            using var doc = JsonDocument.Parse(dataJson);
-            if (!doc.RootElement.TryGetProperty(propertyName, out var property))
-                return null;
-
-            return property.ValueKind switch
-            {
-                JsonValueKind.Number when property.TryGetInt32(out var value) => value,
-                JsonValueKind.String when int.TryParse(
-                    property.GetString(),
-                    NumberStyles.Integer,
-                    CultureInfo.InvariantCulture,
-                    out var value) => value,
-                _ => null
-            };
-        }
-        catch (JsonException)
-        {
+        if (!root.TryGetProperty(propertyName, out var property))
             return null;
-        }
+
+        return property.ValueKind switch
+        {
+            JsonValueKind.Number when property.TryGetInt32(out var value) => value,
+            JsonValueKind.String when int.TryParse(
+                property.GetString(),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var value) => value,
+            _ => null
+        };
     }
 
-    private static string? TryReadString(string? dataJson, string propertyName)
+    private static string? TryReadString(JsonElement root, string propertyName)
     {
-        if (string.IsNullOrWhiteSpace(dataJson)) return null;
-        try
-        {
-            using var doc = JsonDocument.Parse(dataJson);
-            return doc.RootElement.TryGetProperty(propertyName, out var property)
-                && property.ValueKind == JsonValueKind.String
-                && !string.IsNullOrWhiteSpace(property.GetString())
-                    ? property.GetString()
-                    : null;
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
+        return root.TryGetProperty(propertyName, out var property)
+            && property.ValueKind == JsonValueKind.String
+            && !string.IsNullOrWhiteSpace(property.GetString())
+                ? property.GetString()
+                : null;
     }
 
     private sealed record EndGameAssignmentRow(
@@ -314,6 +345,16 @@ public static partial class GameEndpoints
         int? CharacterAssignmentId,
         string Description,
         string? DataJson);
+
+    private sealed record EndGameParsedActivityRow(
+        int ActivityId,
+        DateTime TimestampUtc,
+        WorldActivityType ActivityType,
+        int? CharacterAssignmentId,
+        string Description,
+        int? Level,
+        string? MonsterName,
+        int? MonsterId);
 
     private sealed record EndGameLevelEvent(
         int ActivityId,

--- a/src/OvcinaHra.Api/Endpoints/EndGameStatsEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/EndGameStatsEndpoints.cs
@@ -1,0 +1,329 @@
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Endpoints;
+
+public static partial class GameEndpoints
+{
+    private const string NoKingdomName = "Bez království";
+    private const string NoKingdomColor = "#6A6A6A";
+
+    private static async Task<Results<Ok<EndGameStatsDto>, NotFound>> GetEndGameStats(
+        int gameId,
+        WorldDbContext db)
+    {
+        if (!await db.Games.AsNoTracking().AnyAsync(g => g.Id == gameId))
+            return TypedResults.NotFound();
+
+        var assignments = await db.CharacterAssignments
+            .AsNoTracking()
+            .Where(a => a.GameId == gameId && a.IsActive)
+            .Select(a => new EndGameAssignmentRow(
+                a.Id,
+                a.Character.Name,
+                a.KingdomId,
+                a.Kingdom != null ? a.Kingdom.Name : NoKingdomName,
+                a.Kingdom != null ? a.Kingdom.HexColor : null,
+                a.Kingdom != null ? a.Kingdom.SortOrder : int.MaxValue))
+            .ToListAsync();
+
+        var activities = await db.WorldActivities
+            .AsNoTracking()
+            .Where(a => a.GameId == gameId
+                && (a.ActivityType == WorldActivityType.CharacterLevelUp
+                    || a.ActivityType == WorldActivityType.MonsterDefeated
+                    || a.ActivityType == WorldActivityType.HeroFell))
+            .Select(a => new EndGameActivityRow(
+                a.Id,
+                a.TimestampUtc,
+                a.ActivityType,
+                a.CharacterAssignmentId,
+                a.Description,
+                a.DataJson))
+            .ToListAsync();
+
+        var monsterIds = activities
+            .Select(a => TryReadInt(a.DataJson, "monsterId"))
+            .OfType<int>()
+            .Distinct()
+            .ToArray();
+        var monsterNamesById = monsterIds.Length == 0
+            ? new Dictionary<int, string>()
+            : await db.Monsters
+                .AsNoTracking()
+                .Where(m => monsterIds.Contains(m.Id))
+                .ToDictionaryAsync(m => m.Id, m => m.Name);
+
+        var assignmentById = assignments.ToDictionary(a => a.AssignmentId);
+        var levelEvents = ExtractLevelEvents(activities);
+        var currentLevelByAssignment = levelEvents
+            .GroupBy(e => e.AssignmentId)
+            .ToDictionary(g => g.Key, g => Math.Max(1, g.Max(e => e.Level)));
+
+        var kingdomBreakdowns = BuildKingdomBreakdowns(assignments, currentLevelByAssignment);
+        var firstToLevel5 = BuildFirstToLevel5(levelEvents, assignmentById);
+        var monsterStats = BuildMonsterStats(activities, assignmentById, monsterNamesById);
+
+        var leaderboard = kingdomBreakdowns
+            .Select(k => new KingdomLeaderboardEntryDto(
+                k.KingdomId,
+                k.KingdomName,
+                k.ColorHex,
+                k.HeroCount,
+                k.TotalLevelsGained,
+                k.AverageLevel))
+            .OrderByDescending(k => k.TotalLevelsGained)
+            .ThenByDescending(k => k.AverageLevel)
+            .ThenBy(k => k.KingdomName)
+            .ToArray();
+
+        return TypedResults.Ok(new EndGameStatsDto(
+            kingdomBreakdowns,
+            firstToLevel5,
+            leaderboard,
+            monsterStats));
+    }
+
+    private static KingdomLevelBreakdownDto[] BuildKingdomBreakdowns(
+        List<EndGameAssignmentRow> assignments,
+        Dictionary<int, int> currentLevelByAssignment)
+    {
+        return assignments
+            .GroupBy(a => new EndGameKingdomKey(
+                a.KingdomId,
+                a.KingdomName,
+                CanonKingdomColor(a.KingdomName, a.KingdomColor),
+                a.SortOrder))
+            .OrderBy(g => g.Key.SortOrder)
+            .ThenBy(g => g.Key.KingdomName)
+            .Select(g =>
+            {
+                var levels = g
+                    .Select(a => CurrentLevel(a.AssignmentId, currentLevelByAssignment))
+                    .ToArray();
+                var buckets = Enumerable.Range(1, 5)
+                    .Select(level => new LevelCountDto(
+                        level,
+                        LevelLabel(level),
+                        levels.Count(heroLevel => Math.Min(heroLevel, 5) == level)))
+                    .ToArray();
+                var totalLevelsGained = levels.Sum(level => Math.Max(0, level - 1));
+                var averageLevel = levels.Length == 0
+                    ? 0
+                    : Math.Round((decimal)levels.Average(), 2, MidpointRounding.AwayFromZero);
+
+                return new KingdomLevelBreakdownDto(
+                    g.Key.KingdomId,
+                    g.Key.KingdomName,
+                    g.Key.ColorHex,
+                    levels.Length,
+                    totalLevelsGained,
+                    averageLevel,
+                    buckets);
+            })
+            .ToArray();
+    }
+
+    private static FirstToLevel5Dto? BuildFirstToLevel5(
+        List<EndGameLevelEvent> levelEvents,
+        Dictionary<int, EndGameAssignmentRow> assignmentById)
+    {
+        var first = levelEvents
+            .Where(e => e.Level == 5 && assignmentById.ContainsKey(e.AssignmentId))
+            .OrderBy(e => e.TimestampUtc)
+            .ThenBy(e => e.ActivityId)
+            .FirstOrDefault();
+        if (first is null) return null;
+
+        var assignment = assignmentById[first.AssignmentId];
+        return new FirstToLevel5Dto(
+            assignment.AssignmentId,
+            assignment.HeroName,
+            assignment.KingdomId,
+            assignment.KingdomName,
+            CanonKingdomColor(assignment.KingdomName, assignment.KingdomColor),
+            first.TimestampUtc);
+    }
+
+    private static MonsterStatsDto BuildMonsterStats(
+        List<EndGameActivityRow> activities,
+        Dictionary<int, EndGameAssignmentRow> assignmentById,
+        Dictionary<int, string> monsterNamesById)
+    {
+        var defeated = activities
+            .Where(a => a.ActivityType == WorldActivityType.MonsterDefeated)
+            .Select(a => MonsterName(a, monsterNamesById))
+            .GroupBy(name => name)
+            .Select(g => new MonsterDefeatEntryDto(g.Key, g.Count()))
+            .OrderByDescending(e => e.Count)
+            .ThenBy(e => e.MonsterName)
+            .ToArray();
+
+        var fallen = activities
+            .Where(a => a.ActivityType == WorldActivityType.HeroFell)
+            .GroupBy(a => KingdomFor(a.CharacterAssignmentId, assignmentById))
+            .Select(g => new HeroFellEntryDto(
+                g.Key.KingdomId,
+                g.Key.KingdomName,
+                g.Key.ColorHex,
+                g.Count()))
+            .OrderByDescending(e => e.Count)
+            .ThenBy(e => e.KingdomName)
+            .ToArray();
+
+        return new MonsterStatsDto(
+            defeated,
+            fallen,
+            defeated.Sum(e => e.Count),
+            fallen.Sum(e => e.Count));
+    }
+
+    private static List<EndGameLevelEvent> ExtractLevelEvents(List<EndGameActivityRow> activities)
+    {
+        var events = new List<EndGameLevelEvent>();
+        foreach (var activity in activities)
+        {
+            if (activity.ActivityType != WorldActivityType.CharacterLevelUp
+                || activity.CharacterAssignmentId is not { } assignmentId)
+                continue;
+
+            if (TryReadInt(activity.DataJson, "level") is { } level)
+            {
+                events.Add(new EndGameLevelEvent(
+                    activity.ActivityId,
+                    assignmentId,
+                    level,
+                    activity.TimestampUtc));
+            }
+        }
+        return events;
+    }
+
+    private static int CurrentLevel(int assignmentId, Dictionary<int, int> currentLevelByAssignment) =>
+        currentLevelByAssignment.TryGetValue(assignmentId, out var level) ? Math.Max(1, level) : 1;
+
+    private static EndGameKingdomKey KingdomFor(
+        int? assignmentId,
+        Dictionary<int, EndGameAssignmentRow> assignmentById)
+    {
+        if (assignmentId is { } id && assignmentById.TryGetValue(id, out var assignment))
+        {
+            return new EndGameKingdomKey(
+                assignment.KingdomId,
+                assignment.KingdomName,
+                CanonKingdomColor(assignment.KingdomName, assignment.KingdomColor),
+                assignment.SortOrder);
+        }
+
+        return new EndGameKingdomKey(null, NoKingdomName, NoKingdomColor, int.MaxValue);
+    }
+
+    private static string MonsterName(
+        EndGameActivityRow activity,
+        Dictionary<int, string> monsterNamesById)
+    {
+        if (TryReadString(activity.DataJson, "monsterName") is { } jsonName)
+            return jsonName;
+        if (TryReadString(activity.DataJson, "monster") is { } monster)
+            return monster;
+
+        var monsterId = TryReadInt(activity.DataJson, "monsterId")
+            ?? TryReadInt(activity.DataJson, "monsterNpcId");
+        if (monsterId is { } id)
+            return monsterNamesById.TryGetValue(id, out var name) ? name : $"Nestvůra #{id}";
+
+        return "Neznámá nestvůra";
+    }
+
+    private static string CanonKingdomColor(string kingdomName, string? storedHex) =>
+        kingdomName switch
+        {
+            "Esgaroth" => "#242F3D",
+            "Aradhryand" => "#243525",
+            "Azanulinbar" => "#8C2423",
+            "Arnor" => "#504B25",
+            NoKingdomName => NoKingdomColor,
+            _ when !string.IsNullOrWhiteSpace(storedHex) => storedHex,
+            _ => NoKingdomColor
+        };
+
+    private static string LevelLabel(int level) =>
+        level >= 5 ? "5+" : level.ToString(CultureInfo.InvariantCulture);
+
+    private static int? TryReadInt(string? dataJson, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(dataJson)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(dataJson);
+            if (!doc.RootElement.TryGetProperty(propertyName, out var property))
+                return null;
+
+            return property.ValueKind switch
+            {
+                JsonValueKind.Number when property.TryGetInt32(out var value) => value,
+                JsonValueKind.String when int.TryParse(
+                    property.GetString(),
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var value) => value,
+                _ => null
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? TryReadString(string? dataJson, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(dataJson)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(dataJson);
+            return doc.RootElement.TryGetProperty(propertyName, out var property)
+                && property.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(property.GetString())
+                    ? property.GetString()
+                    : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private sealed record EndGameAssignmentRow(
+        int AssignmentId,
+        string HeroName,
+        int? KingdomId,
+        string KingdomName,
+        string? KingdomColor,
+        int SortOrder);
+
+    private sealed record EndGameActivityRow(
+        int ActivityId,
+        DateTime TimestampUtc,
+        WorldActivityType ActivityType,
+        int? CharacterAssignmentId,
+        string Description,
+        string? DataJson);
+
+    private sealed record EndGameLevelEvent(
+        int ActivityId,
+        int AssignmentId,
+        int Level,
+        DateTime TimestampUtc);
+
+    private sealed record EndGameKingdomKey(
+        int? KingdomId,
+        string KingdomName,
+        string ColorHex,
+        int SortOrder);
+}

--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -14,7 +14,7 @@ using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Endpoints;
 
-public static class GameEndpoints
+public static partial class GameEndpoints
 {
     public static RouteGroupBuilder MapGameEndpoints(this IEndpointRouteBuilder routes)
     {
@@ -52,6 +52,7 @@ public static class GameEndpoints
         group.MapPost("/{gameId:int}/creatures/{monsterId:int}", AddCreatureToGame);
         group.MapDelete("/{gameId:int}/creatures/{monsterId:int}", RemoveCreatureFromGame);
         group.MapDelete("/{gameId:int}/quests/{questId:int}", RemoveQuestFromGame);
+        group.MapGet("/{gameId:int}/end-game-stats", GetEndGameStats);
 
         return group;
     }

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -94,6 +94,10 @@
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-activity ni"></i><span class="oh-nav-label">Aktivita</span>
                     </NavLink>
+                    <NavLink class="oh-nav-item" href="@EndGameStatsHref">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-bar-chart-line-fill ni"></i><span class="oh-nav-label">Statistiky</span>
+                    </NavLink>
                     <NavLink class="oh-nav-item" href="treasures">
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-safe-fill ni"></i><span class="oh-nav-label">Poklady</span>
@@ -287,6 +291,10 @@
     private string QuestGameHref => GameContext.SelectedGameId is int gameId
         ? $"games/{gameId}/quests"
         : "quests?mode=game";
+
+    private string EndGameStatsHref => GameContext.SelectedGameId is int gameId
+        ? $"statistiky-konec-hry?gameId={gameId}"
+        : "statistiky-konec-hry";
 
     protected override void OnInitialized()
     {

--- a/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor
+++ b/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor
@@ -166,6 +166,7 @@
     private List<LevelChartRow> _levelChartRows = [];
     private bool _isLoading;
     private string? _error;
+    private int _loadVersion;
 
     private static readonly System.Drawing.Color EsgarothColor = System.Drawing.Color.FromArgb(0x24, 0x2F, 0x3D);
     private static readonly System.Drawing.Color AradhryandColor = System.Drawing.Color.FromArgb(0x24, 0x35, 0x25);
@@ -194,6 +195,7 @@
 
     private async Task LoadAsync()
     {
+        var loadVersion = System.Threading.Interlocked.Increment(ref _loadVersion);
         var gameId = ActiveGameId;
         _error = null;
         if (gameId is null)
@@ -207,20 +209,26 @@
         _isLoading = true;
         try
         {
-            _stats = await Api.GetAsync<EndGameStatsDto>($"/api/games/{gameId.Value}/end-game-stats");
-            _levelChartRows = BuildLevelChartRows(_stats);
+            var stats = await Api.GetAsync<EndGameStatsDto>($"/api/games/{gameId.Value}/end-game-stats");
+            if (loadVersion != _loadVersion) return;
+
+            _stats = stats;
+            _levelChartRows = BuildLevelChartRows(stats);
             if (_stats is null)
                 _error = "Hra nebyla nalezena.";
         }
         catch (Exception)
         {
+            if (loadVersion != _loadVersion) return;
+
             _stats = null;
             _levelChartRows = [];
             _error = "Statistiky se nepodařilo načíst.";
         }
         finally
         {
-            _isLoading = false;
+            if (loadVersion == _loadVersion)
+                _isLoading = false;
         }
     }
 

--- a/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor
+++ b/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor
@@ -1,0 +1,266 @@
+@page "/statistiky-konec-hry"
+@attribute [Authorize]
+@inject ApiClient Api
+@inject GameContextService GameContext
+@implements IDisposable
+
+<PageTitle>Statistiky konce hry</PageTitle>
+
+<div class="oh-endstats-page">
+    <header class="oh-endstats-head">
+        <div>
+            <p class="oh-endstats-kicker">Přehled Ovčiny</p>
+            <h1>Statistiky konce hry</h1>
+        </div>
+        @if (_stats is not null)
+        {
+            <span class="oh-endstats-pill">@_stats.Kingdoms.Sum(k => k.HeroCount) hrdinové</span>
+        }
+    </header>
+
+    @if (_isLoading)
+    {
+        <p class="text-muted">Načítám…</p>
+    }
+    else if (ActiveGameId is null)
+    {
+        <div class="oh-endstats-empty">Vyber hru, aby bylo co zobrazit.</div>
+    }
+    else if (_stats is null)
+    {
+        <div class="oh-endstats-empty">@(_error ?? "Statistiky nejsou dostupné.")</div>
+    }
+    else
+    {
+        <section class="oh-endstats-summary">
+            <article class="oh-endstats-highlight">
+                <span class="oh-endstats-label">První pátá úroveň</span>
+                @if (_stats.FirstToLevel5 is { } first)
+                {
+                    <strong>@first.HeroName</strong>
+                    <span>
+                        @first.KingdomName, @first.TimestampUtc.ToLocalTime().ToString("d. M. yyyy HH:mm")
+                    </span>
+                }
+                else
+                {
+                    <strong>Pátou úroveň zatím nikdo nedosáhl.</strong>
+                }
+            </article>
+            <article class="oh-endstats-highlight">
+                <span class="oh-endstats-label">Nejzkušenější království</span>
+                @if (_stats.ExperienceLeaderboard.FirstOrDefault() is { } leader)
+                {
+                    <strong>@leader.KingdomName</strong>
+                    <span>@leader.TotalLevelsGained získaných úrovní, průměr @leader.AverageLevel</span>
+                }
+                else
+                {
+                    <strong>Žádná data</strong>
+                }
+            </article>
+        </section>
+
+        <section class="oh-endstats-section">
+            <div class="oh-endstats-section-head">
+                <h2>Úrovně hrdinů podle království</h2>
+            </div>
+            @if (HasLevelData)
+            {
+                <DxChart Data="@_levelChartRows" CssClass="oh-endstats-chart">
+                    <DxChartBarSeries ArgumentField="@((LevelChartRow r) => r.LevelLabel)"
+                                      ValueField="@((LevelChartRow r) => r.Esgaroth)"
+                                      Name="Esgaroth"
+                                      Color="@EsgarothColor" />
+                    <DxChartBarSeries ArgumentField="@((LevelChartRow r) => r.LevelLabel)"
+                                      ValueField="@((LevelChartRow r) => r.Aradhryand)"
+                                      Name="Aradhryand"
+                                      Color="@AradhryandColor" />
+                    <DxChartBarSeries ArgumentField="@((LevelChartRow r) => r.LevelLabel)"
+                                      ValueField="@((LevelChartRow r) => r.Azanulinbar)"
+                                      Name="Azanulinbar"
+                                      Color="@AzanulinbarColor" />
+                    <DxChartBarSeries ArgumentField="@((LevelChartRow r) => r.LevelLabel)"
+                                      ValueField="@((LevelChartRow r) => r.Arnor)"
+                                      Name="Arnor"
+                                      Color="@ArnorColor" />
+                    <DxChartBarSeries ArgumentField="@((LevelChartRow r) => r.LevelLabel)"
+                                      ValueField="@((LevelChartRow r) => r.Other)"
+                                      Name="Ostatní"
+                                      Color="@OtherColor" />
+                </DxChart>
+            }
+            else
+            {
+                <div class="oh-endstats-empty">Žádná data</div>
+            }
+        </section>
+
+        <section class="oh-endstats-grid">
+            <article class="oh-endstats-section">
+                <h2>Žebříček zkušeností</h2>
+                @if (_stats.ExperienceLeaderboard.Length == 0)
+                {
+                    <div class="oh-endstats-empty">Žádná data</div>
+                }
+                else
+                {
+                    <table class="oh-endstats-table">
+                        <thead>
+                            <tr><th>Království</th><th>Hrdinové</th><th>Úrovně</th><th>Průměr</th></tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var row in _stats.ExperienceLeaderboard)
+                            {
+                                <tr>
+                                    <td><span class="oh-endstats-swatch" style="background:@row.ColorHex"></span>@row.KingdomName</td>
+                                    <td>@row.HeroCount</td>
+                                    <td>@row.TotalLevelsGained</td>
+                                    <td>@row.AverageLevel</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            </article>
+
+            <article class="oh-endstats-section">
+                <h2>Nestvůry a pády</h2>
+                @if (!HasMonsterData)
+                {
+                    <div class="oh-endstats-empty">Žádná data</div>
+                }
+                else
+                {
+                    <div class="oh-endstats-monsters">
+                        <div>
+                            <h3>Přemožené nestvůry</h3>
+                            @foreach (var row in _stats.MonsterStats.MostDefeatedMonsters)
+                            {
+                                <div class="oh-endstats-row"><span>@row.MonsterName</span><strong>@row.Count</strong></div>
+                            }
+                        </div>
+                        <div>
+                            <h3>Padlí hrdinové</h3>
+                            @foreach (var row in _stats.MonsterStats.HeroesFallenByKingdom)
+                            {
+                                <div class="oh-endstats-row">
+                                    <span><span class="oh-endstats-swatch" style="background:@row.ColorHex"></span>@row.KingdomName</span>
+                                    <strong>@row.Count</strong>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                }
+            </article>
+        </section>
+    }
+</div>
+
+@code {
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "gameId")]
+    public int? GameId { get; set; }
+
+    private EndGameStatsDto? _stats;
+    private List<LevelChartRow> _levelChartRows = [];
+    private bool _isLoading;
+    private string? _error;
+
+    private static readonly System.Drawing.Color EsgarothColor = System.Drawing.Color.FromArgb(0x24, 0x2F, 0x3D);
+    private static readonly System.Drawing.Color AradhryandColor = System.Drawing.Color.FromArgb(0x24, 0x35, 0x25);
+    private static readonly System.Drawing.Color AzanulinbarColor = System.Drawing.Color.FromArgb(0x8C, 0x24, 0x23);
+    private static readonly System.Drawing.Color ArnorColor = System.Drawing.Color.FromArgb(0x50, 0x4B, 0x25);
+    private static readonly System.Drawing.Color OtherColor = System.Drawing.Color.FromArgb(0x6A, 0x6A, 0x6A);
+
+    private int? ActiveGameId => GameId ?? GameContext.SelectedGameId;
+    private bool HasLevelData => _levelChartRows.Any(r => r.Total > 0);
+    private bool HasMonsterData => _stats?.MonsterStats.MonsterDefeatedCount > 0
+        || _stats?.MonsterStats.HeroFellCount > 0;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        GameContext.OnGameChanged += HandleGameChanged;
+    }
+
+    protected override async Task OnParametersSetAsync() => await LoadAsync();
+
+    private void HandleGameChanged()
+    {
+        if (GameId is null)
+            _ = InvokeAsync(LoadAsync);
+    }
+
+    private async Task LoadAsync()
+    {
+        var gameId = ActiveGameId;
+        _error = null;
+        if (gameId is null)
+        {
+            _stats = null;
+            _levelChartRows = [];
+            _isLoading = false;
+            return;
+        }
+
+        _isLoading = true;
+        try
+        {
+            _stats = await Api.GetAsync<EndGameStatsDto>($"/api/games/{gameId.Value}/end-game-stats");
+            _levelChartRows = BuildLevelChartRows(_stats);
+            if (_stats is null)
+                _error = "Hra nebyla nalezena.";
+        }
+        catch (Exception)
+        {
+            _stats = null;
+            _levelChartRows = [];
+            _error = "Statistiky se nepodařilo načíst.";
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private static List<LevelChartRow> BuildLevelChartRows(EndGameStatsDto? stats)
+    {
+        if (stats is null) return [];
+
+        return Enumerable.Range(1, 5)
+            .Select(level => new LevelChartRow(
+                LevelLabel(level),
+                CountFor(stats, level, "Esgaroth"),
+                CountFor(stats, level, "Aradhryand"),
+                CountFor(stats, level, "Azanulinbar"),
+                CountFor(stats, level, "Arnor"),
+                stats.Kingdoms
+                    .Where(k => !IsCanonKingdom(k.KingdomName))
+                    .Sum(k => k.Levels.FirstOrDefault(l => l.Level == level)?.HeroCount ?? 0)))
+            .ToList();
+    }
+
+    private static int CountFor(EndGameStatsDto stats, int level, string kingdomName) =>
+        stats.Kingdoms
+            .Where(k => k.KingdomName == kingdomName)
+            .Sum(k => k.Levels.FirstOrDefault(l => l.Level == level)?.HeroCount ?? 0);
+
+    private static bool IsCanonKingdom(string kingdomName) =>
+        kingdomName is "Esgaroth" or "Aradhryand" or "Azanulinbar" or "Arnor";
+
+    private static string LevelLabel(int level) => level >= 5 ? "5+" : level.ToString();
+
+    public void Dispose() => GameContext.OnGameChanged -= HandleGameChanged;
+
+    private sealed record LevelChartRow(
+        string LevelLabel,
+        int Esgaroth,
+        int Aradhryand,
+        int Azanulinbar,
+        int Arnor,
+        int Other)
+    {
+        public int Total => Esgaroth + Aradhryand + Azanulinbar + Arnor + Other;
+    }
+}

--- a/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor.css
+++ b/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor.css
@@ -1,0 +1,160 @@
+.oh-endstats-page {
+    display: grid;
+    gap: 18px;
+    padding: 20px clamp(14px, 2vw, 28px) 28px;
+}
+
+.oh-endstats-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: end;
+    border-bottom: 1px solid var(--oh-border, #d8d2be);
+    padding-bottom: 12px;
+}
+
+.oh-endstats-kicker {
+    margin: 0 0 4px;
+    color: var(--oh-text-secondary, #6a6a6a);
+    font: 700 .78rem var(--oh-font-body, system-ui, sans-serif);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+}
+
+.oh-endstats-head h1,
+.oh-endstats-section h2 {
+    margin: 0;
+    color: var(--oh-primary, #243525);
+    font-family: var(--oh-font-heading, Georgia, serif);
+}
+
+.oh-endstats-head h1 {
+    font-size: clamp(1.7rem, 2.4vw, 2.4rem);
+}
+
+.oh-endstats-pill {
+    border: 1px solid var(--oh-border, #d8d2be);
+    border-radius: 999px;
+    padding: 6px 12px;
+    background: var(--oh-surface-alt, #f5f0e1);
+    color: var(--oh-text, #2f2b23);
+    white-space: nowrap;
+}
+
+.oh-endstats-summary,
+.oh-endstats-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.oh-endstats-highlight,
+.oh-endstats-section {
+    border: 1px solid var(--oh-border, #d8d2be);
+    border-radius: 8px;
+    background: var(--oh-surface, #fffdf7);
+    padding: 16px;
+}
+
+.oh-endstats-highlight {
+    display: grid;
+    gap: 4px;
+}
+
+.oh-endstats-highlight strong {
+    color: var(--oh-primary, #243525);
+    font: 800 1.25rem var(--oh-font-heading, Georgia, serif);
+}
+
+.oh-endstats-label {
+    color: var(--oh-text-secondary, #6a6a6a);
+    font-size: .8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+}
+
+.oh-endstats-section {
+    min-width: 0;
+}
+
+.oh-endstats-section h2 {
+    font-size: 1.18rem;
+    margin-bottom: 12px;
+}
+
+.oh-endstats-section h3 {
+    margin: 0 0 8px;
+    color: var(--oh-text, #2f2b23);
+    font: 800 .95rem var(--oh-font-body, system-ui, sans-serif);
+}
+
+.oh-endstats-chart {
+    min-height: 340px;
+}
+
+.oh-endstats-empty {
+    border: 1px dashed var(--oh-border, #d8d2be);
+    border-radius: 8px;
+    background: var(--oh-surface-alt, #f5f0e1);
+    color: var(--oh-text-secondary, #6a6a6a);
+    padding: 18px;
+    text-align: center;
+}
+
+.oh-endstats-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: .93rem;
+}
+
+.oh-endstats-table th,
+.oh-endstats-table td {
+    border-bottom: 1px solid var(--oh-border, #d8d2be);
+    padding: 8px 6px;
+    text-align: right;
+}
+
+.oh-endstats-table th:first-child,
+.oh-endstats-table td:first-child {
+    text-align: left;
+}
+
+.oh-endstats-swatch {
+    display: inline-block;
+    width: .85rem;
+    height: .85rem;
+    border-radius: 50%;
+    margin-right: 7px;
+    vertical-align: -1px;
+}
+
+.oh-endstats-monsters {
+    display: grid;
+    gap: 14px;
+}
+
+.oh-endstats-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 7px 0;
+    border-bottom: 1px solid var(--oh-border, #d8d2be);
+}
+
+.oh-endstats-row strong {
+    color: var(--oh-primary, #243525);
+}
+
+@media (max-width: 860px) {
+    .oh-endstats-head,
+    .oh-endstats-summary,
+    .oh-endstats-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .oh-endstats-head {
+        display: grid;
+        align-items: start;
+    }
+}

--- a/src/OvcinaHra.Shared/Dtos/EndGameStatsDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/EndGameStatsDtos.cs
@@ -1,0 +1,48 @@
+namespace OvcinaHra.Shared.Dtos;
+
+public record EndGameStatsDto(
+    KingdomLevelBreakdownDto[] Kingdoms,
+    FirstToLevel5Dto? FirstToLevel5,
+    KingdomLeaderboardEntryDto[] ExperienceLeaderboard,
+    MonsterStatsDto MonsterStats);
+
+public record KingdomLevelBreakdownDto(
+    int? KingdomId,
+    string KingdomName,
+    string ColorHex,
+    int HeroCount,
+    int TotalLevelsGained,
+    decimal AverageLevel,
+    LevelCountDto[] Levels);
+
+public record LevelCountDto(int Level, string Label, int HeroCount);
+
+public record FirstToLevel5Dto(
+    int CharacterAssignmentId,
+    string HeroName,
+    int? KingdomId,
+    string KingdomName,
+    string ColorHex,
+    DateTime TimestampUtc);
+
+public record KingdomLeaderboardEntryDto(
+    int? KingdomId,
+    string KingdomName,
+    string ColorHex,
+    int HeroCount,
+    int TotalLevelsGained,
+    decimal AverageLevel);
+
+public record MonsterStatsDto(
+    MonsterDefeatEntryDto[] MostDefeatedMonsters,
+    HeroFellEntryDto[] HeroesFallenByKingdom,
+    int MonsterDefeatedCount,
+    int HeroFellCount);
+
+public record MonsterDefeatEntryDto(string MonsterName, int Count);
+
+public record HeroFellEntryDto(
+    int? KingdomId,
+    string KingdomName,
+    string ColorHex,
+    int Count);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/EndGameStatsEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/EndGameStatsEndpointTests.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+public class EndGameStatsEndpointTests(PostgresFixture postgres)
+    : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    [Fact]
+    public async Task EndGameStats_NonExistentGame_Returns404()
+    {
+        var response = await Client.GetAsync("/api/games/999999/end-game-stats");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task EndGameStats_ReturnsKingdomLevelsAndActivityStats()
+    {
+        // Arrange
+        var game = await CreateGameAsync();
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var esgaroth = await GetOrCreateKingdomAsync(db, "Esgaroth", "#000000", 1);
+            var aradhryand = await GetOrCreateKingdomAsync(db, "Aradhryand", "#000000", 2);
+
+            var hilda = new Character { Name = $"Hilda {game.Id}", IsPlayedCharacter = true };
+            var beorn = new Character { Name = $"Beorn {game.Id}", IsPlayedCharacter = true };
+            var mira = new Character { Name = $"Míra {game.Id}", IsPlayedCharacter = true };
+            db.Characters.AddRange(hilda, beorn, mira);
+            await db.SaveChangesAsync();
+
+            var hildaAssignment = new CharacterAssignment
+            {
+                CharacterId = hilda.Id,
+                GameId = game.Id,
+                ExternalPersonId = game.Id * 1000 + 1,
+                KingdomId = esgaroth.Id
+            };
+            var beornAssignment = new CharacterAssignment
+            {
+                CharacterId = beorn.Id,
+                GameId = game.Id,
+                ExternalPersonId = game.Id * 1000 + 2,
+                KingdomId = esgaroth.Id
+            };
+            var miraAssignment = new CharacterAssignment
+            {
+                CharacterId = mira.Id,
+                GameId = game.Id,
+                ExternalPersonId = game.Id * 1000 + 3,
+                KingdomId = aradhryand.Id
+            };
+            db.CharacterAssignments.AddRange(hildaAssignment, beornAssignment, miraAssignment);
+            await db.SaveChangesAsync();
+
+            var start = DateTime.UtcNow.AddHours(-2);
+            db.WorldActivities.AddRange(
+                LevelUp(game.Id, hildaAssignment.Id, start.AddMinutes(1), """{"level":2}"""),
+                LevelUp(game.Id, hildaAssignment.Id, start.AddMinutes(2), """{"level":5}"""),
+                LevelUp(game.Id, beornAssignment.Id, start.AddMinutes(3), """{"level":3}"""),
+                LevelUp(game.Id, miraAssignment.Id, start.AddMinutes(4), """{"level":2}"""),
+                new WorldActivity
+                {
+                    GameId = game.Id,
+                    TimestampUtc = start.AddMinutes(5),
+                    OrganizerUserId = "org",
+                    OrganizerName = "Org",
+                    ActivityType = WorldActivityType.MonsterDefeated,
+                    Description = "Hilda přemohla nestvůru: Skřet",
+                    CharacterAssignmentId = hildaAssignment.Id,
+                    DataJson = """{"monsterName":"Skřet"}"""
+                },
+                new WorldActivity
+                {
+                    GameId = game.Id,
+                    TimestampUtc = start.AddMinutes(6),
+                    OrganizerUserId = "org",
+                    OrganizerName = "Org",
+                    ActivityType = WorldActivityType.MonsterDefeated,
+                    Description = "Beorn přemohl nestvůru: Skřet",
+                    CharacterAssignmentId = beornAssignment.Id,
+                    DataJson = """{"monsterName":"Skřet"}"""
+                },
+                new WorldActivity
+                {
+                    GameId = game.Id,
+                    TimestampUtc = start.AddMinutes(7),
+                    OrganizerUserId = "org",
+                    OrganizerName = "Org",
+                    ActivityType = WorldActivityType.HeroFell,
+                    Description = "Míra padl pod nestvůrou: Vlk",
+                    CharacterAssignmentId = miraAssignment.Id,
+                    DataJson = """{"monsterName":"Vlk"}"""
+                });
+            await db.SaveChangesAsync();
+        }
+
+        // Act
+        var stats = await Client.GetFromJsonAsync<EndGameStatsDto>(
+            $"/api/games/{game.Id}/end-game-stats");
+
+        // Assert
+        Assert.NotNull(stats);
+        Assert.Equal("Esgaroth", stats.FirstToLevel5!.KingdomName);
+        Assert.StartsWith("Hilda", stats.FirstToLevel5.HeroName, StringComparison.Ordinal);
+        Assert.Equal("#242F3D", stats.FirstToLevel5.ColorHex);
+
+        var esgarothStats = stats.Kingdoms.Single(k => k.KingdomName == "Esgaroth");
+        Assert.Equal("#242F3D", esgarothStats.ColorHex);
+        Assert.Equal(2, esgarothStats.HeroCount);
+        Assert.Equal(6, esgarothStats.TotalLevelsGained);
+        Assert.Equal(1, esgarothStats.Levels.Single(l => l.Level == 3).HeroCount);
+        Assert.Equal(1, esgarothStats.Levels.Single(l => l.Level == 5).HeroCount);
+
+        Assert.Equal("Esgaroth", stats.ExperienceLeaderboard[0].KingdomName);
+        Assert.Equal(6, stats.ExperienceLeaderboard[0].TotalLevelsGained);
+
+        var topMonster = Assert.Single(stats.MonsterStats.MostDefeatedMonsters);
+        Assert.Equal("Skřet", topMonster.MonsterName);
+        Assert.Equal(2, topMonster.Count);
+
+        var fallen = Assert.Single(stats.MonsterStats.HeroesFallenByKingdom);
+        Assert.Equal("Aradhryand", fallen.KingdomName);
+        Assert.Equal("#243525", fallen.ColorHex);
+        Assert.Equal(1, fallen.Count);
+    }
+
+    private async Task<GameDetailDto> CreateGameAsync()
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("End game stats", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    private static async Task<Kingdom> GetOrCreateKingdomAsync(
+        WorldDbContext db,
+        string name,
+        string hexColor,
+        int sortOrder)
+    {
+        var kingdom = await db.Kingdoms.FirstOrDefaultAsync(k => k.Name == name);
+        if (kingdom is not null) return kingdom;
+
+        kingdom = new Kingdom { Name = name, HexColor = hexColor, SortOrder = sortOrder };
+        db.Kingdoms.Add(kingdom);
+        await db.SaveChangesAsync();
+        return kingdom;
+    }
+
+    private static WorldActivity LevelUp(
+        int gameId,
+        int assignmentId,
+        DateTime timestampUtc,
+        string dataJson) => new()
+    {
+        GameId = gameId,
+        TimestampUtc = timestampUtc,
+        OrganizerUserId = "org",
+        OrganizerName = "Org",
+        ActivityType = WorldActivityType.CharacterLevelUp,
+        Description = "Hrdina dosáhl nové úrovně",
+        CharacterAssignmentId = assignmentId,
+        DataJson = dataJson
+    };
+}

--- a/tests/OvcinaHra.Api.Tests/Endpoints/EndGameStatsEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/EndGameStatsEndpointTests.cs
@@ -96,6 +96,17 @@ public class EndGameStatsEndpointTests(PostgresFixture postgres)
                     TimestampUtc = start.AddMinutes(7),
                     OrganizerUserId = "org",
                     OrganizerName = "Org",
+                    ActivityType = WorldActivityType.MonsterDefeated,
+                    Description = "Míra přemohl nestvůru: Vlk",
+                    CharacterAssignmentId = miraAssignment.Id,
+                    DataJson = "{}"
+                },
+                new WorldActivity
+                {
+                    GameId = game.Id,
+                    TimestampUtc = start.AddMinutes(8),
+                    OrganizerUserId = "org",
+                    OrganizerName = "Org",
                     ActivityType = WorldActivityType.HeroFell,
                     Description = "Míra padl pod nestvůrou: Vlk",
                     CharacterAssignmentId = miraAssignment.Id,
@@ -124,9 +135,12 @@ public class EndGameStatsEndpointTests(PostgresFixture postgres)
         Assert.Equal("Esgaroth", stats.ExperienceLeaderboard[0].KingdomName);
         Assert.Equal(6, stats.ExperienceLeaderboard[0].TotalLevelsGained);
 
-        var topMonster = Assert.Single(stats.MonsterStats.MostDefeatedMonsters);
+        Assert.Equal(2, stats.MonsterStats.MostDefeatedMonsters.Length);
+        var topMonster = stats.MonsterStats.MostDefeatedMonsters[0];
         Assert.Equal("Skřet", topMonster.MonsterName);
         Assert.Equal(2, topMonster.Count);
+        Assert.Contains(stats.MonsterStats.MostDefeatedMonsters,
+            m => m.MonsterName == "Vlk" && m.Count == 1);
 
         var fallen = Assert.Single(stats.MonsterStats.HeroesFallenByKingdom);
         Assert.Equal("Aradhryand", fallen.KingdomName);


### PR DESCRIPTION
## Summary
- Adds `GET /api/games/{gameId}/end-game-stats` returning `EndGameStatsDto` for kingdom level buckets, first-to-level-5, experience leaderboard, and monster stats.
- Adds the `Statistiky konce hry` Blazor page with a DevExpress level chart, canonical kingdom-seal palette, empty states, and nav entry.
- Adds integration coverage for 404 behavior and aggregation output.

## WorldActivity fields read
- `ActivityType` for `CharacterLevelUp`, `MonsterDefeated`, and `HeroFell`.
- `TimestampUtc` for first-to-level-5 ordering.
- `CharacterAssignmentId` for hero and kingdom joins.
- `DataJson` for `level`, `monsterName`, and optional `monsterId`.
- `Description` as monster-name fallback context.

## Notes
- Experience leaderboard uses total derived levels gained per active hero (`current level - 1`) as the most honest per-kingdom measure.

## Verification
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter EndGameStatsEndpointTests --logger 'console;verbosity=minimal'` passed: 2 tests.
- `dotnet build OvcinaHra.slnx --no-restore /clp:ErrorsOnly` passed.
- `dotnet test OvcinaHra.slnx --no-build --logger 'console;verbosity=minimal'` passed: API 674, E2E 8.

Closes #526