### PR TITLE
fix(progression): chart x-axis shows just HH:mm

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/ProgressionStatsEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ProgressionStatsEndpoints.cs
@@ -100,7 +100,8 @@ public static partial class GameEndpoints
                     s.Stage,
                     s.InGameYear,
                     s.StartTime,
-                    (decimal)s.Duration.TotalHours)))
+                    (decimal)s.Duration.TotalHours),
+                ShortTimeSlotDisplay(s.StartTime)))
             .ToListAsync(ct);
 
         logger.LogInformation("[progression] CharacterEvent query start gameId={GameId}", gameId);
@@ -142,6 +143,7 @@ public static partial class GameEndpoints
                 e.KingdomHexColor,
                 e.TimeSlotId,
                 e.TimeSlotLabel,
+                e.TimeSlotShortLabel,
                 e.EventType,
                 e.LevelGained,
                 e.TimestampUtc))
@@ -191,6 +193,7 @@ public static partial class GameEndpoints
                 bucket.Id,
                 timeSlots.IndexOf(bucket),
                 bucket.Label,
+                bucket.ShortLabel,
                 PlayerFullName(ev.PlayerFirstName, ev.PlayerLastName) ?? "Neznámý hráč",
                 ev.CharacterName,
                 ev.EventType == CharacterEventType.LevelUp ? "LevelUp" : "MasterySkillGained",
@@ -358,6 +361,7 @@ public static partial class GameEndpoints
                     .Select((slot, index) => new TimeSlotBucketDto(
                         slot.Id,
                         slot.Label,
+                        slot.ShortLabel,
                         countsByKingdomAndBucket[k.KingdomId][index]))
                     .ToArray()))
             .ToArray();
@@ -411,6 +415,9 @@ public static partial class GameEndpoints
         return string.IsNullOrWhiteSpace(fullName) ? null : fullName;
     }
 
+    private static string ShortTimeSlotDisplay(DateTime startTime) =>
+        startTime.ToLocalTime().ToString("HH:mm", CultureInfo.InvariantCulture);
+
     private sealed record ProgressionKingdomRow(
         int KingdomId,
         string KingdomName,
@@ -423,7 +430,8 @@ public static partial class GameEndpoints
         TimeSpan Duration,
         GameTimePhase Stage,
         int? InGameYear,
-        string Label);
+        string Label,
+        string ShortLabel);
 
     private sealed record ProgressionCharacterEventRow(
         int EventId,
@@ -447,6 +455,7 @@ public static partial class GameEndpoints
         int TimeSlotId,
         int TimeSlotIndex,
         string TimeSlotLabel,
+        string TimeSlotShortLabel,
         string PlayerName,
         string CharacterName,
         string EventType,

--- a/src/OvcinaHra.Client/Pages/ProgresPostavVCase.razor
+++ b/src/OvcinaHra.Client/Pages/ProgresPostavVCase.razor
@@ -52,7 +52,7 @@
                             @foreach (var level in Levels)
                             {
                                 var currentLevel = level;
-                                <DxChartStackedBarSeries ArgumentField="@((ProgressionChartRow r) => r.TimeSlotLabel)"
+                                <DxChartStackedBarSeries ArgumentField="@((ProgressionChartRow r) => r.TimeSlotShortLabel)"
                                                          ValueField="@((ProgressionChartRow r) => r.CountFor(currentLevel))"
                                                          Name="@LevelSeriesName(currentLevel)"
                                                          Color="@LevelColor(currentLevel)"
@@ -61,7 +61,7 @@
                             <DxChartTooltip Enabled="true" Context="tooltip">
                                 <div>
                                     <strong>@tooltip.Point.SeriesName</strong>
-                                    <div>@tooltip.Point.Argument: @tooltip.Point.Value</div>
+                                    <div>@TooltipTimeSlotLabel(tooltip): @tooltip.Point.Value</div>
                                 </div>
                             </DxChartTooltip>
                         </DxChart>
@@ -229,7 +229,11 @@
                 k.KingdomName,
                 k.HexColor,
                 k.SortOrder,
-                k.Buckets.Select(b => new ProgressionChartRow(b.TimeSlotId, b.Label, b.HeroCountByLevel)).ToList()))
+                k.Buckets.Select(b => new ProgressionChartRow(
+                    b.TimeSlotId,
+                    b.Label,
+                    b.TimeSlotShortLabel,
+                    b.HeroCountByLevel)).ToList()))
             .ToList() ?? [];
 
     private static List<ProgressionEventGridRow> BuildEventRows(ProgressionStatsDto? stats) =>
@@ -266,6 +270,23 @@
         7 => "Úroveň 7 (2 mistrovství)",
         _ => $"Úroveň {level.ToString(CultureInfo.InvariantCulture)}"
     };
+
+    private static string TooltipTimeSlotLabel(DevExpress.Blazor.ChartTooltipData tooltip)
+    {
+        var labels = tooltip.Point.DataItems
+            .OfType<ProgressionChartRow>()
+            .Select(r => r.TimeSlotLabel)
+            .Distinct()
+            .ToArray();
+
+        return labels.Length switch
+        {
+            0 => tooltip.Point.Argument?.ToString() ?? "Časový blok",
+            1 => labels[0],
+            _ => string.Join(", ", labels)
+        };
+    }
+
 
     private static System.Drawing.Color LevelColor(int level) => level switch
     {
@@ -310,6 +331,7 @@
     private sealed record ProgressionChartRow(
         int TimeSlotId,
         string TimeSlotLabel,
+        string TimeSlotShortLabel,
         int[] Counts)
     {
         public int CountFor(int level) =>

--- a/src/OvcinaHra.Shared/Dtos/ProgressionStatsDtos.cs
+++ b/src/OvcinaHra.Shared/Dtos/ProgressionStatsDtos.cs
@@ -14,6 +14,7 @@ public record KingdomProgressionDto(
 public record TimeSlotBucketDto(
     int TimeSlotId,
     string Label,
+    string TimeSlotShortLabel,
     int[] HeroCountByLevel);
 
 public record ProgressionEventRow(
@@ -23,6 +24,7 @@ public record ProgressionEventRow(
     string KingdomHexColor,
     int TimeSlotId,
     string TimeSlotLabel,
+    string TimeSlotShortLabel,
     string EventType,
     int LevelGained,
     DateTime TimestampUtc);

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ProgressionStatsEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ProgressionStatsEndpointTests.cs
@@ -32,6 +32,9 @@ public class ProgressionStatsEndpointTests(PostgresFixture postgres)
         int day1LastSlotId;
         int slot5Id;
         int slot7Id;
+        string day1LastSlotShortLabel;
+        string day1LastSlotLongLabel;
+        string slot5ShortLabel;
 
         using (var scope = Factory.Services.CreateScope())
         {
@@ -48,6 +51,9 @@ public class ProgressionStatsEndpointTests(PostgresFixture postgres)
             day1LastSlotId = slots[2].Id;
             slot5Id = slots[4].Id;
             slot7Id = slots[6].Id;
+            day1LastSlotShortLabel = slots[2].StartTime.ToLocalTime().ToString("HH:mm");
+            day1LastSlotLongLabel = StatsLabel(slots[2]);
+            slot5ShortLabel = slots[4].StartTime.ToLocalTime().ToString("HH:mm");
 
             var gapHero = Character("Gap Hero", "Gita", "Mezera");
             var finalHero = Character("Final Hero", "Fero", "Finále");
@@ -89,8 +95,14 @@ public class ProgressionStatsEndpointTests(PostgresFixture postgres)
         });
 
         var esgarothStats = stats.Kingdoms.Single(k => k.KingdomName == "Esgaroth");
-        Assert.Equal(1, esgarothStats.Buckets.Single(b => b.TimeSlotId == day1LastSlotId).HeroCountByLevel[0]);
-        Assert.Equal(1, esgarothStats.Buckets.Single(b => b.TimeSlotId == slot5Id).HeroCountByLevel[1]);
+        var day1LastBucket = esgarothStats.Buckets.Single(b => b.TimeSlotId == day1LastSlotId);
+        Assert.Equal(day1LastSlotShortLabel, day1LastBucket.TimeSlotShortLabel);
+        Assert.Equal(day1LastSlotLongLabel, day1LastBucket.Label);
+        Assert.Equal(1, day1LastBucket.HeroCountByLevel[0]);
+
+        var slot5Bucket = esgarothStats.Buckets.Single(b => b.TimeSlotId == slot5Id);
+        Assert.Equal(slot5ShortLabel, slot5Bucket.TimeSlotShortLabel);
+        Assert.Equal(1, slot5Bucket.HeroCountByLevel[1]);
         Assert.Equal(1, esgarothStats.Buckets.Single(b => b.TimeSlotId == slot7Id).HeroCountByLevel[5]);
 
         var aradhryandStats = stats.Kingdoms.Single(k => k.KingdomName == "Aradhryand");
@@ -105,6 +117,8 @@ public class ProgressionStatsEndpointTests(PostgresFixture postgres)
         Assert.Contains(stats.Events, e =>
             e.CharacterName.StartsWith("Gap Hero", StringComparison.Ordinal)
             && e.TimeSlotId == day1LastSlotId
+            && e.TimeSlotShortLabel == day1LastSlotShortLabel
+            && e.TimeSlotLabel == day1LastSlotLongLabel
             && e.LevelGained == 1);
         Assert.Contains(stats.Events, e =>
             e.EventType == "MasterySkillGained"
@@ -192,6 +206,13 @@ public class ProgressionStatsEndpointTests(PostgresFixture postgres)
         Stage = phase,
         InGameYear = 1
     };
+
+    private static string StatsLabel(GameTimeSlot slot) =>
+        OvcinaHra.Shared.Extensions.TimeSlotDisplayExtensions.FormatTimeSlotDisplay(
+            slot.Stage,
+            slot.InGameYear,
+            slot.StartTime,
+            (decimal)slot.Duration.TotalHours);
 
     private static Character Character(string name, string firstName, string lastName) => new()
     {


### PR DESCRIPTION
## Summary\n- adds TimeSlotShortLabel to progression bucket and event DTOs\n- builds the short label server-side from local slot start time using HH:mm\n- binds progression chart x-axis to the short label while keeping the grid on the long label\n- keeps chart tooltip on the full timeslot label for context\n\n## Tests\n- dotnet build OvcinaHra.slnx /clp:ErrorsOnly\n- dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter ProgressionStatsEndpointTests --logger "console;verbosity=minimal"\n- dotnet test OvcinaHra.slnx --no-build --logger "console;verbosity=minimal"\n\n## Visual sanity\n- Source-level sanity checked: chart ArgumentField now uses TimeSlotShortLabel; grid keeps TimeSlotLabel; tooltip maps short label back to full TimeSlotLabel.\n- Local browser run was not performed because the brief target game 30 requires a seeded local environment.