### PR TITLE
fix(time-display): convert scoped surfaces to Prague time

### DIFF
--- a/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/LocationEndpoints.cs
@@ -736,7 +736,7 @@ public static class LocationEndpoints
     {
         var trimmed = value?.Trim();
         return string.IsNullOrWhiteSpace(trimmed)
-            ? fallbackUtc.ToLocalTime().ToString("dd/MM HH:mm", CultureInfo.InvariantCulture)
+            ? PragueTimeFormatter.Format(fallbackUtc, "dd/MM HH:mm", CultureInfo.InvariantCulture)
             : trimmed.Length <= 32 ? trimmed : trimmed[..32];
     }
 }

--- a/src/OvcinaHra.Api/Endpoints/ProgressionStatsEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/ProgressionStatsEndpoints.cs
@@ -5,10 +5,10 @@ using ClosedXML.Excel;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Domain.Rules;
 using OvcinaHra.Shared.Dtos;
-using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Api.Endpoints;
 
@@ -96,7 +96,7 @@ public static partial class GameEndpoints
                 s.Duration,
                 s.Stage,
                 s.InGameYear,
-                TimeSlotDisplayExtensions.FormatTimeSlotDisplay(
+                PragueTimeFormatter.FormatTimeSlotDisplay(
                     s.Stage,
                     s.InGameYear,
                     s.StartTime,
@@ -379,7 +379,7 @@ public static partial class GameEndpoints
             "Časový blok",
             "Událost",
             "Získaná úroveň",
-            "Čas UTC"
+            "Čas (Praha)"
         ];
 
         for (var column = 0; column < headers.Length; column++)
@@ -394,12 +394,13 @@ public static partial class GameEndpoints
             worksheet.Cell(rowIndex, 4).Value = row.TimeSlotLabel;
             worksheet.Cell(rowIndex, 5).Value = row.EventType;
             worksheet.Cell(rowIndex, 6).Value = row.LevelGained;
-            worksheet.Cell(rowIndex, 7).Value = row.TimestampUtc;
+            worksheet.Cell(rowIndex, 7).Value = PragueTimeFormatter.ToPragueTime(row.TimestampUtc);
             rowIndex++;
         }
 
         var usedRange = worksheet.Range(1, 1, Math.Max(1, rowIndex - 1), headers.Length);
         worksheet.Range(1, 1, 1, headers.Length).Style.Font.Bold = true;
+        worksheet.Column(7).Style.DateFormat.Format = "d.M.yyyy HH:mm";
         usedRange.SetAutoFilter();
         worksheet.SheetView.FreezeRows(1);
         worksheet.Columns().AdjustToContents();
@@ -416,7 +417,7 @@ public static partial class GameEndpoints
     }
 
     private static string ShortTimeSlotDisplay(DateTime startTime) =>
-        startTime.ToLocalTime().ToString("HH:mm", CultureInfo.InvariantCulture);
+        PragueTimeFormatter.Format(startTime, "HH:mm", CultureInfo.InvariantCulture);
 
     private sealed record ProgressionKingdomRow(
         int KingdomId,

--- a/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
+++ b/src/OvcinaHra.Api/Endpoints/QuestEndpoints.cs
@@ -3,10 +3,10 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
-using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Api.Endpoints;
 
@@ -116,7 +116,7 @@ public static class QuestEndpoints
         int? inGameYear,
         DateTime startTime,
         TimeSpan duration) =>
-        TimeSlotDisplayExtensions.FormatTimeSlotDisplay(
+        PragueTimeFormatter.FormatTimeSlotDisplay(
             stage, inGameYear, startTime, (decimal)duration.TotalHours);
 
     private static string? FormatTimeSlotName(

--- a/src/OvcinaHra.Api/Services/PragueTimeFormatter.cs
+++ b/src/OvcinaHra.Api/Services/PragueTimeFormatter.cs
@@ -1,0 +1,47 @@
+using System.Globalization;
+using OvcinaHra.Shared.Domain.Enums;
+using OvcinaHra.Shared.Extensions;
+
+namespace OvcinaHra.Api.Services;
+
+public static class PragueTimeFormatter
+{
+    private const string PragueWindowsTimeZoneId = "Central European Standard Time";
+
+    public static DateTime ToPragueTime(DateTime utcDateTime)
+    {
+        var utc = utcDateTime.Kind switch
+        {
+            DateTimeKind.Utc => utcDateTime,
+            DateTimeKind.Local => utcDateTime.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(utcDateTime, DateTimeKind.Utc)
+        };
+
+        try
+        {
+            return TimeZoneInfo.ConvertTimeBySystemTimeZoneId(utc, PragueWindowsTimeZoneId);
+        }
+        catch (TimeZoneNotFoundException) when (TimeZoneInfo.TryConvertWindowsIdToIanaId(PragueWindowsTimeZoneId, out var ianaId))
+        {
+            return TimeZoneInfo.ConvertTimeBySystemTimeZoneId(utc, ianaId);
+        }
+        catch (InvalidTimeZoneException) when (TimeZoneInfo.TryConvertWindowsIdToIanaId(PragueWindowsTimeZoneId, out var ianaId))
+        {
+            return TimeZoneInfo.ConvertTimeBySystemTimeZoneId(utc, ianaId);
+        }
+    }
+
+    public static string Format(DateTime utcDateTime, string format, IFormatProvider? provider = null) =>
+        ToPragueTime(utcDateTime).ToString(format, provider);
+
+    public static string FormatTimeSlotDisplay(
+        GameTimePhase stage,
+        int? inGameYear,
+        DateTime startTimeUtc,
+        decimal durationHours)
+    {
+        var yearPrefix = inGameYear is int year ? $"Rok {year}, " : "";
+        var start = Format(startTimeUtc, "d.M. HH:mm", CultureInfo.InvariantCulture);
+        return $"{stage.GetDisplayName()}: {yearPrefix}{start} ({durationHours:0.#} h)";
+    }
+}

--- a/src/OvcinaHra.Client/Pages/Events/GameEventList.razor
+++ b/src/OvcinaHra.Client/Pages/Events/GameEventList.razor
@@ -170,7 +170,7 @@ else
             var slots = await Api.GetListAsync<GameTimeSlotDto>($"/api/timeline/slots/by-game/{gid}");
             availableTimeSlots = slots
                 .OrderBy(s => s.StartTime)
-                .Select(s => new TimeSlotOption(s.Id, $"{s.StartTime:d.M. HH:mm} ({s.DurationHours}h)"))
+                .Select(s => new TimeSlotOption(s.Id, $"{s.StartTime.ToLocalTime():d.M. HH:mm} ({s.DurationHours}h)"))
                 .ToList();
 
             availableLocations = await Api.GetListAsync<LocationListDto>($"/api/locations/by-game/{gid}");

--- a/tests/OvcinaHra.Api.Tests/Endpoints/ProgressionStatsEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/ProgressionStatsEndpointTests.cs
@@ -5,6 +5,7 @@ using ClosedXML.Excel;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using OvcinaHra.Api.Data;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Entities;
 using OvcinaHra.Shared.Domain.Enums;
@@ -51,9 +52,9 @@ public class ProgressionStatsEndpointTests(PostgresFixture postgres)
             day1LastSlotId = slots[2].Id;
             slot5Id = slots[4].Id;
             slot7Id = slots[6].Id;
-            day1LastSlotShortLabel = slots[2].StartTime.ToLocalTime().ToString("HH:mm");
+            day1LastSlotShortLabel = PragueTimeFormatter.Format(slots[2].StartTime, "HH:mm");
             day1LastSlotLongLabel = StatsLabel(slots[2]);
-            slot5ShortLabel = slots[4].StartTime.ToLocalTime().ToString("HH:mm");
+            slot5ShortLabel = PragueTimeFormatter.Format(slots[4].StartTime, "HH:mm");
 
             var gapHero = Character("Gap Hero", "Gita", "Mezera");
             var finalHero = Character("Final Hero", "Fero", "Finále");
@@ -171,8 +172,11 @@ public class ProgressionStatsEndpointTests(PostgresFixture postgres)
         var worksheet = workbook.Worksheet("Progres");
         Assert.Equal("Hráč", worksheet.Cell(1, 1).GetString());
         Assert.Equal("Postava", worksheet.Cell(1, 2).GetString());
+        Assert.Equal("Čas (Praha)", worksheet.Cell(1, 7).GetString());
         Assert.Equal("Eliška Export", worksheet.Cell(2, 1).GetString());
         Assert.StartsWith("Excel Hero", worksheet.Cell(2, 2).GetString(), StringComparison.Ordinal);
+        Assert.Equal(new DateTime(2026, 5, 1, 10, 5, 0), worksheet.Cell(2, 7).GetDateTime());
+        Assert.Equal("d.M.yyyy HH:mm", worksheet.Cell(2, 7).Style.DateFormat.Format);
     }
 
     private async Task<GameDetailDto> CreateGameAsync()
@@ -208,7 +212,7 @@ public class ProgressionStatsEndpointTests(PostgresFixture postgres)
     };
 
     private static string StatsLabel(GameTimeSlot slot) =>
-        OvcinaHra.Shared.Extensions.TimeSlotDisplayExtensions.FormatTimeSlotDisplay(
+        PragueTimeFormatter.FormatTimeSlotDisplay(
             slot.Stage,
             slot.InGameYear,
             slot.StartTime,

--- a/tests/OvcinaHra.Api.Tests/Endpoints/QuestEndpointTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Endpoints/QuestEndpointTests.cs
@@ -1,9 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
+using OvcinaHra.Api.Services;
 using OvcinaHra.Api.Tests.Fixtures;
 using OvcinaHra.Shared.Domain.Enums;
 using OvcinaHra.Shared.Dtos;
-using OvcinaHra.Shared.Extensions;
 
 namespace OvcinaHra.Api.Tests.Endpoints;
 
@@ -149,7 +149,7 @@ public class QuestEndpointTests(PostgresFixture postgres) : IntegrationTestBase(
         var game = await CreateGameAsync();
         var startTime = new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc);
         var slot = await CreateTimeSlotAsync(game.Id, startTime, GameTimePhase.Midgame);
-        var expectedName = TimeSlotDisplayExtensions.FormatTimeSlotDisplay(
+        var expectedName = PragueTimeFormatter.FormatTimeSlotDisplay(
             GameTimePhase.Midgame, 1247, startTime, 2);
 
         var response = await Client.PostAsJsonAsync("/api/quests",

--- a/tests/OvcinaHra.Api.Tests/Services/PragueTimeFormatterTests.cs
+++ b/tests/OvcinaHra.Api.Tests/Services/PragueTimeFormatterTests.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using OvcinaHra.Api.Services;
+using OvcinaHra.Shared.Domain.Enums;
+
+namespace OvcinaHra.Api.Tests.Services;
+
+public class PragueTimeFormatterTests
+{
+    [Fact]
+    public void ToPragueTime_ConvertsUtcTimestampToCzechLocalTime()
+    {
+        var utc = new DateTime(2026, 5, 1, 8, 0, 0, DateTimeKind.Utc);
+
+        var local = PragueTimeFormatter.ToPragueTime(utc);
+
+        Assert.Equal(new DateTime(2026, 5, 1, 10, 0, 0), local);
+    }
+
+    [Fact]
+    public void FormatTimeSlotDisplay_UsesPragueTimeInServerGeneratedLabel()
+    {
+        var utc = new DateTime(2026, 5, 1, 8, 0, 0, DateTimeKind.Utc);
+
+        var label = PragueTimeFormatter.FormatTimeSlotDisplay(
+            GameTimePhase.Start,
+            2865,
+            utc,
+            2m);
+
+        Assert.Equal("Start: Rok 2865, 1.5. 10:00 (2 h)", label);
+    }
+
+    [Fact]
+    public void Format_UsesPragueTimeAndRequestedFormat()
+    {
+        var utc = new DateTime(2026, 5, 1, 8, 0, 0, DateTimeKind.Utc);
+
+        var value = PragueTimeFormatter.Format(
+            utc,
+            "d.M.yyyy HH:mm",
+            CultureInfo.InvariantCulture);
+
+        Assert.Equal("1.5.2026 10:00", value);
+    }
+}


### PR DESCRIPTION
Closes #542.

## Summary
- Added API-side `PragueTimeFormatter` for server-rendered/exported Prague-time strings.
- Converted progression chart/grid/export slot labels and XLSX event timestamps to Prague time.
- Converted quest time-slot names and location placement fallback timestamps to Prague time.
- Updated the game-event slot picker to use browser-local `.ToLocalTime()` in WASM.

## Phase 0 Mapping
| Phase 0 row | Fix |
|---|---|
| Progression XLSX `row.TimestampUtc` | Convert via `PragueTimeFormatter.ToPragueTime`, set `d.M.yyyy HH:mm` Excel format |
| Progression server labels | Use `PragueTimeFormatter.FormatTimeSlotDisplay` / `Format` |
| Quest server `TimeSlotName` | Use `PragueTimeFormatter.FormatTimeSlotDisplay` |
| `GameEventList` Razor slot label | Use `s.StartTime.ToLocalTime()` |
| Location placement fallback timestamp | Use `PragueTimeFormatter.Format` |

DTO rename is left to #543; operational logs remain UTC as scoped.

## Verification
- `dotnet test tests/OvcinaHra.Api.Tests/OvcinaHra.Api.Tests.csproj --filter "FullyQualifiedName~ProgressionStatsEndpointTests|FullyQualifiedName~PragueTimeFormatterTests|FullyQualifiedName~QuestEndpointTests.Create_WithValidTimeSlot_PersistsProjection" --logger "console;verbosity=minimal"` passed: 7/7
- `dotnet build OvcinaHra.slnx` passed: 0 warnings, 0 errors
- `dotnet test OvcinaHra.slnx --logger "console;verbosity=minimal"` passed: API 692/692, E2E 8/8
- `git diff --check` clean