### PR TITLE
feat(nav): split post-game tooling into Materiály sub-section

### DIFF
--- a/src/OvcinaHra.Client/Layout/NavMenu.razor
+++ b/src/OvcinaHra.Client/Layout/NavMenu.razor
@@ -94,14 +94,6 @@
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-activity ni"></i><span class="oh-nav-label">Aktivita</span>
                     </NavLink>
-                    <NavLink class="oh-nav-item" href="@EndGameStatsHref">
-                        <span class="oh-nav-rail"></span>
-                        <i class="bi bi-bar-chart-line-fill ni"></i><span class="oh-nav-label">Statistiky</span>
-                    </NavLink>
-                    <NavLink class="oh-nav-item" href="@ProgressionStatsHref">
-                        <span class="oh-nav-rail"></span>
-                        <i class="bi bi-graph-up-arrow ni"></i><span class="oh-nav-label">Progrese</span>
-                    </NavLink>
                     <NavLink class="oh-nav-item" href="treasures">
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-safe-fill ni"></i><span class="oh-nav-label">Poklady</span>
@@ -175,6 +167,15 @@
                     <NavLink class="oh-nav-item" href="npcs">
                         <span class="oh-nav-rail"></span>
                         <i class="bi bi-person-badge-fill ni"></i><span class="oh-nav-label">NPC</span>
+                    </NavLink>
+                    <div class="oh-nav-tools-head">Materiály</div>
+                    <NavLink class="oh-nav-item" href="@EndGameStatsHref">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-bar-chart-line-fill ni"></i><span class="oh-nav-label">Statistiky</span>
+                    </NavLink>
+                    <NavLink class="oh-nav-item" href="@ProgressionStatsHref">
+                        <span class="oh-nav-rail"></span>
+                        <i class="bi bi-graph-up-arrow ni"></i><span class="oh-nav-label">Progres postav v čase</span>
                     </NavLink>
                     <NavLink class="oh-nav-item" href="exports">
                         <span class="oh-nav-rail"></span>


### PR DESCRIPTION
## Summary
- Move Statistiky, Progres postav v čase, and Exporty under a static Materiály header in the Hra nav pane.
- Keep Šifry, Knihovna, catalog nav, and bottom Nástroje unchanged.

## Verification
- dotnet build OvcinaHra.slnx
- Ran API + client dev servers and browser-checked desktop and narrow mobile nav layout.

Closes #538