### PR TITLE
feat(progression): per-timeslot character progression dashboard

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/GameEndpoints.cs
@@ -53,6 +53,8 @@ public static partial class GameEndpoints
         group.MapDelete("/{gameId:int}/creatures/{monsterId:int}", RemoveCreatureFromGame);
         group.MapDelete("/{gameId:int}/quests/{questId:int}", RemoveQuestFromGame);
         group.MapGet("/{gameId:int}/end-game-stats", GetEndGameStats);
+        group.MapGet("/{gameId:int}/progression-stats", GetProgressionStats);
+        group.MapGet("/{gameId:int}/progression-stats.xlsx", DownloadProgressionStatsXlsx);
 
         return group;
     }

--- a/src/OvcinaHra.Api/Endpoints/ProgressionStatsEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ProgressionStatsEndpoints.cs
@@ -1,0 +1,457 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Domain.Rules;
+using OvcinaHra.Shared.Dtos;
+using OvcinaHra.Shared.Extensions;
+
+namespace OvcinaHra.Api.Endpoints;
+
+public static partial class GameEndpoints
+{
+    private const string ProgressionXlsxContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private static async Task<Results<Ok<ProgressionStatsDto>, NotFound>> GetProgressionStats(
+        int gameId,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.ProgressionStats");
+        logger.LogInformation("[progression] entry gameId={GameId}", gameId);
+
+        var stats = await BuildProgressionStatsAsync(gameId, db, logger, ct);
+        return stats is null
+            ? TypedResults.NotFound()
+            : TypedResults.Ok(stats);
+    }
+
+    private static async Task<Results<FileContentHttpResult, NotFound>> DownloadProgressionStatsXlsx(
+        int gameId,
+        WorldDbContext db,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("OvcinaHra.Api.Endpoints.ProgressionStats");
+        logger.LogInformation("[progression] entry xlsx gameId={GameId}", gameId);
+
+        var stats = await BuildProgressionStatsAsync(gameId, db, logger, ct);
+        if (stats is null)
+            return TypedResults.NotFound();
+
+        try
+        {
+            logger.LogInformation("[progression] xlsx write start gameId={GameId} rows={RowCount}", gameId, stats.Events.Length);
+            var timer = Stopwatch.StartNew();
+            var bytes = WriteProgressionWorkbook(stats);
+            timer.Stop();
+            logger.LogInformation(
+                "[progression] xlsx write complete gameId={GameId} rows={RowCount} elapsedMs={ElapsedMs} bytes={Bytes}",
+                gameId,
+                stats.Events.Length,
+                timer.ElapsedMilliseconds,
+                bytes.Length);
+
+            return TypedResults.File(
+                bytes,
+                ProgressionXlsxContentType,
+                fileDownloadName: $"progres-postav-{gameId.ToString(CultureInfo.InvariantCulture)}.xlsx");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "[progression] xlsx write failed gameId={GameId}", gameId);
+            throw;
+        }
+    }
+
+    private static async Task<ProgressionStatsDto?> BuildProgressionStatsAsync(
+        int gameId,
+        WorldDbContext db,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        if (!await db.Games.AsNoTracking().AnyAsync(g => g.Id == gameId, ct))
+            return null;
+
+        var kingdoms = await db.Kingdoms
+            .AsNoTracking()
+            .OrderBy(k => k.SortOrder)
+            .ThenBy(k => k.Name)
+            .Select(k => new ProgressionKingdomRow(k.Id, k.Name, k.HexColor, k.SortOrder))
+            .ToListAsync(ct);
+
+        var timeSlots = await db.GameTimeSlots
+            .AsNoTracking()
+            .Where(s => s.GameId == gameId)
+            .OrderBy(s => s.StartTime)
+            .ThenBy(s => s.Id)
+            .Select(s => new ProgressionTimeSlotRow(
+                s.Id,
+                s.StartTime,
+                s.Duration,
+                s.Stage,
+                s.InGameYear,
+                TimeSlotDisplayExtensions.FormatTimeSlotDisplay(
+                    s.Stage,
+                    s.InGameYear,
+                    s.StartTime,
+                    (decimal)s.Duration.TotalHours)))
+            .ToListAsync(ct);
+
+        logger.LogInformation("[progression] CharacterEvent query start gameId={GameId}", gameId);
+        var timer = Stopwatch.StartNew();
+        var events = await db.CharacterEvents
+            .AsNoTracking()
+            .Where(e => e.Assignment.GameId == gameId
+                && (e.EventType == CharacterEventType.LevelUp
+                    || e.EventType == CharacterEventType.SkillGained))
+            .OrderBy(e => e.Timestamp)
+            .ThenBy(e => e.Id)
+            .Select(e => new ProgressionCharacterEventRow(
+                e.Id,
+                e.CharacterAssignmentId,
+                e.Timestamp,
+                e.EventType,
+                e.Data,
+                e.Assignment.Character.Name,
+                e.Assignment.Character.PlayerFirstName,
+                e.Assignment.Character.PlayerLastName,
+                e.Assignment.KingdomId,
+                e.Assignment.Kingdom != null ? e.Assignment.Kingdom.Name : NoKingdomName,
+                e.Assignment.Kingdom != null ? e.Assignment.Kingdom.HexColor : null))
+            .ToListAsync(ct);
+        timer.Stop();
+        logger.LogInformation(
+            "[progression] CharacterEvent query complete gameId={GameId} elapsedMs={ElapsedMs} rowCount={RowCount}",
+            gameId,
+            timer.ElapsedMilliseconds,
+            events.Count);
+
+        var normalizedEvents = BuildProgressionEvents(events, timeSlots, logger);
+        var chartKingdoms = BuildProgressionKingdoms(kingdoms, timeSlots, normalizedEvents);
+        var eventRows = normalizedEvents
+            .Select(e => new ProgressionEventRow(
+                e.PlayerName,
+                e.CharacterName,
+                e.KingdomName,
+                e.KingdomHexColor,
+                e.TimeSlotId,
+                e.TimeSlotLabel,
+                e.EventType,
+                e.LevelGained,
+                e.TimestampUtc))
+            .OrderBy(e => e.TimestampUtc)
+            .ThenBy(e => e.CharacterName)
+            .ToArray();
+
+        return new ProgressionStatsDto(chartKingdoms, eventRows);
+    }
+
+    private static List<ProgressionNormalizedEvent> BuildProgressionEvents(
+        List<ProgressionCharacterEventRow> events,
+        List<ProgressionTimeSlotRow> timeSlots,
+        ILogger logger)
+    {
+        var normalized = new List<ProgressionNormalizedEvent>();
+        var masteryCountByAssignment = new Dictionary<int, int>();
+        var fallbackLevelByAssignment = new Dictionary<int, int>();
+        var extraMasteryWarningLogged = false;
+
+        foreach (var ev in events)
+        {
+            var levelGained = ev.EventType switch
+            {
+                CharacterEventType.LevelUp => ReadLevelUpLevel(ev, fallbackLevelByAssignment, logger),
+                CharacterEventType.SkillGained when IsMasterySkillEvent(ev.Data, ev.EventId, logger) =>
+                    ReadMasteryLevel(ev, masteryCountByAssignment, logger, ref extraMasteryWarningLogged),
+                _ => null
+            };
+
+            if (levelGained is not { } level)
+                continue;
+
+            if (ev.KingdomId is null)
+                continue;
+
+            var bucket = ResolveProgressionBucket(ev.TimestampUtc, timeSlots, logger);
+            if (bucket is null)
+                continue;
+
+            normalized.Add(new ProgressionNormalizedEvent(
+                ev.EventId,
+                ev.AssignmentId,
+                ev.KingdomId.Value,
+                ev.KingdomName,
+                StoredColorOrEmpty(ev.KingdomHexColor),
+                bucket.Id,
+                timeSlots.IndexOf(bucket),
+                bucket.Label,
+                PlayerFullName(ev.PlayerFirstName, ev.PlayerLastName) ?? "Neznámý hráč",
+                ev.CharacterName,
+                ev.EventType == CharacterEventType.LevelUp ? "LevelUp" : "MasterySkillGained",
+                level,
+                ev.TimestampUtc));
+        }
+
+        return normalized;
+    }
+
+    private static int? ReadLevelUpLevel(
+        ProgressionCharacterEventRow ev,
+        Dictionary<int, int> fallbackLevelByAssignment,
+        ILogger logger)
+    {
+        int? dataLevel = null;
+        if (!string.IsNullOrWhiteSpace(ev.Data))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(ev.Data);
+                dataLevel = TryReadInt(doc.RootElement, "level");
+            }
+            catch (JsonException)
+            {
+                logger.LogWarning(
+                    "[progression] malformed LevelUp data eventId={EventId} assignmentId={AssignmentId}",
+                    ev.EventId,
+                    ev.AssignmentId);
+                dataLevel = null;
+            }
+        }
+
+        var nextFallback = fallbackLevelByAssignment.TryGetValue(ev.AssignmentId, out var current)
+            ? current + 1
+            : 1;
+        var level = dataLevel ?? nextFallback;
+        level = Math.Clamp(level, 1, LevelingRules.MaxLevel);
+        fallbackLevelByAssignment[ev.AssignmentId] = Math.Max(nextFallback, level);
+        return level;
+    }
+
+    private static int? ReadMasteryLevel(
+        ProgressionCharacterEventRow ev,
+        Dictionary<int, int> masteryCountByAssignment,
+        ILogger logger,
+        ref bool extraMasteryWarningLogged)
+    {
+        var masteryCount = masteryCountByAssignment.TryGetValue(ev.AssignmentId, out var current)
+            ? current + 1
+            : 1;
+        masteryCountByAssignment[ev.AssignmentId] = masteryCount;
+
+        if (masteryCount > LevelingRules.MaxBuyableMasteries)
+        {
+            if (!extraMasteryWarningLogged)
+            {
+                logger.LogWarning(
+                    "[progression] skipped extra mastery event assignmentId={AssignmentId} eventId={EventId}",
+                    ev.AssignmentId,
+                    ev.EventId);
+                extraMasteryWarningLogged = true;
+            }
+
+            return null;
+        }
+
+        return LevelingRules.MaxLevel + masteryCount;
+    }
+
+    private static bool IsMasterySkillEvent(string data, int eventId, ILogger logger)
+    {
+        if (string.IsNullOrWhiteSpace(data))
+            return false;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(data);
+            return TryReadBool(doc.RootElement, "mastery") == true;
+        }
+        catch (JsonException)
+        {
+            logger.LogWarning("[progression] malformed SkillGained data eventId={EventId}", eventId);
+            return false;
+        }
+    }
+
+    private static ProgressionTimeSlotRow? ResolveProgressionBucket(
+        DateTime timestampUtc,
+        List<ProgressionTimeSlotRow> timeSlots,
+        ILogger logger)
+    {
+        if (timeSlots.Count == 0)
+            return null;
+
+        if (timeSlots.Count > 1 && timestampUtc >= timeSlots[^1].StartTime)
+        {
+            var penultimate = timeSlots[^2];
+            logger.LogDebug(
+                "[progression] bucket fallback reason=final-or-post-game timestampUtc={TimestampUtc:o} bucketId={TimeSlotId}",
+                timestampUtc,
+                penultimate.Id);
+            return penultimate;
+        }
+
+        var natural = timeSlots.FirstOrDefault(s =>
+            timestampUtc >= s.StartTime && timestampUtc < s.StartTime + s.Duration);
+        if (natural is not null)
+            return natural;
+
+        var previous = timeSlots.LastOrDefault(s => s.StartTime < timestampUtc);
+        if (previous is not null)
+        {
+            logger.LogDebug(
+                "[progression] bucket fallback reason=previous-slot timestampUtc={TimestampUtc:o} bucketId={TimeSlotId}",
+                timestampUtc,
+                previous.Id);
+            return previous;
+        }
+
+        return null;
+    }
+
+    private static KingdomProgressionDto[] BuildProgressionKingdoms(
+        List<ProgressionKingdomRow> kingdoms,
+        List<ProgressionTimeSlotRow> timeSlots,
+        List<ProgressionNormalizedEvent> events)
+    {
+        var stateByAssignment = new Dictionary<int, ProgressionAssignmentState>();
+        var eventsByBucket = events
+            .GroupBy(e => e.TimeSlotIndex)
+            .ToDictionary(g => g.Key, g => g.OrderBy(e => e.TimestampUtc).ThenBy(e => e.EventId).ToList());
+        var countsByKingdomAndBucket = kingdoms.ToDictionary(
+            k => k.KingdomId,
+            _ => Enumerable.Range(0, timeSlots.Count)
+                .Select(_ => new int[MaxStatsLevel])
+                .ToArray());
+
+        for (var bucketIndex = 0; bucketIndex < timeSlots.Count; bucketIndex++)
+        {
+            if (eventsByBucket.TryGetValue(bucketIndex, out var bucketEvents))
+            {
+                foreach (var ev in bucketEvents)
+                    stateByAssignment[ev.AssignmentId] = new ProgressionAssignmentState(ev.KingdomId, ev.LevelGained);
+            }
+
+            foreach (var state in stateByAssignment.Values)
+            {
+                if (!countsByKingdomAndBucket.TryGetValue(state.KingdomId, out var bucketCounts))
+                    continue;
+
+                bucketCounts[bucketIndex][state.Level - 1]++;
+            }
+        }
+
+        return kingdoms
+            .OrderBy(k => k.SortOrder)
+            .ThenBy(k => k.KingdomName)
+            .Select(k => new KingdomProgressionDto(
+                k.KingdomId,
+                k.KingdomName,
+                StoredColorOrEmpty(k.KingdomHexColor),
+                k.SortOrder,
+                timeSlots
+                    .Select((slot, index) => new TimeSlotBucketDto(
+                        slot.Id,
+                        slot.Label,
+                        countsByKingdomAndBucket[k.KingdomId][index]))
+                    .ToArray()))
+            .ToArray();
+    }
+
+    private static byte[] WriteProgressionWorkbook(ProgressionStatsDto stats)
+    {
+        using var workbook = new XLWorkbook();
+        var worksheet = workbook.Worksheets.Add("Progres");
+        string[] headers =
+        [
+            "Hráč",
+            "Postava",
+            "Království",
+            "Časový blok",
+            "Událost",
+            "Získaná úroveň",
+            "Čas UTC"
+        ];
+
+        for (var column = 0; column < headers.Length; column++)
+            worksheet.Cell(1, column + 1).Value = headers[column];
+
+        var rowIndex = 2;
+        foreach (var row in stats.Events)
+        {
+            worksheet.Cell(rowIndex, 1).Value = row.PlayerName;
+            worksheet.Cell(rowIndex, 2).Value = row.CharacterName;
+            worksheet.Cell(rowIndex, 3).Value = row.KingdomName;
+            worksheet.Cell(rowIndex, 4).Value = row.TimeSlotLabel;
+            worksheet.Cell(rowIndex, 5).Value = row.EventType;
+            worksheet.Cell(rowIndex, 6).Value = row.LevelGained;
+            worksheet.Cell(rowIndex, 7).Value = row.TimestampUtc;
+            rowIndex++;
+        }
+
+        var usedRange = worksheet.Range(1, 1, Math.Max(1, rowIndex - 1), headers.Length);
+        worksheet.Range(1, 1, 1, headers.Length).Style.Font.Bold = true;
+        usedRange.SetAutoFilter();
+        worksheet.SheetView.FreezeRows(1);
+        worksheet.Columns().AdjustToContents();
+
+        using var stream = new MemoryStream();
+        workbook.SaveAs(stream);
+        return stream.ToArray();
+    }
+
+    private static string? PlayerFullName(string? firstName, string? lastName)
+    {
+        var fullName = $"{firstName} {lastName}".Trim();
+        return string.IsNullOrWhiteSpace(fullName) ? null : fullName;
+    }
+
+    private sealed record ProgressionKingdomRow(
+        int KingdomId,
+        string KingdomName,
+        string? KingdomHexColor,
+        int SortOrder);
+
+    private sealed record ProgressionTimeSlotRow(
+        int Id,
+        DateTime StartTime,
+        TimeSpan Duration,
+        GameTimePhase Stage,
+        int? InGameYear,
+        string Label);
+
+    private sealed record ProgressionCharacterEventRow(
+        int EventId,
+        int AssignmentId,
+        DateTime TimestampUtc,
+        CharacterEventType EventType,
+        string Data,
+        string CharacterName,
+        string? PlayerFirstName,
+        string? PlayerLastName,
+        int? KingdomId,
+        string KingdomName,
+        string? KingdomHexColor);
+
+    private sealed record ProgressionNormalizedEvent(
+        int EventId,
+        int AssignmentId,
+        int KingdomId,
+        string KingdomName,
+        string KingdomHexColor,
+        int TimeSlotId,
+        int TimeSlotIndex,
+        string TimeSlotLabel,
+        string PlayerName,
+        string CharacterName,
+        string EventType,
+        int LevelGained,
+        DateTime TimestampUtc);
+
+    private sealed record ProgressionAssignmentState(int KingdomId, int Level);
+}

--- a/src/OvcinaHra.Api/OvcinaHra.Api.csproj
+++ b/src/OvcinaHra.Api/OvcinaHra.Api.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Anthropic.SDK" Version="5.10.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">

--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -98,6 +98,10 @@
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-bar-chart-line-fill ni"></i><span class="oh-nav-label">Statistiky</span>
                     </NavLink>
+                    <NavLink class="oh-nav-item" href="@ProgressionStatsHref">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-graph-up-arrow ni"></i><span class="oh-nav-label">Progrese</span>
+                    </NavLink>
                     <NavLink class="oh-nav-item" href="treasures">
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-safe-fill ni"></i><span class="oh-nav-label">Poklady</span>
@@ -299,6 +303,10 @@
     private string EndGameStatsHref => GameContext.SelectedGameId is int gameId
         ? $"statistiky-konec-hry?gameId={gameId}"
         : "statistiky-konec-hry";
+
+    private string ProgressionStatsHref => GameContext.SelectedGameId is int gameId
+        ? $"progres-postav-v-case?gameId={gameId}"
+        : "progres-postav-v-case";
 
     protected override void OnInitialized()
     {

--- a/src/OvcinaHra.Client/Pages/ProgresPostavVCase.razor
+++ b/src/OvcinaHra.Client/Pages/ProgresPostavVCase.razor
@@ -1,0 +1,330 @@
+@page "/progres-postav-v-case"
+@attribute [Authorize]
+@using System.Globalization
+@using Microsoft.JSInterop
+@inject ApiClient Api
+@inject GameContextService GameContext
+@inject IJSRuntime JS
+@implements IDisposable
+
+<PageTitle>Progres postav v čase</PageTitle>
+
+<div class="oh-progression-page">
+    <header class="oh-progression-head">
+        <div>
+            <p class="oh-progression-kicker">Vývoj hrdinů</p>
+            <h1>Progres postav v čase</h1>
+        </div>
+        <button type="button"
+                class="btn btn-primary oh-progression-export"
+                disabled="@(_isLoading || _isDownloading || ActiveGameId is null)"
+                @onclick="DownloadExcelAsync">
+            <i class="bi bi-file-earmark-excel"></i>
+            <span>@(_isDownloading ? "Stahuji…" : "XLSX")</span>
+        </button>
+    </header>
+
+    @if (_isLoading)
+    {
+        <p class="text-muted">Načítám…</p>
+    }
+    else if (ActiveGameId is null)
+    {
+        <div class="oh-progression-empty">Vyber hru, aby bylo co zobrazit.</div>
+    }
+    else if (_stats is null)
+    {
+        <div class="oh-progression-empty">@(_error ?? "Progres není dostupný.")</div>
+    }
+    else
+    {
+        <section class="oh-progression-charts">
+            @foreach (var kingdom in _kingdomCharts)
+            {
+                <article class="oh-progression-panel">
+                    <div class="oh-progression-panel-head">
+                        <span class="oh-progression-swatch" style="background:@SwatchBackground(kingdom.HexColor)"></span>
+                        <h2>@kingdom.KingdomName</h2>
+                    </div>
+                    @if (kingdom.HasData)
+                    {
+                        <DxChart Data="@kingdom.Rows" CssClass="oh-progression-chart">
+                            @foreach (var level in Levels)
+                            {
+                                var currentLevel = level;
+                                <DxChartStackedBarSeries ArgumentField="@((ProgressionChartRow r) => r.TimeSlotLabel)"
+                                                         ValueField="@((ProgressionChartRow r) => r.CountFor(currentLevel))"
+                                                         Name="@LevelSeriesName(currentLevel)"
+                                                         Color="@LevelColor(currentLevel)"
+                                                         Stack="Úrovně" />
+                            }
+                            <DxChartTooltip Enabled="true" Context="tooltip">
+                                <div>
+                                    <strong>@tooltip.Point.SeriesName</strong>
+                                    <div>@tooltip.Point.Argument: @tooltip.Point.Value</div>
+                                </div>
+                            </DxChartTooltip>
+                        </DxChart>
+                    }
+                    else
+                    {
+                        <div class="oh-progression-empty">Žádné události</div>
+                    }
+                </article>
+            }
+        </section>
+
+        <section class="oh-progression-grid-section">
+            <div class="oh-progression-section-head">
+                <h2>Události progrese</h2>
+                <span>@_eventRows.Count událostí</span>
+            </div>
+            <OvcinaGrid Data="@_eventRows"
+                        KeyFieldName="Id"
+                        LayoutKey="grid-progression-v1"
+                        ShowGroupPanel="true"
+                        AutoExpandAllGroupRows="false"
+                        SelectionMode="GridSelectionMode.Multiple">
+                <Columns>
+                    <DxGridDataColumn FieldName="PlayerName" Caption="Hráč" MinWidth="170" />
+                    <DxGridDataColumn FieldName="CharacterName" Caption="Postava" MinWidth="170" />
+                    <DxGridDataColumn FieldName="KingdomName" Caption="Království" Width="180px">
+                        <CellDisplayTemplate>
+                            @{
+                                var row = (ProgressionEventGridRow)context.DataItem;
+                            }
+                            <span class="oh-progression-kingdom-cell"
+                                  style="border-left-color:@SwatchBackground(row.KingdomHexColor);background:@TintBackground(row.KingdomHexColor)">
+                                @row.KingdomName
+                            </span>
+                        </CellDisplayTemplate>
+                    </DxGridDataColumn>
+                    <DxGridDataColumn FieldName="TimeSlotLabel" Caption="Časový blok" MinWidth="260" />
+                    <DxGridDataColumn FieldName="EventTypeDisplay" Caption="Událost" Width="160px" />
+                    <DxGridDataColumn FieldName="LevelDisplay" Caption="Úroveň" Width="110px" />
+                </Columns>
+                <EmptyDataAreaTemplate>
+                    <div class="text-center text-muted py-5">Žádné události progrese.</div>
+                </EmptyDataAreaTemplate>
+            </OvcinaGrid>
+        </section>
+    }
+</div>
+
+@code {
+    private static readonly int[] Levels = [1, 2, 3, 4, 5, 6, 7];
+
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "gameId")]
+    public int? GameId { get; set; }
+
+    private ProgressionStatsDto? _stats;
+    private List<KingdomProgressionChart> _kingdomCharts = [];
+    private List<ProgressionEventGridRow> _eventRows = [];
+    private bool _isLoading;
+    private bool _isDownloading;
+    private string? _error;
+    private int _loadVersion;
+
+    private int? ActiveGameId => GameId ?? GameContext.SelectedGameId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GameContext.InitializeAsync();
+        GameContext.OnGameChanged += HandleGameChanged;
+    }
+
+    protected override async Task OnParametersSetAsync() => await LoadAsync();
+
+    private void HandleGameChanged()
+    {
+        if (GameId is null)
+            _ = InvokeAsync(LoadAsync);
+    }
+
+    private async Task LoadAsync()
+    {
+        var loadVersion = System.Threading.Interlocked.Increment(ref _loadVersion);
+        var gameId = ActiveGameId;
+        _error = null;
+        if (gameId is null)
+        {
+            _stats = null;
+            _kingdomCharts = [];
+            _eventRows = [];
+            _isLoading = false;
+            return;
+        }
+
+        _isLoading = true;
+        try
+        {
+            Console.WriteLine($"[progression] fetch start gameId={gameId.Value}");
+            var stats = await Api.GetAsync<ProgressionStatsDto>($"/api/games/{gameId.Value}/progression-stats");
+            if (loadVersion != _loadVersion) return;
+
+            _stats = stats;
+            _kingdomCharts = BuildKingdomCharts(stats);
+            _eventRows = BuildEventRows(stats);
+            Console.WriteLine(
+                $"[progression] fetch complete gameId={gameId.Value} kingdoms={_kingdomCharts.Count} events={_eventRows.Count}");
+            if (_stats is null)
+                _error = "Hra nebyla nalezena.";
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[progression] fetch failed {ex}");
+            if (loadVersion != _loadVersion) return;
+
+            _stats = null;
+            _kingdomCharts = [];
+            _eventRows = [];
+            _error = "Progres se nepodařilo načíst.";
+        }
+        finally
+        {
+            if (loadVersion == _loadVersion)
+                _isLoading = false;
+        }
+    }
+
+    private async Task DownloadExcelAsync()
+    {
+        if (ActiveGameId is not int gameId)
+            return;
+
+        _isDownloading = true;
+        _error = null;
+        try
+        {
+            Console.WriteLine($"[progression] excel download start gameId={gameId}");
+            var (ok, file, problem) = await Api.DownloadWithProblemAsync($"/api/games/{gameId}/progression-stats.xlsx");
+            if (!ok || file is null)
+            {
+                _error = problem ?? "XLSX se nepodařilo připravit.";
+                return;
+            }
+
+            await using var stream = new MemoryStream(file.Bytes);
+            using var streamReference = new DotNetStreamReference(stream);
+            Console.WriteLine($"[progression] excel interop start gameId={gameId} bytes={file.Bytes.Length}");
+            await JS.InvokeVoidAsync("ovcinaDownloadFile", file.FileName, file.ContentType, streamReference);
+            Console.WriteLine($"[progression] excel interop complete gameId={gameId}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[progression] excel download failed {ex}");
+            _error = "XLSX se nepodařilo stáhnout.";
+        }
+        finally
+        {
+            _isDownloading = false;
+        }
+    }
+
+    private static List<KingdomProgressionChart> BuildKingdomCharts(ProgressionStatsDto? stats) =>
+        stats?.Kingdoms
+            .Select(k => new KingdomProgressionChart(
+                k.KingdomId,
+                k.KingdomName,
+                k.HexColor,
+                k.SortOrder,
+                k.Buckets.Select(b => new ProgressionChartRow(b.TimeSlotId, b.Label, b.HeroCountByLevel)).ToList()))
+            .ToList() ?? [];
+
+    private static List<ProgressionEventGridRow> BuildEventRows(ProgressionStatsDto? stats) =>
+        stats?.Events
+            .Select((e, index) => new ProgressionEventGridRow(
+                index + 1,
+                e.PlayerName,
+                e.CharacterName,
+                e.KingdomName,
+                e.KingdomHexColor,
+                e.TimeSlotLabel,
+                EventTypeDisplay(e.EventType),
+                LevelDisplay(e.LevelGained)))
+            .ToList() ?? [];
+
+    private static string EventTypeDisplay(string eventType) => eventType switch
+    {
+        "LevelUp" => "Zvýšení úrovně",
+        "MasterySkillGained" => "Mistrovství",
+        _ => eventType
+    };
+
+    private static string LevelDisplay(int level)
+    {
+        var masteryCount = level - LevelingRules.MaxLevel;
+        return masteryCount > 0
+            ? $"{level.ToString(CultureInfo.InvariantCulture)} ({masteryCount} mistrovství)"
+            : level.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string LevelSeriesName(int level) => level switch
+    {
+        6 => "Úroveň 6 (1 mistrovství)",
+        7 => "Úroveň 7 (2 mistrovství)",
+        _ => $"Úroveň {level.ToString(CultureInfo.InvariantCulture)}"
+    };
+
+    private static System.Drawing.Color LevelColor(int level) => level switch
+    {
+        1 => System.Drawing.Color.FromArgb(0xD5, 0xD8, 0xD0),
+        2 => System.Drawing.Color.FromArgb(0xB9, 0xBD, 0xAF),
+        3 => System.Drawing.Color.FromArgb(0x98, 0x9F, 0x8D),
+        4 => System.Drawing.Color.FromArgb(0x73, 0x7C, 0x6E),
+        5 => System.Drawing.Color.FromArgb(0x4F, 0x59, 0x4D),
+        6 => System.Drawing.Color.FromArgb(0xD7, 0x9B, 0x2D),
+        _ => System.Drawing.Color.FromArgb(0xF9, 0xC7, 0x4F)
+    };
+
+    private static string SwatchBackground(string? colorHex) =>
+        IsHexColor(colorHex) ? colorHex!.Trim() : "#6A6A6A";
+
+    private static string TintBackground(string? colorHex) =>
+        IsHexColor(colorHex) ? $"{colorHex!.Trim()}22" : "#6A6A6A22";
+
+    private static bool IsHexColor(string? colorHex)
+    {
+        if (string.IsNullOrWhiteSpace(colorHex))
+            return false;
+
+        var hex = colorHex.AsSpan().Trim();
+        return hex.Length == 7
+            && hex[0] == '#'
+            && int.TryParse(hex[1..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _);
+    }
+
+    public void Dispose() => GameContext.OnGameChanged -= HandleGameChanged;
+
+    private sealed record KingdomProgressionChart(
+        int KingdomId,
+        string KingdomName,
+        string HexColor,
+        int SortOrder,
+        List<ProgressionChartRow> Rows)
+    {
+        public bool HasData => Rows.Any(r => r.Total > 0);
+    }
+
+    private sealed record ProgressionChartRow(
+        int TimeSlotId,
+        string TimeSlotLabel,
+        int[] Counts)
+    {
+        public int CountFor(int level) =>
+            level >= 1 && level <= Counts.Length ? Counts[level - 1] : 0;
+
+        public int Total => Counts.Sum();
+    }
+
+    private sealed record ProgressionEventGridRow(
+        int Id,
+        string PlayerName,
+        string CharacterName,
+        string KingdomName,
+        string KingdomHexColor,
+        string TimeSlotLabel,
+        string EventTypeDisplay,
+        string LevelDisplay);
+}

--- a/src/OvcinaHra.Client/Pages/ProgresPostavVCase.razor.css
+++ b/src/OvcinaHra.Client/Pages/ProgresPostavVCase.razor.css
@@ -1,0 +1,134 @@
+.oh-progression-page {
+    display: grid;
+    gap: 18px;
+    padding: 20px clamp(14px, 2vw, 28px) 28px;
+}
+
+.oh-progression-head {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 16px;
+    border-bottom: 1px solid var(--oh-border, #d8d2be);
+    padding-bottom: 12px;
+}
+
+.oh-progression-kicker {
+    margin: 0 0 4px;
+    color: var(--oh-text-secondary, #6a6a6a);
+    font: 700 .78rem var(--oh-font-body, system-ui, sans-serif);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+}
+
+.oh-progression-head h1,
+.oh-progression-panel h2,
+.oh-progression-grid-section h2 {
+    margin: 0;
+    color: var(--oh-primary, #243525);
+    font-family: var(--oh-font-heading, Georgia, serif);
+}
+
+.oh-progression-head h1 {
+    font-size: clamp(1.7rem, 2.4vw, 2.4rem);
+}
+
+.oh-progression-export {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    white-space: nowrap;
+}
+
+.oh-progression-charts {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.oh-progression-panel,
+.oh-progression-grid-section {
+    min-width: 0;
+    border: 1px solid var(--oh-border, #d8d2be);
+    border-radius: 8px;
+    background: var(--oh-surface, #fffdf7);
+    padding: 16px;
+}
+
+.oh-progression-panel-head,
+.oh-progression-section-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.oh-progression-panel-head {
+    justify-content: flex-start;
+}
+
+.oh-progression-panel h2,
+.oh-progression-grid-section h2 {
+    font-size: 1.08rem;
+}
+
+.oh-progression-section-head span {
+    color: var(--oh-text-secondary, #6a6a6a);
+    font-size: .9rem;
+    white-space: nowrap;
+}
+
+.oh-progression-swatch {
+    width: 1rem;
+    height: 1rem;
+    border-radius: 50%;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, .14);
+    flex: 0 0 auto;
+}
+
+.oh-progression-chart {
+    min-height: 320px;
+}
+
+.oh-progression-empty {
+    border: 1px dashed var(--oh-border, #d8d2be);
+    border-radius: 8px;
+    background: var(--oh-surface-alt, #f5f0e1);
+    color: var(--oh-text-secondary, #6a6a6a);
+    padding: 18px;
+    text-align: center;
+}
+
+.oh-progression-grid-section {
+    display: grid;
+    gap: 10px;
+}
+
+.oh-progression-kingdom-cell {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    border-left: 4px solid;
+    border-radius: 6px;
+    padding: 3px 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+@media (max-width: 960px) {
+    .oh-progression-head {
+        display: grid;
+        align-items: start;
+    }
+
+    .oh-progression-charts {
+        grid-template-columns: 1fr;
+    }
+
+    .oh-progression-section-head {
+        align-items: start;
+        flex-direction: column;
+    }
+}

--- a/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor
+++ b/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor
@@ -13,10 +13,16 @@
             <p class="oh-endstats-kicker">Přehled Ovčiny</p>
             <h1>Statistiky konce hry</h1>
         </div>
-        @if (_stats is not null)
-        {
-            <span class="oh-endstats-pill">@_stats.Kingdoms.Sum(k => k.HeroCount) hrdinové</span>
-        }
+        <div class="oh-endstats-actions">
+            <a class="btn btn-sm btn-outline-secondary" href="@ProgressionHref">
+                <i class="bi bi-graph-up-arrow"></i>
+                <span>Progrese v čase</span>
+            </a>
+            @if (_stats is not null)
+            {
+                <span class="oh-endstats-pill">@_stats.Kingdoms.Sum(k => k.HeroCount) hrdinové</span>
+            }
+        </div>
     </header>
 
     @if (_isLoading)
@@ -165,6 +171,9 @@
     private int _loadVersion;
 
     private int? ActiveGameId => GameId ?? GameContext.SelectedGameId;
+    private string ProgressionHref => ActiveGameId is int gameId
+        ? $"progres-postav-v-case?gameId={gameId.ToString(CultureInfo.InvariantCulture)}"
+        : "progres-postav-v-case";
     private bool HasLevelData => _levelChartRows.Any(r => r.Total > 0);
     private bool HasMonsterData => _stats?.MonsterStats.MonsterDefeatedCount > 0
         || _stats?.MonsterStats.HeroFellCount > 0;

--- a/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor.css
+++ b/src/OvcinaHra.Client/Pages/StatistikyKonecHry.razor.css
@@ -41,6 +41,14 @@
     white-space: nowrap;
 }
 
+.oh-endstats-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
 .oh-endstats-summary,
 .oh-endstats-grid {
     display: grid;
@@ -156,5 +164,9 @@
     .oh-endstats-head {
         display: grid;
         align-items: start;
+    }
+
+    .oh-endstats-actions {
+        justify-content: flex-start;
     }
 }

--- a/src/OvcinaHra.Shared/Dtos/ProgressionStatsDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/ProgressionStatsDtos.cs
@@ -1,0 +1,28 @@
+namespace OvcinaHra.Shared.Dtos;
+
+public record ProgressionStatsDto(
+    KingdomProgressionDto[] Kingdoms,
+    ProgressionEventRow[] Events);
+
+public record KingdomProgressionDto(
+    int KingdomId,
+    string KingdomName,
+    string HexColor,
+    int SortOrder,
+    TimeSlotBucketDto[] Buckets);
+
+public record TimeSlotBucketDto(
+    int TimeSlotId,
+    string Label,
+    int[] HeroCountByLevel);
+
+public record ProgressionEventRow(
+    string PlayerName,
+    string CharacterName,
+    string KingdomName,
+    string KingdomHexColor,
+    int TimeSlotId,
+    string TimeSlotLabel,
+    string EventType,
+    int LevelGained,
+    DateTime TimestampUtc);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ProgressionStatsEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ProgressionStatsEndpointTests.cs
@@ -1,0 +1,239 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClosedXML.Excel;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Tests.Fixtures;
+using OvcinaHra.Shared.Domain.Entities;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Dtos;
+
+namespace OvcinaHra.Api.Tests.Endpoints;
+
+public class ProgressionStatsEndpointTests(PostgresFixture postgres)
+    : IntegrationTestBase(postgres), IClassFixture<PostgresFixture>
+{
+    [Fact]
+    public async Task ProgressionStats_NonExistentGame_Returns404()
+    {
+        var json = await Client.GetAsync("/api/games/999999/progression-stats");
+        var xlsx = await Client.GetAsync("/api/games/999999/progression-stats.xlsx");
+
+        Assert.Equal(HttpStatusCode.NotFound, json.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, xlsx.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProgressionStats_ReturnsTimeslotSnapshotsAndEventRows()
+    {
+        var game = await CreateGameAsync();
+        int day1LastSlotId;
+        int slot5Id;
+        int slot7Id;
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var aradhryand = await GetKingdomAsync(db, "Aradhryand");
+            var azanulinbar = await GetKingdomAsync(db, "Azanulinbar-Dum");
+            var esgaroth = await GetKingdomAsync(db, "Esgaroth");
+            var arnor = await GetKingdomAsync(db, "Nový Arnor");
+
+            var start = new DateTime(2026, 5, 1, 8, 0, 0, DateTimeKind.Utc);
+            var slots = SeedTimeSlots(game.Id, start);
+            db.GameTimeSlots.AddRange(slots);
+            await db.SaveChangesAsync();
+            day1LastSlotId = slots[2].Id;
+            slot5Id = slots[4].Id;
+            slot7Id = slots[6].Id;
+
+            var gapHero = Character("Gap Hero", "Gita", "Mezera");
+            var finalHero = Character("Final Hero", "Fero", "Finále");
+            var afterHero = Character("After Hero", "Anežka", "Dohra");
+            var masteryHero = Character("Master Hero", "Marek", "Mistr");
+            db.Characters.AddRange(gapHero, finalHero, afterHero, masteryHero);
+            await db.SaveChangesAsync();
+
+            var gapAssignment = Assignment(game, gapHero, esgaroth, 1);
+            var finalAssignment = Assignment(game, finalHero, aradhryand, 2);
+            var afterAssignment = Assignment(game, afterHero, azanulinbar, 3);
+            var masteryAssignment = Assignment(game, masteryHero, arnor, 4);
+            db.CharacterAssignments.AddRange(gapAssignment, finalAssignment, afterAssignment, masteryAssignment);
+            await db.SaveChangesAsync();
+
+            db.CharacterEvents.AddRange(
+                LevelUp(gapAssignment.Id, start.AddHours(13), 1),
+                LevelUp(gapAssignment.Id, slots[4].StartTime.AddMinutes(5), 2),
+                Mastery(gapAssignment.Id, slots[6].StartTime.AddMinutes(10), "Berserk"),
+                LevelUp(finalAssignment.Id, slots[7].StartTime.AddMinutes(20), 4),
+                LevelUp(afterAssignment.Id, slots[7].StartTime.Add(slots[7].Duration).AddHours(1), 3),
+                LevelUp(masteryAssignment.Id, slots[5].StartTime.AddMinutes(5), 5),
+                Mastery(masteryAssignment.Id, slots[6].StartTime.AddMinutes(15), "Berserk"),
+                Mastery(masteryAssignment.Id, slots[6].StartTime.AddMinutes(16), "Houževnatý"),
+                Mastery(masteryAssignment.Id, slots[6].StartTime.AddMinutes(17), "Navíc"),
+                SkillEvent(masteryAssignment.Id, slots[6].StartTime.AddMinutes(18), new { skill = "Legacy" }));
+            await db.SaveChangesAsync();
+        }
+
+        var stats = await Client.GetFromJsonAsync<ProgressionStatsDto>(
+            $"/api/games/{game.Id}/progression-stats");
+
+        Assert.NotNull(stats);
+        Assert.Equal(4, stats.Kingdoms.Length);
+        Assert.All(stats.Kingdoms, kingdom =>
+        {
+            Assert.Equal(8, kingdom.Buckets.Length);
+            Assert.All(kingdom.Buckets, bucket => Assert.Equal(7, bucket.HeroCountByLevel.Length));
+        });
+
+        var esgarothStats = stats.Kingdoms.Single(k => k.KingdomName == "Esgaroth");
+        Assert.Equal(1, esgarothStats.Buckets.Single(b => b.TimeSlotId == day1LastSlotId).HeroCountByLevel[0]);
+        Assert.Equal(1, esgarothStats.Buckets.Single(b => b.TimeSlotId == slot5Id).HeroCountByLevel[1]);
+        Assert.Equal(1, esgarothStats.Buckets.Single(b => b.TimeSlotId == slot7Id).HeroCountByLevel[5]);
+
+        var aradhryandStats = stats.Kingdoms.Single(k => k.KingdomName == "Aradhryand");
+        Assert.Equal(1, aradhryandStats.Buckets.Single(b => b.TimeSlotId == slot7Id).HeroCountByLevel[3]);
+
+        var azanulinbarStats = stats.Kingdoms.Single(k => k.KingdomName == "Azanulinbar-Dum");
+        Assert.Equal(1, azanulinbarStats.Buckets.Single(b => b.TimeSlotId == slot7Id).HeroCountByLevel[2]);
+
+        var arnorStats = stats.Kingdoms.Single(k => k.KingdomName == "Nový Arnor");
+        Assert.Equal(1, arnorStats.Buckets.Single(b => b.TimeSlotId == slot7Id).HeroCountByLevel[6]);
+
+        Assert.Contains(stats.Events, e =>
+            e.CharacterName.StartsWith("Gap Hero", StringComparison.Ordinal)
+            && e.TimeSlotId == day1LastSlotId
+            && e.LevelGained == 1);
+        Assert.Contains(stats.Events, e =>
+            e.EventType == "MasterySkillGained"
+            && e.LevelGained == 6);
+        Assert.Contains(stats.Events, e =>
+            e.EventType == "MasterySkillGained"
+            && e.LevelGained == 7);
+        Assert.Equal(8, stats.Events.Length);
+        Assert.DoesNotContain(stats.Events, e =>
+            e.CharacterName.StartsWith("Master Hero", StringComparison.Ordinal)
+            && e.EventType == "MasterySkillGained"
+            && e.LevelGained > 7);
+    }
+
+    [Fact]
+    public async Task ProgressionStatsXlsx_ReturnsWorkbookWithRows()
+    {
+        var game = await CreateGameAsync();
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<WorldDbContext>();
+            var esgaroth = await GetKingdomAsync(db, "Esgaroth");
+            var start = new DateTime(2026, 5, 1, 8, 0, 0, DateTimeKind.Utc);
+            var slots = SeedTimeSlots(game.Id, start);
+            db.GameTimeSlots.AddRange(slots);
+            var hero = Character("Excel Hero", "Eliška", "Export");
+            db.Characters.Add(hero);
+            await db.SaveChangesAsync();
+
+            var assignment = Assignment(game, hero, esgaroth, 9);
+            db.CharacterAssignments.Add(assignment);
+            await db.SaveChangesAsync();
+            db.CharacterEvents.Add(LevelUp(assignment.Id, slots[0].StartTime.AddMinutes(5), 1));
+            await db.SaveChangesAsync();
+        }
+
+        var response = await Client.GetAsync($"/api/games/{game.Id}/progression-stats.xlsx");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            response.Content.Headers.ContentType?.MediaType);
+        var contentDisposition = response.Content.Headers.ContentDisposition;
+        var fileName = contentDisposition?.FileNameStar ?? contentDisposition?.FileName?.Trim('"');
+        Assert.Equal($"progres-postav-{game.Id}.xlsx", fileName);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        Assert.True(stream.Length > 0);
+        using var workbook = new XLWorkbook(stream);
+        var worksheet = workbook.Worksheet("Progres");
+        Assert.Equal("Hráč", worksheet.Cell(1, 1).GetString());
+        Assert.Equal("Postava", worksheet.Cell(1, 2).GetString());
+        Assert.Equal("Eliška Export", worksheet.Cell(2, 1).GetString());
+        Assert.StartsWith("Excel Hero", worksheet.Cell(2, 2).GetString(), StringComparison.Ordinal);
+    }
+
+    private async Task<GameDetailDto> CreateGameAsync()
+    {
+        var response = await Client.PostAsJsonAsync("/api/games",
+            new CreateGameDto("Progression stats", 1, new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 3)));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GameDetailDto>())!;
+    }
+
+    private static Task<Kingdom> GetKingdomAsync(WorldDbContext db, string name) =>
+        db.Kingdoms.SingleAsync(k => k.Name == name);
+
+    private static List<GameTimeSlot> SeedTimeSlots(int gameId, DateTime start) =>
+    [
+        Slot(gameId, start, GameTimePhase.Early),
+        Slot(gameId, start.AddHours(2), GameTimePhase.Early),
+        Slot(gameId, start.AddHours(4), GameTimePhase.Midgame),
+        Slot(gameId, start.AddDays(1), GameTimePhase.Midgame),
+        Slot(gameId, start.AddDays(1).AddHours(2), GameTimePhase.Midgame),
+        Slot(gameId, start.AddDays(1).AddHours(4), GameTimePhase.Lategame),
+        Slot(gameId, start.AddDays(1).AddHours(6), GameTimePhase.Lategame),
+        Slot(gameId, start.AddDays(1).AddHours(8), GameTimePhase.EndGame)
+    ];
+
+    private static GameTimeSlot Slot(int gameId, DateTime start, GameTimePhase phase) => new()
+    {
+        GameId = gameId,
+        StartTime = start,
+        Duration = TimeSpan.FromHours(2),
+        Stage = phase,
+        InGameYear = 1
+    };
+
+    private static Character Character(string name, string firstName, string lastName) => new()
+    {
+        Name = $"{name} {Guid.NewGuid():N}",
+        PlayerFirstName = firstName,
+        PlayerLastName = lastName,
+        IsPlayedCharacter = true
+    };
+
+    private static CharacterAssignment Assignment(
+        GameDetailDto game,
+        Character character,
+        Kingdom kingdom,
+        int personOffset) => new()
+        {
+            CharacterId = character.Id,
+            GameId = game.Id,
+            ExternalPersonId = game.Id * 1000 + personOffset,
+            Class = PlayerClass.Warrior,
+            KingdomId = kingdom.Id
+        };
+
+    private static CharacterEvent LevelUp(int assignmentId, DateTime timestampUtc, int level) => new()
+    {
+        CharacterAssignmentId = assignmentId,
+        Timestamp = timestampUtc,
+        OrganizerUserId = "org",
+        OrganizerName = "Org",
+        EventType = CharacterEventType.LevelUp,
+        Data = JsonSerializer.Serialize(new { level })
+    };
+
+    private static CharacterEvent Mastery(int assignmentId, DateTime timestampUtc, string skillName) =>
+        SkillEvent(assignmentId, timestampUtc, new { skill = skillName, mastery = true });
+
+    private static CharacterEvent SkillEvent(int assignmentId, DateTime timestampUtc, object data) => new()
+    {
+        CharacterAssignmentId = assignmentId,
+        Timestamp = timestampUtc,
+        OrganizerUserId = "org",
+        OrganizerName = "Org",
+        EventType = CharacterEventType.SkillGained,
+        Data = JsonSerializer.Serialize(data)
+    };
+}

--- a/tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj
+++ b/tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />


### PR DESCRIPTION
Closes #535.\n\n## Summary\n- adds /api/games/{gameId}/progression-stats from CharacterEvent LevelUp and mastery-flagged SkillGained rows\n- adds ClosedXML /progression-stats.xlsx export with Progres worksheet\n- adds /progres-postav-v-case with per-kingdom stacked small-multiple charts, event grid, xlsx download, and nav/stat links\n- applies overnight-gap and final/post-game-to-penultimate bucketing with [progression] diagnostics\n\n## Tests\n- dotnet build OvcinaHra.slnx /clp:ErrorsOnly\n- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter ProgressionStatsEndpointTests --logger "console;verbosity=minimal"\n- dotnet test OvcinaHra.slnx --no-build --logger "console;verbosity=minimal"