### PR TITLE
fix(stats): drop mastery name-fallback + (6)(7) tooltip text

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/EndGameStatsEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/EndGameStatsEndpoints.cs
@@ -38,7 +38,6 @@ public static partial class GameEndpoints
             .Select(a => new EndGameAssignmentRow(
                 a.Id,
                 a.Character.Name,
-                a.Class,
                 a.KingdomId,
                 a.Kingdom != null ? a.Kingdom.Name : NoKingdomName,
                 a.Kingdom != null ? a.Kingdom.HexColor : null,
@@ -83,8 +82,7 @@ public static partial class GameEndpoints
             .ToDictionary(g => g.Key, g => Math.Max(1, g.Max(e => e.Level)));
         var masteryCountByAssignment = await BuildMasteryCountByAssignment(
             db,
-            assignments.Select(a => a.AssignmentId).ToArray(),
-            assignmentById);
+            assignments.Select(a => a.AssignmentId).ToArray());
 
         var kingdomBreakdowns = BuildKingdomBreakdowns(
             kingdoms,
@@ -327,8 +325,7 @@ public static partial class GameEndpoints
 
     private static async Task<Dictionary<int, int>> BuildMasteryCountByAssignment(
         WorldDbContext db,
-        int[] assignmentIds,
-        Dictionary<int, EndGameAssignmentRow> assignmentById)
+        int[] assignmentIds)
     {
         if (assignmentIds.Length == 0)
             return [];
@@ -341,14 +338,12 @@ public static partial class GameEndpoints
             .ToListAsync();
 
         return skillEvents
-            .Where(e => IsMasterySkillEvent(e, assignmentById))
+            .Where(IsMasterySkillEvent)
             .GroupBy(e => e.AssignmentId)
             .ToDictionary(g => g.Key, g => g.Count());
     }
 
-    private static bool IsMasterySkillEvent(
-        EndGameSkillEventRow skillEvent,
-        Dictionary<int, EndGameAssignmentRow> assignmentById)
+    private static bool IsMasterySkillEvent(EndGameSkillEventRow skillEvent)
     {
         if (string.IsNullOrWhiteSpace(skillEvent.Data))
             return false;
@@ -356,17 +351,7 @@ public static partial class GameEndpoints
         try
         {
             using var doc = JsonDocument.Parse(skillEvent.Data);
-            if (TryReadBool(doc.RootElement, "mastery") is { } mastery)
-                return mastery;
-
-            var skillName = TryReadString(doc.RootElement, "skill");
-            if (string.IsNullOrWhiteSpace(skillName)
-                || !assignmentById.TryGetValue(skillEvent.AssignmentId, out var assignment)
-                || assignment.Class is not { } playerClass)
-                return false;
-
-            return LevelingRules.BuyableMasteriesAtL5(playerClass)
-                .Any(m => string.Equals(m.Name, skillName, StringComparison.OrdinalIgnoreCase));
+            return TryReadBool(doc.RootElement, "mastery") == true;
         }
         catch (JsonException)
         {
@@ -451,7 +436,6 @@ public static partial class GameEndpoints
     private sealed record EndGameAssignmentRow(
         int AssignmentId,
         string HeroName,
-        PlayerClass? Class,
         int? KingdomId,
         string KingdomName,
         string? KingdomColor,

--- a/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor
+++ b/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor
@@ -77,6 +77,12 @@
                                           Name="@currentSeries.Name"
                                           Color="@currentSeries.Color" />
                     }
+                    <DxChartTooltip Enabled="true" Context="tooltip">
+                        <div>
+                            <strong>@TooltipLevelText(tooltip)</strong>
+                            <div>@tooltip.Point.SeriesName: @tooltip.Point.Value</div>
+                        </div>
+                    </DxChartTooltip>
                 </DxChart>
             }
             else
@@ -245,6 +251,30 @@
 
     private static string SwatchBackground(string? colorHex) =>
         IsHexColor(colorHex) ? colorHex!.Trim() : System.Drawing.Color.Gray.Name;
+
+    private static string TooltipLevelText(DevExpress.Blazor.ChartTooltipData tooltip)
+    {
+        if (!TryReadTooltipLevel(tooltip.Point.Argument?.ToString(), out var level))
+            return "Úroveň";
+
+        var masteryCount = level - OvcinaHra.Shared.Domain.Rules.LevelingRules.MaxLevel;
+        return masteryCount > 0
+            ? $"Úroveň {level} ({masteryCount} mistrovství)"
+            : $"Úroveň {level}";
+    }
+
+    private static bool TryReadTooltipLevel(string? label, out int level)
+    {
+        level = 0;
+        if (string.IsNullOrWhiteSpace(label))
+            return false;
+
+        var normalized = label.Trim();
+        if (normalized.Length > 2 && normalized[0] == '(' && normalized[^1] == ')')
+            normalized = normalized[1..^1];
+
+        return int.TryParse(normalized, NumberStyles.Integer, CultureInfo.InvariantCulture, out level);
+    }
 
     private static System.Drawing.Color ParseColor(string? colorHex)
     {

--- a/tests/OvcinaHra.Api.Tests/Endpoints/EndGameStatsEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/EndGameStatsEndpointTests.cs
@@ -222,6 +222,45 @@ public class EndGameStatsEndpointTests(PostgresFixture postgres)
         Assert.Equal(2, esgarothStats.Levels.Single(l => l.Level == 7).HeroCount);
     }
 
+    [Fact]
+    public async Task EndGameStats_DoesNotCountSkillNamesWithoutMasteryFlagAsMasteries()
+    {
+        // Arrange
+        var game = await CreateGameAsync();
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var esgaroth = await GetKingdomAsync(db, "Esgaroth");
+
+            var hrdina = new Character { Name = $"Legacy Skill {game.Id}", IsPlayedCharacter = true };
+            db.Characters.Add(hrdina);
+            await db.SaveChangesAsync();
+
+            var assignment = Assignment(game, hrdina, esgaroth, 21);
+            db.CharacterAssignments.Add(assignment);
+            await db.SaveChangesAsync();
+
+            var start = DateTime.UtcNow.AddHours(-1);
+            db.WorldActivities.Add(LevelUp(game.Id, assignment.Id, start.AddMinutes(1), """{"level":5}"""));
+            db.CharacterEvents.AddRange(
+                SkillEvent(assignment.Id, start.AddMinutes(2), JsonSerializer.Serialize(new { skill = "Berserk" })),
+                SkillEvent(assignment.Id, start.AddMinutes(3), JsonSerializer.Serialize(new { skill = "Houževnatý", mastery = false })),
+                SkillEvent(assignment.Id, start.AddMinutes(4), string.Empty));
+            await db.SaveChangesAsync();
+        }
+
+        // Act
+        var stats = await Client.GetFromJsonAsync<EndGameStatsDto>(
+            $"/api/games/{game.Id}/end-game-stats");
+
+        // Assert
+        Assert.NotNull(stats);
+        var esgarothStats = stats.Kingdoms.Single(k => k.KingdomName == "Esgaroth");
+        Assert.Equal(1, esgarothStats.Levels.Single(l => l.Level == 5).HeroCount);
+        Assert.Equal(0, esgarothStats.Levels.Single(l => l.Level == 6).HeroCount);
+        Assert.Equal(0, esgarothStats.Levels.Single(l => l.Level == 7).HeroCount);
+    }
+
     private async Task<GameDetailDto> CreateGameAsync()
     {
         var response = await Client.PostAsJsonAsync("/api/games",
@@ -273,6 +312,19 @@ public class EndGameStatsEndpointTests(PostgresFixture postgres)
         OrganizerName = "Org",
         EventType = CharacterEventType.SkillGained,
         Data = JsonSerializer.Serialize(new { skill = skillName, mastery = true })
+    };
+
+    private static CharacterEvent SkillEvent(
+        int assignmentId,
+        DateTime timestampUtc,
+        string data) => new()
+    {
+        CharacterAssignmentId = assignmentId,
+        Timestamp = timestampUtc,
+        OrganizerUserId = "org",
+        OrganizerName = "Org",
+        EventType = CharacterEventType.SkillGained,
+        Data = data
     };
 
     private static void AssertCompleteLevelGrid(KingdomLevelBreakdownDto kingdom)


### PR DESCRIPTION
## Summary
- drop the brittle `SkillGained` skill-name fallback and count only explicit `mastery: true`
- add chart tooltip text for levels `1..5`, `(6)`, and `(7)`
- add a negative mastery aggregation test for matching mastery names without the flag

Audit: repository fixture/seed/code search found paid mastery writes already emit `mastery = true`; no test/seed mastery-name events without the flag were found. Auto-skill writes omit the flag, but were not counted by the removed fallback.

`EndGameAssignmentRow.SortOrder` was left in place because `KingdomFor` still reads it for hero-fell grouping order.

Closes #533.

## Verification
- `dotnet build OvcinaHra.slnx`
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter EndGameStatsEndpointTests --logger "console;verbosity=minimal"`
- `dotnet test OvcinaHra.slnx --no-build --logger "console;verbosity=minimal"`