### PR TITLE
fix(scan): make DELETE last-* idempotent via X-Idempotency-Key + audit rows

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -1,7 +1,10 @@
 using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
@@ -486,7 +489,7 @@ public static class ScanEndpoints
             "[scan-idem] entry endpoint={Endpoint} personId={PersonId} idempotencyKey={IdempotencyKey}",
             endpoint,
             personId,
-            rawIdempotencyKey ?? "<missing>");
+            DescribeIdempotencyKey(rawIdempotencyKey));
 
         var assignment = await db.CharacterAssignments
             .Include(a => a.Character)
@@ -520,7 +523,7 @@ public static class ScanEndpoints
                     "[scan-idem] lookup-start endpoint={Endpoint} assignmentId={AssignmentId} idempotencyKey={IdempotencyKey}",
                     endpoint,
                     assignment.Id,
-                    rawIdempotencyKey);
+                    DescribeIdempotencyKey(rawIdempotencyKey));
 
                 var alreadyReverted = await db.EventIdempotencies.AnyAsync(e =>
                     e.CharacterAssignmentId == assignment.Id && e.IdempotencyKey == scopedIdempotencyKey);
@@ -536,7 +539,7 @@ public static class ScanEndpoints
                         "[scan-idem] idempotency-hit endpoint={Endpoint} assignmentId={AssignmentId} idempotencyKey={IdempotencyKey}",
                         endpoint,
                         assignment.Id,
-                        rawIdempotencyKey);
+                        DescribeIdempotencyKey(rawIdempotencyKey));
                     await transaction.CommitAsync();
                     return TypedResults.NoContent();
                 }
@@ -622,6 +625,17 @@ public static class ScanEndpoints
                 audit.Id);
             return TypedResults.NoContent();
         }
+        catch (DbUpdateException ex) when (IsEventIdempotencyUniqueViolation(ex))
+        {
+            await transaction.RollbackAsync();
+            logger.LogInformation(
+                ex,
+                "[scan-idem] idempotency-duplicate-race endpoint={Endpoint} assignmentId={AssignmentId} idempotencyKey={IdempotencyKey}",
+                endpoint,
+                assignment.Id,
+                DescribeIdempotencyKey(rawIdempotencyKey));
+            return TypedResults.NoContent();
+        }
         catch (Exception ex)
         {
             logger.LogError(
@@ -629,7 +643,7 @@ public static class ScanEndpoints
                 "[scan-idem] transaction-failed endpoint={Endpoint} assignmentId={AssignmentId} idempotencyKey={IdempotencyKey}",
                 endpoint,
                 assignment.Id,
-                rawIdempotencyKey ?? "<missing>");
+                DescribeIdempotencyKey(rawIdempotencyKey));
             throw;
         }
     }
@@ -668,8 +682,11 @@ public static class ScanEndpoints
             return true;
         }
 
-        scopedKey = $"revert:{endpoint}:{key}";
-        if (IsValidIdempotencyKey(scopedKey)) return true;
+        if (IsValidIdempotencyKey(key))
+        {
+            scopedKey = $"revert:{endpoint}:{HashIdempotencyKey(key)}";
+            return true;
+        }
 
         logger.LogWarning(
             "[scan-idem] idempotency-key-too-long endpoint={Endpoint} personId={PersonId} length={Length}",
@@ -717,11 +734,27 @@ public static class ScanEndpoints
         });
     }
 
+    private static bool IsEventIdempotencyUniqueViolation(DbUpdateException ex) =>
+        ex.Entries.Any(e => e.Entity is EventIdempotency)
+        && ex.InnerException is PostgresException
+        {
+            SqlState: PostgresErrorCodes.UniqueViolation,
+            ConstraintName: "PK_EventIdempotencies"
+        };
+
     private static ProblemHttpResult SaveFailed(string detail) =>
         TypedResults.Problem(
             title: "Uložení selhalo",
             detail: detail,
             statusCode: StatusCodes.Status400BadRequest);
+
+    private static string DescribeIdempotencyKey(string? key) =>
+        key is null
+            ? "<missing>"
+            : $"present:length={key.Length}:sha256={HashIdempotencyKey(key)[..12]}";
+
+    private static string HashIdempotencyKey(string key) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key))).ToLowerInvariant();
 
     private static string CreateGenericRevertData(CharacterEvent original, string? key, DateTime revertedAtUtc) =>
         JsonSerializer.Serialize(new

--- a/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ScanEndpoints.cs
@@ -261,90 +261,27 @@ public static class ScanEndpoints
         return TypedResults.Created($"/api/scan/{personId}/events/{ev.Id}", ToDto(ev));
     }
 
-    private static async Task<IResult> DeleteLastLevelUp(
+    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> DeleteLastLevelUp(
         int personId, WorldDbContext db, HttpContext httpContext, ILoggerFactory loggerFactory)
     {
-        var assignment = await db.CharacterAssignments
-            .Include(a => a.Character)
-            .Include(a => a.Events)
-            .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
-
-        if (assignment is null) return TypedResults.NotFound();
-
-        var idempotencyKey = GetIdempotencyKey(httpContext);
-        if (await TryGetIdempotentEventAsync(db, assignment.Id, idempotencyKey) is { } replay)
-            return TypedResults.Ok(replay);
-
-        var levelUp = assignment.Events
-            .Where(e => e.EventType == CharacterEventType.LevelUp)
-            .OrderByDescending(e => e.Timestamp)
-            .ThenByDescending(e => e.Id)
-            .FirstOrDefault();
-
-        if (levelUp is null) return TypedResults.NotFound();
-        if (!IsValidIdempotencyKey(idempotencyKey))
-            return SaveFailed("Hlavička X-Idempotency-Key je příliš dlouhá.");
-
-        var organizer = GetOrganizer(httpContext);
-        var audit = new CharacterEvent
-        {
-            CharacterAssignmentId = assignment.Id,
-            Timestamp = DateTime.UtcNow,
-            OrganizerUserId = organizer.UserId,
-            OrganizerName = organizer.Name,
-            EventType = CharacterEventType.LevelUpReverted,
-            Data = JsonSerializer.Serialize(new
+        return await DeleteLastMatchingEventAsync(
+            personId,
+            db,
+            httpContext,
+            loggerFactory,
+            "last-levelup",
+            [CharacterEventType.LevelUp],
+            CharacterEventType.LevelUpReverted,
+            WorldActivityType.CharacterLevelReverted,
+            assignment => $"{assignment.Character.Name} – vrácena úroveň",
+            (original, key, revertedAtUtc) => JsonSerializer.Serialize(new
             {
-                revertedEventId = levelUp.Id,
-                revertedLevel = ExtractLevel(levelUp.Data)
-            }),
-            Location = levelUp.Location
-        };
-
-        db.CharacterEvents.Remove(levelUp);
-        db.CharacterEvents.Add(audit);
-        TrackIdempotency(db, assignment.Id, idempotencyKey, audit);
-        await db.SaveChangesAsync();
-
-        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.WorldActivityMirror");
-        if (!await db.Games.AnyAsync(g => g.Id == assignment.GameId))
-        {
-            logger.LogInformation(
-                "[world-activity-mirror] level-reverted assignmentId={AssignmentId} gameId={GameId} skipped-no-game=true",
-                assignment.Id,
-                assignment.GameId);
-        }
-        else
-        {
-            logger.LogInformation(
-                "[world-activity-mirror] level-reverted assignmentId={AssignmentId} gameId={GameId} skipped-no-game=false",
-                assignment.Id,
-                assignment.GameId);
-            try
-            {
-                db.WorldActivities.Add(new WorldActivity
-                {
-                    GameId = assignment.GameId,
-                    TimestampUtc = audit.Timestamp,
-                    OrganizerUserId = organizer.UserId,
-                    OrganizerName = organizer.Name,
-                    ActivityType = WorldActivityType.CharacterLevelReverted,
-                    Description = $"{assignment.Character.Name} – vrácena úroveň",
-                    CharacterAssignmentId = assignment.Id,
-                    DataJson = audit.Data
-                });
-                await db.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex,
-                    "[world-activity-mirror] level-reverted audit-failed assignmentId={AssignmentId} gameId={GameId}",
-                    assignment.Id,
-                    assignment.GameId);
-            }
-        }
-
-        return TypedResults.Ok(ToDto(audit));
+                revertedEventId = original.Id,
+                revertedLevel = ExtractLevel(original.Data),
+                originalTimestampUtc = original.Timestamp,
+                revertedAtUtc,
+                idempotencyKey = key
+            }));
     }
 
     /// <summary>
@@ -354,24 +291,20 @@ public static class ScanEndpoints
     /// <c>/api/scan/*</c> may undo, matching the existing
     /// <see cref="DeleteLastLevelUp"/> permission model.
     /// </summary>
-    private static async Task<Results<NoContent, NotFound>> DeleteLastNote(
-        int personId, WorldDbContext db)
+    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> DeleteLastNote(
+        int personId, WorldDbContext db, HttpContext httpContext, ILoggerFactory loggerFactory)
     {
-        var assignment = await db.CharacterAssignments
-            .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
-        if (assignment is null) return TypedResults.NotFound();
-
-        var lastNote = await db.CharacterEvents
-            .Where(e => e.CharacterAssignmentId == assignment.Id
-                && e.EventType == CharacterEventType.Note)
-            .OrderByDescending(e => e.Timestamp)
-            .ThenByDescending(e => e.Id)
-            .FirstOrDefaultAsync();
-        if (lastNote is null) return TypedResults.NotFound();
-
-        db.CharacterEvents.Remove(lastNote);
-        await db.SaveChangesAsync();
-        return TypedResults.NoContent();
+        return await DeleteLastMatchingEventAsync(
+            personId,
+            db,
+            httpContext,
+            loggerFactory,
+            "last-note",
+            [CharacterEventType.Note],
+            CharacterEventType.NoteReverted,
+            WorldActivityType.NoteReverted,
+            assignment => $"{assignment.Character.Name} – vrácena poznámka",
+            CreateGenericRevertData);
     }
 
     /// <summary>
@@ -380,25 +313,20 @@ public static class ScanEndpoints
     /// LevelUp recorded after the combat is intentionally ignored — the
     /// scope is "newest combat row, even if other event types are newer".
     /// </summary>
-    private static async Task<Results<NoContent, NotFound>> DeleteLastCombat(
-        int personId, WorldDbContext db)
+    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> DeleteLastCombat(
+        int personId, WorldDbContext db, HttpContext httpContext, ILoggerFactory loggerFactory)
     {
-        var assignment = await db.CharacterAssignments
-            .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
-        if (assignment is null) return TypedResults.NotFound();
-
-        var lastCombat = await db.CharacterEvents
-            .Where(e => e.CharacterAssignmentId == assignment.Id
-                && (e.EventType == CharacterEventType.MonsterVictory
-                    || e.EventType == CharacterEventType.MonsterDefeat))
-            .OrderByDescending(e => e.Timestamp)
-            .ThenByDescending(e => e.Id)
-            .FirstOrDefaultAsync();
-        if (lastCombat is null) return TypedResults.NotFound();
-
-        db.CharacterEvents.Remove(lastCombat);
-        await db.SaveChangesAsync();
-        return TypedResults.NoContent();
+        return await DeleteLastMatchingEventAsync(
+            personId,
+            db,
+            httpContext,
+            loggerFactory,
+            "last-combat",
+            [CharacterEventType.MonsterVictory, CharacterEventType.MonsterDefeat],
+            CharacterEventType.MonsterCombatReverted,
+            WorldActivityType.MonsterCombatReverted,
+            assignment => $"{assignment.Character.Name} – vrácen souboj s nestvůrou",
+            CreateGenericRevertData);
     }
 
     private static async Task<Results<Ok<List<CharacterEventDto>>, NotFound>> GetRecentEvents(
@@ -540,6 +468,172 @@ public static class ScanEndpoints
         return TypedResults.Created($"/api/scan/{personId}/events/{ev.Id}", ToDto(ev));
     }
 
+    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> DeleteLastMatchingEventAsync(
+        int personId,
+        WorldDbContext db,
+        HttpContext httpContext,
+        ILoggerFactory loggerFactory,
+        string endpoint,
+        IReadOnlyCollection<CharacterEventType> eventTypes,
+        CharacterEventType auditEventType,
+        WorldActivityType worldActivityType,
+        Func<CharacterAssignment, string> description,
+        Func<CharacterEvent, string?, DateTime, string> data)
+    {
+        var rawIdempotencyKey = GetIdempotencyKey(httpContext);
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.ScanIdempotency");
+        logger.LogInformation(
+            "[scan-idem] entry endpoint={Endpoint} personId={PersonId} idempotencyKey={IdempotencyKey}",
+            endpoint,
+            personId,
+            rawIdempotencyKey ?? "<missing>");
+
+        var assignment = await db.CharacterAssignments
+            .Include(a => a.Character)
+            .FirstOrDefaultAsync(a => a.ExternalPersonId == personId && a.IsActive);
+        if (assignment is null)
+        {
+            logger.LogInformation(
+                "[scan-idem] assignment-miss endpoint={Endpoint} personId={PersonId}",
+                endpoint,
+                personId);
+            return TypedResults.NotFound();
+        }
+
+        if (!TryScopeRevertIdempotencyKey(
+            endpoint,
+            rawIdempotencyKey,
+            logger,
+            personId,
+            out var scopedIdempotencyKey,
+            out var problem))
+        {
+            return problem!;
+        }
+
+        await using var transaction = await db.Database.BeginTransactionAsync();
+        try
+        {
+            if (scopedIdempotencyKey is not null)
+            {
+                logger.LogInformation(
+                    "[scan-idem] lookup-start endpoint={Endpoint} assignmentId={AssignmentId} idempotencyKey={IdempotencyKey}",
+                    endpoint,
+                    assignment.Id,
+                    rawIdempotencyKey);
+
+                var alreadyReverted = await db.EventIdempotencies.AnyAsync(e =>
+                    e.CharacterAssignmentId == assignment.Id && e.IdempotencyKey == scopedIdempotencyKey);
+                logger.LogInformation(
+                    "[scan-idem] lookup-complete endpoint={Endpoint} assignmentId={AssignmentId} idempotencyHit={IdempotencyHit}",
+                    endpoint,
+                    assignment.Id,
+                    alreadyReverted);
+
+                if (alreadyReverted)
+                {
+                    logger.LogInformation(
+                        "[scan-idem] idempotency-hit endpoint={Endpoint} assignmentId={AssignmentId} idempotencyKey={IdempotencyKey}",
+                        endpoint,
+                        assignment.Id,
+                        rawIdempotencyKey);
+                    await transaction.CommitAsync();
+                    return TypedResults.NoContent();
+                }
+            }
+
+            var original = await db.CharacterEvents
+                .Where(e => e.CharacterAssignmentId == assignment.Id && eventTypes.Contains(e.EventType))
+                .OrderByDescending(e => e.Timestamp)
+                .ThenByDescending(e => e.Id)
+                .FirstOrDefaultAsync();
+            if (original is null)
+            {
+                logger.LogInformation(
+                    "[scan-idem] no-matching-event endpoint={Endpoint} assignmentId={AssignmentId}",
+                    endpoint,
+                    assignment.Id);
+                await transaction.CommitAsync();
+                return TypedResults.NotFound();
+            }
+
+            var organizer = GetOrganizer(httpContext);
+            var revertedAtUtc = DateTime.UtcNow;
+            var audit = new CharacterEvent
+            {
+                CharacterAssignmentId = assignment.Id,
+                Timestamp = revertedAtUtc,
+                OrganizerUserId = organizer.UserId,
+                OrganizerName = organizer.Name,
+                EventType = auditEventType,
+                Data = data(original, rawIdempotencyKey, revertedAtUtc),
+                Location = original.Location
+            };
+
+            logger.LogInformation(
+                "[scan-idem] fresh-revert-start endpoint={Endpoint} assignmentId={AssignmentId} originalEventId={OriginalEventId} originalEventType={OriginalEventType}",
+                endpoint,
+                assignment.Id,
+                original.Id,
+                original.EventType);
+
+            db.CharacterEvents.Remove(original);
+            db.CharacterEvents.Add(audit);
+            TrackIdempotency(db, assignment.Id, scopedIdempotencyKey, audit);
+
+            if (await db.Games.AnyAsync(g => g.Id == assignment.GameId))
+            {
+                db.WorldActivities.Add(new WorldActivity
+                {
+                    GameId = assignment.GameId,
+                    TimestampUtc = audit.Timestamp,
+                    OrganizerUserId = organizer.UserId,
+                    OrganizerName = organizer.Name,
+                    ActivityType = worldActivityType,
+                    Description = description(assignment),
+                    CharacterAssignmentId = assignment.Id,
+                    DataJson = audit.Data
+                });
+                logger.LogInformation(
+                    "[scan-idem] world-activity-added endpoint={Endpoint} assignmentId={AssignmentId} gameId={GameId}",
+                    endpoint,
+                    assignment.Id,
+                    assignment.GameId);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "[scan-idem] world-activity-skipped-no-game endpoint={Endpoint} assignmentId={AssignmentId} gameId={GameId}",
+                    endpoint,
+                    assignment.Id,
+                    assignment.GameId);
+            }
+
+            logger.LogInformation(
+                "[scan-idem] transaction-save-start endpoint={Endpoint} assignmentId={AssignmentId}",
+                endpoint,
+                assignment.Id);
+            await db.SaveChangesAsync();
+            await transaction.CommitAsync();
+            logger.LogInformation(
+                "[scan-idem] transaction-committed endpoint={Endpoint} assignmentId={AssignmentId} auditEventId={AuditEventId}",
+                endpoint,
+                assignment.Id,
+                audit.Id);
+            return TypedResults.NoContent();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "[scan-idem] transaction-failed endpoint={Endpoint} assignmentId={AssignmentId} idempotencyKey={IdempotencyKey}",
+                endpoint,
+                assignment.Id,
+                rawIdempotencyKey ?? "<missing>");
+            throw;
+        }
+    }
+
     private static CharacterEventDto ToDto(CharacterEvent ev) =>
         new(ev.Id, ev.EventType, ev.Data, ev.Location, ev.OrganizerName, ev.Timestamp);
 
@@ -554,6 +648,37 @@ public static class ScanEndpoints
 
     private static bool IsValidIdempotencyKey(string? key) =>
         key is null || key.Length <= MaxIdempotencyKeyLength;
+
+    private static bool TryScopeRevertIdempotencyKey(
+        string endpoint,
+        string? key,
+        ILogger logger,
+        int personId,
+        out string? scopedKey,
+        out ProblemHttpResult? problem)
+    {
+        scopedKey = null;
+        problem = null;
+        if (key is null)
+        {
+            logger.LogWarning(
+                "[scan-idem] missing-idempotency-key endpoint={Endpoint} personId={PersonId}",
+                endpoint,
+                personId);
+            return true;
+        }
+
+        scopedKey = $"revert:{endpoint}:{key}";
+        if (IsValidIdempotencyKey(scopedKey)) return true;
+
+        logger.LogWarning(
+            "[scan-idem] idempotency-key-too-long endpoint={Endpoint} personId={PersonId} length={Length}",
+            endpoint,
+            personId,
+            key.Length);
+        problem = SaveFailed("Hlavička X-Idempotency-Key je příliš dlouhá.");
+        return false;
+    }
 
     private static async Task<CharacterEventDto?> TryGetIdempotentEventAsync(
         WorldDbContext db,
@@ -592,11 +717,23 @@ public static class ScanEndpoints
         });
     }
 
-    private static IResult SaveFailed(string detail) =>
+    private static ProblemHttpResult SaveFailed(string detail) =>
         TypedResults.Problem(
             title: "Uložení selhalo",
             detail: detail,
             statusCode: StatusCodes.Status400BadRequest);
+
+    private static string CreateGenericRevertData(CharacterEvent original, string? key, DateTime revertedAtUtc) =>
+        JsonSerializer.Serialize(new
+        {
+            revertedEventId = original.Id,
+            originalEventType = original.EventType.ToString(),
+            originalTimestampUtc = original.Timestamp,
+            originalData = original.Data,
+            originalLocation = original.Location,
+            revertedAtUtc,
+            idempotencyKey = key
+        });
 
     private static int? ExtractLevel(string data)
     {

--- a/src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/CharacterEventType.cs
@@ -31,5 +31,11 @@ public enum CharacterEventType
     MonsterVictory,
 
     [Display(Name = "Porážka nestvůrou")]
-    MonsterDefeat
+    MonsterDefeat,
+
+    [Display(Name = "Vrácení poznámky")]
+    NoteReverted,
+
+    [Display(Name = "Vrácení souboje s nestvůrou")]
+    MonsterCombatReverted
 }

--- a/src/OvcinaHra.Shared/Domain/Enums/WorldActivityType.cs
+++ b/src/OvcinaHra.Shared/Domain/Enums/WorldActivityType.cs
@@ -11,4 +11,6 @@ public enum WorldActivityType
     CharacterLevelReverted = 3,
     MonsterDefeated = 4,
     HeroFell = 5,
+    NoteReverted = 6,
+    MonsterCombatReverted = 7,
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanEndpointTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Api.Services;
 using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
 
@@ -61,6 +62,34 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
         using var request = new HttpRequestMessage(HttpMethod.Delete, url);
         request.Headers.Add("X-Idempotency-Key", key);
         return await Client.SendAsync(request);
+    }
+
+    private async Task SeedScanEventAsync(
+        int assignmentId,
+        CharacterEventType eventType,
+        string data,
+        DateTime timestamp)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        db.CharacterEvents.Add(new CharacterEvent
+        {
+            CharacterAssignmentId = assignmentId,
+            Timestamp = timestamp,
+            OrganizerUserId = "test-organizer",
+            OrganizerName = "Test Organizátor",
+            EventType = eventType,
+            Data = data
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<int> CountWorldActivitiesAsync(int gameId, WorldActivityType activityType)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+        return await db.WorldActivities.CountAsync(a =>
+            a.GameId == gameId && a.ActivityType == activityType);
     }
 
     private async Task<(CharacterDetailDto character, CharacterAssignmentDto assignment)> SeedCharacterWithAssignment(
@@ -215,12 +244,7 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
 
         var response = await Client.DeleteAsync("/api/scan/105/events/last-levelup");
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var audit = await response.Content.ReadFromJsonAsync<CharacterEventDto>();
-        Assert.NotNull(audit);
-        Assert.Equal(CharacterEventType.LevelUpReverted, audit.EventType);
-        Assert.Equal("Test Organizátor", audit.OrganizerName);
-        Assert.Contains("\"revertedLevel\":2", audit.Data);
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
         var profile = await Client.GetFromJsonAsync<ScanCharacterDto>("/api/scan/105");
         Assert.NotNull(profile);
@@ -243,7 +267,7 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
 
         var response = await Client.DeleteAsync("/api/scan/115/events/last-levelup");
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
@@ -266,9 +290,12 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
     }
 
     [Fact]
-    public async Task DeleteLastLevelUp_WithSameIdempotencyKey_ReplaysAuditEvent()
+    public async Task DeleteLastLevelUp_WithSameIdempotencyKey_DoesNotDeleteNextLevelUp()
     {
-        await SeedCharacterWithAssignment(externalPersonId: 112);
+        var game = await CreateGameAsync("Scan level retry");
+        await SeedCharacterWithAssignment(externalPersonId: 112, gameId: game.Id);
+        await Client.PostAsJsonAsync("/api/scan/112/events",
+            new CreateCharacterEventDto(CharacterEventType.LevelUp, "{}"));
         await Client.PostAsJsonAsync("/api/scan/112/events",
             new CreateCharacterEventDto(CharacterEventType.LevelUp, "{}"));
 
@@ -277,16 +304,135 @@ public class ScanEndpointTests(PostgresFixture postgres) : IntegrationTestBase(p
         var secondResponse = await DeleteWithIdempotencyAsync(
             "/api/scan/112/events/last-levelup", "undo-level-112");
 
-        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
-        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
-        var first = await firstResponse.Content.ReadFromJsonAsync<CharacterEventDto>();
-        var second = await secondResponse.Content.ReadFromJsonAsync<CharacterEventDto>();
-        Assert.Equal(first!.Id, second!.Id);
+        firstResponse.EnsureSuccessStatusCode();
+        secondResponse.EnsureSuccessStatusCode();
 
         var events = await Client.GetFromJsonAsync<List<CharacterEventDto>>("/api/scan/112/events");
         Assert.NotNull(events);
-        Assert.DoesNotContain(events, e => e.EventType == CharacterEventType.LevelUp);
+        Assert.Equal(1, events.Count(e => e.EventType == CharacterEventType.LevelUp));
         Assert.Single(events, e => e.EventType == CharacterEventType.LevelUpReverted);
+        Assert.Equal(1, await CountWorldActivitiesAsync(game.Id, WorldActivityType.CharacterLevelReverted));
+
+        var thirdResponse = await DeleteWithIdempotencyAsync(
+            "/api/scan/112/events/last-levelup", "undo-level-112-second");
+        thirdResponse.EnsureSuccessStatusCode();
+
+        events = await Client.GetFromJsonAsync<List<CharacterEventDto>>("/api/scan/112/events");
+        Assert.NotNull(events);
+        Assert.DoesNotContain(events, e => e.EventType == CharacterEventType.LevelUp);
+        Assert.Equal(2, events.Count(e => e.EventType == CharacterEventType.LevelUpReverted));
+        Assert.Equal(2, await CountWorldActivitiesAsync(game.Id, WorldActivityType.CharacterLevelReverted));
+    }
+
+    [Fact]
+    public async Task DeleteLastNote_WithoutIdempotencyKey_RemovesNewestNoteAndWritesAudit()
+    {
+        var game = await CreateGameAsync("Scan note legacy");
+        var (_, assignment) = await SeedCharacterWithAssignment(externalPersonId: 116, gameId: game.Id);
+        await SeedScanEventAsync(assignment.Id, CharacterEventType.Note, """{"text":"Starší"}""",
+            DateTime.UtcNow.AddMinutes(-2));
+        await SeedScanEventAsync(assignment.Id, CharacterEventType.Note, """{"text":"Novější"}""",
+            DateTime.UtcNow.AddMinutes(-1));
+
+        var response = await Client.DeleteAsync("/api/scan/116/events/last-note");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var events = await Client.GetFromJsonAsync<List<CharacterEventDto>>("/api/scan/116/events");
+        Assert.NotNull(events);
+        Assert.Equal(1, events.Count(e => e.EventType == CharacterEventType.Note));
+        Assert.Single(events, e => e.EventType == CharacterEventType.NoteReverted);
+        Assert.Equal(1, await CountWorldActivitiesAsync(game.Id, WorldActivityType.NoteReverted));
+    }
+
+    [Fact]
+    public async Task DeleteLastNote_WithSameIdempotencyKey_DoesNotDeleteNextNote()
+    {
+        var game = await CreateGameAsync("Scan note retry");
+        var (_, assignment) = await SeedCharacterWithAssignment(externalPersonId: 117, gameId: game.Id);
+        await SeedScanEventAsync(assignment.Id, CharacterEventType.Note, """{"text":"První"}""",
+            DateTime.UtcNow.AddMinutes(-2));
+        await SeedScanEventAsync(assignment.Id, CharacterEventType.Note, """{"text":"Druhá"}""",
+            DateTime.UtcNow.AddMinutes(-1));
+
+        var firstResponse = await DeleteWithIdempotencyAsync(
+            "/api/scan/117/events/last-note", "undo-note-117");
+        var secondResponse = await DeleteWithIdempotencyAsync(
+            "/api/scan/117/events/last-note", "undo-note-117");
+
+        firstResponse.EnsureSuccessStatusCode();
+        secondResponse.EnsureSuccessStatusCode();
+        var events = await Client.GetFromJsonAsync<List<CharacterEventDto>>("/api/scan/117/events");
+        Assert.NotNull(events);
+        Assert.Equal(1, events.Count(e => e.EventType == CharacterEventType.Note));
+        Assert.Single(events, e => e.EventType == CharacterEventType.NoteReverted);
+        Assert.Equal(1, await CountWorldActivitiesAsync(game.Id, WorldActivityType.NoteReverted));
+
+        var thirdResponse = await DeleteWithIdempotencyAsync(
+            "/api/scan/117/events/last-note", "undo-note-117-second");
+        thirdResponse.EnsureSuccessStatusCode();
+
+        events = await Client.GetFromJsonAsync<List<CharacterEventDto>>("/api/scan/117/events");
+        Assert.NotNull(events);
+        Assert.DoesNotContain(events, e => e.EventType == CharacterEventType.Note);
+        Assert.Equal(2, events.Count(e => e.EventType == CharacterEventType.NoteReverted));
+        Assert.Equal(2, await CountWorldActivitiesAsync(game.Id, WorldActivityType.NoteReverted));
+    }
+
+    [Fact]
+    public async Task DeleteLastCombat_WithoutIdempotencyKey_RemovesNewestCombatAndWritesAudit()
+    {
+        var game = await CreateGameAsync("Scan combat legacy");
+        var (_, assignment) = await SeedCharacterWithAssignment(externalPersonId: 118, gameId: game.Id);
+        await SeedScanEventAsync(assignment.Id, CharacterEventType.MonsterVictory, """{"monsterName":"Skřet"}""",
+            DateTime.UtcNow.AddMinutes(-2));
+        await SeedScanEventAsync(assignment.Id, CharacterEventType.MonsterDefeat, """{"monsterName":"Vlk"}""",
+            DateTime.UtcNow.AddMinutes(-1));
+
+        var response = await Client.DeleteAsync("/api/scan/118/events/last-combat");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var events = await Client.GetFromJsonAsync<List<CharacterEventDto>>("/api/scan/118/events");
+        Assert.NotNull(events);
+        Assert.Equal(1, events.Count(e =>
+            e.EventType is CharacterEventType.MonsterVictory or CharacterEventType.MonsterDefeat));
+        Assert.Single(events, e => e.EventType == CharacterEventType.MonsterCombatReverted);
+        Assert.Equal(1, await CountWorldActivitiesAsync(game.Id, WorldActivityType.MonsterCombatReverted));
+    }
+
+    [Fact]
+    public async Task DeleteLastCombat_WithSameIdempotencyKey_DoesNotDeleteNextCombat()
+    {
+        var game = await CreateGameAsync("Scan combat retry");
+        var (_, assignment) = await SeedCharacterWithAssignment(externalPersonId: 119, gameId: game.Id);
+        await SeedScanEventAsync(assignment.Id, CharacterEventType.MonsterVictory, """{"monsterName":"Skřet"}""",
+            DateTime.UtcNow.AddMinutes(-2));
+        await SeedScanEventAsync(assignment.Id, CharacterEventType.MonsterDefeat, """{"monsterName":"Vlk"}""",
+            DateTime.UtcNow.AddMinutes(-1));
+
+        var firstResponse = await DeleteWithIdempotencyAsync(
+            "/api/scan/119/events/last-combat", "undo-combat-119");
+        var secondResponse = await DeleteWithIdempotencyAsync(
+            "/api/scan/119/events/last-combat", "undo-combat-119");
+
+        firstResponse.EnsureSuccessStatusCode();
+        secondResponse.EnsureSuccessStatusCode();
+        var events = await Client.GetFromJsonAsync<List<CharacterEventDto>>("/api/scan/119/events");
+        Assert.NotNull(events);
+        Assert.Equal(1, events.Count(e =>
+            e.EventType is CharacterEventType.MonsterVictory or CharacterEventType.MonsterDefeat));
+        Assert.Single(events, e => e.EventType == CharacterEventType.MonsterCombatReverted);
+        Assert.Equal(1, await CountWorldActivitiesAsync(game.Id, WorldActivityType.MonsterCombatReverted));
+
+        var thirdResponse = await DeleteWithIdempotencyAsync(
+            "/api/scan/119/events/last-combat", "undo-combat-119-second");
+        thirdResponse.EnsureSuccessStatusCode();
+
+        events = await Client.GetFromJsonAsync<List<CharacterEventDto>>("/api/scan/119/events");
+        Assert.NotNull(events);
+        Assert.DoesNotContain(events,
+            e => e.EventType is CharacterEventType.MonsterVictory or CharacterEventType.MonsterDefeat);
+        Assert.Equal(2, events.Count(e => e.EventType == CharacterEventType.MonsterCombatReverted));
+        Assert.Equal(2, await CountWorldActivitiesAsync(game.Id, WorldActivityType.MonsterCombatReverted));
     }
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
@@ -285,9 +285,11 @@ public class ScanMonsterCombatEndpointTests(PostgresFixture postgres)
             .OrderBy(e => e.Timestamp)
             .ToListAsync();
 
-        // LevelUp is preserved; MonsterVictory is gone.
-        Assert.Single(events);
-        Assert.Equal(CharacterEventType.LevelUp, events[0].EventType);
+        // LevelUp is preserved; MonsterVictory is gone. The revert audit row is
+        // intentionally observable and must not count as remaining combat.
+        Assert.Single(events, e => e.EventType == CharacterEventType.LevelUp);
+        Assert.DoesNotContain(events, e => e.EventType == CharacterEventType.MonsterVictory);
+        Assert.Single(events, e => e.EventType == CharacterEventType.MonsterCombatReverted);
     }
 
     [Fact]

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ScanMonsterCombatEndpointTests.cs
@@ -287,8 +287,10 @@ public class ScanMonsterCombatEndpointTests(PostgresFixture postgres)
 
         // LevelUp is preserved; MonsterVictory is gone. The revert audit row is
         // intentionally observable and must not count as remaining combat.
+        Assert.Equal(2, events.Count);
         Assert.Single(events, e => e.EventType == CharacterEventType.LevelUp);
         Assert.DoesNotContain(events, e => e.EventType == CharacterEventType.MonsterVictory);
+        Assert.DoesNotContain(events, e => e.EventType == CharacterEventType.MonsterDefeat);
         Assert.Single(events, e => e.EventType == CharacterEventType.MonsterCombatReverted);
     }
 


### PR DESCRIPTION
## Summary
- Makes `DELETE /api/scan/{personId}/events/last-levelup`, `last-note`, and `last-combat` idempotent when `X-Idempotency-Key` is present.
- Reuses the existing `EventIdempotency` table with operation-scoped hashed keys (`revert:last-*:{sha256}`), so no schema migration is needed and raw keys are not logged/stored as table keys.
- Writes persistent `*Reverted` character events for replay tracking and mirrors `*Reverted` `WorldActivity` audit rows for visibility.
- Leaves Glejt/frontend files and project versions untouched.

## Tests
- `dotnet build OvcinaHra.slnx --verbosity minimal`
- `dotnet test OvcinaHra.slnx --verbosity minimal`

## Notes
Playwright E2E passed in this run; no #92 deferral needed.