### PR TITLE
fix(stats): use DB kingdom palette + add mastery levels (6)(7) to chart

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/EndGameStatsEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/EndGameStatsEndpoints.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
 using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Domain.Rules;
 using OvcinaHra.Shared.Dtos;
 
 namespace OvcinaHra.Api.Endpoints;
@@ -11,7 +12,7 @@ namespace OvcinaHra.Api.Endpoints;
 public static partial class GameEndpoints
 {
     private const string NoKingdomName = "Bez království";
-    private const string NoKingdomColor = "#6A6A6A";
+    private const int MaxStatsLevel = LevelingRules.MaxLevel + LevelingRules.MaxBuyableMasteries;
 
     private static async Task<Results<Ok<EndGameStatsDto>, NotFound>> GetEndGameStats(
         int gameId,
@@ -20,12 +21,24 @@ public static partial class GameEndpoints
         if (!await db.Games.AsNoTracking().AnyAsync(g => g.Id == gameId))
             return TypedResults.NotFound();
 
+        var kingdoms = await db.Kingdoms
+            .AsNoTracking()
+            .OrderBy(k => k.SortOrder)
+            .ThenBy(k => k.Name)
+            .Select(k => new EndGameKingdomRow(
+                k.Id,
+                k.Name,
+                k.HexColor,
+                k.SortOrder))
+            .ToListAsync();
+
         var assignments = await db.CharacterAssignments
             .AsNoTracking()
             .Where(a => a.GameId == gameId && a.IsActive)
             .Select(a => new EndGameAssignmentRow(
                 a.Id,
                 a.Character.Name,
+                a.Class,
                 a.KingdomId,
                 a.Kingdom != null ? a.Kingdom.Name : NoKingdomName,
                 a.Kingdom != null ? a.Kingdom.HexColor : null,
@@ -68,12 +81,21 @@ public static partial class GameEndpoints
         var currentLevelByAssignment = levelEvents
             .GroupBy(e => e.AssignmentId)
             .ToDictionary(g => g.Key, g => Math.Max(1, g.Max(e => e.Level)));
+        var masteryCountByAssignment = await BuildMasteryCountByAssignment(
+            db,
+            assignments.Select(a => a.AssignmentId).ToArray(),
+            assignmentById);
 
-        var kingdomBreakdowns = BuildKingdomBreakdowns(assignments, currentLevelByAssignment);
+        var kingdomBreakdowns = BuildKingdomBreakdowns(
+            kingdoms,
+            assignments,
+            currentLevelByAssignment,
+            masteryCountByAssignment);
         var firstToLevel5 = BuildFirstToLevel5(levelEvents, assignmentById);
         var monsterStats = BuildMonsterStats(parsedActivities, assignmentById, monsterNamesById);
 
         var leaderboard = kingdomBreakdowns
+            .Where(k => k.HeroCount > 0)
             .Select(k => new KingdomLeaderboardEntryDto(
                 k.KingdomId,
                 k.KingdomName,
@@ -94,27 +116,41 @@ public static partial class GameEndpoints
     }
 
     private static KingdomLevelBreakdownDto[] BuildKingdomBreakdowns(
+        List<EndGameKingdomRow> kingdoms,
         List<EndGameAssignmentRow> assignments,
-        Dictionary<int, int> currentLevelByAssignment)
+        Dictionary<int, int> currentLevelByAssignment,
+        Dictionary<int, int> masteryCountByAssignment)
     {
-        return assignments
-            .GroupBy(a => new EndGameKingdomKey(
-                a.KingdomId,
-                a.KingdomName,
-                CanonKingdomColor(a.KingdomName, a.KingdomColor),
-                a.SortOrder))
-            .OrderBy(g => g.Key.SortOrder)
-            .ThenBy(g => g.Key.KingdomName)
-            .Select(g =>
+        var kingdomKeys = kingdoms
+            .Select(k => new EndGameKingdomKey(
+                k.KingdomId,
+                k.KingdomName,
+                StoredColorOrEmpty(k.KingdomColor),
+                k.SortOrder))
+            .ToList();
+
+        if (assignments.Any(a => a.KingdomId is null))
+            kingdomKeys.Add(new EndGameKingdomKey(null, NoKingdomName, string.Empty, int.MaxValue));
+
+        var assignmentsByKingdomId = assignments.ToLookup(a => a.KingdomId);
+
+        return kingdomKeys
+            .OrderBy(k => k.SortOrder)
+            .ThenBy(k => k.KingdomName)
+            .Select(k =>
             {
-                var levels = g
-                    .Select(a => CurrentLevel(a.AssignmentId, currentLevelByAssignment))
+                var kingdomAssignments = assignmentsByKingdomId[k.KingdomId];
+                var levels = kingdomAssignments
+                    .Select(a => EffectiveLevel(
+                        a.AssignmentId,
+                        currentLevelByAssignment,
+                        masteryCountByAssignment))
                     .ToArray();
-                var buckets = Enumerable.Range(1, 5)
+                var buckets = Enumerable.Range(1, MaxStatsLevel)
                     .Select(level => new LevelCountDto(
                         level,
                         LevelLabel(level),
-                        levels.Count(heroLevel => Math.Min(heroLevel, 5) == level)))
+                        levels.Count(heroLevel => heroLevel == level)))
                     .ToArray();
                 var totalLevelsGained = levels.Sum(level => Math.Max(0, level - 1));
                 var averageLevel = levels.Length == 0
@@ -122,9 +158,9 @@ public static partial class GameEndpoints
                     : Math.Round((decimal)levels.Average(), 2, MidpointRounding.AwayFromZero);
 
                 return new KingdomLevelBreakdownDto(
-                    g.Key.KingdomId,
-                    g.Key.KingdomName,
-                    g.Key.ColorHex,
+                    k.KingdomId,
+                    k.KingdomName,
+                    k.ColorHex,
                     levels.Length,
                     totalLevelsGained,
                     averageLevel,
@@ -150,7 +186,7 @@ public static partial class GameEndpoints
             assignment.HeroName,
             assignment.KingdomId,
             assignment.KingdomName,
-            CanonKingdomColor(assignment.KingdomName, assignment.KingdomColor),
+            StoredColorOrEmpty(assignment.KingdomColor),
             first.TimestampUtc);
     }
 
@@ -254,11 +290,11 @@ public static partial class GameEndpoints
             return new EndGameKingdomKey(
                 assignment.KingdomId,
                 assignment.KingdomName,
-                CanonKingdomColor(assignment.KingdomName, assignment.KingdomColor),
+                StoredColorOrEmpty(assignment.KingdomColor),
                 assignment.SortOrder);
         }
 
-        return new EndGameKingdomKey(null, NoKingdomName, NoKingdomColor, int.MaxValue);
+        return new EndGameKingdomKey(null, NoKingdomName, string.Empty, int.MaxValue);
     }
 
     private static string MonsterName(
@@ -289,20 +325,82 @@ public static partial class GameEndpoints
         return string.IsNullOrWhiteSpace(name) ? null : name;
     }
 
-    private static string CanonKingdomColor(string kingdomName, string? storedHex) =>
-        kingdomName switch
+    private static async Task<Dictionary<int, int>> BuildMasteryCountByAssignment(
+        WorldDbContext db,
+        int[] assignmentIds,
+        Dictionary<int, EndGameAssignmentRow> assignmentById)
+    {
+        if (assignmentIds.Length == 0)
+            return [];
+
+        var skillEvents = await db.CharacterEvents
+            .AsNoTracking()
+            .Where(e => assignmentIds.Contains(e.CharacterAssignmentId)
+                && e.EventType == CharacterEventType.SkillGained)
+            .Select(e => new EndGameSkillEventRow(e.CharacterAssignmentId, e.Data))
+            .ToListAsync();
+
+        return skillEvents
+            .Where(e => IsMasterySkillEvent(e, assignmentById))
+            .GroupBy(e => e.AssignmentId)
+            .ToDictionary(g => g.Key, g => g.Count());
+    }
+
+    private static bool IsMasterySkillEvent(
+        EndGameSkillEventRow skillEvent,
+        Dictionary<int, EndGameAssignmentRow> assignmentById)
+    {
+        if (string.IsNullOrWhiteSpace(skillEvent.Data))
+            return false;
+
+        try
         {
-            "Esgaroth" => "#242F3D",
-            "Aradhryand" => "#243525",
-            "Azanulinbar" => "#8C2423",
-            "Arnor" => "#504B25",
-            NoKingdomName => NoKingdomColor,
-            _ when !string.IsNullOrWhiteSpace(storedHex) => storedHex,
-            _ => NoKingdomColor
-        };
+            using var doc = JsonDocument.Parse(skillEvent.Data);
+            if (TryReadBool(doc.RootElement, "mastery") is { } mastery)
+                return mastery;
+
+            var skillName = TryReadString(doc.RootElement, "skill");
+            if (string.IsNullOrWhiteSpace(skillName)
+                || !assignmentById.TryGetValue(skillEvent.AssignmentId, out var assignment)
+                || assignment.Class is not { } playerClass)
+                return false;
+
+            return LevelingRules.BuyableMasteriesAtL5(playerClass)
+                .Any(m => string.Equals(m.Name, skillName, StringComparison.OrdinalIgnoreCase));
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static int EffectiveLevel(
+        int assignmentId,
+        Dictionary<int, int> currentLevelByAssignment,
+        Dictionary<int, int> masteryCountByAssignment)
+    {
+        var level = Math.Clamp(
+            CurrentLevel(assignmentId, currentLevelByAssignment),
+            1,
+            LevelingRules.MaxLevel);
+
+        if (level < LevelingRules.MaxLevel)
+            return level;
+
+        var masteryCount = masteryCountByAssignment.TryGetValue(assignmentId, out var count)
+            ? Math.Min(count, LevelingRules.MaxBuyableMasteries)
+            : 0;
+
+        return level + masteryCount;
+    }
+
+    private static string StoredColorOrEmpty(string? storedHex) =>
+        string.IsNullOrWhiteSpace(storedHex) ? string.Empty : storedHex;
 
     private static string LevelLabel(int level) =>
-        level >= 5 ? "5+" : level.ToString(CultureInfo.InvariantCulture);
+        level > LevelingRules.MaxLevel
+            ? $"({level.ToString(CultureInfo.InvariantCulture)})"
+            : level.ToString(CultureInfo.InvariantCulture);
 
     private static int? TryReadInt(JsonElement root, string propertyName)
     {
@@ -330,9 +428,30 @@ public static partial class GameEndpoints
                 : null;
     }
 
+    private static bool? TryReadBool(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var property))
+            return null;
+
+        return property.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.String when bool.TryParse(property.GetString(), out var value) => value,
+            _ => null
+        };
+    }
+
+    private sealed record EndGameKingdomRow(
+        int KingdomId,
+        string KingdomName,
+        string? KingdomColor,
+        int SortOrder);
+
     private sealed record EndGameAssignmentRow(
         int AssignmentId,
         string HeroName,
+        PlayerClass? Class,
         int? KingdomId,
         string KingdomName,
         string? KingdomColor,
@@ -367,4 +486,6 @@ public static partial class GameEndpoints
         string KingdomName,
         string ColorHex,
         int SortOrder);
+
+    private sealed record EndGameSkillEventRow(int AssignmentId, string Data);
 }

--- a/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor
+++ b/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor
@@ -1,5 +1,6 @@
 @page "/statistiky-konec-hry"
 @attribute [Authorize]
+@using System.Globalization
 @inject ApiClient Api
 @inject GameContextService GameContext
 @implements IDisposable
@@ -68,26 +69,14 @@
             @if (HasLevelData)
             {
                 <DxChart Data="@_levelChartRows" CssClass="oh-endstats-chart">
-                    <DxChartBarSeries ArgumentField="@((LevelChartRow r) => r.LevelLabel)"
-                                      ValueField="@((LevelChartRow r) => r.Esgaroth)"
-                                      Name="Esgaroth"
-                                      Color="@EsgarothColor" />
-                    <DxChartBarSeries ArgumentField="@((LevelChartRow r) => r.LevelLabel)"
-                                      ValueField="@((LevelChartRow r) => r.Aradhryand)"
-                                      Name="Aradhryand"
-                                      Color="@AradhryandColor" />
-                    <DxChartBarSeries ArgumentField="@((LevelChartRow r) => r.LevelLabel)"
-                                      ValueField="@((LevelChartRow r) => r.Azanulinbar)"
-                                      Name="Azanulinbar"
-                                      Color="@AzanulinbarColor" />
-                    <DxChartBarSeries ArgumentField="@((LevelChartRow r) => r.LevelLabel)"
-                                      ValueField="@((LevelChartRow r) => r.Arnor)"
-                                      Name="Arnor"
-                                      Color="@ArnorColor" />
-                    <DxChartBarSeries ArgumentField="@((LevelChartRow r) => r.LevelLabel)"
-                                      ValueField="@((LevelChartRow r) => r.Other)"
-                                      Name="Ostatní"
-                                      Color="@OtherColor" />
+                    @foreach (var series in _levelChartSeries)
+                    {
+                        var currentSeries = series;
+                        <DxChartBarSeries ArgumentField="@((LevelChartRow r) => r.LevelLabel)"
+                                          ValueField="@((LevelChartRow r) => r.CountFor(currentSeries.Key))"
+                                          Name="@currentSeries.Name"
+                                          Color="@currentSeries.Color" />
+                    }
                 </DxChart>
             }
             else
@@ -113,7 +102,7 @@
                             @foreach (var row in _stats.ExperienceLeaderboard)
                             {
                                 <tr>
-                                    <td><span class="oh-endstats-swatch" style="background:@row.ColorHex"></span>@row.KingdomName</td>
+                                    <td><span class="oh-endstats-swatch" style="background:@SwatchBackground(row.ColorHex)"></span>@row.KingdomName</td>
                                     <td>@row.HeroCount</td>
                                     <td>@row.TotalLevelsGained</td>
                                     <td>@row.AverageLevel</td>
@@ -145,7 +134,7 @@
                             @foreach (var row in _stats.MonsterStats.HeroesFallenByKingdom)
                             {
                                 <div class="oh-endstats-row">
-                                    <span><span class="oh-endstats-swatch" style="background:@row.ColorHex"></span>@row.KingdomName</span>
+                                    <span><span class="oh-endstats-swatch" style="background:@SwatchBackground(row.ColorHex)"></span>@row.KingdomName</span>
                                     <strong>@row.Count</strong>
                                 </div>
                             }
@@ -164,15 +153,10 @@
 
     private EndGameStatsDto? _stats;
     private List<LevelChartRow> _levelChartRows = [];
+    private List<LevelChartSeries> _levelChartSeries = [];
     private bool _isLoading;
     private string? _error;
     private int _loadVersion;
-
-    private static readonly System.Drawing.Color EsgarothColor = System.Drawing.Color.FromArgb(0x24, 0x2F, 0x3D);
-    private static readonly System.Drawing.Color AradhryandColor = System.Drawing.Color.FromArgb(0x24, 0x35, 0x25);
-    private static readonly System.Drawing.Color AzanulinbarColor = System.Drawing.Color.FromArgb(0x8C, 0x24, 0x23);
-    private static readonly System.Drawing.Color ArnorColor = System.Drawing.Color.FromArgb(0x50, 0x4B, 0x25);
-    private static readonly System.Drawing.Color OtherColor = System.Drawing.Color.FromArgb(0x6A, 0x6A, 0x6A);
 
     private int? ActiveGameId => GameId ?? GameContext.SelectedGameId;
     private bool HasLevelData => _levelChartRows.Any(r => r.Total > 0);
@@ -202,6 +186,7 @@
         {
             _stats = null;
             _levelChartRows = [];
+            _levelChartSeries = [];
             _isLoading = false;
             return;
         }
@@ -214,6 +199,7 @@
 
             _stats = stats;
             _levelChartRows = BuildLevelChartRows(stats);
+            _levelChartSeries = BuildLevelChartSeries(stats);
             if (_stats is null)
                 _error = "Hra nebyla nalezena.";
         }
@@ -223,6 +209,7 @@
 
             _stats = null;
             _levelChartRows = [];
+            _levelChartSeries = [];
             _error = "Statistiky se nepodařilo načíst.";
         }
         finally
@@ -236,39 +223,64 @@
     {
         if (stats is null) return [];
 
-        return Enumerable.Range(1, 5)
-            .Select(level => new LevelChartRow(
-                LevelLabel(level),
-                CountFor(stats, level, "Esgaroth"),
-                CountFor(stats, level, "Aradhryand"),
-                CountFor(stats, level, "Azanulinbar"),
-                CountFor(stats, level, "Arnor"),
-                stats.Kingdoms
-                    .Where(k => !IsCanonKingdom(k.KingdomName))
-                    .Sum(k => k.Levels.FirstOrDefault(l => l.Level == level)?.HeroCount ?? 0)))
+        return stats.Kingdoms
+            .SelectMany(k => k.Levels)
+            .GroupBy(level => level.Level)
+            .OrderBy(g => g.Key)
+            .Select(g => new LevelChartRow(
+                g.First().Label,
+                stats.Kingdoms.ToDictionary(
+                    SeriesKey,
+                    kingdom => kingdom.Levels.FirstOrDefault(level => level.Level == g.Key)?.HeroCount ?? 0)))
             .ToList();
     }
 
-    private static int CountFor(EndGameStatsDto stats, int level, string kingdomName) =>
-        stats.Kingdoms
-            .Where(k => k.KingdomName == kingdomName)
-            .Sum(k => k.Levels.FirstOrDefault(l => l.Level == level)?.HeroCount ?? 0);
+    private static List<LevelChartSeries> BuildLevelChartSeries(EndGameStatsDto? stats) =>
+        stats?.Kingdoms
+            .Select(k => new LevelChartSeries(SeriesKey(k), k.KingdomName, ParseColor(k.ColorHex)))
+            .ToList() ?? [];
 
-    private static bool IsCanonKingdom(string kingdomName) =>
-        kingdomName is "Esgaroth" or "Aradhryand" or "Azanulinbar" or "Arnor";
+    private static string SeriesKey(KingdomLevelBreakdownDto kingdom) =>
+        kingdom.KingdomId?.ToString(CultureInfo.InvariantCulture) ?? kingdom.KingdomName;
 
-    private static string LevelLabel(int level) => level >= 5 ? "5+" : level.ToString();
+    private static string SwatchBackground(string? colorHex) =>
+        IsHexColor(colorHex) ? colorHex!.Trim() : System.Drawing.Color.Gray.Name;
+
+    private static System.Drawing.Color ParseColor(string? colorHex)
+    {
+        if (!IsHexColor(colorHex))
+            return System.Drawing.Color.Gray;
+
+        var hex = colorHex.AsSpan().Trim();
+        return System.Drawing.Color.FromArgb(
+            int.Parse(hex.Slice(1, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+            int.Parse(hex.Slice(3, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+            int.Parse(hex.Slice(5, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture));
+    }
+
+    private static bool IsHexColor(string? colorHex)
+    {
+        if (string.IsNullOrWhiteSpace(colorHex))
+            return false;
+
+        var hex = colorHex.AsSpan().Trim();
+        return hex.Length == 7
+            && hex[0] == '#'
+            && int.TryParse(hex[1..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _);
+    }
 
     public void Dispose() => GameContext.OnGameChanged -= HandleGameChanged;
 
     private sealed record LevelChartRow(
         string LevelLabel,
-        int Esgaroth,
-        int Aradhryand,
-        int Azanulinbar,
-        int Arnor,
-        int Other)
+        Dictionary<string, int> Counts)
     {
-        public int Total => Esgaroth + Aradhryand + Azanulinbar + Arnor + Other;
+        public int CountFor(string key) => Counts.TryGetValue(key, out var count) ? count : 0;
+        public int Total => Counts.Values.Sum();
     }
+
+    private sealed record LevelChartSeries(
+        string Key,
+        string Name,
+        System.Drawing.Color Color);
 }

--- a/tests/OvcinaHra.Api.Tests/Endpoints/EndGameStatsEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/EndGameStatsEndpointTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using OvcinaHra.Api.Data;
@@ -26,11 +27,18 @@ public class EndGameStatsEndpointTests(PostgresFixture postgres)
     {
         // Arrange
         var game = await CreateGameAsync();
+        Kingdom esgaroth;
+        Kingdom aradhryand;
+        Kingdom azanulinbar;
+        Kingdom arnor;
+
         using (var scope = Factory.Services.CreateScope())
         {
             var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
-            var esgaroth = await GetOrCreateKingdomAsync(db, "Esgaroth", "#000000", 1);
-            var aradhryand = await GetOrCreateKingdomAsync(db, "Aradhryand", "#000000", 2);
+            esgaroth = await GetKingdomAsync(db, "Esgaroth");
+            aradhryand = await GetKingdomAsync(db, "Aradhryand");
+            azanulinbar = await GetKingdomAsync(db, "Azanulinbar-Dum");
+            arnor = await GetKingdomAsync(db, "Nový Arnor");
 
             var hilda = new Character { Name = $"Hilda {game.Id}", IsPlayedCharacter = true };
             var beorn = new Character { Name = $"Beorn {game.Id}", IsPlayedCharacter = true };
@@ -43,6 +51,7 @@ public class EndGameStatsEndpointTests(PostgresFixture postgres)
                 CharacterId = hilda.Id,
                 GameId = game.Id,
                 ExternalPersonId = game.Id * 1000 + 1,
+                Class = PlayerClass.Warrior,
                 KingdomId = esgaroth.Id
             };
             var beornAssignment = new CharacterAssignment
@@ -112,6 +121,7 @@ public class EndGameStatsEndpointTests(PostgresFixture postgres)
                     CharacterAssignmentId = miraAssignment.Id,
                     DataJson = """{"monsterName":"Vlk"}"""
                 });
+            db.CharacterEvents.Add(Mastery(hildaAssignment.Id, start.AddMinutes(9), "Berserk"));
             await db.SaveChangesAsync();
         }
 
@@ -123,17 +133,29 @@ public class EndGameStatsEndpointTests(PostgresFixture postgres)
         Assert.NotNull(stats);
         Assert.Equal("Esgaroth", stats.FirstToLevel5!.KingdomName);
         Assert.StartsWith("Hilda", stats.FirstToLevel5.HeroName, StringComparison.Ordinal);
-        Assert.Equal("#242F3D", stats.FirstToLevel5.ColorHex);
+        Assert.Equal(esgaroth.HexColor, stats.FirstToLevel5.ColorHex);
+
+        Assert.Contains(stats.Kingdoms, k => k.KingdomName == aradhryand.Name);
+        Assert.Contains(stats.Kingdoms, k => k.KingdomName == azanulinbar.Name);
+        Assert.Contains(stats.Kingdoms, k => k.KingdomName == esgaroth.Name);
+        Assert.Contains(stats.Kingdoms, k => k.KingdomName == arnor.Name);
+        Assert.All(stats.Kingdoms, AssertCompleteLevelGrid);
 
         var esgarothStats = stats.Kingdoms.Single(k => k.KingdomName == "Esgaroth");
-        Assert.Equal("#242F3D", esgarothStats.ColorHex);
+        Assert.Equal(esgaroth.HexColor, esgarothStats.ColorHex);
         Assert.Equal(2, esgarothStats.HeroCount);
-        Assert.Equal(6, esgarothStats.TotalLevelsGained);
+        Assert.Equal(7, esgarothStats.TotalLevelsGained);
         Assert.Equal(1, esgarothStats.Levels.Single(l => l.Level == 3).HeroCount);
-        Assert.Equal(1, esgarothStats.Levels.Single(l => l.Level == 5).HeroCount);
+        Assert.Equal(0, esgarothStats.Levels.Single(l => l.Level == 5).HeroCount);
+        Assert.Equal(1, esgarothStats.Levels.Single(l => l.Level == 6).HeroCount);
+
+        var azanulinbarStats = stats.Kingdoms.Single(k => k.KingdomName == azanulinbar.Name);
+        Assert.Equal(azanulinbar.HexColor, azanulinbarStats.ColorHex);
+        Assert.Equal(0, azanulinbarStats.HeroCount);
+        Assert.All(azanulinbarStats.Levels, level => Assert.Equal(0, level.HeroCount));
 
         Assert.Equal("Esgaroth", stats.ExperienceLeaderboard[0].KingdomName);
-        Assert.Equal(6, stats.ExperienceLeaderboard[0].TotalLevelsGained);
+        Assert.Equal(7, stats.ExperienceLeaderboard[0].TotalLevelsGained);
 
         Assert.Equal(2, stats.MonsterStats.MostDefeatedMonsters.Length);
         var topMonster = stats.MonsterStats.MostDefeatedMonsters[0];
@@ -144,8 +166,60 @@ public class EndGameStatsEndpointTests(PostgresFixture postgres)
 
         var fallen = Assert.Single(stats.MonsterStats.HeroesFallenByKingdom);
         Assert.Equal("Aradhryand", fallen.KingdomName);
-        Assert.Equal("#243525", fallen.ColorHex);
+        Assert.Equal(aradhryand.HexColor, fallen.ColorHex);
         Assert.Equal(1, fallen.Count);
+    }
+
+    [Fact]
+    public async Task EndGameStats_ReportsMasteryLevelsSixAndSevenAndClampsExtraMasteries()
+    {
+        // Arrange
+        var game = await CreateGameAsync();
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var esgaroth = await GetKingdomAsync(db, "Esgaroth");
+
+            var oneMastery = new Character { Name = $"One Mastery {game.Id}", IsPlayedCharacter = true };
+            var twoMasteries = new Character { Name = $"Two Masteries {game.Id}", IsPlayedCharacter = true };
+            var corruptMasteries = new Character { Name = $"Corrupt Masteries {game.Id}", IsPlayedCharacter = true };
+            db.Characters.AddRange(oneMastery, twoMasteries, corruptMasteries);
+            await db.SaveChangesAsync();
+
+            var oneAssignment = Assignment(game, oneMastery, esgaroth, 11);
+            var twoAssignment = Assignment(game, twoMasteries, esgaroth, 12);
+            var corruptAssignment = Assignment(game, corruptMasteries, esgaroth, 13);
+            db.CharacterAssignments.AddRange(oneAssignment, twoAssignment, corruptAssignment);
+            await db.SaveChangesAsync();
+
+            var start = DateTime.UtcNow.AddHours(-1);
+            db.WorldActivities.AddRange(
+                LevelUp(game.Id, oneAssignment.Id, start.AddMinutes(1), """{"level":5}"""),
+                LevelUp(game.Id, twoAssignment.Id, start.AddMinutes(2), """{"level":5}"""),
+                LevelUp(game.Id, corruptAssignment.Id, start.AddMinutes(3), """{"level":5}"""));
+            db.CharacterEvents.AddRange(
+                Mastery(oneAssignment.Id, start.AddMinutes(4), "Berserk"),
+                Mastery(twoAssignment.Id, start.AddMinutes(5), "Berserk"),
+                Mastery(twoAssignment.Id, start.AddMinutes(6), "Houževnatý"),
+                Mastery(corruptAssignment.Id, start.AddMinutes(7), "Berserk"),
+                Mastery(corruptAssignment.Id, start.AddMinutes(8), "Houževnatý"),
+                Mastery(corruptAssignment.Id, start.AddMinutes(9), "Navíc"));
+            await db.SaveChangesAsync();
+        }
+
+        // Act
+        var stats = await Client.GetFromJsonAsync<EndGameStatsDto>(
+            $"/api/games/{game.Id}/end-game-stats");
+
+        // Assert
+        Assert.NotNull(stats);
+        var esgarothStats = stats.Kingdoms.Single(k => k.KingdomName == "Esgaroth");
+        AssertCompleteLevelGrid(esgarothStats);
+        Assert.Equal("(6)", esgarothStats.Levels.Single(l => l.Level == 6).Label);
+        Assert.Equal("(7)", esgarothStats.Levels.Single(l => l.Level == 7).Label);
+        Assert.Equal(0, esgarothStats.Levels.Single(l => l.Level == 5).HeroCount);
+        Assert.Equal(1, esgarothStats.Levels.Single(l => l.Level == 6).HeroCount);
+        Assert.Equal(2, esgarothStats.Levels.Single(l => l.Level == 7).HeroCount);
     }
 
     private async Task<GameDetailDto> CreateGameAsync()
@@ -156,20 +230,21 @@ public class EndGameStatsEndpointTests(PostgresFixture postgres)
         return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
     }
 
-    private static async Task<Kingdom> GetOrCreateKingdomAsync(
-        WorldDbContext db,
-        string name,
-        string hexColor,
-        int sortOrder)
-    {
-        var kingdom = await db.Kingdoms.FirstOrDefaultAsync(k => k.Name == name);
-        if (kingdom is not null) return kingdom;
+    private static Task<Kingdom> GetKingdomAsync(WorldDbContext db, string name) =>
+        db.Kingdoms.SingleAsync(k => k.Name == name);
 
-        kingdom = new Kingdom { Name = name, HexColor = hexColor, SortOrder = sortOrder };
-        db.Kingdoms.Add(kingdom);
-        await db.SaveChangesAsync();
-        return kingdom;
-    }
+    private static CharacterAssignment Assignment(
+        GameDetailDto game,
+        Character character,
+        Kingdom kingdom,
+        int personOffset) => new()
+        {
+            CharacterId = character.Id,
+            GameId = game.Id,
+            ExternalPersonId = game.Id * 1000 + personOffset,
+            Class = PlayerClass.Warrior,
+            KingdomId = kingdom.Id
+        };
 
     private static WorldActivity LevelUp(
         int gameId,
@@ -186,4 +261,24 @@ public class EndGameStatsEndpointTests(PostgresFixture postgres)
         CharacterAssignmentId = assignmentId,
         DataJson = dataJson
     };
+
+    private static CharacterEvent Mastery(
+        int assignmentId,
+        DateTime timestampUtc,
+        string skillName) => new()
+    {
+        CharacterAssignmentId = assignmentId,
+        Timestamp = timestampUtc,
+        OrganizerUserId = "org",
+        OrganizerName = "Org",
+        EventType = CharacterEventType.SkillGained,
+        Data = JsonSerializer.Serialize(new { skill = skillName, mastery = true })
+    };
+
+    private static void AssertCompleteLevelGrid(KingdomLevelBreakdownDto kingdom)
+    {
+        Assert.Equal(7, kingdom.Levels.Length);
+        Assert.Equal(Enumerable.Range(1, 7), kingdom.Levels.Select(l => l.Level));
+        Assert.Equal(["1", "2", "3", "4", "5", "(6)", "(7)"], kingdom.Levels.Select(l => l.Label));
+    }
 }


### PR DESCRIPTION
## Summary
- remove hardcoded muted stats chart palette and drive kingdom colors from `Kingdom.HexColor`
- zero-fill every kingdom/level bucket for levels `1..5`, `(6)`, and `(7)`
- count mastery `SkillGained` events as effective levels 6/7, clamped at two masteries

Closes #531.

## Verification
- `dotnet build OvcinaHra.slnx`
- `dotnet test OvcinaHra.slnx --no-build --logger "console;verbosity=minimal"`